### PR TITLE
Add phase banner

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Header.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Header.cshtml
@@ -16,3 +16,18 @@
 
   </div>
 </header>
+
+<div class="app-banner app-banner--s">
+  <div class="dfe-width-container">
+    <div class="govuk-phase-banner">
+      <p class="govuk-phase-banner__content">
+        <strong class="govuk-tag govuk-phase-banner__content__tag">
+          Beta
+        </strong>
+        <span class="govuk-phase-banner__text">
+          This is a new product – your <a class="govuk-link" href="@ViewConstants.FeedbackFormLink" target="_blank">feedback (opens in a new tab)</a> will help us to improve it.
+        </span>
+      </p>
+    </div>
+  </div>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
@@ -7,4 +7,7 @@ public static class ViewConstants
 
     public const string ReportAProblemLink =
         "https://forms.office.com.mcas.ms/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VCFjdIWb7BPh79bON_K__tUNzdaMUNUR0ozOVpDRFBGMTVTRlNETUlOWi4u";
+
+    public const string FeedbackFormLink =
+        "https://forms.office.com.mcas.ms/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-VCFjdIWb7BPh79bON_K__tUOTdJMlZZUzBMMFhHV1lHNERFM041U0dUUy4u";
 }

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
@@ -19,6 +19,10 @@
     @include govuk-responsive-padding(9, "top");
     @include govuk-responsive-padding(8, "bottom");
   }
+
+  &.app-banner--s {
+    @include govuk-responsive-padding(0);
+  }
 }
 
 .app-search-results-summary-list {

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_variables.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_variables.scss
@@ -1,4 +1,4 @@
-$app-color-blue-light: #e6eff4;
+$app-color-blue-light: #ebf2f6;
 
 // colours taken from DfE Frontend
 $app-color-dfe-blue: #003a69;


### PR DESCRIPTION
[User Story 136779](https://dev.azure.com.mcas.ms/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/136779?McasTsid=26110&McasCtx=4): Build: Phase banner (BETA)

This change adds the GOV.UK phase banner component to show users your service is still being worked on. 

We have changed the design slightly to match the background colour of our app banners, used on the home page and trust pages. The feedback form link opens an external Microsoft Office form in a new window.

## Changes

- Add GOV.UK [phase banner](https://design-system.service.gov.uk/components/phase-banner/) component to Header partial. 
- Change colour used in `app-banner` class, as the contrast ratio between the background colour and link text was not passing WCAG AA criteria

## Screenshots of UI changes

### Before

Screenshot showing old banner colour: 
<img width="1424" alt="" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/b777b93b-74c6-4998-b525-774b5f9fd5e5">

### After

Screenshot showing new banner colour and new beta phase banner on homepage: 
<img width="1426" alt="" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/aec2c3c7-d97f-480d-b3c0-6e694311cc46">

Phase banner on search page: 
<img width="1424" alt="" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/3472921b-f49d-4d39-a2d1-92dbbf2f39e8">

## Checklist

- [x] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
