### PR TITLE
Page not found

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml
@@ -3,15 +3,27 @@
 
 @{
   Layout = "_ContentLayout";
-  ViewData["Title"] = "There is a problem with the product";
+  ViewData["Title"] = Model.Is404Result ? "Page not found" : "There is a problem with the product";
 }
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-three-quarters">
-    <h1 class="govuk-heading-l">Sorry, there is a problem with the product</h1>
-    <p class="govuk-body">Try again later.</p>
-    <p class="govuk-body">
-      <a class="govuk-link" href="https://forms.office.com.mcas.ms/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VCFjdIWb7BPh79bON_K__tUNzdaMUNUR0ozOVpDRFBGMTVTRlNETUlOWi4u">Report this problem</a> if it continues.
-    </p>
+    @if (Model.Is404Result)
+    {
+      <h1 class="govuk-heading-l">Page not found</h1>
+      <p class="govuk-body">If you typed the web address, check it is correct.</p>
+      <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+      <p class="govuk-body">
+        <a class="govuk-link" href="@ViewConstants.ReportAProblemLink">Report this problem</a> if the web address is correct or you selected a link or button.
+      </p>
+    }
+    else
+    {
+      <h1 class="govuk-heading-l">Sorry, there is a problem with the product</h1>
+      <p class="govuk-body">Try again later.</p>
+      <p class="govuk-body">
+        <a class="govuk-link" href="@ViewConstants.ReportAProblemLink">Report this problem</a> if it continues.
+      </p>
+    }
   </section>
 </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml.cs
