### PR TITLE
Remove GOV.UK heading style

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
@@ -12,8 +12,8 @@
   <ul class="govuk-list">
     @foreach (var trust in Model.Trusts)
     {
-      <li>
-        <a asp-page="./Trusts/Details" asp-route-ukprn="@trust.Ukprn" class="govuk-heading-m govuk-!-font-weight-bold govuk-!-margin-top-6 govuk-link">@Html.DisplayFor(modelItem => trust.Name)</a>
+      <li class="govuk-!-margin-bottom-6">
+        <a asp-page="./Trusts/Details" asp-route-ukprn="@trust.Ukprn" class="govuk-!-font-weight-bold govuk-link govuk-!-font-size-24">@Html.DisplayFor(modelItem => trust.Name)</a>
         <dl class="govuk-summary-list govuk-summary-list--no-border app-search-results-summary-list">
           <div class="govuk-summary-list__row govuk-body app-search-results-summary-list__row">
             <dt class="govuk-summary-list__key app-search-results-summary-list__key app-search-results-summary-list__item">

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
@@ -54,6 +54,7 @@
 }
 
 .app-search-results-summary-list {
+  @include govuk-responsive-margin(4, "top");
   display: block;
 
   .app-search-results-summary-list__row {


### PR DESCRIPTION
The use of a GOV.UK heading style class on a link element makes the focus area of the link spread across the width of the page. This causes difficulties for a user trying to highlight and copy the trust name. As this element is not actually a heading, have removed this class and replicated with styles to override the font size, weight and spacing.