### PR TITLE
Problem with product page

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml
@@ -3,6 +3,7 @@
 
 @{
   Layout = "_ContentLayout";
+  ViewData["Title"] = "There is a problem with the product";
 }
 
 <div class="govuk-grid-row">
@@ -10,9 +11,7 @@
     <h1 class="govuk-heading-l">Sorry, there is a problem with the product</h1>
     <p class="govuk-body">Try again later.</p>
     <p class="govuk-body">
-      <a class="govuk-link" href="https://forms.office.com.mcas.ms/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VCFjdIWb7BPh79bON_K__tUNzdaMUNUR0ozOVpDRFBGMTVTRlNETUlOWi4u">
-        Report this problem
-      </a> if it continues.
+      <a class="govuk-link" href="https://forms.office.com.mcas.ms/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VCFjdIWb7BPh79bON_K__tUNzdaMUNUR0ozOVpDRFBGMTVTRlNETUlOWi4u">Report this problem</a> if it continues.
     </p>
   </section>
 </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml
@@ -1,26 +1,18 @@
-﻿@page
+@page
 @model ErrorModel
+
 @{
-    ViewData["Title"] = "Error";
+  Layout = "_ContentLayout";
 }
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
-
-@if (Model.ShowRequestId)
-{
-    <p>
-        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-three-quarters">
+    <h1 class="govuk-heading-l">Sorry, there is a problem with the product</h1>
+    <p class="govuk-body">Try again later.</p>
+    <p class="govuk-body">
+      <a class="govuk-link" href="https://forms.office.com.mcas.ms/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VCFjdIWb7BPh79bON_K__tUNzdaMUNUR0ozOVpDRFBGMTVTRlNETUlOWi4u">
+        Report this problem
+      </a> if it continues.
     </p>
-}
-
-<h3>Development Mode</h3>
-<p>
-    Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
-</p>
-<p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-    It can result in displaying sensitive information from exceptions to end users.
-    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-    and restarting the app.
-</p>
+  </section>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml.cs
@@ -1,26 +1,7 @@
-using System.Diagnostics;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages;
 
-[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
-[IgnoreAntiforgeryToken]
 public class ErrorModel : PageModel
 {
-    public string? RequestId { get; set; }
-
-    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
-
-    private readonly ILogger<ErrorModel> _logger;
-
-    public ErrorModel(ILogger<ErrorModel> logger)
-    {
-        _logger = logger;
-    }
-
-    public void OnGet()
-    {
-        RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
-    }
 }

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -72,7 +72,7 @@ internal static class Program
         });
 
         app.UseHttpsRedirection();
-
+        app.UseStatusCodePagesWithReExecute("/Error");
         //For Azure AD redirect uri to remain https
         var forwardOptions = new ForwardedHeadersOptions
             { ForwardedHeaders = ForwardedHeaders.All, RequireHeaderSymmetry = false };


### PR DESCRIPTION
This change adds a page which will tell the user there is something wrong with the service. This will be displayed for any error response codes. Not Found (404) responses will handled slightly differently n a separate pull request.

It is related to [User Story 130386](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/130386?McasTsid=26110&McasCtx=4): Build: "500 - Internal Server Error" page 

## Changes

- Add a new page for handling errors titled 'There is a problem with the product', using the GOV.UK pattern
- Use [ASP.NET StatusCodePages](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.statuscodepagesextensions.usestatuscodepageswithreexecute?view=aspnetcore-7.0) middleware to generate an error response body to display to the user

## Screenshots of UI changes

<img width="739" alt="Screenshot of page with text 'there is a problem with the product'" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/994ec213-9a77-4fa5-a506-9320d5b9a666">

## Checklist

- [x] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
