### PR TITLE
Improve accessibility test setup

### DIFF
--- a/tests/playwright/accessibility-tests/a11y-test.ts
+++ b/tests/playwright/accessibility-tests/a11y-test.ts
@@ -1,0 +1,21 @@
+import { test as base, expect } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+interface A11yTest {
+  expectNoAccessibilityViolations: () => Promise<void>
+}
+
+export const test = base.extend<A11yTest>({
+  expectNoAccessibilityViolations: async ({ page }, use) => {
+    const accessibilityScanner = new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+
+    const doScan: () => Promise<void> = async () => {
+      const accessibilityScanResults = await accessibilityScanner.analyze()
+
+      expect(accessibilityScanResults.violations).toEqual([])
+    }
+
+    await use(doScan)
+  }
+})

--- a/tests/playwright/accessibility-tests/homepage.spec.ts
+++ b/tests/playwright/accessibility-tests/homepage.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from '@playwright/test'
-import AxeBuilder from '@axe-core/playwright'
+import { test } from './a11y-test'
 import { HomePage } from '../page-object-model/home-page'
 
 test.describe('home page', () => {
@@ -10,23 +9,16 @@ test.describe('home page', () => {
     await homePage.goTo()
   })
 
-  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+  test('should not have any automatically detectable accessibility issues', async ({ expectNoAccessibilityViolations }) => {
     await homePage.expect.toBeOnTheRightPage()
-    const accessibilityScanResults = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-      .analyze()
 
-    expect(accessibilityScanResults.violations).toEqual([])
+    await expectNoAccessibilityViolations()
   })
 
-  test('when typing a search term and autocomplete is shown', async ({ page }) => {
+  test('when typing a search term and autocomplete is shown', async ({ expectNoAccessibilityViolations }) => {
     await homePage.searchForm.typeSearchTerm('trust')
     await homePage.searchForm.expect.toShowAllResultsInAutocomplete()
 
-    const accessibilityScanResults = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-      .analyze()
-
-    expect(accessibilityScanResults.violations).toEqual([])
+    await expectNoAccessibilityViolations()
   })
 })

--- a/tests/playwright/accessibility-tests/notfoundpage.spec.ts
+++ b/tests/playwright/accessibility-tests/notfoundpage.spec.ts
@@ -1,5 +1,4 @@
-import { expect, test } from '@playwright/test'
-import AxeBuilder from '@axe-core/playwright'
+import { test } from './a11y-test'
 import { NotFoundPage } from '../page-object-model/not-found-page'
 
 test.describe('Page not found', () => {
@@ -9,14 +8,10 @@ test.describe('Page not found', () => {
     notFoundPage = new NotFoundPage(page)
   })
 
-  test('when a user tries to type in a url that does not exist', async ({ page }) => {
+  test('when a user tries to type in a url that does not exist', async ({ expectNoAccessibilityViolations }) => {
     await notFoundPage.goToNonExistingUrl()
     await notFoundPage.expect.toBeShownNotFoundMessage()
 
-    const accessibilityScanResults = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-      .analyze()
-
-    expect(accessibilityScanResults.violations).toEqual([])
+    await expectNoAccessibilityViolations()
   })
 })

--- a/tests/playwright/accessibility-tests/searchpage.spec.ts
+++ b/tests/playwright/accessibility-tests/searchpage.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect } from '@playwright/test'
-import { AxeBuilder } from '@axe-core/playwright'
+import { test } from './a11y-test'
 import { SearchPage } from '../page-object-model/search-page'
 
 test.describe('search page should not have any automatically detectable accessibility issues', () => {
@@ -9,53 +8,39 @@ test.describe('search page should not have any automatically detectable accessib
     searchPage = new SearchPage(page)
   })
 
-  test('when going to a search page with no search term', async ({ page }) => {
+  test('when going to a search page with no search term', async ({ expectNoAccessibilityViolations }) => {
     await searchPage.goTo()
     await searchPage.expect.toSeeNoResultsMessage()
 
-    const accessibilityScanResults = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-      .analyze()
-
-    expect(accessibilityScanResults.violations).toEqual([])
+    await expectNoAccessibilityViolations()
   })
 
-  test('when going to a search page with a search term', async ({ page }) => {
+  test('when going to a search page with a search term', async ({ expectNoAccessibilityViolations }) => {
     await searchPage.goToSearchFor('trust')
     await searchPage.expect.toBeOnPageWithResultsFor('trust')
     await searchPage.expect.toShowResults()
 
-    const accessibilityScanResults = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-      .analyze()
-
-    expect(accessibilityScanResults.violations).toEqual([])
+    await expectNoAccessibilityViolations()
   })
 
-  test('when typing a search term and autocomplete is shown', async ({ page }) => {
+  test('when typing a search term and autocomplete is shown', async ({ expectNoAccessibilityViolations }) => {
     await searchPage.goTo()
     await searchPage.searchForm.typeSearchTerm('trust')
     await searchPage.searchForm.expect.toShowAllResultsInAutocomplete()
 
-    const accessibilityScanResults = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-      .analyze()
-
-    expect(accessibilityScanResults.violations).toEqual([])
+    await expectNoAccessibilityViolations()
   })
 
   // Skipping this test as the autocomplete element fails accessibility tests when showing the no results found message
   // message: 'Element has children which are not allowed'
   // This is referring to an li element, however the ul and li nesting seems to be correct.
   // As this is not our application code we will skip this test for now, and see if we face any issues in our audit.
-  test.skip('when typing a search term with no results, no results is shown in autocomplete', async ({ page }) => {
+  test.skip('when typing a search term with no results, no results is shown in autocomplete', async ({ expectNoAccessibilityViolations }) => {
     await searchPage.goTo()
 
     await searchPage.searchForm.typeSearchTerm('non')
     await searchPage.searchForm.expect.toshowNoResultsFoundInAutocomplete()
-    const accessibilityScanResults = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']).analyze()
 
-    expect(accessibilityScanResults.violations).toEqual([])
+    await expectNoAccessibilityViolations()
   })
 })

--- a/tests/playwright/accessibility-tests/trusts/detailspage.spec.ts
+++ b/tests/playwright/accessibility-tests/trusts/detailspage.spec.ts
@@ -1,18 +1,13 @@
-import { expect, test } from '@playwright/test'
+import { test } from '../a11y-test'
 import { DetailsPage } from '../../page-object-model/trust/details-page'
-import AxeBuilder from '@axe-core/playwright'
 
 test.describe('Details page', () => {
-  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+  test('should not have any automatically detectable accessibility issues', async ({ expectNoAccessibilityViolations, page }) => {
     const detailsPage = new DetailsPage(page)
     await detailsPage.goTo()
     await detailsPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
     await detailsPage.trustNavigation.expect.toBeVisible()
 
-    const accessibilityScanResults = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-      .analyze()
-
-    expect(accessibilityScanResults.violations).toEqual([])
+    await expectNoAccessibilityViolations()
   })
 })


### PR DESCRIPTION
This change improves the setup of our accessibility tests, which uses [playwright's axe-core](https://playwright.dev/docs/accessibility-testing) extension to check for accessibility issues in our application. 

This builds upon the initial setup of cypress-axe in **Add Accessibility test #34**, but as we have added more tests we now need to extract this setup to reduce setup overhead in our tests. 

## Changes

- Add a test extension with custom assertion, which sets up and runs the [axe-core accessibility scanner](https://playwright.dev/docs/accessibility-testing) at the required point in our test.
- Update all accessibility tests to replace accessibility scanner setup with the new assertion.

## Improvements needed

The test failure message is a json string of failures which are quite detailed and hard to read. It would be good to add a prettified output in a table format which will be easier for developers to understand.

## Screenshots of changes

Here is a screenshot of a list of accessibility failures found using the axe-core scanner in our tests
![Screenshot of accessibility test errors)](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/ef9fa104-cd28-4669-82d6-1f78567cb6dd)

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
