### PR TITLE
Set up connection to Academies Database

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/AcademiesDbContext.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/AcademiesDbContext.cs
@@ -1,8 +1,10 @@
-﻿using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models;
+﻿using System.Diagnostics.CodeAnalysis;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb;
 
+[ExcludeFromCodeCoverage]
 public class AcademiesDbContext : DbContext
 {
     public AcademiesDbContext()

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/AcademiesDbContext.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/AcademiesDbContext.cs
@@ -14,12 +14,7 @@ public class AcademiesDbContext : DbContext
     {
     }
 
-    public virtual DbSet<Group> Groups { get; set; }
-
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    {
-        optionsBuilder.UseSqlServer("Name=AcademiesDb:ConnectionString");
-    }
+    public DbSet<Group> Groups { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/AcademiesDbContext.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/AcademiesDbContext.cs
@@ -1,0 +1,97 @@
+﻿using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb;
+
+public class AcademiesDbContext : DbContext
+{
+    public AcademiesDbContext()
+    {
+    }
+
+    public AcademiesDbContext(DbContextOptions<AcademiesDbContext> options)
+        : base(options)
+    {
+    }
+
+    public virtual DbSet<Group> Groups { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer("Name=AcademiesDb:ConnectionString");
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("sdd");
+
+        modelBuilder.Entity<Group>(entity =>
+        {
+            entity
+                .HasNoKey()
+                .ToTable("Group", "gias");
+
+            entity.Property(e => e.ClosedDate)
+                .IsUnicode(false)
+                .HasColumnName("Closed Date");
+            entity.Property(e => e.CompaniesHouseNumber)
+                .IsUnicode(false)
+                .HasColumnName("Companies House Number");
+            entity.Property(e => e.GroupContactAddress3)
+                .IsUnicode(false)
+                .HasColumnName("Group Contact Address 3");
+            entity.Property(e => e.GroupContactCounty)
+                .IsUnicode(false)
+                .HasColumnName("Group Contact County");
+            entity.Property(e => e.GroupContactLocality)
+                .IsUnicode(false)
+                .HasColumnName("Group Contact Locality");
+            entity.Property(e => e.GroupContactPostcode)
+                .IsUnicode(false)
+                .HasColumnName("Group Contact Postcode");
+            entity.Property(e => e.GroupContactStreet)
+                .IsUnicode(false)
+                .HasColumnName("Group Contact Street");
+            entity.Property(e => e.GroupContactTown)
+                .IsUnicode(false)
+                .HasColumnName("Group Contact Town");
+            entity.Property(e => e.GroupId)
+                .IsUnicode(false)
+                .HasColumnName("Group ID");
+            entity.Property(e => e.GroupName)
+                .IsUnicode(false)
+                .HasColumnName("Group Name");
+            entity.Property(e => e.GroupStatus)
+                .IsUnicode(false)
+                .HasColumnName("Group Status");
+            entity.Property(e => e.GroupStatusCode)
+                .IsUnicode(false)
+                .HasColumnName("Group Status (code)");
+            entity.Property(e => e.GroupType)
+                .IsUnicode(false)
+                .HasColumnName("Group Type");
+            entity.Property(e => e.GroupTypeCode)
+                .IsUnicode(false)
+                .HasColumnName("Group Type (code)");
+            entity.Property(e => e.GroupUid)
+                .IsUnicode(false)
+                .HasColumnName("Group UID");
+            entity.Property(e => e.HeadOfGroupFirstName)
+                .IsUnicode(false)
+                .HasColumnName("Head of Group First Name");
+            entity.Property(e => e.HeadOfGroupLastName)
+                .IsUnicode(false)
+                .HasColumnName("Head of Group Last Name");
+            entity.Property(e => e.HeadOfGroupTitle)
+                .IsUnicode(false)
+                .HasColumnName("Head of Group Title");
+            entity.Property(e => e.IncorporatedOnOpenDate)
+                .IsUnicode(false)
+                .HasColumnName("Incorporated on (open date)");
+            entity.Property(e => e.OpenDate)
+                .IsUnicode(false)
+                .HasColumnName("Open date");
+            entity.Property(e => e.Ukprn).HasColumnName("UKPRN");
+        });
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+</Project>

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj
@@ -6,4 +6,12 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.11">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.11"/>
+    </ItemGroup>
+
 </Project>

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Group.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Group.cs
@@ -1,5 +1,8 @@
-﻿namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models;
+﻿using System.Diagnostics.CodeAnalysis;
 
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models;
+
+[ExcludeFromCodeCoverage] // Database model POCO
 public class Group
 {
     public string? GroupUid { get; set; }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Group.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Group.cs
@@ -1,0 +1,46 @@
+﻿namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models;
+
+public class Group
+{
+    public string? GroupUid { get; set; }
+
+    public string? GroupId { get; set; }
+
+    public string? GroupName { get; set; }
+
+    public string? CompaniesHouseNumber { get; set; }
+
+    public string? GroupTypeCode { get; set; }
+
+    public string? GroupType { get; set; }
+
+    public string? ClosedDate { get; set; }
+
+    public string? GroupStatusCode { get; set; }
+
+    public string? GroupStatus { get; set; }
+
+    public string? GroupContactStreet { get; set; }
+
+    public string? GroupContactLocality { get; set; }
+
+    public string? GroupContactAddress3 { get; set; }
+
+    public string? GroupContactTown { get; set; }
+
+    public string? GroupContactCounty { get; set; }
+
+    public string? GroupContactPostcode { get; set; }
+
+    public string? HeadOfGroupTitle { get; set; }
+
+    public string? HeadOfGroupFirstName { get; set; }
+
+    public string? HeadOfGroupLastName { get; set; }
+
+    public string? Ukprn { get; set; }
+
+    public string? IncorporatedOnOpenDate { get; set; }
+
+    public string? OpenDate { get; set; }
+}

--- a/DfE.FindInformationAcademiesTrusts.sln
+++ b/DfE.FindInformationAcademiesTrusts.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademie
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademiesTrusts.Data.AcademiesDb", "DfE.FindInformationAcademiesTrusts.Data.AcademiesDb\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj", "{5E03FD8B-A86F-4E66-A67A-BC53B3032B44}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +22,10 @@ Global
 		{0A3416F9-33DB-4870-97EA-7CFF8D828031}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0A3416F9-33DB-4870-97EA-7CFF8D828031}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0A3416F9-33DB-4870-97EA-7CFF8D828031}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E03FD8B-A86F-4E66-A67A-BC53B3032B44}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E03FD8B-A86F-4E66-A67A-BC53B3032B44}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E03FD8B-A86F-4E66-A67A-BC53B3032B44}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E03FD8B-A86F-4E66-A67A-BC53B3032B44}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0A3416F9-33DB-4870-97EA-7CFF8D828031} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}

