### PR TITLE
.NET build task pipeline

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -1,0 +1,26 @@
+name: .NET Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened]
+
+jobs:
+  build:
+    name: Build .NET
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Build solution
+      run: |
+        dotnet restore DfE.FindInformationAcademiesTrusts
+        dotnet build DfE.FindInformationAcademiesTrusts -c Release


### PR DESCRIPTION
- This GitHub Workflow will ensure that the dotnet app can be built whenever a PR is opened against `main`