### PR TITLE
Deploy an Azure Storage Account

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -132,7 +132,9 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.65.0 |
 
 ## Modules
 
@@ -143,7 +145,12 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [azurerm_monitor_diagnostic_setting.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_storage_account.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
+| [azurerm_storage_account_network_rules.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_network_rules) | resource |
+| [azurerm_storage_container.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 
 ## Inputs
 
@@ -198,6 +205,7 @@ No resources.
 | <a name="input_redis_cache_capacity"></a> [redis\_cache\_capacity](#input\_redis\_cache\_capacity) | Redis Cache Capacity | `number` | n/a | yes |
 | <a name="input_redis_cache_sku"></a> [redis\_cache\_sku](#input\_redis\_cache\_sku) | Redis Cache SKU | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | n/a | yes |
+| <a name="input_test_reports_storage_ipv4_allow_list"></a> [test\_reports\_storage\_ipv4\_allow\_list](#input\_test\_reports\_storage\_ipv4\_allow\_list) | List of IPv4 Addresses that are permitted to access the Storage Container that holds CI Test Reports | `list(string)` | n/a | yes |
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | tfvars filename. This file is uploaded and stored encrypted within Key Vault, to ensure that the latest tfvars are stored in a shared place. | `string` | n/a | yes |
 | <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual network address space CIDR | `string` | n/a | yes |
 

--- a/terraform/ci-storage.tf
+++ b/terraform/ci-storage.tf
@@ -1,0 +1,46 @@
+locals {
+  resource_prefix = "${local.environment}${local.project_name}"
+}
+
+resource "azurerm_storage_account" "ci-test-reports" {
+  name                          = "${replace(local.resource_prefix, "-", "")}reports"
+  resource_group_name           = module.azure_container_apps_hosting.azurerm_resource_group_default.name
+  location                      = module.azure_container_apps_hosting.azurerm_resource_group_default.location
+  account_tier                  = "Standard"
+  account_replication_type      = "LRS"
+  min_tls_version               = "TLS1_2"
+  enable_https_traffic_only     = true
+  public_network_access_enabled = true
+
+  tags = local.tags
+}
+
+resource "azurerm_storage_account_network_rules" "ci-test-reports" {
+  storage_account_id         = azurerm_storage_account.ci-test-reports.id
+  default_action             = "Deny"
+  bypass                     = []
+  virtual_network_subnet_ids = []
+  ip_rules                   = local.test_reports_storage_ipv4_allow_list
+}
+
+resource "azurerm_storage_container" "ci-test-reports" {
+  name                  = "${local.resource_prefix}-reports"
+  storage_account_name  = azurerm_storage_account.ci-test-reports.name
+  container_access_type = "blob"
+}
+
+resource "azurerm_monitor_diagnostic_setting" "ci-test-reports" {
+  name                           = "${local.resource_prefix}-reports-diag"
+  target_resource_id             = azurerm_storage_account.ci-test-reports.id
+  log_analytics_workspace_id     = module.azure_container_apps_hosting.azurerm_log_analytics_workspace_container_app.id
+  log_analytics_destination_type = "Dedicated"
+  eventhub_name                  = local.enable_event_hub ? module.azure_container_apps_hosting.azurerm_eventhub_container_app.name : null
+
+  metric {
+    category = "Transaction"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -50,4 +50,5 @@ locals {
   key_vault_access_users                        = var.key_vault_access_users
   key_vault_access_ipv4                         = var.key_vault_access_ipv4
   tfvars_filename                               = var.tfvars_filename
+  test_reports_storage_ipv4_allow_list          = var.test_reports_storage_ipv4_allow_list
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -278,6 +278,11 @@ variable "key_vault_access_ipv4" {
   type        = list(string)
 }
 
+variable "test_reports_storage_ipv4_allow_list" {
+  description = "List of IPv4 Addresses that are permitted to access the Storage Container that holds CI Test Reports"
+  type        = list(string)
+}
+
 variable "tfvars_filename" {
   description = "tfvars filename. This file is uploaded and stored encrypted within Key Vault, to ensure that the latest tfvars are stored in a shared place."
   type        = string


### PR DESCRIPTION
- This storage account will be used for escrowing reports generated by Playwright or other similar CI tools