@@ -4,4 +4,13 @@ namespace DfE.FindInformationAcademiesTrusts.Pages;
 
 public class ErrorModel : PageModel
 {
+    public bool Is404Result { get; set; }
+
+    public void OnGet(string statusCode)
+    {
+        if (statusCode == "404")
+        {
+            Is404Result = true;
+        }
+    }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml.cs
@@ -25,7 +25,7 @@ public class SearchModel : PageModel, ISearchFormModel
         if (!string.IsNullOrWhiteSpace(TrustId))
         {
             var trust = await _trustProvider.GetTrustByUkprnAsync(TrustId);
-            if (string.Equals(trust.Name, KeyWords, StringComparison.CurrentCultureIgnoreCase))
+            if (trust != null && string.Equals(trust.Name, KeyWords, StringComparison.CurrentCultureIgnoreCase))
             {
                 return RedirectToPage("/Trusts/Details", new { Ukprn = TrustId });
             }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml.cs
@@ -20,6 +20,12 @@ public class ContactsModel : PageModel, ITrustsAreaModel
     public async Task<IActionResult> OnGetAsync()
     {
         var trust = await _trustProvider.GetTrustByUkprnAsync(Ukprn);
+
+        if (trust == null)
+        {
+            return new NotFoundResult();
+        }
+
         Trust = trust;
         return Page();
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Details.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Details.cshtml.cs
@@ -21,6 +21,12 @@ public class DetailsModel : PageModel, ITrustsAreaModel
     public async Task<IActionResult> OnGetAsync()
     {
         var trust = await _trustProvider.GetTrustByUkprnAsync(Ukprn);
+
+        if (trust == null)
+        {
+            return new NotFoundResult();
+        }
+
         Trust = trust;
         return Page();
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
@@ -4,4 +4,7 @@ public static class ViewConstants
 {
     public const string ServiceName = "Find information about academies and trusts";
     public const string AboutTheTrustSectionName = "About the trust";
+
+    public const string ReportAProblemLink =
+        "https://forms.office.com.mcas.ms/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VCFjdIWb7BPh79bON_K__tUNzdaMUNUR0ozOVpDRFBGMTVTRlNETUlOWi4u";
 }

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -57,7 +57,7 @@ internal static class Program
 
     private static void ConfigureHttpRequestPipeline(WebApplication app)
     {
-        if (!app.Environment.IsDevelopment() && !app.Environment.IsLocalDevelopment())
+        if (!app.Environment.IsLocalDevelopment())
         {
             app.UseExceptionHandler("/Error");
             app.UseHsts();

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -72,7 +72,7 @@ internal static class Program
         });
 
         app.UseHttpsRedirection();
-        app.UseStatusCodePagesWithReExecute("/Error");
+        app.UseStatusCodePagesWithReExecute("/Error", "?statusCode={0}");
         //For Azure AD redirect uri to remain https
         var forwardOptions = new ForwardedHeadersOptions
             { ForwardedHeaders = ForwardedHeaders.All, RequireHeaderSymmetry = false };

--- a/DfE.FindInformationAcademiesTrusts/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts/TrustProvider.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using DfE.FindInformationAcademiesTrusts.AcademiesApiResponseModels;
 
@@ -7,7 +8,7 @@ public interface ITrustProvider
 {
     public Task<IEnumerable<TrustSearchEntry>> GetTrustsAsync();
     public Task<IEnumerable<TrustSearchEntry>> GetTrustsByNameAsync(string name);
-    public Task<Trust> GetTrustByUkprnAsync(string ukprn);
+    public Task<Trust?> GetTrustByUkprnAsync(string ukprn);
 }
 
 public class TrustProvider : ITrustProvider
@@ -63,7 +64,7 @@ public class TrustProvider : ITrustProvider
         throw new HttpRequestException("Problem communicating with Academies API");
     }
 
-    public async Task<Trust> GetTrustByUkprnAsync(string ukprn)
+    public async Task<Trust?> GetTrustByUkprnAsync(string ukprn)
     {
         var httpResponseMessage = await _httpClient.GetAsync($"v3/trust/{ukprn}");
         if (httpResponseMessage.IsSuccessStatusCode)
@@ -80,8 +81,12 @@ public class TrustProvider : ITrustProvider
                 json.Data.GiasData.GroupType ?? string.Empty
             );
 
-
             return trust;
+        }
+
+        if (httpResponseMessage.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
         }
 
         var errorMessage = await httpResponseMessage.Content.ReadAsStringAsync();

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/ErrorModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/ErrorModelTests.cs
@@ -2,19 +2,19 @@ using DfE.FindInformationAcademiesTrusts.Pages;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages;
 
-public class ProblemWithProductModelTests
+public class ErrorModelTests
 {
     [Fact]
     public void Is404Result_should_be_false_by_default()
     {
-        var sut = new ProblemWithProduct();
+        var sut = new ErrorModel();
         sut.Is404Result.Should().BeFalse();
     }
 
     [Fact]
     public void Is404Result_should_be_true_if_404_Status_Code()
     {
-        var sut = new ProblemWithProduct();
+        var sut = new ErrorModel();
         sut.OnGet("404");
 
         sut.Is404Result.Should().BeTrue();
@@ -26,7 +26,7 @@ public class ProblemWithProductModelTests
     [InlineData("403")]
     public void Is404Result_should_be_false_if_not_Status_Code(string code)
     {
-        var sut = new ProblemWithProduct();
+        var sut = new ErrorModel();
         sut.OnGet(code);
         sut.Is404Result.Should().BeFalse();
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/ErrorModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/ErrorModelTests.cs
@@ -1,0 +1,33 @@
+using DfE.FindInformationAcademiesTrusts.Pages;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages;
+
+public class ProblemWithProductModelTests
+{
+    [Fact]
+    public void Is404Result_should_be_false_by_default()
+    {
+        var sut = new ProblemWithProduct();
+        sut.Is404Result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Is404Result_should_be_true_if_404_Status_Code()
+    {
+        var sut = new ProblemWithProduct();
+        sut.OnGet("404");
+
+        sut.Is404Result.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("500")]
+    [InlineData("400")]
+    [InlineData("403")]
+    public void Is404Result_should_be_false_if_not_Status_Code(string code)
+    {
+        var sut = new ProblemWithProduct();
+        sut.OnGet(code);
+        sut.Is404Result.Should().BeFalse();
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
@@ -1,73 +1,64 @@
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 using Microsoft.AspNetCore.Mvc;
 
-namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages;
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
 
 public class ContactsModelTests
 {
+    private readonly Mock<ITrustProvider> _mockTrustProvider;
+    private readonly ContactsModel _sut;
+
+    public ContactsModelTests()
+    {
+        _mockTrustProvider = new Mock<ITrustProvider>();
+        _sut = new ContactsModel(_mockTrustProvider.Object);
+    }
+
     [Fact]
     public async void OnGetAsync_should_fetch_a_trust_by_ukprn()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
-        mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1234").Result)
+        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1234").Result)
             .Returns(new Trust("test", "test", "Multi-academy trust"));
-        var sut = new ContactsModel(mockTrustProvider.Object)
-        {
-            Ukprn = "1234"
-        };
-
-        await sut.OnGetAsync();
-        sut.Trust.Should().BeEquivalentTo(new Trust("test", "test", "Multi-academy trust"));
+        _sut.Ukprn = "1234";
+        await _sut.OnGetAsync();
+        _sut.Trust.Should().BeEquivalentTo(new Trust("test", "test", "Multi-academy trust"));
     }
 
     [Fact]
     public async void Ukprn_should_be_empty_string_by_default()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
-        var sut = new ContactsModel(mockTrustProvider.Object);
-
-        await sut.OnGetAsync();
-        sut.Ukprn.Should().BeEquivalentTo(string.Empty);
+        await _sut.OnGetAsync();
+        _sut.Ukprn.Should().BeEquivalentTo(string.Empty);
     }
 
     [Fact]
     public void PageName_should_be_Contacts()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
-        var sut = new ContactsModel(mockTrustProvider.Object);
-        sut.PageName.Should().Be("Contacts");
+        _sut.PageName.Should().Be("Contacts");
     }
 
     [Fact]
     public void PageSection_should_be_AboutTheTrust()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
-        var sut = new ContactsModel(mockTrustProvider.Object);
-        sut.Section.Should().Be("About the trust");
+        _sut.Section.Should().Be("About the trust");
     }
 
     [Fact]
     public async void OnGetAsync_should_return_not_found_result_if_trust_is_not_found()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
-        mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1111").Result)
+        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1111").Result)
             .Returns((Trust?)null);
 
-        var sut = new ContactsModel(mockTrustProvider.Object)
-        {
-            Ukprn = "1111"
-        };
-        var result = await sut.OnGetAsync();
+        _sut.Ukprn = "1111";
+
+        var result = await _sut.OnGetAsync();
         result.Should().BeOfType<NotFoundResult>();
     }
 
     [Fact]
     public async void OnGetAsync_should_return_not_found_result_if_Ukprn_is_not_provided()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
-
-        var sut = new ContactsModel(mockTrustProvider.Object);
-        var result = await sut.OnGetAsync();
+        var result = await _sut.OnGetAsync();
         result.Should().BeOfType<NotFoundResult>();
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
@@ -1,6 +1,7 @@
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+using Microsoft.AspNetCore.Mvc;
 
-namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages;
 
 public class ContactsModelTests
 {
@@ -43,5 +44,30 @@ public class ContactsModelTests
         var mockTrustProvider = new Mock<ITrustProvider>();
         var sut = new ContactsModel(mockTrustProvider.Object);
         sut.Section.Should().Be("About the trust");
+    }
+
+    [Fact]
+    public async void OnGetAsync_should_return_not_found_result_if_trust_is_not_found()
+    {
+        var mockTrustProvider = new Mock<ITrustProvider>();
+        mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1111").Result)
+            .Returns((Trust?)null);
+
+        var sut = new ContactsModel(mockTrustProvider.Object)
+        {
+            Ukprn = "1111"
+        };
+        var result = await sut.OnGetAsync();
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async void OnGetAsync_should_return_not_found_result_if_Ukprn_is_not_provided()
+    {
+        var mockTrustProvider = new Mock<ITrustProvider>();
+
+        var sut = new ContactsModel(mockTrustProvider.Object);
+        var result = await sut.OnGetAsync();
+        result.Should().BeOfType<NotFoundResult>();
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/DetailsModelTests.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages;
 
@@ -43,5 +44,30 @@ public class DetailsModelTests
         var mockTrustProvider = new Mock<ITrustProvider>();
         var sut = new DetailsModel(mockTrustProvider.Object);
         sut.Section.Should().Be("About the trust");
+    }
+
+    [Fact]
+    public async void OnGetAsync_should_return_not_found_result_if_trust_is_not_found()
+    {
+        var mockTrustProvider = new Mock<ITrustProvider>();
+        mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1111").Result)
+            .Returns((Trust?)null);
+
+        var sut = new DetailsModel(mockTrustProvider.Object)
+        {
+            Ukprn = "1111"
+        };
+        var result = await sut.OnGetAsync();
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async void OnGetAsync_should_return_not_found_result_if_Ukprn_is_not_provided()
+    {
+        var mockTrustProvider = new Mock<ITrustProvider>();
+
+        var sut = new DetailsModel(mockTrustProvider.Object);
+        var result = await sut.OnGetAsync();
+        result.Should().BeOfType<NotFoundResult>();
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/DetailsModelTests.cs
@@ -1,73 +1,64 @@
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 using Microsoft.AspNetCore.Mvc;
 
-namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages;
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
 
 public class DetailsModelTests
 {
+    private readonly Mock<ITrustProvider> _mockTrustProvider;
+    private readonly DetailsModel _sut;
+
+    public DetailsModelTests()
+    {
+        _mockTrustProvider = new Mock<ITrustProvider>();
+        _sut = new DetailsModel(_mockTrustProvider.Object);
+    }
+
     [Fact]
     public async void OnGetAsync_should_fetch_a_trust_by_ukprn()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
-        mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1234").Result)
+        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1234").Result)
             .Returns(new Trust("test", "test", "Multi-academy trust"));
-        var sut = new DetailsModel(mockTrustProvider.Object)
-        {
-            Ukprn = "1234"
-        };
+        _sut.Ukprn = "1234";
 
-        await sut.OnGetAsync();
-        sut.Trust.Should().BeEquivalentTo(new Trust("test", "test", "Multi-academy trust"));
+        await _sut.OnGetAsync();
+        _sut.Trust.Should().BeEquivalentTo(new Trust("test", "test", "Multi-academy trust"));
     }
 
     [Fact]
     public async void Ukprn_should_be_empty_string_by_default()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
-        var sut = new DetailsModel(mockTrustProvider.Object);
-
-        await sut.OnGetAsync();
-        sut.Ukprn.Should().BeEquivalentTo(string.Empty);
+        await _sut.OnGetAsync();
+        _sut.Ukprn.Should().BeEquivalentTo(string.Empty);
     }
 
     [Fact]
     public void PageName_should_be_Details()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
-        var sut = new DetailsModel(mockTrustProvider.Object);
-        sut.PageName.Should().Be("Details");
+        _sut.PageName.Should().Be("Details");
     }
 
     [Fact]
     public void PageSection_should_be_AboutTheTrust()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
-        var sut = new DetailsModel(mockTrustProvider.Object);
-        sut.Section.Should().Be("About the trust");
+        _sut.Section.Should().Be("About the trust");
     }
 
     [Fact]
     public async void OnGetAsync_should_return_not_found_result_if_trust_is_not_found()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
-        mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1111").Result)
+        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1111").Result)
             .Returns((Trust?)null);
 
-        var sut = new DetailsModel(mockTrustProvider.Object)
-        {
-            Ukprn = "1111"
-        };
-        var result = await sut.OnGetAsync();
+        _sut.Ukprn = "1111";
+        var result = await _sut.OnGetAsync();
         result.Should().BeOfType<NotFoundResult>();
     }
 
     [Fact]
     public async void OnGetAsync_should_return_not_found_result_if_Ukprn_is_not_provided()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
-
-        var sut = new DetailsModel(mockTrustProvider.Object);
-        var result = await sut.OnGetAsync();
+        var result = await _sut.OnGetAsync();
         result.Should().BeOfType<NotFoundResult>();
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/TrustProviderTests.cs
@@ -248,7 +248,7 @@ public class TrustProviderTests
         var sut = new TrustProvider(_mockHttpClientFactory.Object, _mockLogger.Object);
 
         var result = await sut.GetTrustByUkprnAsync("1234");
-        result.Type.Should().Be(expected);
+        result?.Type.Should().Be(expected);
     }
 
     [Fact]
@@ -324,5 +324,20 @@ public class TrustProviderTests
 
         var result = await sut.GetTrustsByNameAsync("trust");
         result.Should().HaveCount(3).And.OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public async Task GetTrustsByUkprnAsync_should_return_null_on_Not_Found_Result()
+    {
+        var responseMessage = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent("")
+        };
+
+        _mockHttpClientFactory.SetUpHttpGetResponse(TrustEndpoint, responseMessage);
+
+        var sut = new TrustProvider(_mockHttpClientFactory.Object, _mockLogger.Object);
+        var result = await sut.GetTrustByUkprnAsync("1234");
+        result.Should().BeNull();
     }
 }

