### PR TITLE
Adds Sonar scanning to the dotnet ci workflow

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
     types: [ opened, synchronize, reopened]
 
+env:
+  JAVA_VERSION: '11'
+
 jobs:
   build:
     name: Build .NET
@@ -14,13 +17,46 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.ref }}
+        fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
 
-    - name: Build solution
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: 'microsoft'
+
+    - name: Cache SonarCloud packages
+      uses: actions/cache@v3
+      with:
+        path: ~\sonar\cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
+
+    - name: Cache SonarCloud scanner
+      id: cache-sonar-scanner
+      uses: actions/cache@v3
+      with:
+        path: .\.sonar\scanner
+        key: ${{ runner.os }}-sonar-scanner
+        restore-keys: ${{ runner.os }}-sonar-scanner
+
+    - name: Install SonarCloud scanner
+      if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+      run: dotnet tool install --global dotnet-sonarscanner
+
+    - name: Build and Analyze solution
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
+        dotnet-sonarscanner begin /k:"DFE-Digital-find-information-about-academies-and-trusts" /o:"dfe-digital" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
         dotnet restore DfE.FindInformationAcademiesTrusts
         dotnet build DfE.FindInformationAcademiesTrusts -c Release
+        dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
> **Note**
> This PR can't be merged until SonarCloud integration has been set up by support

## Description

Adds the capability to use the SonarCloud scanner to collect information about code quality, code smells etc for the dotnet code.

*To-do*
- [ ] Once SonarCloud has been set up, we will need to ensure the key passed to the scanner is correct, or updated otherwise.
- [ ] The SONAR_TOKEN secret will need adding to the secrets