### PR TITLE
Add integration tests for search

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -114,6 +114,25 @@ docker compose -f ../../docker/docker-compose.ci.yml down
 ```
 For more information on running and debugging Playwright tests it is worth familiarising yourself with the Playwright docs on [debugging](https://playwright.dev/docs/debug) and [command line flags](https://playwright.dev/docs/test-cli).
 
+### Integration tests
+
+[Integration tests](./test-approach.md) are also run in [Playwright](https://playwright.dev/), but do not have dependencies mocked. If you wish to run these locally you will need to run the app locally before running your tests.
+
+1. Run the .NET application using your preferred IDE or by running `dotnet run`
+2. Check the localhost port the application is running on and add it `tests/playwright/.env` as `PLAYWRIGHT_BASEURL`
+
+```dotenv
+ PLAYWRIGHT_BASEURL="http://localhost:5163"
+```
+
+3. Open a terminal to run your tests
+
+```shell
+ cd DfE.FindInformationAcademiesTrusts.UnitTests/playwright
+ npm install
+ npm run test:integration
+```
+
 ### Accessing test reports in the pipeline
 
 Automated tests are run in the pipeline as a GitHub workflow on opening a pull request to main—as per our [test approach](./test-approach.md). To access reports and traces for tests run in the pipeline:

--- a/tests/playwright/integration-tests/database-connection.spec.ts
+++ b/tests/playwright/integration-tests/database-connection.spec.ts
@@ -1,0 +1,27 @@
+import { test } from '@playwright/test'
+import { HomePage } from '../page-object-model/home-page'
+import { SearchResultsPage } from '../page-object-model/search-results-page'
+
+test.describe('search for trusts', () => {
+  let homePage: HomePage
+  let searchResultsPage: SearchResultsPage
+
+  test.beforeEach(({ page }) => {
+    homePage = new HomePage(page)
+    searchResultsPage = new SearchResultsPage(page)
+  })
+
+  test('returns results', async () => {
+    await homePage.goTo()
+    await homePage.searchFor('education')
+
+    await searchResultsPage.expect.toShowResults()
+  })
+
+  test('returns empty results', async () => {
+    await homePage.goTo()
+    await homePage.searchFor('trust that does not exist')
+
+    await searchResultsPage.expect.toShowEmptyResultMessage()
+  })
+})

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -9,7 +9,8 @@
     "test:a11y": "npx playwright test accessibility-tests/* --project=chromium --project=firefox --project=webkit --project=\"Microsoft Edge\"",
     "test:ui": "npx playwright test ui-tests/* --project=chromium --project=firefox --project=webkit --project=\"Microsoft Edge\"",
     "test:ci": "npx playwright test accessibility-tests/* ui-tests/* --project=chromium --project=firefox --project=webkit --project=\"Microsoft Edge\"",
-    "test:deployment": "npx playwright test --project=\"deployment-tests\""
+    "test:deployment": "npx playwright test --project=\"deployment-tests\"",
+    "test:integration": "npx playwright test --project=\"integration-tests\""
   },
   "keywords": [],
   "author": "",

--- a/tests/playwright/page-object-model/search-results-page.ts
+++ b/tests/playwright/page-object-model/search-results-page.ts
@@ -3,12 +3,12 @@ import { Locator, Page, expect } from '@playwright/test'
 export class SearchResultsPage {
   readonly expect: SearchResultsPageAssertions
   readonly _headerLocator: Locator
-  readonly _searchResultsListLocator: Locator
+  readonly _searchResultsListItemLocator: Locator
 
   constructor (readonly page: Page) {
     this.expect = new SearchResultsPageAssertions(this)
     this._headerLocator = this.page.locator('h1')
-    this._searchResultsListLocator = this.page.locator('ul')
+    this._searchResultsListItemLocator = this.page.locator('li')
   }
 }
 
@@ -20,6 +20,6 @@ class SearchResultsPageAssertions {
   }
 
   async toShowResults (): Promise<void> {
-    await expect(this.searchResultsPage._searchResultsListLocator).not.toHaveCount(0)
+    await expect(this.searchResultsPage._searchResultsListItemLocator).not.toHaveCount(0)
   }
 }

--- a/tests/playwright/page-object-model/search-results-page.ts
+++ b/tests/playwright/page-object-model/search-results-page.ts
@@ -22,4 +22,8 @@ class SearchResultsPageAssertions {
   async toShowResults (): Promise<void> {
     await expect(this.searchResultsPage._searchResultsListItemLocator).not.toHaveCount(0)
   }
+
+  async toShowEmptyResultMessage (): Promise<void> {
+    await expect(this.searchResultsPage._searchResultsListItemLocator).toHaveCount(0)
+  }
 }

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -55,7 +55,14 @@ export default defineConfig({
       },
       testDir: './deployment-tests'
     },
-
+    {
+      name: 'integration-tests',
+      use: {
+        ...devices['Desktop Chrome'],
+        channel: 'chrome',
+      },
+      testDir: './integration-tests'
+    },
     {
       name: 'zap-tests',
       use: {


### PR DESCRIPTION
# Added

- integration tests for searching for a trust, to test database connection (currently testing connection to Academies API)
- playwright project and npm script for running integration tests