### PR TITLE
Add tools manifest

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "7.0.11",
+      "commands": [
+        "dotnet-ef"
+      ]
+    },
+    "dotnet-stryker": {
+      "version": "3.10.0",
+      "commands": [
+        "dotnet-stryker"
+      ]
+    }
+  }
+}

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -55,7 +55,7 @@ jobs:
       run: dotnet tool install --global dotnet-coverage
 
     - name: Install dotnet-stryker (mutation testing tool)
-      run: dotnet tool install --global dotnet-stryker
+      run: dotnet tool restore
 
     - name: Build and Analyse solution
       env:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,6 +53,7 @@ You will need to stop (`ctrl-c`) and rerun the script if you change any saved im
 
 ### Build and run dotnet project
 
+- Install project tools by running `dotnet tool restore` from project directory.
 - Ensure you have [built the frontend assets](#build-and-watch-frontend-assets) before building the dotnet project.
 - Run/debug project as normal in your chosen IDE
 
@@ -169,9 +170,11 @@ We recommend setting Rider to run unit tests on save, for fast feedback on chang
 ### Analyse test coverage
 
 This project uses a [mutation score](https://stryker-mutator.io/docs/) to analyse effective test coverage when opening up a new pull request.
-To check these scores locally you will need to [install Stryker.Net](https://stryker-mutator.io/docs/stryker-net/getting-started/).
+Stryker.Net is included in our dotnet-tools manifest for checking mutation score locally. 
 
-Once Stryker is installed, run the following to run and open a Stryker report:
+Install tools by running `dotnet tool restore`.
+
+Run the following to run and open a Stryker report:
 
 ```bash
 dotnet stryker -o


### PR DESCRIPTION
This adds a manifest file to the project for managing local tools. This will minimise setup required for developers, and ensure consistency across development environments. 

It also reduces conflicts that can arise from different IDEs installing .NET and global tools in different locations.

It is related to [Task 141589](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/141589?McasTsid=26110&McasCtx=4): Setup dotnet tools project settings

## Changes

- Add manifest file `dotnet-tools.json`
- Install the following tools locally:
  - Stryker.NET: for generating mutation test scores
  - Entity Framework Core tools: for scaffolding models for connection to the Academies database
- Update 'Getting started' documentation to step to install local tools
- Edit `Build, analyse and test .NET code` workflow to replace global installation of `dotnet-stryker` with installation of local tools. When a tool is installed locally a global installation in CI causes the pipeline to fail. 

## Potential improvements

Is it worth adding all tools used in the  `Build, analyse and test .NET code` workflow to our tools manifest so that there is just one installation step? 

## Checklist

- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed