### PR TITLE
Fix search input wrapping on small screens

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_SearchForm.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_SearchForm.cshtml
@@ -5,7 +5,7 @@
   </div>
 
   @* This is used by the no javascript users *@
-  <div class="govuk-input__wrapper app-search--main">
+  <div class="app-search__wrapper">
     <div id="@Model.InputId-no-js-search-container">
       <input class="govuk-input app-search__input" id="@Model.InputId" type="search" asp-for="KeyWords" name="keywords">
     </div>

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_search.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_search.scss
@@ -84,9 +84,27 @@
   }
 }
 
-.app-search--main {
+.app-search__wrapper {
+  display: -ms-flexbox;
+  display: flex;
+
   & > div {
     width: 100%;
+  }
+
+  .govuk-input {
+    -ms-flex: 0 1 auto;
+    flex: 0 1 auto;
+  }
+
+  .govuk-input__wrapper .govuk-input:focus {
+    z-index: 2;
+  }
+
+  @media (width <= 19.99em) {
+    .govuk-input__wrapper .govuk-input {
+      max-width: 100%;
+    }
   }
 
   .autocomplete__input,

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_search.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_search.scss
@@ -44,6 +44,7 @@
     display: flex;
     gap: 10px;
     height: 3rem;
+    width: unset;
   }
 
   .app-search__icon {
@@ -80,12 +81,6 @@
     .app-search__icon {
       fill: govuk-colour("white");
     }
-  }
-}
-
-@media (width <=40.0525em) {
-  .app-search__button {
-    padding: 0 8px;
   }
 }
 

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_search.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_search.scss
@@ -48,7 +48,6 @@
   }
 
   .app-search__icon {
-    width: 100%;
     height: 100%;
   }
 


### PR DESCRIPTION
This change fixes the alignment of the search input and button on smaller screens, or as a user zooms in and changes the font size. 

Related to [User Story 130923](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/130923?McasTsid=26110&McasCtx=4): Build: Homepage/Search page - search for a trust - autocomplete

## Changes

- reduce the size of the search button as the screen gets smaller - to allow maximum space for the input

## Screenshots of UI changes

### Before

![Search input on smaller screen](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/a259208e-c540-4397-8045-c956baf938a8)

### After

<img width="500" alt="Search input on smaller screen with fix" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/fbfb89c7-8dcb-45ab-a53c-7f622f181d31">

## Checklist

- [x] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
