### PR TITLE
Update deployment tests to cover searching for a trust

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,6 +86,11 @@ dotnet test
 Accessibility and UI tests are written using [Playwright](https://playwright.dev/), with external dependencies (e.g. APIs) mocked using [WireMock](https://github.com/HBOCodeLabs/wiremock-captain). 
 To run these tests locally it is easiest to run your app and the mock API using Docker:
 
+1. Create or update the file `tests/playwright/.env` with
+```
+PLAYWRIGHT_BASEURL="http://localhost/"
+```
+2. Open a terminal in your repository and run:
 ```bash
 cd DfE.FindInformationAcademiesTrusts.UnitTests/playwright
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,7 +87,7 @@ Accessibility and UI tests are written using [Playwright](https://playwright.dev
 To run these tests locally it is easiest to run your app and the mock API using Docker:
 
 1. Create or update the file `tests/playwright/.env` with
-```
+```dotenv
 PLAYWRIGHT_BASEURL="http://localhost/"
 ```
 2. Open a terminal in your repository and run:

--- a/tests/playwright/accessibility-tests/homepage.spec.ts
+++ b/tests/playwright/accessibility-tests/homepage.spec.ts
@@ -1,9 +1,11 @@
 import { test, expect } from '@playwright/test'
 import AxeBuilder from '@axe-core/playwright'
+import { HomePage } from '../page-object-model/home-page'
 
-test.describe('homepage', () => {
+test.describe('home page', () => {
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
-    await page.goto('/')
+    const homePage = new HomePage(page)
+    await homePage.goTo()
 
     const accessibilityScanResults = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])

--- a/tests/playwright/deployment-tests/deployment.spec.ts
+++ b/tests/playwright/deployment-tests/deployment.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect } from '@playwright/test'
+import { test } from '@playwright/test'
+import { HomePage } from '../page-object-model/home-page'
 
 test('is deployed', async ({ page }) => {
-  await page.goto('/')
-
-  await expect(page).toHaveTitle('Home page - Find information about academies and trusts')
+  const homePage = new HomePage(page)
+  await homePage.goTo()
+  await homePage.expect.toBeOnTheRightPage()
 })

--- a/tests/playwright/deployment-tests/deployment.spec.ts
+++ b/tests/playwright/deployment-tests/deployment.spec.ts
@@ -1,8 +1,13 @@
 import { test } from '@playwright/test'
 import { HomePage } from '../page-object-model/home-page'
+import { SearchResultsPage } from '../page-object-model/search-results-page'
 
 test('is deployed', async ({ page }) => {
   const homePage = new HomePage(page)
+  const searchResultsPage = new SearchResultsPage(page)
   await homePage.goTo()
   await homePage.expect.toBeOnTheRightPage()
+
+  await homePage.searchFor('education')
+  await searchResultsPage.expect.toShowResults()
 })

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -8,7 +8,8 @@
     "lint:fix": "ts-standard --fix",
     "test:a11y": "npx playwright test accessibility-tests/* --project=chromium --project=firefox --project=webkit --project=\"Microsoft Edge\"",
     "test:ui": "npx playwright test ui-tests/* --project=chromium --project=firefox --project=webkit --project=\"Microsoft Edge\"",
-    "test:ci": "npx playwright test accessibility-tests/* ui-tests/* --project=chromium --project=firefox --project=webkit --project=\"Microsoft Edge\""
+    "test:ci": "npx playwright test accessibility-tests/* ui-tests/* --project=chromium --project=firefox --project=webkit --project=\"Microsoft Edge\"",
+    "test:deployment": "npx playwright test --project=\"deployment-tests\""
   },
   "keywords": [],
   "author": "",
@@ -26,5 +27,4 @@
       "playwright.config.ts"
     ]
   }
-
 }

--- a/tests/playwright/page-object-model/home-page.ts
+++ b/tests/playwright/page-object-model/home-page.ts
@@ -1,14 +1,23 @@
-import { Page, expect } from '@playwright/test'
+import { Locator, Page, expect } from '@playwright/test'
 
 export class HomePage {
   readonly expect: HomePageAssertions
+  readonly _searchBoxLocator: Locator
+  readonly _searchButtonLocator: Locator
 
   constructor (readonly page: Page) {
     this.expect = new HomePageAssertions(this)
+    this._searchBoxLocator = this.page.getByLabel('Find information about academies and trusts')
+    this._searchButtonLocator = this.page.getByRole('button', { name: 'Search' })
   }
 
   async goTo (): Promise<void> {
     await this.page.goto('/')
+  }
+
+  async searchFor (searchTerm: string): Promise<void> {
+    await this._searchBoxLocator.fill(searchTerm)
+    await this._searchButtonLocator.click()
   }
 }
 

