### PR TITLE
Add no results message to search

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
@@ -20,40 +20,57 @@
 <div class="govuk-grid-row">
   <section aria-labelledby="results-details" class="govuk-grid-column-three-quarters">
     <h2 id="results-details" class="govuk-heading-m">@Model.Trusts.Count() results for "@Model.KeyWords"</h2>
-    <ul class="govuk-list">
-      @foreach (var trust in Model.Trusts)
-      {
-        <li class="govuk-!-margin-bottom-6">
-          <a asp-page="./Trusts/Details" asp-route-ukprn="@trust.Ukprn" class="govuk-!-font-weight-bold govuk-link govuk-!-font-size-24">@Html.DisplayFor(modelItem => trust.Name)</a>
-          <dl class="govuk-summary-list govuk-summary-list--no-border app-search-results-summary-list">
-            <div class="govuk-summary-list__row govuk-body app-search-results-summary-list__row">
-              <dt class="govuk-summary-list__key app-search-results-summary-list__key app-search-results-summary-list__item">
-                Address:
-              </dt>
-              <dd class="govuk-summary-list__value app-search-results-summary-list__item">
-                @Html.DisplayFor(modelItem => trust.Address)
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row govuk-body app-search-results-summary-list__row">
-              <dt class="govuk-summary-list__key app-search-results-summary-list__key app-search-results-summary-list__item">
-                UKPRN:
-              </dt>
-              <dd class="govuk-summary-list__value app-search-results-summary-list__item">
-                @Html.DisplayFor(modelItem => trust.Ukprn)
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row app-search-results-summary-list__row">
-              <dt class="govuk-summary-list__key app-search-results-summary-list__key app-search-results-summary-list__item">
-                Academies in this trust:
-              </dt>
-              <dd class="govuk-summary-list__value app-search-results-summary-list__item">
-                @Html.DisplayFor(modelItem => trust.AcademyCount)
-              </dd>
-            </div>
-          </dl>
-          <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6">
-        </li>
-      }
-    </ul>
+    @if (Model.Trusts.Any())
+    {
+      <ul class="govuk-list">
+        @foreach (var trust in Model.Trusts)
+        {
+          <li class="govuk-!-margin-bottom-6">
+            <a asp-page="./Trusts/Details" asp-route-ukprn="@trust.Ukprn" class="govuk-!-font-weight-bold govuk-link govuk-!-font-size-24">@Html.DisplayFor(modelItem => trust.Name)</a>
+            <dl class="govuk-summary-list govuk-summary-list--no-border app-search-results-summary-list">
+              <div class="govuk-summary-list__row govuk-body app-search-results-summary-list__row">
+                <dt class="govuk-summary-list__key app-search-results-summary-list__key app-search-results-summary-list__item">
+                  Address:
+                </dt>
+                <dd class="govuk-summary-list__value app-search-results-summary-list__item">
+                  @Html.DisplayFor(modelItem => trust.Address)
+                </dd>
+              </div>
+              <div class="govuk-summary-list__row govuk-body app-search-results-summary-list__row">
+                <dt class="govuk-summary-list__key app-search-results-summary-list__key app-search-results-summary-list__item">
+                  UKPRN:
+                </dt>
+                <dd class="govuk-summary-list__value app-search-results-summary-list__item">
+                  @Html.DisplayFor(modelItem => trust.Ukprn)
+                </dd>
+              </div>
+              <div class="govuk-summary-list__row app-search-results-summary-list__row">
+                <dt class="govuk-summary-list__key app-search-results-summary-list__key app-search-results-summary-list__item">
+                  Academies in this trust:
+                </dt>
+                <dd class="govuk-summary-list__value app-search-results-summary-list__item">
+                  @Html.DisplayFor(modelItem => trust.AcademyCount)
+                </dd>
+              </div>
+            </dl>
+            <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6">
+          </li>
+        }
+      </ul>
+    }
+    else
+    {
+      <p>Check the spelling of the trust name. </p>
+
+      <p>Enter a reference number in the right format. For example:</p>
+
+      <ul>
+        <li>TRN (trust reference number) or Group ID - TR00123</li>
+        <li>UID (unique identifier) - 2034</li>
+        <li>UKPRN (UK provider number) - 100023456</li>
+        <li>Companies House number - 00123456</li>
+      </ul>
+    }
+
   </section>
 </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
