### PR TITLE
Add cache for GitHub workflow tasks

### DIFF
--- a/.github/workflows/continuous-integration-assets-playwright.yml
+++ b/.github/workflows/continuous-integration-assets-playwright.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches:
       - main
+env:
+  NODE_VERSION: 18.13.0
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -10,17 +12,25 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       name: Check out repository
+
     - uses: actions/setup-node@v3
       name: Set up Node.js
       with:
-        node-version: 18.13.0
+        node-version: ${{ env.NODE_VERSION }}
+        cache: npm
+        cache-dependency-path: |
+          DfE.FindInformationAcademiesTrusts/package-lock.json
+          tests/playwright/package-lock.json
+
+    - name: Install dependencies
+      run: |
+        (cd DfE.FindInformationAcademiesTrusts && npm ci)
+        (cd tests/playwright && npm ci)
+
     - name: Analyse front end assets
       run: |
-        cd DfE.FindInformationAcademiesTrusts
-        npm ci
-        npm run lint
+        cd DfE.FindInformationAcademiesTrusts && npm run lint
+
     - name: Analyse playwright tests
       run: |
-        cd tests/playwright
-        npm ci
-        npm run lint
+        cd tests/playwright && npm run lint

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -51,6 +51,17 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Azure Container Registry login
         uses: docker/login-action@v2
         with:
@@ -61,6 +72,8 @@ jobs:
       - name: Build and push docker image
         uses: docker/build-push-action@v4
         with:
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           context: .
           file: docker/Dockerfile
           tags: |
@@ -68,6 +81,14 @@ jobs:
             ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.sha }}
             ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:latest
           push: true
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   deploy-image:
     name: Deploy to ${{ needs.set-env.outputs.environment }} (${{ needs.set-env.outputs.sha }})

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -37,9 +37,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Get installed Playwright version
+      - name: Pin Playwright cache key
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
+        run: |
+          PLAYWRIGHT_VERSION="$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")"
+          PIN_VERSION=${PLAYWRIGHT_VERSION}-`date +%Y-%m-%d`
+          echo "PLAYWRIGHT_VERSION=$PIN_VERSION" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
         uses: actions/cache@v3

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -3,14 +3,15 @@ run-name: Deployment tests for '${{ inputs.environment }}' - `${{ inputs.branch-
 
 on:
   workflow_call:
-    inputs: 
-      environment: 
+    inputs:
+      environment:
         required: true
         type: string
-      branch-name: 
+      branch-name:
         required: true
         type: string
-
+env:
+  NODE_VERSION: 18.13.0
 jobs:
   playwright:
     name: Smoke deployment tests
@@ -22,22 +23,39 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref }} 
+          ref: ${{ github.ref }}
 
       - name: Set up NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: |
+            DfE.FindInformationAcademiesTrusts/package-lock.json
+            tests/playwright/package-lock.json
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages[''].version)")" >> $GITHUB_ENV
+
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chrome
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
 
       - name: Run Playwright deployment tests
         env:
-          PLAYWRIGHT_BASEURL: ${{ secrets.BASE_URL }} 
+          PLAYWRIGHT_BASEURL: ${{ secrets.BASE_URL }}
         run: npm run test:deployment
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Set up NodeJS
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
+        name: Set up Node.js
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Get installed Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages[''].version)")" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
         uses: actions/cache@v3
@@ -50,7 +50,6 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
       - name: Run Playwright deployment tests

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -37,9 +37,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Get installed Playwright version
+      - name: Pin Playwright cache key
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./playwright/package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
+        run: |
+          PLAYWRIGHT_VERSION="$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")"
+          PIN_VERSION=${PLAYWRIGHT_VERSION}-`date +%Y-%m-%d`
+          echo "PLAYWRIGHT_VERSION=$PIN_VERSION" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
         uses: actions/cache@v3

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -3,14 +3,15 @@ run-name: Integration tests for '${{ inputs.environment }}' - `${{ inputs.branch
 
 on:
   workflow_call:
-    inputs: 
-      environment: 
+    inputs:
+      environment:
         required: true
         type: string
-      branch-name: 
+      branch-name:
         required: true
         type: string
-
+env:
+  NODE_VERSION: 18.13.0
 jobs:
   playwright:
     name: Integration tests
@@ -22,22 +23,39 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref }} 
+          ref: ${{ github.ref }}
 
       - name: Set up NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: |
+            DfE.FindInformationAcademiesTrusts/package-lock.json
+            tests/playwright/package-lock.json
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./playwright/package-lock.json').packages[''].version)")" >> $GITHUB_ENV
+
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chrome
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
 
       - name: Run Playwright integration tests
         env:
