### PR TITLE
Deprecated resource policy

### DIFF
--- a/terraform/ci-storage.tf
+++ b/terraform/ci-storage.tf
@@ -30,9 +30,5 @@ resource "azurerm_monitor_diagnostic_setting" "ci-test-reports" {
 
   metric {
     category = "Transaction"
-
-    retention_policy {
-      enabled = false
-    }
   }
 }


### PR DESCRIPTION
The retention period for storage diagnostic logs is no longer accepted as a property of the diagnostic_setting resource, and instead is now defined at a policy level assigned to the storage account.

## Changes

Removed deprecated property from the diagnostic setting resource
