### PR TITLE
Add testing documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,7 +71,8 @@ Under most circumstances you won't need to run the application in Docker locally
 
 ### Unit tests
 
-To run the project's unit tests, open a terminal in the project directory and run:
+All .NET code is [unit tested](./test-approach.md) where possible. You can run unit tests using your preferred IDE, or
+open a terminal in the project directory and run:
 
 ```bash
 cd tests/DfE.FindInformationAcademiesTrusts.UnitTests

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ Use this documentation to configure your local development environment.
   - [Unit tests](#unit-tests)
   - [Accessibility and UI tests](#accessibility-and-ui-tests)
 - [Supercharge your dev environment](#supercharge-your-dev-environment)
-  - Configure continuous testing
+  - [Set up continuous testing](#set-up-continuous-testing)
   - [Analyse test coverage](#analyse-test-coverage)
   - [Configure linting and code cleanup](#configure-linting-and-code-cleanup)
 
@@ -102,6 +102,14 @@ docker compose -f ../../docker/docker-compose.ci.yml down
 For more information on running and debugging Playwright tests it is worth familiarising yourself with the Playwright docs on [debugging](https://playwright.dev/docs/debug) and [command line flags](https://playwright.dev/docs/test-cli).
 
 ## Supercharge your dev environment
+
+### Set up continuous testing
+
+We recommend setting Rider to run unit tests on save, for fast feedback on changes.
+
+- Go to Settings -> Plugins and check that `dotCover` is enabled
+- Go to Settings -> Build, Execution, Deployment -> Unit Testing -> Continuous Testing and select 'Automatically start tests in continuous testing sessions on **Save**'
+- Go to or open a Unit Tests session (Tests -> Create New Session), open the 'Continuous testing modes' menu and select 'Run all tests'
 
 ### Analyse test coverage
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,11 +71,11 @@ Under most circumstances you won't need to run the application in Docker locally
 
 ### Unit tests
 
-All .NET code is [unit tested](./test-approach.md) where possible. You can run unit tests using your preferred IDE, or
-open a terminal in the project directory and run:
+All .NET code is [unit tested](./test-approach.md) where possible. 
+
+You can run unit tests using your preferred IDE, or open a terminal in the project directory and run:
 
 ```bash
-cd tests/DfE.FindInformationAcademiesTrusts.UnitTests
 dotnet test
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,8 +87,8 @@ To run these tests locally it is easiest to run your app and the mock API using 
 ```bash
 cd DfE.FindInformationAcademiesTrusts.UnitTests/playwright
 
-# run docker image
-docker compose -f ../../docker/docker-compose.ci.yml up -d
+# run docker image with build flag to watch for the latest code changes
+docker compose -f ../../docker/docker-compose.ci.yml up -d --build
 
 # run playwright tests
 npm install

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,12 @@ Use this documentation to configure your local development environment.
   - [Build and watch frontend assets](#build-and-watch-frontend-assets)
   - [Build and run dotnet project](#build-and-run-dotnet-project)
   - [Run in Docker (optional)](#run-in-docker-optional)
+- [Run tests](#run-tests)
+  - [Unit tests](#unit-tests)
+  - [Accessibility and UI tests](#accessibility-and-ui-tests)
 - [Supercharge your dev environment](#supercharge-your-dev-environment)
+  - Configure continuous testing
+  - [Analyse test coverage](#analyse-test-coverage)
   - [Configure linting and code cleanup](#configure-linting-and-code-cleanup)
 
 ## Get it working
@@ -62,7 +67,55 @@ Under most circumstances you won't need to run the application in Docker locally
 - copy the `.env.example` file, save as `.env` and populate the secrets within
 - run `docker-compose up`
 
+## Run tests
+
+### Unit tests
+
+To run the project's unit tests, open a terminal in the project directory and run:
+
+```bash
+cd tests/DfE.FindInformationAcademiesTrusts.UnitTests
+dotnet test
+```
+
+### Accessibility and UI tests
+
+Accessibility and UI tests are written using [Playwright](https://playwright.dev/), with external dependencies (e.g. APIs) mocked using [WireMock](https://github.com/HBOCodeLabs/wiremock-captain). 
+To run these tests locally it is easiest to run your app and the mock API using Docker:
+
+```bash
+cd DfE.FindInformationAcademiesTrusts.UnitTests/playwright
+
+# run docker image
+docker compose -f ../../docker/docker-compose.ci.yml up -d
+
+# run playwright tests
+npm install
+npx playwright test 
+# OR
+npx playwright/{folder-name}/* 
+
+# remove docker image when done
+docker compose -f ../../docker/docker-compose.ci.yml down
+
+```
+For more information on running and debugging Playwright tests it is worth familiarising yourself with the Playwright docs on [debugging](https://playwright.dev/docs/debug) and [command line flags](https://playwright.dev/docs/test-cli).
+
 ## Supercharge your dev environment
+
+### Analyse test coverage
+
+This project uses a [mutation score](https://stryker-mutator.io/docs/) to analyse effective test coverage when opening up a new pull request.
+To check these scores locally you will need to [install Stryker.Net](https://stryker-mutator.io/docs/stryker-net/getting-started/).
+
+Once Stryker is installed:
+
+```bash
+cd tests/DfE.FindInformationAcademiesTrusts.UnitTests
+dotnet stryker
+```
+
+You should see a new folder `StrykerOutput` inside your project's UnitTests directory, with reports grouped by timestamp.
 
 ### Configure linting and code cleanup
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,11 +90,16 @@ cd DfE.FindInformationAcademiesTrusts.UnitTests/playwright
 # run docker image with build flag to watch for the latest code changes
 docker compose -f ../../docker/docker-compose.ci.yml up -d --build
 
-# run playwright tests
+# install dependencies
 npm install
+
+# run tests 
 npx playwright test 
+
 # OR
-npx playwright/{folder-name}/* 
+npx playwright test {folder-name}/* # run a particular set of tests
+npx playright test --headed # run in headed mode
+npx playwright test --trace <mode> # overwrite tracing mode set in config 
 
 # remove docker image when done
 docker compose -f ../../docker/docker-compose.ci.yml down

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,14 +116,13 @@ We recommend setting Rider to run unit tests on save, for fast feedback on chang
 This project uses a [mutation score](https://stryker-mutator.io/docs/) to analyse effective test coverage when opening up a new pull request.
 To check these scores locally you will need to [install Stryker.Net](https://stryker-mutator.io/docs/stryker-net/getting-started/).
 
-Once Stryker is installed:
+Once Stryker is installed, run the following to run and open a Stryker report:
 
 ```bash
-cd tests/DfE.FindInformationAcademiesTrusts.UnitTests
-dotnet stryker
+dotnet stryker -o
 ```
 
-You should see a new folder `StrykerOutput` inside your project's UnitTests directory, with reports grouped by timestamp.
+You will be able to find all reports in the `StrykerOutput` folder in your project root.
 
 ### Configure linting and code cleanup
 


### PR DESCRIPTION
# Changed

Added the guidance on the following to the `Getting started` doc:
- Running unit tests
- Running Accessibility and UI tests
- Analysing test coverage
- Setting up continuous testing in Rider

