### PR TITLE
Update npm scripts

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/package.json
+++ b/DfE.FindInformationAcademiesTrusts/package.json
@@ -8,7 +8,7 @@
     "lint": "standard && stylelint \"assets/**/*.(s)?css\" && prettier . --check",
     "lint:fix": "standard --fix && stylelint \"assets/**/*.(s)?css\" --fix && prettier . --write",
     "build": "webpack --mode=production",
-    "dev": "webpack --mode=development --watch"
+    "dev": "webpack --mode=development --devtool=\"source-map\" --watch"
   },
   "author": "",
   "license": "ISC",

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -13,7 +13,9 @@
     "test:deployment": "npx playwright test --project=\"deployment-tests\"",
     "test:integration": "npx playwright test --project=\"integration-tests\"",
     "docker:start": "docker compose -f ../../docker/docker-compose.ci.yml up -d --build",
-    "docker:stop": "docker compose -f ../../docker/docker-compose.ci.yml down"
+    "docker:stop": "docker compose -f ../../docker/docker-compose.ci.yml down",
+    "docker:wiremock": "docker run -itd --rm --name wiremock-container -p 8080:8080 wiremock/wiremock:2.32.0 --record-mappings --verbose",
+    "docker:wiremock:stop": "docker stop wiremock-container"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
A small update to our npm scripts to aid local development:

1. Update `npm run dev` script which is used to compile assets. Following the update to our Content Security Policy we were able to use compiled JavaScript assets in development mode, as the Content Security Policy blocks the use of eval which is [used by devtool](https://webpack.js.org/configuration/devtool/#development). Added a new flag to our development script which does not use eval, but will allow us to watch asset files for changes. 
2. Add new scripts in our playwright directory to run a local instance of wiremock. For the majority of tests we can run our docker compose script to spin up a docker container with our app alongside a docker container running the wiremock instance, however for debugging it is useful to run the wiremock instance only, and run the app locally.

These scripts were added during the development of #137  and I have split them out as they are not directly related to those changes.

## Screenshots of UI changes
N/A

## Checklist
N/A - no changes to production code. 
- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