-          PLAYWRIGHT_BASEURL: ${{ secrets.BASE_URL }} 
+          PLAYWRIGHT_BASEURL: ${{ secrets.BASE_URL }}
         run: npm run test:integration
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Set up NodeJS
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
+        name: Set up Node.js
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Get installed Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./playwright/package-lock.json').packages[''].version)")" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./playwright/package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
         uses: actions/cache@v3
@@ -50,7 +50,6 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
       - name: Run Playwright integration tests

--- a/.github/workflows/test-isolated-ui.yml
+++ b/.github/workflows/test-isolated-ui.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get installed Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages[''].version)")" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
         uses: actions/cache@v3
@@ -45,7 +45,6 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
       - name: Start services

--- a/.github/workflows/test-isolated-ui.yml
+++ b/.github/workflows/test-isolated-ui.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Set up NodeJS
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
+        name: Set up Node.js
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/test-isolated-ui.yml
+++ b/.github/workflows/test-isolated-ui.yml
@@ -32,9 +32,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Get installed Playwright version
+      - name: Pin Playwright cache key
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
+        run: |
+          PLAYWRIGHT_VERSION="$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")"
+          PIN_VERSION=${PLAYWRIGHT_VERSION}-`date +%Y-%m-%d`
+          echo "PLAYWRIGHT_VERSION=$PIN_VERSION" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
         uses: actions/cache@v3

--- a/.github/workflows/test-isolated-ui.yml
+++ b/.github/workflows/test-isolated-ui.yml
@@ -6,7 +6,8 @@ on:
     types: [ opened, synchronize, reopened]
   push:
     branches: [ main ]
-
+env:
+  NODE_VERSION: 18.13.0
 jobs:
   playwright:
     name: Set up container and run tests
@@ -22,12 +23,29 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: |
+            DfE.FindInformationAcademiesTrusts/package-lock.json
+            tests/playwright/package-lock.json
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages[''].version)")" >> $GITHUB_ENV
+
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
       - name: Start services

--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -11,6 +11,7 @@ env:
   ZAP_ADDRESS: localhost
   ZAP_PORT: 9876
   ZAP_API_KEY: 5c93eec3-b5c0-4252-9061-017ebff89450
+  NODE_VERSION: 18.13.0
 
 jobs:
   run-tests-with-zap:
@@ -53,16 +54,34 @@ jobs:
           ZAP_PORT: 9876
         run: docker run --name zap_container --rm -d -v ${{ github.workspace }}/zapoutput/:/zap/wrk:rw -u zap -p ${{ env.ZAP_PORT }}:${{ env.ZAP_PORT }} -i softwaresecurityproject/zap-stable zap.sh -daemon -port ${{ env.ZAP_PORT }} -host 0.0.0.0 -config api.key=${{ env.ZAP_API_KEY }} -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -config network.localServers.mainProxy.alpn.enabled=false -config network.localServers.mainProxy.address=0.0.0.0
 
-      - name: Set up NodeJS
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
+        name: Set up Node.js
         with:
-          node-version: 18
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: |
+            DfE.FindInformationAcademiesTrusts/package-lock.json
+            tests/playwright/package-lock.json
 
-      - name: Install dependencies
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: Install dependencies
         run: npm ci
 
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages[''].version)")" >> $GITHUB_ENV
+
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chrome
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
 
       - name: Run Playwright tests
         env:

--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Get installed Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages[''].version)")" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
         uses: actions/cache@v3
@@ -79,7 +79,6 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
       - name: Run Playwright tests

--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -63,8 +63,7 @@ jobs:
             DfE.FindInformationAcademiesTrusts/package-lock.json
             tests/playwright/package-lock.json
 
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-        name: Install dependencies
+      - name: Install dependencies
         run: npm ci
 
       - name: Get installed Playwright version

--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -66,9 +66,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Get installed Playwright version
+      - name: Pin Playwright cache key
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
+        run: |
+          PLAYWRIGHT_VERSION="$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")"
+          PIN_VERSION=${PLAYWRIGHT_VERSION}-`date +%Y-%m-%d`
+          echo "PLAYWRIGHT_VERSION=$PIN_VERSION" >> $GITHUB_ENV
 
       - name: Cache playwright binaries
         uses: actions/cache@v3


### PR DESCRIPTION
Adds a number of caching steps into the test workflows.

- Cache playwright installed browsers
- Cache NPM and ensure the same version is used across all workflows to make use of the cache
- Cache [docker layers using buildx (experimental)](https://docs.docker.com/build/ci/github-actions/cache/#github-cache)