### PR TITLE
Update security test workflow to use new mount

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -24,10 +24,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Create directory on runner
+        run: |
+          mkdir -m 777 ${{ github.workspace }}/zapoutput
+
       - name: Start ZAP container
         env:
           ZAP_PORT: 9876
-        run: docker run --name zap_container --rm -v /zapoutput/:/home/zap/:rw -u zap -p ${{ env.ZAP_PORT }}:${{ env.ZAP_PORT }} -i owasp/zap2docker-stable zap.sh -daemon -port ${{ env.ZAP_PORT }} -host 0.0.0.0 -config api.key=${{ env.ZAP_API_KEY }} -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -config network.localServers.mainProxy.alpn.enabled=false -config network.localServers.mainProxy.address=0.0.0.0
+        run: docker run --name zap_container --rm -d -v ${{ github.workspace }}/zapoutput/:/zap/wrk:rw -u zap -p ${{ env.ZAP_PORT }}:${{ env.ZAP_PORT }} -i owasp/zap2docker-stable zap.sh -daemon -port ${{ env.ZAP_PORT }} -host 0.0.0.0 -config api.key=${{ env.ZAP_API_KEY }} -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -config network.localServers.mainProxy.alpn.enabled=false -config network.localServers.mainProxy.address=0.0.0.0
 
       - name: Set up NodeJS
         uses: actions/setup-node@v3
@@ -81,7 +85,7 @@ jobs:
             az storage blob upload \
               --container-name ${{ secrets.OWASP_STORAGE_CONTAINER_NAME }} \
               --account-name ${{ secrets.OWASP_STORAGE_ACCOUNT_NAME }} \
-              --file "/zapoutput/ZAP-Report.html" \
+              --file "${{ github.workspace }}/zapoutput/ZAP-Report.html" \
               --name "Dfe.FindInformationAcademiesTrusts/${{ env.checked_out_sha }}/ZAP-Report.html" \
               --auth-mode login \
               --overwrite

--- a/tests/playwright/global.teardown.ts
+++ b/tests/playwright/global.teardown.ts
@@ -32,7 +32,7 @@ teardown('Generate ZAP report', async () => {
           }
         })
         .catch((err: string) => {
-          console.log(`Error from the ZAP API: ${err}`)
+          console.log(`Error from the ZAP Passive Scan API: ${err}`)
           recordsRemaining = 0
         })
     }
@@ -40,13 +40,14 @@ teardown('Generate ZAP report', async () => {
     await zap.reports.generate({
       title: 'Report',
       template: 'traditional-html',
-      reportfilename: 'ZAP-Report.html'
+      reportfilename: 'ZAP-Report.html',
+      reportdir: '/zap/wrk'
     })
       .then((resp) => {
         console.log(`${JSON.stringify(resp)}`)
       })
       .catch((err: string) => {
-        console.log(`Error from ZAP API: ${err}`)
+        console.log(`Error from ZAP Report API: ${err}`)
       })
   }
 })


### PR DESCRIPTION
## What is the change?
Previously, the security tests workflow could not successfully mount the given directory for report generation. This has been updated to the example directory given in the ZAP documentation of /zap/wrk.

Also updates the report generation request to point at this directory, plus improves the error messaging in case of failing API requests.