### PR TITLE
Add asp nonce tag helper for inline scripts

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
+++ b/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
@@ -18,6 +18,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0"/>
         <PackageReference Include="Microsoft.Identity.Web" Version="2.13.2"/>
+        <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.20.0"/>
+        <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.20.0"/>
         <PackageReference Include="Serilog.AspNetCore" Version="7.0.0"/>
         <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0"/>
     </ItemGroup>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Layout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Layout.cshtml
@@ -19,7 +19,7 @@
 </head>
 
 <body class="govuk-template__body ">
-  <script>
+  <script asp-add-nonce>
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
   </script>
   <partial name="_Header"/>

--- a/DfE.FindInformationAcademiesTrusts/Pages/_ViewImports.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/_ViewImports.cshtml
@@ -1,3 +1,4 @@
 ﻿@using DfE.FindInformationAcademiesTrusts
 @namespace DfE.FindInformationAcademiesTrusts.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, NetEscapades.AspNetCore.SecurityHeaders.TagHelpers

--- a/DfE.FindInformationAcademiesTrusts/ResponseHeadersMiddleware.cs
+++ b/DfE.FindInformationAcademiesTrusts/ResponseHeadersMiddleware.cs
@@ -11,19 +11,7 @@ public class ResponseHeadersMiddleware
 
     public Task Invoke(HttpContext context)
     {
-        SetHeaderIfEmpty(context, "X-Frame-Options", "deny");
-        SetHeaderIfEmpty(context, "X-Content-Type-Options", "nosniff");
-        SetHeaderIfEmpty(context, "Referrer-Policy", "no-referrer");
-        SetHeaderIfEmpty(context, "X-Permitted-Cross-Domain-Policies", "none");
         SetHeaderIfEmpty(context, "X-Robots-Tag", "noindex, nofollow");
-        SetHeaderIfEmpty(context, "Content-Security-Policy",
-            "default-src 'self'; form-action 'self'; object-src 'none'; frame-ancestors 'none'");
-        SetHeaderIfEmpty(context, "Permissions-Policy",
-            "accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=(),layout-animations=(),legacy-image-formats=(),magnetometer=(),microphone=(),midi=(),oversized-images=(),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=(),sync-xhr=(),unoptimized-images=(),unsized-media=(),usb=(),screen-wake-lock=(),web-share=(),xr-spatial-tracking=()");
-        SetHeaderIfEmpty(context, "Cross-Origin-Embedder-Policy", "require-corp");
-        SetHeaderIfEmpty(context, "Cross-Origin-Opener-Policy", "same-origin");
-        SetHeaderIfEmpty(context, "Cross-Origin-Resource-Policy", "same-origin");
-
         return _next(context);
     }
 

--- a/DfE.FindInformationAcademiesTrusts/package.json
+++ b/DfE.FindInformationAcademiesTrusts/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "standard && stylelint \"assets/**/*.(s)?css\" && prettier . --check",
     "lint:fix": "standard --fix && stylelint \"assets/**/*.(s)?css\" --fix && prettier . --write",
-    "build": "webpack",
+    "build": "webpack --mode=production",
     "dev": "webpack --mode=development --watch"
   },
   "author": "",