--- a/tests/playwright/accessibility-tests/notfoundpage.spec.ts
+++ b/tests/playwright/accessibility-tests/notfoundpage.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+import { NotFoundPage } from '../page-object-model/not-found-page'
+
+test.describe('Page not found', () => {
+  let notFoundPage: NotFoundPage
+
+  test.beforeEach(async ({ page }) => {
+    notFoundPage = new NotFoundPage(page)
+  })
+
+  test('when a user tries to type in a url that does not exist', async ({ page }) => {
+    await notFoundPage.goToNonExistingUrl()
+    await notFoundPage.expect.toBeShownNotFoundMessage()
+
+    const accessibilityScanResults = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze()
+
+    expect(accessibilityScanResults.violations).toEqual([])
+  })
+})

--- a/tests/playwright/mocks.setup.ts
+++ b/tests/playwright/mocks.setup.ts
@@ -17,4 +17,6 @@ setup('mock trust provider', async () => {
   for (const trust of MockTrustsProvider.fakeTrustsResponseData[secondSearchTerm]) {
     await mockTrustProvider.registerGetTrustByUkprn(trust.GroupName, trust.Ukprn)
   }
+
+  await mockTrustProvider.registerGetTrustNotFoundResponse()
 })

--- a/tests/playwright/mocks/mock-trusts-provider.ts
+++ b/tests/playwright/mocks/mock-trusts-provider.ts
@@ -20,6 +20,8 @@ export class MockTrustsProvider {
     type: 'Multi-academy trust'
   }
 
