### PR TITLE
Update .NET version to 7.0

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
 
     - name: Set up JDK
       uses: actions/setup-java@v3

--- a/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
+++ b/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>7a95582b-ec63-4991-9635-addb5c80a266</UserSecretsId>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-ARG ASPNET_IMAGE_TAG=6.0-bullseye-slim
+ARG ASPNET_IMAGE_TAG=7.0-bullseye-slim
 ARG NODEJS_IMAGE_TAG=18-bullseye-slim
-ARG DOTNET_SDK=6.0
+ARG DOTNET_SDK=7.0
 
 # Stage 1 - Build frontend assets
 FROM node:${NODEJS_IMAGE_TAG} as assets

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ Use this documentation to configure your local development environment.
 
 You will need:
 
-- .NET 6 SDK
+- .NET 7 SDK
 - npm
 
 Recommended:

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 


### PR DESCRIPTION
There is a department wide move to .NET 7, this is to make the move to the next long term support version of .NET (.NET 8 which will be released in November 2023) easier.

Moving to .NET 7 will also enable us to use the latest language features which will make development easier.

# Changed
- Project .NET Target Framework to .NET 7.0
- Unit Test Project .NEW Target Framework to .NET 7.0
- Docker .NET image to 7.0
- .NET version used in continuous integration workflow
- Updated project requirements in `Getting Started` docs 