### PR TITLE
Add Link for users to report problems

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
@@ -6,6 +6,10 @@
   ViewData["Title"] = string.IsNullOrWhiteSpace(Model.KeyWords) ? "Search" : $"{Model.KeyWords} - Search";
 }
 
+@section reportProblem {
+    <partial name="_ReportProblemLink"/>
+}
+
 <div class="govuk-grid-row govuk-!-margin-bottom-6">
   <div class="govuk-grid-column-one-half">
     <form class="govuk-form-group app-search" role="search" aria-label="sitewide">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_ContentLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_ContentLayout.cshtml
@@ -7,5 +7,6 @@
     <main id="main-content" role="main">
       @RenderBody()
     </main>
+    @RenderSection("reportProblem", required: false)
   </div>
 </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_ReportProblemLink.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_ReportProblemLink.cshtml
@@ -1,1 +1,3 @@
-﻿<a class="govuk-body govuk-link govuk-link--no-visited-state" href="@ViewConstants.ReportAProblemLink">Report a problem with information on this page</a>
+﻿<div class="govuk-!-margin-top-8 govuk-!-margin-bottom-4">
+  <a class="govuk-body govuk-link" href="@ViewConstants.ReportAProblemLink">Report a problem with information on this page</a>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_ReportProblemLink.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_ReportProblemLink.cshtml
@@ -1,0 +1,1 @@
+﻿<a class="govuk-body govuk-link govuk-link--no-visited-state" href="@ViewConstants.ReportAProblemLink">Report a problem with information on this page</a>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
@@ -30,6 +30,7 @@
           </header>
           @RenderBody()
         </main>
+        <partial name="_ReportProblemLink" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Adds a link on the Trust and search pages to take users to the feedback and problems form, allowing them to report problems they have using FIAT.
[User Story](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/134802)

## Changes

Created a new partial for the report issues link
Added a report issues section on the content layout
Used the partial on the details layout and the search page through the report issues section

## Screenshots of UI changes

### Before
<img width="623" alt="OldDetails" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/128540970/b8d1f636-b481-4e9d-88df-5ade3c0e55b8">
<img width="634" alt="OldSearch" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/128540970/87c70948-672c-4e02-92f4-4905df4df5f4">

### After
<img width="625" alt="NewDetails" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/128540970/22d0c3cb-ec38-4cf7-ba48-cddf36532e47">
<img width="615" alt="NewSearch" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/128540970/1c0abeee-8ce8-42b6-818f-e90ebf49802f">

## Checklist

- [x] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