--- a/docs/adrs/0002-use-netescapades-for-security-headers.md
+++ b/docs/adrs/0002-use-netescapades-for-security-headers.md
@@ -1,0 +1,30 @@
+# 2. Use NetEscapades for security headers
+
+Date: 2023-09-05
+
+## Status
+
+Accepted
+
+## Context
+
+Up until now, we have been setting static response security headers in a custom middleware. We encountered some scenarios where we need to use inline `<script>` tags:
+
+* The GOV.UK design system requires the use of inline script tags (to add the `js-enabled` class name).
+* We may also need to use inline script to initialise the accessible-autocomplete component, which we will be using for search.
+
+These uses of inline script should be secured with nonces.
+
+## Decision
+
+We will use [NetEscapades.AspNetCore.SecurityHeaders nuget package](https://github.com/andrewlock/NetEscapades.AspNetCore.SecurityHeaders) to secure our inline scripts. This package is widely used across RSD products and is recommended by the [SDD technical documentation repo](https://github.com/DFE-Digital/sdd-technical-documentation/blob/main/how_to_guides/security_hardening_in_aspnet_core_web_apps.md).
+
+In order to keep our security header configuration consistent, we will also use this package to configure our other security headers.
+
+## Consequences
+
+We have added nonce attributes to inline scripts using the [NetEscapades.AspNetCore.SecurityHeaders nuget package](https://github.com/andrewlock/NetEscapades.AspNetCore.SecurityHeaders).
+
+We have made further use of NetEscapade security header methods to replace the majority of security headers previously set in our middleware—so that all of the security headers are set in one place.
+
+We still need to manually set the X-Robots-Tag using the custom middleware, to define our desired search engine behaviour.

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/ResponseHeadersMiddlewareTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/ResponseHeadersMiddlewareTests.cs
@@ -28,16 +28,8 @@ public class ResponseHeadersMiddlewareTests
     }
 
     [Theory]
-    [InlineData("X-Frame-Options")]
-    [InlineData("X-Content-Type-Options")]
-    [InlineData("Referrer-Policy")]
-    [InlineData("Permissions-Policy")]
-    [InlineData("X-Permitted-Cross-Domain-Policies")]
     [InlineData("X-Robots-Tag")]
-    [InlineData("Content-Security-Policy")]
-    [InlineData("Cross-Origin-Embedder-Policy")]
-    [InlineData("Cross-Origin-Opener-Policy")]
-    [InlineData("Cross-Origin-Resource-Policy")]
+    [InlineData("Some-Other-Header")]
     public async Task Invoke_should_not_override_existing_headers(string headerName)
     {
         _mockContext.Object.Response.Headers[headerName] = "existing header";
@@ -48,40 +40,10 @@ public class ResponseHeadersMiddlewareTests
     }
 
     [Fact]
-    public async Task Invoke_should_set_XFrameOptions_to_deny()
+    public async Task Invoke_should_set_XRobotTag_header_to_noindex_nofollow()
     {
         await _sut.Invoke(_mockContext.Object);
-        _mockContext.Object.Response.Headers.XFrameOptions.Should().ContainSingle().Which.Should().Be("deny");
-    }
-
-    [Fact]
-    public async Task Invoke_should_set_XContentTypeOptions_to_nosniff()
-    {
-        await _sut.Invoke(_mockContext.Object);
-        _mockContext.Object.Response.Headers.XContentTypeOptions.Should().ContainSingle().Which.Should().Be("nosniff");
-    }
-
-    [Fact]
-    public async Task Invoke_should_set_ContentSecurityPolicy_to_be_secure()
-    {
-        await _sut.Invoke(_mockContext.Object);
-        _mockContext.Object.Response.Headers.ContentSecurityPolicy.Should().ContainSingle().Which.Should().Be(
-            "default-src 'self'; form-action 'self'; object-src 'none'; frame-ancestors 'none'");
-    }
-
-    [Theory]
-    [InlineData("Referrer-Policy", "no-referrer")]
-    [InlineData("Permissions-Policy",
-        "accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=(),layout-animations=(),legacy-image-formats=(),magnetometer=(),microphone=(),midi=(),oversized-images=(),payment=(),picture-in-picture=(),publickey-credentials-get=(),speaker-selection=(),sync-xhr=(),unoptimized-images=(),unsized-media=(),usb=(),screen-wake-lock=(),web-share=(),xr-spatial-tracking=()")]
-    [InlineData("X-Permitted-Cross-Domain-Policies", "none")]
-    [InlineData("X-Robots-Tag", "noindex, nofollow")]
-    [InlineData("Cross-Origin-Embedder-Policy", "require-corp")]
-    [InlineData("Cross-Origin-Opener-Policy", "same-origin")]
-    [InlineData("Cross-Origin-Resource-Policy", "same-origin")]
-    public async Task Invoke_should_set_other_security_headers_to_correct_values(string headername,
-        string expectedValue)
-    {
-        await _sut.Invoke(_mockContext.Object);
-        _mockContext.Object.Response.Headers[headername].Should().ContainSingle().Which.Should().Be(expectedValue);
+        _mockContext.Object.Response.Headers["X-Robots-Tag"].Should().ContainSingle().Which.Should()
+            .Be("noindex, nofollow");
     }
 }


### PR DESCRIPTION
The GOV.UK design system requires the use of inline script tags (to add the `js-enabled` class name). We may also need to use inline script to initialise the `accessible-autocomplete` component, which we will be using for search.  

These uses of inline script should be secured with nonces. We have added nonce attributes to inline scripts using the NetEscapade package, as commonly used in RSD products.

We have made further use of NetEscapade security header methods to replace the majority of security headers previously set in our middleware—so that all of the security headers are set in one place. 

We took this opportunity to review which headers are being set, and made some small amendments. We still need to manually set the X-Robots-Tag using the custom middleware, to define search engine behaviour.

This is related to [Bug 133475](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/133475?McasTsid=26110&McasCtx=4): Content Security Policy console error for inline script

## Changes

- Install [NetEscapades.AspNetCore.SecurityHeaders](https://github.com/andrewlock/NetEscapades.AspNetCore.SecurityHeaders/blob/8553c050783a0e68bb8dee4e5fb09dbbde499d1f/README.md#netescapadesaspnetcoresecurityheaders) and NetEscapades.AspNetCore.SecurityHeaders.TagHelpers NuGet packages
- Set content security policy 'self' 'unsafe-inline' with nonce, using NetEscapades policy builder
- Add `asp-add-nonce` tag helper to add nonce to inline script in HTML
- Move security policy header configuration from custom middleware to NetEscapades policy builder

## Checklist

- [x] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [x] Update the ADR decision log if needed