@@ -60,11 +60,11 @@
     }
     else
     {
-      <p>Check the spelling of the trust name. </p>
+      <p class="govuk-body">Check the spelling of the trust name.</p>
 
-      <p>Enter a reference number in the right format. For example:</p>
+      <p class="govuk-body">Enter a reference number in the right format. For example:</p>
 
-      <ul>
+      <ul class="govuk-list govuk-list--bullet">
         <li>TRN (trust reference number) or Group ID - TR00123</li>
         <li>UID (unique identifier) - 2034</li>
         <li>UKPRN (UK provider number) - 100023456</li>

--- a/tests/playwright/accessibility-tests/searchpage.spec.ts
+++ b/tests/playwright/accessibility-tests/searchpage.spec.ts
@@ -6,6 +6,7 @@ test.describe('search page should not have any automatically detectable accessib
   test('when going to a search page with no search term', async ({ page }) => {
     const searchPage = new SearchPage(page)
     await searchPage.goTo()
+    await searchPage.expect.toSeeNoResultsMessage()
 
     const accessibilityScanResults = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
@@ -18,6 +19,7 @@ test.describe('search page should not have any automatically detectable accessib
     const searchPage = new SearchPage(page)
     await searchPage.goToSearchFor('trust')
     await searchPage.expect.toBeOnPageWithResultsFor('trust')
+    await searchPage.expect.toShowResults()
 
     const accessibilityScanResults = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])

--- a/tests/playwright/page-object-model/search-page.ts
+++ b/tests/playwright/page-object-model/search-page.ts
@@ -11,23 +11,25 @@ export class SearchPage {
   readonly expect: SearchPageAssertions
   readonly _headerLocator: Locator
   readonly _searchResultsListHeaderLocator: Locator
+  readonly _searchResultsSectionLocator: Locator
   readonly _searchResultsListItemLocator: Locator
   readonly _searchInputLocator: Locator
   readonly _searchButtonLocator: Locator
   _currentSearchTerm = ''
 
   constructor (readonly page: Page) {
-    const searchResultsHeadingName = 'results for'
-
     this.expect = new SearchPageAssertions(this)
     this._headerLocator = this.page.locator('h1')
     this._searchResultsListHeaderLocator = this.page.getByRole('heading', {
-      name: searchResultsHeadingName
+      name: this._searchResultsHeadingName
     })
-    this._searchResultsListItemLocator = this.page.getByLabel(searchResultsHeadingName).getByRole('listitem')
+    this._searchResultsSectionLocator = this.page.getByLabel(this._searchResultsHeadingName)
+    this._searchResultsListItemLocator = this._searchResultsSectionLocator.getByRole('listitem')
     this._searchInputLocator = this.page.getByLabel('Search')
     this._searchButtonLocator = this.page.getByRole('button', { name: 'Search' })
   }
+
+  readonly _searchResultsHeadingName = 'results for'
 
   readonly expectedSearchResults: { [key: string]: expectedResult[] } = {
     trust: [
@@ -69,7 +71,9 @@ class SearchPageAssertions {
   constructor (readonly searchPage: SearchPage) {}
 
   async toBeOnPageWithResultsFor (searchTerm: string): Promise<void> {
-    await expect(this.searchPage._searchResultsListHeaderLocator).toContainText(`results for "${searchTerm}"`)
+    await expect(this.searchPage._searchResultsListHeaderLocator).toContainText(
+      `${this.searchPage._searchResultsHeadingName} "${searchTerm}"`
+    )
   }
 
   async toBeOnTheRightPage (): Promise<void> {
@@ -108,5 +112,12 @@ class SearchPageAssertions {
 
   async toSeeSearchInputContainingNoSearchTerm (): Promise<void> {
     await expect(this.searchPage._searchInputLocator).toHaveValue('')
+  }
+
+  async toSeeNoResultsMessage (): Promise<void> {
+    await expect(this.searchPage._searchResultsListHeaderLocator).toContainText(`0 ${this.searchPage._searchResultsHeadingName}`)
+    await expect(this.searchPage._searchResultsSectionLocator).toContainText(
+      'Check the spelling of the trust name. Enter a reference number in the right format'
+    )
   }
 }

--- a/tests/playwright/ui-tests/searchpage.spec.ts
+++ b/tests/playwright/ui-tests/searchpage.spec.ts
@@ -56,5 +56,10 @@ test.describe('Search page', () => {
       await searchPage.goToSearchFor('non')
       await searchPage.expect.toSeeSearchInputContainingSearchTerm()
     })
+
+    test('they see a helpful message to help them change their search', async () => {
+      await searchPage.goToSearchFor('non')
+      await searchPage.expect.toSeeNoResultsMessage()
+    })
   })
 })

--- a/tests/playwright/ui-tests/searchpage.spec.ts
+++ b/tests/playwright/ui-tests/searchpage.spec.ts
@@ -17,6 +17,7 @@ test.describe('Search page', () => {
     test('then they see an empty search input and can search by a new term', async () => {
       await searchPage.goTo()
       await searchPage.expect.toSeeSearchInputContainingNoSearchTerm()
+      await searchPage.expect.toSeeNoResultsMessage()
       await searchPage.searchFor(searchTerm)
       await searchPage.expect.toSeeInformationForEachResult()
     })


### PR DESCRIPTION
This changes adds a helpful message to the Search page, should no results be found or if a user tries to click search without entering a term. 

This is related to [User Story 130919](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/130919?McasTsid=26110&McasCtx=4): Build: Search results page - no results found

## Changes

- Add a message to the search page which is shown if the trust count is 0 (no results are found, or a search is not performed
- Add and update UI tests to check that a message is shown in both scenarios

## Screenshots of UI changes

<img width="721" alt="Search page with message 0 results for foobar" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/46da1b2f-0b53-4c87-97ec-aa3b5d324b0d">

<img width="721" alt="Search oage with message 0 results for ''" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/f422e7e5-1f20-4e9d-a17a-fe742d202b73">

## Checklist

- [x] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [x] Update the ADR decision log if needed
