### PR TITLE
Authenticate with the Storage Container to upload Playwright reports

### DIFF
--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -12,6 +12,9 @@ on:
         type: string
 env:
   NODE_VERSION: 18.13.0
+  PLAYWRIGHT_VERSION: default
+  LAST_COMMIT_SHA: default
+
 jobs:
   playwright:
     name: Smoke deployment tests

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -3,11 +3,11 @@ run-name: Deployment tests for '${{ inputs.environment }}' - `${{ inputs.branch-
 
 on:
   workflow_call:
-    inputs: 
-      environment: 
+    inputs:
+      environment:
         required: true
         type: string
-      branch-name: 
+      branch-name:
         required: true
         type: string
 env:
@@ -24,6 +24,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+
+      - name: Set SHA environment variable
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          echo "LAST_COMMIT_SHA=${GITHUB_SHA}" >> $GITHUB_ENV
 
       - uses: actions/setup-node@v3
         name: Set up Node.js
@@ -62,9 +67,27 @@ jobs:
           TEST_USER_ACCOUNT_PASSWORD: ${{ secrets.TEST_USER_ACCOUNT_PASSWORD }}
         run: npm run test:deployment
 
-      - uses: actions/upload-artifact@v3
-        if: always()
+      - name: Prepare report for upload
+        run: |
+          zip -qq -r ${{ inputs.environment }}-${{ env.LAST_COMMIT_SHA }}.zip ./playwright-report/
+
+      - name: Azure login with SPN
+        if: '!cancelled()'
+        uses: azure/login@v1
         with:
-          name: deployment-tests-playwright-report
-          path: tests/playwright/playwright-report/
-          retention-days: 7
+          creds: ${{ secrets.CI_REPORTS_AZ_CREDENTIALS }}
+
+      - name: Push report to blob storage
+        if: '!cancelled()'
+        uses: azure/CLI@v1
+        id: azure
+        with:
+          azcliversion: 2.53.0
+          inlineScript: |
+            az storage blob upload \
+              --container-name ${{ secrets.CI_REPORTS_STORAGE_CONTAINER_NAME }} \
+              --account-name ${{ secrets.CI_REPORTS_STORAGE_ACCOUNT_NAME }} \
+              --file "./tests/playwright/${{ inputs.environment }}-${{ env.LAST_COMMIT_SHA }}.zip" \
+              --name "Dfe.FindInformationAcademiesTrusts/playwright-report/" \
+              --auth-mode login \
+              --overwrite

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -151,6 +151,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | [azurerm_monitor_diagnostic_setting.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_storage_account.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [azurerm_storage_container.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_account_blob_container_sas.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account_blob_container_sas) | data source |
 
 ## Inputs
 
@@ -180,6 +181,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | <a name="input_dns_zone_domain_name"></a> [dns\_zone\_domain\_name](#input\_dns\_zone\_domain\_name) | DNS zone domain name. If created, records will automatically be created to point to the CDN. | `string` | n/a | yes |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN FrontDoor. This will use the Container Apps endpoint as the origin. | `bool` | `false` | no |
 | <a name="input_enable_cdn_frontdoor_health_probe"></a> [enable\_cdn\_frontdoor\_health\_probe](#input\_enable\_cdn\_frontdoor\_health\_probe) | Enable CDN Front Door health probe | `bool` | n/a | yes |
+| <a name="input_enable_ci_report_storage_container"></a> [enable\_ci\_report\_storage\_container](#input\_enable\_ci\_report\_storage\_container) | Deploy a Blob Storage Container to store CI Reports in | `bool` | `false` | no |
 | <a name="input_enable_container_health_probe"></a> [enable\_container\_health\_probe](#input\_enable\_container\_health\_probe) | Enable liveness probes for the Container | `bool` | `true` | no |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |
 | <a name="input_enable_dns_zone"></a> [enable\_dns\_zone](#input\_enable\_dns\_zone) | Conditionally create a DNS zone | `bool` | n/a | yes |
@@ -214,5 +216,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_ci-test-reports-storage-sas-url"></a> [ci-test-reports-storage-sas-url](#output\_ci-test-reports-storage-sas-url) | A SAS tokenised URL for accessing the CI Reports in the Blob Storage Container |
 <!-- END_TF_DOCS -->

--- a/terraform/ci-storage.tf
+++ b/terraform/ci-storage.tf
@@ -3,6 +3,8 @@ locals {
 }
 
 resource "azurerm_storage_account" "ci-test-reports" {
+  count = local.enable_ci_report_storage_container ? 1 : 0
+
   name                          = "${replace(local.resource_prefix, "-", "")}reports"
   resource_group_name           = module.azure_container_apps_hosting.azurerm_resource_group_default.name
   location                      = module.azure_container_apps_hosting.azurerm_resource_group_default.location
@@ -16,14 +18,18 @@ resource "azurerm_storage_account" "ci-test-reports" {
 }
 
 resource "azurerm_storage_container" "ci-test-reports" {
+  count = local.enable_ci_report_storage_container ? 1 : 0
+
   name                  = "${local.resource_prefix}-reports"
-  storage_account_name  = azurerm_storage_account.ci-test-reports.name
-  container_access_type = "blob"
+  storage_account_name  = azurerm_storage_account.ci-test-reports[0].name
+  container_access_type = "private"
 }
 
 resource "azurerm_monitor_diagnostic_setting" "ci-test-reports" {
+  count = local.enable_ci_report_storage_container ? 1 : 0
+
   name                           = "${local.resource_prefix}-reports-diag"
-  target_resource_id             = azurerm_storage_account.ci-test-reports.id
+  target_resource_id             = azurerm_storage_account.ci-test-reports[0].id
   log_analytics_workspace_id     = module.azure_container_apps_hosting.azurerm_log_analytics_workspace_container_app.id
   log_analytics_destination_type = "Dedicated"
   eventhub_name                  = local.enable_event_hub ? module.azure_container_apps_hosting.azurerm_eventhub_container_app.name : null
@@ -31,4 +37,29 @@ resource "azurerm_monitor_diagnostic_setting" "ci-test-reports" {
   metric {
     category = "Transaction"
   }
+}
+
+data "azurerm_storage_account_blob_container_sas" "ci-test-reports" {
+  count = local.enable_ci_report_storage_container ? 1 : 0
+
+  connection_string = azurerm_storage_account.ci-test-reports[0].primary_connection_string
+  container_name    = azurerm_storage_container.ci-test-reports[0].name
+  https_only        = true
+
+  start  = formatdate("YYYY-MM-DD'T'hh:mm:ssZ", timestamp())
+  expiry = formatdate("YYYY-MM-DD'T'hh:mm:ssZ", timeadd(timestamp(), "+4380h")) # +6 months
+
+  permissions {
+    read   = true
+    add    = true
+    create = true
+    write  = true
+    delete = true
+    list   = true
+  }
+}
+
+output "ci-test-reports-storage-sas-url" {
+  description = "A SAS tokenised URL for accessing the CI Reports in the Blob Storage Container"
+  value       = nonsensitive(local.enable_ci_report_storage_container ? "${azurerm_storage_account.ci-test-reports[0].primary_blob_endpoint}${azurerm_storage_container.ci-test-reports[0].name}${data.azurerm_storage_account_blob_container_sas.ci-test-reports[0].sas}" : null)
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -53,4 +53,5 @@ locals {
   statuscake_contact_group_name                = var.statuscake_contact_group_name
   statuscake_contact_group_integrations        = var.statuscake_contact_group_integrations
   statuscake_contact_group_email_addresses     = var.statuscake_contact_group_email_addresses
+  enable_ci_report_storage_container           = var.enable_ci_report_storage_container
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -308,3 +308,9 @@ variable "statuscake_contact_group_email_addresses" {
   type        = list(string)
   default     = []
 }
+
+variable "enable_ci_report_storage_container" {
+  description = "Deploy a Blob Storage Container to store CI Reports in"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Adding an extra step onto the deployment tests workflow allows us to push playwright reports discreetly onto Azure Blob Storage without holding any artefacts in GitHub workflows.

This is necessary because if a playwright test fails, it will include any and all HTML `POST`ed values, which includes the potential of a username/password combination. We dont want that to be exposed in public CI artefacts.

The CI workflow authenticates using a Service Principal which has authority to act on the Storage Account.

The Terraform also outputs a SAS URL which allows humans to connect to the Storage Container using something like [Azure Storage Explorer](https://azure.microsoft.com/en-gb/products/storage/storage-explorer) to read the playwright reports if they don't have direct access via the Azure Portal.