### PR TITLE
Add `**-feature` to PR github actions trigger

### DIFF
--- a/.github/workflows/continuous-integration-assets-playwright.yml
+++ b/.github/workflows/continuous-integration-assets-playwright.yml
@@ -1,8 +1,9 @@
 name: Lint assets and playwright tests
 on:
   pull_request:
-    branches:
-      - main
+    branches: [ main, '**-feature' ]
+    types: [ opened, synchronize, reopened]
+
 env:
   NODE_VERSION: 18.13.0
 jobs:

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, '**-feature' ]
     types: [ opened, synchronize, reopened]
 
 env:

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -2,7 +2,7 @@ name: Deploy to environment
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, '**-feature' ]
     types: [ opened, synchronize, reopened]
   push:
     branches: [ main ]

--- a/.github/workflows/test-isolated-ui.yml
+++ b/.github/workflows/test-isolated-ui.yml
@@ -2,7 +2,7 @@ name: Run UI tests on isolated environment
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, '**-feature' ]
     types: [ opened, synchronize, reopened]
   push:
     branches: [ main ]


### PR DESCRIPTION
We are using feature branches to manage longer running pieces of work and want to be able to PR into these protected branches so we can review the code as work progresses. This change lets us do that and also standardises the notation used to specify branch triggers.

[Task 142119](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/142119): Configure github actions to run on prs to feature branches

## Changes

- Add `**-feature` to PR github actions trigger
- Use the same notation for branch matching across workflow files 

## Screenshots of UI changes

n/a

## Checklist

- [x] Attach this pull request to the appropriate user story in Azure DevOps