--- a/DfE.FindInformationAcademiesTrusts.sln
+++ b/DfE.FindInformationAcademiesTrusts.sln
@@ -8,6 +8,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E22DC2DA
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademiesTrusts.Data.AcademiesDb", "DfE.FindInformationAcademiesTrusts.Data.AcademiesDb\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj", "{5E03FD8B-A86F-4E66-A67A-BC53B3032B44}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests", "tests\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj", "{E20D30CB-8EB1-453B-8C49-77CAFBF16A13}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,8 +28,13 @@ Global
 		{5E03FD8B-A86F-4E66-A67A-BC53B3032B44}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E03FD8B-A86F-4E66-A67A-BC53B3032B44}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5E03FD8B-A86F-4E66-A67A-BC53B3032B44}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E20D30CB-8EB1-453B-8C49-77CAFBF16A13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E20D30CB-8EB1-453B-8C49-77CAFBF16A13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E20D30CB-8EB1-453B-8C49-77CAFBF16A13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E20D30CB-8EB1-453B-8C49-77CAFBF16A13}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0A3416F9-33DB-4870-97EA-7CFF8D828031} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}
+		{E20D30CB-8EB1-453B-8C49-77CAFBF16A13} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}
 	EndGlobalSection
 EndGlobal

--- a/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
+++ b/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
@@ -17,6 +17,10 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.11">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Identity.Web" Version="2.14.0"/>
         <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.20.0"/>
         <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.20.0"/>
@@ -37,5 +41,9 @@
         <None Include=".stylelintrc.json">
             <CopyToOutputDirectory>Never</CopyToOutputDirectory>
         </None>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj"/>
     </ItemGroup>
 </Project>

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -1,10 +1,12 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.CookiePolicy;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Microsoft.Identity.Web;
 using Serilog;
@@ -141,6 +143,10 @@ internal static class Program
 
     private static void AddDependenciesTo(WebApplicationBuilder builder)
     {
+        builder.Services.AddDbContext<AcademiesDbContext>(options =>
+            options.UseSqlServer(builder.Configuration.GetConnectionString("AcademiesDb") ??
+                                 throw new InvalidOperationException("Connection string 'AcademiesDb' not found.")));
+
         builder.Services.AddScoped<ITrustSearch, TrustSearch>();
         builder.Services.AddScoped<ITrustProvider, TrustProvider>();
 

--- a/DfE.FindInformationAcademiesTrusts/appsettings.json
+++ b/DfE.FindInformationAcademiesTrusts/appsettings.json
@@ -16,6 +16,9 @@
     "RedirectUri": "",
     "CallbackPath": "/signin-oidc"
   },
+  "ConnectionStrings": {
+    "AcademiesDb": ""
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,6 +36,7 @@ dotnet user-secrets set "AcademiesApi:Key" "[secret goes here]"
 dotnet user-secrets set "AzureAd:ClientID" "[secret goes here]"
 dotnet user-secrets set "AzureAd:ClientSecret" "[secret goes here]"
 dotnet user-secrets set "AzureAd:TenantID" "[secret goes here]"
+dotnet user-secrets set "ConnectionStrings:AcademiesDb" "[secret goes here]"
 ```
 
 ### Build and watch frontend assets

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Usings.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
This change configures a connection to academies database, and adds a model for the `Gias.Group` table.

We are migrating from using the Academies API to fetch Trust data to the Academies database, and this is the first step.

This is related to [User Story 134572](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/134572): Build: Connect to Academies DB

<!-- Do you need to add any environment variables? -->
To make the successful connection the following user secrets will need to be added:
`ConnectionStrings:AcademiesDb`

## Changes

- Created `DfE.FindInformationAcademiesTrusts.AcademiesDb` and `DfE.FindInformationAcademiesTrusts.AcademiesDb.UnitTests` projects, which will host the database models and provider classes.  
- Installed Entity Framework Core nuget packages: `SqlServer` and `Design`
- Added database connection string to dotnet user secrets and appsettings.json
- Initialise DbContext on application start
- Ran scaffolding against AcademiesDb `Gias.Group` table to create DbContext
- Updated documentation with new user secrets

## Checklist

- [ ] Update GitHub secrets
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
