### PR TITLE
Improve pipelines

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -13,6 +13,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.environment }}
+  cancel-in-progress: true
 
 env:
   DOCKER_IMAGE: fiat-app

--- a/.github/workflows/deployment-smoke-tests.yml
+++ b/.github/workflows/deployment-smoke-tests.yml
@@ -1,17 +1,18 @@
-name: Playwright tests
-run-name: Playwright tests for '${{ github.event.deployment.environment }}'
+name: Deployment smoke tests
+run-name: Deployment smoke tests for '${{ github.event.deployment.environment }}' - `${{github.event.workflow_run.head_branch}}`
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.deployment.environment }}
+  group: ${{ github.workflow }}-${{ github.event.deployment.environment }}-${{ github.event.workflow_run.status == 'completed' && github.event.workflow.name == 'Deploy to environment' && github.event.deployment_status.state == 'success' }}
+  cancel-in-progress: true
 
 on:
-  deployment:
+  deployment_status:
 
 jobs:
   playwright:
-    name: Playwright tests
+    name: Deployment smoke tests
     runs-on: ubuntu-22.04
-    if: ${{ github.event.workflow_run.status }} == 'completed' && ${{ github.event.workflow_run.name }} == 'Deploy to environment'
+    if: ${{ github.event.workflow_run.status == 'completed' && github.event.workflow.name == 'Deploy to environment' && github.event.deployment_status.state == 'success'}}
     environment: ${{ github.event.deployment.environment }}
     defaults:
       run:
@@ -32,11 +33,11 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
 
-      - name: Run Playwright tests
+      - name: Run Playwright deployment tests
         env:
           CI: true
           PLAYWRIGHT_BASEURL: ${{ secrets.BASE_URL }}
-        run: npx playwright test
+        run: npx playwright test deployment-tests/*
 
       - uses: actions/upload-artifact@v3
         if: always()


### PR DESCRIPTION
# Changed

* Environment deployments will cancel if there is a newer deployment pending
* Deployment tests will cancel if there is new code pushed to PR
* `Playwright tests` is now called `Deployment smoke tests`. This name is more descriptive and allows us to use Playwright for different types of testing in other future pipelines
* Deployment smoke tests `if` condition fixed and also now depends upon the deployment being successful
* Playwright will specifically only run deployment tests rather than all Playwright tests