### PR TITLE
Remove concurrency cancel

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -15,7 +15,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.environment }}
-  cancel-in-progress: true
 
 env:
   DOCKER_IMAGE: fiat-app


### PR DESCRIPTION
`cancel-in-progress: true` is hindering our workflow. As deployment and integration tests are now part of this workflow (rather than being triggered by a deployment status event), we no longer need to cancel everything is a new deployment triggers - we can wait for it (and the tests) to finish