### PR TITLE
Update search results order and page title

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
@@ -2,7 +2,7 @@
 @model SearchModel
 
 @{
-  ViewData["Title"] = "Search";
+  ViewData["Title"] = string.IsNullOrWhiteSpace(Model.KeyWords) ? "Search" : $"{Model.KeyWords} - Search";
 }
 
 <h1 class="govuk-heading-l">Search</h1>

--- a/DfE.FindInformationAcademiesTrusts/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts/TrustProvider.cs
@@ -55,7 +55,7 @@ public class TrustProvider : ITrustProvider
                     t.Ukprn,
                     t.Establishments?.Count ?? 0
                 ));
-            return transformedData;
+            return transformedData.OrderBy(t => t.Name);
         }
 
         var errorMessage = await httpResponseMessage.Content.ReadAsStringAsync();


### PR DESCRIPTION
# Changed
- Update page title for search to reflect the search term. The title will remain 'Search - Find information about academies and trust' if there is no search term
- Updated the order of search results to be alphabetical