### PR TITLE
Update getting started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,6 +30,7 @@ Use this documentation to configure your local development environment.
 Use the dotnet user secrets tool to set local secrets, any missing required secrets will cause the application to fail at startup with an exception detailing which secrets are missing.
 
 ```bash
+cd DfE.FindInformationAcademiesTrusts
 dotnet user-secrets set "AcademiesApi:Endpoint" "[secret goes here]"
 dotnet user-secrets set "AcademiesApi:Key" "[secret goes here]"
 dotnet user-secrets set "AzureAd:ClientID" "[secret goes here]"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,7 +109,7 @@ WIREMOCK_BASEURL="http://localhost:8080"
 2. Open a terminal in your repository and run:
 
 ```bash
-cd DfE.FindInformationAcademiesTrusts.UnitTests/playwright
+cd tests/playwright
 
 # install dependencies
 npm install

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,6 +113,7 @@ cd tests/playwright
 
 # install dependencies
 npm install
+npx playwright install
 
 # run docker image with an application rebuild
 npm run docker:start


### PR DESCRIPTION
This change fixes a couple of mistakes or steps overlooked in the `Getting started` documentation for _Find information about academies and trusts_, found when onboarding new team members. 

It is related to [Task 141983](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/141983?McasTsid=26110&McasCtx=4): Update github docs with any observations from onboarding

## Changes

- Specify directory from which to add .NET user secrets
- Fix directory from which to setup and run Playwright tests
- Add missing `npx playwright install` step

## Screenshots of UI changes

N/A

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