--- a/tests/playwright/page-object-model/home-page.ts
+++ b/tests/playwright/page-object-model/home-page.ts
@@ -1,0 +1,21 @@
+import { Page, expect } from '@playwright/test'
+
+export class HomePage {
+  readonly expect: HomePageAssertions
+
+  constructor (readonly page: Page) {
+    this.expect = new HomePageAssertions(this)
+  }
+
+  async goTo (): Promise<void> {
+    await this.page.goto('/')
+  }
+}
+
+class HomePageAssertions {
+  constructor (readonly homePage: HomePage) {}
+
+  async toBeOnTheRightPage (): Promise<void> {
+    await expect(this.homePage.page).toHaveTitle('Home page - Find information about academies and trusts')
+  }
+}

--- a/tests/playwright/page-object-model/search-results-page.ts
+++ b/tests/playwright/page-object-model/search-results-page.ts
@@ -1,0 +1,18 @@
+import { Locator, Page, expect } from '@playwright/test'
+
+export class SearchResultsPage {
+  readonly expect: SearchResultsPageAssertions
+  readonly _headerLocator: Locator
+  constructor (readonly page: Page) {
+    this.expect = new SearchResultsPageAssertions(this)
+    this._headerLocator = this.page.locator('h1')
+  }
+}
+
+class SearchResultsPageAssertions {
+  constructor (readonly searchResultsPage: SearchResultsPage) {}
+
+  async toBeOnPageWithResultsFor (searchTerm: string): Promise<void> {
+    await expect(this.searchResultsPage._headerLocator).toHaveText(`Search results for "${searchTerm}"`)
+  }
+}

--- a/tests/playwright/page-object-model/search-results-page.ts
+++ b/tests/playwright/page-object-model/search-results-page.ts
@@ -3,9 +3,12 @@ import { Locator, Page, expect } from '@playwright/test'
 export class SearchResultsPage {
   readonly expect: SearchResultsPageAssertions
   readonly _headerLocator: Locator
+  readonly _searchResultsListLocator: Locator
+
   constructor (readonly page: Page) {
     this.expect = new SearchResultsPageAssertions(this)
     this._headerLocator = this.page.locator('h1')
+    this._searchResultsListLocator = this.page.locator('ul')
   }
 }
 
@@ -14,5 +17,9 @@ class SearchResultsPageAssertions {
 
   async toBeOnPageWithResultsFor (searchTerm: string): Promise<void> {
     await expect(this.searchResultsPage._headerLocator).toHaveText(`Search results for "${searchTerm}"`)
+  }
+
+  async toShowResults (): Promise<void> {
+    await expect(this.searchResultsPage._searchResultsListLocator).not.toHaveCount(0)
   }
 }

--- a/tests/playwright/ui-tests/homepage.spec.ts
+++ b/tests/playwright/ui-tests/homepage.spec.ts
@@ -1,8 +1,12 @@
-import { test, expect } from '@playwright/test'
+import { test } from '@playwright/test'
 import { IWireMockRequest, IWireMockResponse, WireMock } from 'wiremock-captain'
+import { HomePage } from '../page-object-model/home-page'
+import { SearchResultsPage } from '../page-object-model/search-results-page'
 
 test.describe('homepage', () => {
   const mock = new WireMock(process.env.WIREMOCK_BASEURL ?? 'http://localhost:8080')
+  let homePage: HomePage
+  let searchResultsPage: SearchResultsPage
 
   test.beforeAll(async () => {
     const request: IWireMockRequest = {
@@ -24,15 +28,19 @@ test.describe('homepage', () => {
     await mock.register(request, mockedResponse)
   })
 
+  test.beforeEach(async ({ page }) => {
+    homePage = new HomePage(page)
+    searchResultsPage = new SearchResultsPage(page)
+    await homePage.goTo()
+  })
+
   const searchTerms = ['1', 'trust']
 
   for (const searchTerm of searchTerms) {
-    test(`Searching for a trust with "${searchTerm}" navigates to search results page`, async ({ page }) => {
-      await page.goto('/')
-      await page.getByLabel('Find information about academies and trusts').fill(searchTerm)
-      await page.getByRole('button', { name: 'Search' }).click()
+    test(`Searching for a trust with "${searchTerm}" navigates to search results page`, async () => {
+      await homePage.searchFor(searchTerm)
 
-      await expect(page.locator('h1')).toHaveText(`Search results for "${searchTerm}"`)
+      await searchResultsPage.expect.toBeOnPageWithResultsFor(searchTerm)
     })
   }
 })


### PR DESCRIPTION
# Added

- Page Object Model pattern to Playwright tests, for reusability and readability of UI test code.

# Changed

- Deployment test to cover search functionality
- Documentation on running UI tests locally - to update the developer's .env file with the correct baseurl when run using docker