### PR TITLE
Update docs on how to run UI tests

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,22 +109,26 @@ WIREMOCK_BASEURL="http://localhost:8080"
 ```bash
 cd DfE.FindInformationAcademiesTrusts.UnitTests/playwright
 
-# run docker image with build flag to watch for the latest code changes
-docker compose -f ../../docker/docker-compose.ci.yml up -d --build
-
 # install dependencies
 npm install
+
+# run docker image with build flag to watch for the latest code changes
+npm run docker:start
 
 # run tests 
 npm run test:ci
 
 # OR
+npm run test:ui # run only ui tests
+npm run test:ui:trace # run only ui tests in chromium, with trace mode
+npm run test:a11y # run only accessibility tests
+
 npx playwright test {folder-name}/* # run a particular set of tests
 npx playright test --headed # run in headed mode
 npx playwright test --trace=on # get a time machine attached to each test result in the report
 
 # remove docker image when done
-docker compose -f ../../docker/docker-compose.ci.yml down
+npm run docker:stop
 ```
 
 For more information on running and debugging Playwright tests it is worth familiarising yourself with the Playwright docs on [debugging](https://playwright.dev/docs/debug) and [command line flags](https://playwright.dev/docs/test-cli).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -112,7 +112,7 @@ cd DfE.FindInformationAcademiesTrusts.UnitTests/playwright
 # install dependencies
 npm install
 
-# run docker image with build flag to watch for the latest code changes
+# run docker image with an application rebuild
 npm run docker:start
 
 # run tests 


### PR DESCRIPTION
In the last change we added some new npm scripts in the playwright folder, to make it easier to run the docker image for mocking tests. Have added these to the getting started docs, as well as some of the recent scripts for running different sets of ui tests.

Will not deploy this branch to test - as there is no update to production code.

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
