### PR TITLE
Add Serilog logging to console if environment is Development

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
+++ b/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
@@ -14,4 +14,8 @@
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Serilog.AspNetCore" Version="7.0.0"/>
+    </ItemGroup>
 </Project>

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -9,6 +10,12 @@ builder.Services.AddOptions<AcademiesApiOptions>()
     .Bind(builder.Configuration.GetSection(AcademiesApiOptions.ConfigurationSection))
     .ValidateDataAnnotations()
     .ValidateOnStart();
+
+if (builder.Environment.IsDevelopment())
+{
+    builder.Host.UseSerilog((ctx, lc) => lc
+        .WriteTo.Console());
+}
 
 var app = builder.Build();
 


### PR DESCRIPTION
# Added 

- Serilog as per RSD standards
- Configured Serilog to write to Console in local development environment, as we will log to Application Insights in deployed application