+  static nonExistingTrustUkprn = '1111'
+
   constructor () {
     this._mock = new WireMock(process.env.WIREMOCK_BASEURL ?? 'http://localhost:8080')
   }
@@ -74,5 +76,18 @@ export class MockTrustsProvider {
     }
 
     await this._mock.register(trustRequest, mockedTrustResponse)
+  }
+
+  registerGetTrustNotFoundResponse = async (): Promise<void> => {
+    const trustRequest: IWireMockRequest = {
+      method: 'GET',
+      endpoint: `/v3/trust/${MockTrustsProvider.nonExistingTrustUkprn}`
+    }
+
+    const mockedResponse: IWireMockResponse = {
+      status: 404
+    }
+
+    await this._mock.register(trustRequest, mockedResponse)
   }
 }

--- a/tests/playwright/page-object-model/not-found-page.ts
+++ b/tests/playwright/page-object-model/not-found-page.ts
@@ -1,0 +1,23 @@
+import { Locator, Page, expect } from '@playwright/test'
+
+export class NotFoundPage {
+  readonly expect: NotFoundPageAssertions
+  readonly _headerLocator: Locator
+
+  constructor (readonly page: Page) {
+    this.expect = new NotFoundPageAssertions(this)
+    this._headerLocator = this.page.locator('h1')
+  }
+
+  async goToNonExistingUrl (): Promise<void> {
+    await this.page.goto('/non-page')
+  }
+}
+
+class NotFoundPageAssertions {
+  constructor (readonly notFoundPage: NotFoundPage) {}
+
+  async toBeShownNotFoundMessage (): Promise<void> {
+    await expect(this.notFoundPage._headerLocator).toHaveText('Page not found')
+  }
+}

