### PR TITLE
Removed ipv4 rule policy

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -149,7 +149,6 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 |------|------|
 | [azurerm_monitor_diagnostic_setting.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_storage_account.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
-| [azurerm_storage_account_network_rules.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_network_rules) | resource |
 | [azurerm_storage_container.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 
 ## Inputs
@@ -205,7 +204,6 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | <a name="input_redis_cache_capacity"></a> [redis\_cache\_capacity](#input\_redis\_cache\_capacity) | Redis Cache Capacity | `number` | n/a | yes |
 | <a name="input_redis_cache_sku"></a> [redis\_cache\_sku](#input\_redis\_cache\_sku) | Redis Cache SKU | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | n/a | yes |
-| <a name="input_test_reports_storage_ipv4_allow_list"></a> [test\_reports\_storage\_ipv4\_allow\_list](#input\_test\_reports\_storage\_ipv4\_allow\_list) | List of IPv4 Addresses that are permitted to access the Storage Container that holds CI Test Reports | `list(string)` | n/a | yes |
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | tfvars filename. This file is uploaded and stored encrypted within Key Vault, to ensure that the latest tfvars are stored in a shared place. | `string` | n/a | yes |
 | <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual network address space CIDR | `string` | n/a | yes |
 

--- a/terraform/ci-storage.tf
+++ b/terraform/ci-storage.tf
@@ -15,14 +15,6 @@ resource "azurerm_storage_account" "ci-test-reports" {
   tags = local.tags
 }
 
-resource "azurerm_storage_account_network_rules" "ci-test-reports" {
-  storage_account_id         = azurerm_storage_account.ci-test-reports.id
-  default_action             = "Deny"
-  bypass                     = []
-  virtual_network_subnet_ids = []
-  ip_rules                   = local.test_reports_storage_ipv4_allow_list
-}
-
 resource "azurerm_storage_container" "ci-test-reports" {
   name                  = "${local.resource_prefix}-reports"
   storage_account_name  = azurerm_storage_account.ci-test-reports.name

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -50,5 +50,4 @@ locals {
   key_vault_access_users                        = var.key_vault_access_users
   key_vault_access_ipv4                         = var.key_vault_access_ipv4
   tfvars_filename                               = var.tfvars_filename
-  test_reports_storage_ipv4_allow_list          = var.test_reports_storage_ipv4_allow_list
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -278,11 +278,6 @@ variable "key_vault_access_ipv4" {
   type        = list(string)
 }
 
-variable "test_reports_storage_ipv4_allow_list" {
-  description = "List of IPv4 Addresses that are permitted to access the Storage Container that holds CI Test Reports"
-  type        = list(string)
-}
-
 variable "tfvars_filename" {
   description = "tfvars filename. This file is uploaded and stored encrypted within Key Vault, to ensure that the latest tfvars are stored in a shared place."
   type        = string


### PR DESCRIPTION
This isn't required as we need the storage account to be available to any of the Github runners