### PR TITLE
Use GitHub token with Get Latest Release job

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -84,6 +84,7 @@ jobs:
         id: get-latest-release-tag
         uses: "actions/github-script@v6"
         with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |
             try {
               const { data } = await github.repos.getLatestRelease({


### PR DESCRIPTION
* I thought this may not be required, as this is publicly readable, but it's not working - So trying with the addition of the token