--- a/tests/playwright/ui-tests/notfoundpage.spec.ts
+++ b/tests/playwright/ui-tests/notfoundpage.spec.ts
@@ -1,0 +1,15 @@
+import { test } from '@playwright/test'
+import { NotFoundPage } from '../page-object-model/not-found-page'
+
+test.describe('Page not found', () => {
+  let notFoundPage: NotFoundPage
+
+  test.beforeEach(async ({ page }) => {
+    notFoundPage = new NotFoundPage(page)
+  })
+
+  test('when a user tries to type in a url that does not exist', async () => {
+    await notFoundPage.goToNonExistingUrl()
+    await notFoundPage.expect.toBeShownNotFoundMessage()
+  })
+})

--- a/tests/playwright/ui-tests/trusts/contactspage.spec.ts
+++ b/tests/playwright/ui-tests/trusts/contactspage.spec.ts
@@ -1,8 +1,11 @@
 import { test } from '@playwright/test'
 import { ContactsPage } from '../../page-object-model/trust/contacts-page'
+import { NotFoundPage } from '../../page-object-model/not-found-page'
+import { MockTrustsProvider } from '../../mocks/mock-trusts-provider'
 
 test.describe('Details page', () => {
   let contactsPage: ContactsPage
+  let notFoundPage: NotFoundPage
 
   test.beforeEach(async ({ page }) => {
     contactsPage = new ContactsPage(page)
@@ -11,5 +14,19 @@ test.describe('Details page', () => {
 
   test('user should see trust name and type', async () => {
     await contactsPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
+  })
+
+  test.describe('given a user tries to visit the url without an existing trust', () => {
+    test.beforeEach(({ page }) => {
+      notFoundPage = new NotFoundPage(page)
+    })
+
+    test('then they should see a not found message', async () => {
+      await contactsPage.goTo('')
+      await notFoundPage.expect.toBeShownNotFoundMessage()
+
+      await contactsPage.goTo(MockTrustsProvider.nonExistingTrustUkprn)
+      await notFoundPage.expect.toBeShownNotFoundMessage()
+    })
   })
 })

--- a/tests/playwright/ui-tests/trusts/detailspage.spec.ts
+++ b/tests/playwright/ui-tests/trusts/detailspage.spec.ts
@@ -1,8 +1,11 @@
 import { test } from '@playwright/test'
 import { DetailsPage } from '../../page-object-model/trust/details-page'
+import { NotFoundPage } from '../../page-object-model/not-found-page'
+import { MockTrustsProvider } from '../../mocks/mock-trusts-provider'
 
 test.describe('Details page', () => {
   let detailsPage: DetailsPage
+  let notFoundPage: NotFoundPage
 
   test.beforeEach(async ({ page }) => {
     detailsPage = new DetailsPage(page)
@@ -11,5 +14,19 @@ test.describe('Details page', () => {
 
   test('user should see trust name and type', async () => {
     await detailsPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
+  })
+
+  test.describe('given a user tries to visit the url without an existing trust', () => {
+    test.beforeEach(({ page }) => {
+      notFoundPage = new NotFoundPage(page)
+    })
+
+    test('then they should see a not found message', async () => {
+      await detailsPage.goTo('')
+      await notFoundPage.expect.toBeShownNotFoundMessage()
+
+      await detailsPage.goTo(MockTrustsProvider.nonExistingTrustUkprn)
+      await notFoundPage.expect.toBeShownNotFoundMessage()
+    })
   })
 })


### PR DESCRIPTION
This change adds a page which will tell the user we cannot find the page they were trying to view. This will be displayed for any 404 error response codes. Any other http error responses are handled in #148 - Problem with product page.

The change also ensures that this page is shown if the user tries to enter the url for a trust that doesn't exist, for example if they bookmarked a trust that has since been deleted.

It is related to [User Story 130385](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/130385?McasTsid=26110&McasCtx=4): Build: "404 - Not Found" page

## Changes

- Update error handling to display different title and html content for any Not Found (404) responses
- Update trust provider to handle Not Found status codes differently, returning null.
- Update trust pages to return a Not Found result if the trust result is null - which will result in the user seeing the Not Found Page.

## Screenshots of UI changes

<img width="1427" alt="screenshot of page with text 'page not found'" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/5b61de66-893f-4fad-bad9-dfb7f15d07fa">

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
