### PR TITLE
Bump container apps hosting module to v0.19.1

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -138,7 +138,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.18.1 |
+| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.19.1 |
 | <a name="module_azurerm_key_vault"></a> [azurerm\_key\_vault](#module\_azurerm\_key\_vault) | github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars | v0.1.3 |
 
 ## Resources
@@ -152,12 +152,14 @@ No resources.
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
 | <a name="input_cdn_frontdoor_custom_domains"></a> [cdn\_frontdoor\_custom\_domains](#input\_cdn\_frontdoor\_custom\_domains) | Azure CDN Front Door custom domains. If they are within the DNS zone (optionally created), the Validation TXT records and ALIAS/CNAME records will be created | `list(string)` | n/a | yes |
 | <a name="input_cdn_frontdoor_enable_rate_limiting"></a> [cdn\_frontdoor\_enable\_rate\_limiting](#input\_cdn\_frontdoor\_enable\_rate\_limiting) | Enable CDN Front Door Rate Limiting. This will create a WAF policy, and CDN security policy. For pricing reasons, there will only be one WAF policy created. | `bool` | n/a | yes |
+| <a name="input_cdn_frontdoor_forwarding_protocol"></a> [cdn\_frontdoor\_forwarding\_protocol](#input\_cdn\_frontdoor\_forwarding\_protocol) | Azure CDN Front Door forwarding protocol | `string` | `"HttpsOnly"` | no |
 | <a name="input_cdn_frontdoor_health_probe_path"></a> [cdn\_frontdoor\_health\_probe\_path](#input\_cdn\_frontdoor\_health\_probe\_path) | Specifies the path relative to the origin that is used to determine the health of the origin. | `string` | n/a | yes |
 | <a name="input_cdn_frontdoor_host_add_response_headers"></a> [cdn\_frontdoor\_host\_add\_response\_headers](#input\_cdn\_frontdoor\_host\_add\_response\_headers) | List of response headers to add at the CDN Front Door `[{ "name" = "Strict-Transport-Security", "value" = "max-age=31536000" }]` | `list(map(string))` | n/a | yes |
 | <a name="input_cdn_frontdoor_host_redirects"></a> [cdn\_frontdoor\_host\_redirects](#input\_cdn\_frontdoor\_host\_redirects) | CDN Front Door host redirects `[{ "from" = "example.com", "to" = "www.example.com" }]` | `list(map(string))` | `[]` | no |
 | <a name="input_cdn_frontdoor_origin_fqdn_override"></a> [cdn\_frontdoor\_origin\_fqdn\_override](#input\_cdn\_frontdoor\_origin\_fqdn\_override) | Manually specify the hostname that the CDN Front Door should target. Defaults to the Container App FQDN | `string` | `""` | no |
 | <a name="input_cdn_frontdoor_origin_host_header_override"></a> [cdn\_frontdoor\_origin\_host\_header\_override](#input\_cdn\_frontdoor\_origin\_host\_header\_override) | Manually specify the host header that the CDN sends to the target. Defaults to the recieved host header. Set to null to set it to the host\_name (`cdn_frontdoor_origin_fqdn_override`) | `string` | `""` | no |
 | <a name="input_cdn_frontdoor_rate_limiting_threshold"></a> [cdn\_frontdoor\_rate\_limiting\_threshold](#input\_cdn\_frontdoor\_rate\_limiting\_threshold) | Number of connection requests per minute threshold for the CDN Rate Limiting policy | `number` | n/a | yes |
+| <a name="input_container_apps_allow_ips_inbound"></a> [container\_apps\_allow\_ips\_inbound](#input\_container\_apps\_allow\_ips\_inbound) | Restricts access to the Container Apps by creating a network security group rule that only allow inbound traffic from the provided list of IPs | `list(string)` | `[]` | no |
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | Container command | `list(any)` | n/a | yes |
 | <a name="input_container_cpu"></a> [container\_cpu](#input\_container\_cpu) | Number of container CPU cores | `number` | n/a | yes |
 | <a name="input_container_health_probe_path"></a> [container\_health\_probe\_path](#input\_container\_health\_probe\_path) | Specifies the path that is used to determine the liveness of the Container | `string` | `"/"` | no |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -1,5 +1,5 @@
 module "azure_container_apps_hosting" {
-  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.18.1"
+  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.19.1"
 
   environment    = local.environment
   project_name   = local.project_name
@@ -32,6 +32,7 @@ module "azure_container_apps_hosting" {
   redis_cache_capacity = local.redis_cache_capacity
 
   enable_cdn_frontdoor                      = local.enable_cdn_frontdoor
+  cdn_frontdoor_forwarding_protocol         = local.cdn_frontdoor_forwarding_protocol
   cdn_frontdoor_custom_domains              = local.cdn_frontdoor_custom_domains
   cdn_frontdoor_host_redirects              = local.cdn_frontdoor_host_redirects
   cdn_frontdoor_host_add_response_headers   = local.cdn_frontdoor_host_add_response_headers
@@ -41,6 +42,7 @@ module "azure_container_apps_hosting" {
   enable_cdn_frontdoor_health_probe         = local.enable_cdn_frontdoor_health_probe
   cdn_frontdoor_origin_fqdn_override        = local.cdn_frontdoor_origin_fqdn_override
   cdn_frontdoor_origin_host_header_override = local.cdn_frontdoor_origin_host_header_override
+  container_apps_allow_ips_inbound          = local.container_apps_allow_ips_inbound
 
   enable_dns_zone      = local.enable_dns_zone
   dns_zone_domain_name = local.dns_zone_domain_name

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -25,6 +25,7 @@ locals {
   dns_zone_domain_name                          = var.dns_zone_domain_name
   dns_ns_records                                = var.dns_ns_records
   dns_txt_records                               = var.dns_txt_records
+  container_apps_allow_ips_inbound              = var.container_apps_allow_ips_inbound
   cdn_frontdoor_custom_domains                  = var.cdn_frontdoor_custom_domains
   cdn_frontdoor_host_redirects                  = var.cdn_frontdoor_host_redirects
   cdn_frontdoor_host_add_response_headers       = var.cdn_frontdoor_host_add_response_headers
@@ -35,6 +36,7 @@ locals {
   cdn_frontdoor_rate_limiting_threshold         = var.cdn_frontdoor_rate_limiting_threshold
   cdn_frontdoor_origin_fqdn_override            = var.cdn_frontdoor_origin_fqdn_override
   cdn_frontdoor_origin_host_header_override     = var.cdn_frontdoor_origin_host_header_override
+  cdn_frontdoor_forwarding_protocol             = var.cdn_frontdoor_forwarding_protocol
   enable_cdn_frontdoor_health_probe             = var.enable_cdn_frontdoor_health_probe
   enable_event_hub                              = var.enable_event_hub
   enable_monitoring                             = var.enable_monitoring

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -55,6 +55,12 @@ variable "enable_cdn_frontdoor" {
   default     = false
 }
 
+variable "container_apps_allow_ips_inbound" {
+  description = "Restricts access to the Container Apps by creating a network security group rule that only allow inbound traffic from the provided list of IPs"
+  type        = list(string)
+  default     = []
+}
+
 variable "enable_cdn_frontdoor_health_probe" {
   description = "Enable CDN Front Door health probe"
   type        = bool
@@ -104,6 +110,12 @@ variable "cdn_frontdoor_host_redirects" {
 variable "cdn_frontdoor_host_add_response_headers" {
   description = "List of response headers to add at the CDN Front Door `[{ \"name\" = \"Strict-Transport-Security\", \"value\" = \"max-age=31536000\" }]`"
   type        = list(map(string))
+}
+
+variable "cdn_frontdoor_forwarding_protocol" {
+  description = "Azure CDN Front Door forwarding protocol"
+  type        = string
+  default     = "HttpsOnly"
 }
 
 variable "redis_cache_sku" {


### PR DESCRIPTION
* Allows specifying the Front Door CDN forwarding protocol
* Allows adding a list of IP addresses allowed to access the Container App