### PR TITLE
Reduce Digital Scotland design system imports

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_resets.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_resets.scss
@@ -2,4 +2,5 @@ ul,
 ol,
 dd {
   margin: 0;
+  padding: 0;
 }

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_side-navigation.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_side-navigation.scss
@@ -5,10 +5,6 @@
     padding: 0 40px 8px 0;
   }
 
-  &__list &__list {
-    margin-left: -16px;
-  }
-
   &__item--has-children {
     @include govuk-responsive-margin(6, "top");
     @include govuk-responsive-margin(6, "bottom");
@@ -19,6 +15,10 @@
   .app-side-navigation {
     &__item--has-children {
       @include govuk-responsive-margin(0, "top");
+    }
+
+    &__list &__list {
+      margin-left: -16px;
     }
   }
 }

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/imports/_digital-scotland.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/imports/_digital-scotland.scss
@@ -46,5 +46,26 @@ $ds_breakpoints: (
 $ds_colour__brand: $govuk-link-colour;
 // stylelint-enable scss/dollar-variable-pattern
 
-@import "@scottish-government/pattern-library/src/base/all-base";
+@import "@scottish-government/pattern-library/src/base/helpers/all";
+@import "@scottish-government/pattern-library/src/base/settings/all";
+@import "@scottish-government/pattern-library/src/base/tools/all";
+@import "@scottish-government/pattern-library/src/base/core/box-sizing/box-sizing";
+@import "@scottish-government/pattern-library/src/base/utilities/all";
+
+// Digital Scotland core element styles are also applied to the html element tag, which we do not want, so directly applying the dslink media query to the dslink class
+// from DfE.FindInformationAcademiesTrusts/node_modules/@scottish-government/pattern-library/src/base/core/links/_links.scss
+.ds_link {
+  @include ds_link;
+  background: transparent;
+  border: 0;
+  display: inline;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  margin: 0;
+  min-height: 0;
+  min-width: 0;
+  padding: 0;
+  text-align: left; // .ds_link applied to a button would otherwise have centered text
+}
 @import "@scottish-government/pattern-library/src/components/side-navigation/side-navigation";


### PR DESCRIPTION
We have installed the Digital Scotland Design system in order to use the [Side Navigation](https://designsystem.gov.scot/components/side-navigation) component for Trust page layouts. 

While we have only imported the component we are using into our scss files, we also need to import the base styles so that the file has access to Digital Scotland colour variables and media queries. 

However, the base styles are also responsible for setting up global Digital Scotland styles to html tags such as `a` and `ul`. As we are using the GOV.UK design system to manage global styles, we only have a need to use certain components on top of this. 

This change updates our imports of the Digital Scotland to only the required variables, media queries and mix-ins for the component rather than all base styles. 

We do need the `ds-link` style from the core styles, as this is programmatically applied in the js version of side nav. Unfortunately this is tied to the `a` tag in the stylesheet, so directly applying the style in our `_digital-scotland.scss` imports file, using the `@ds-link` mixin.

This is related to [Bug 142219](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/142219?McasTsid=26110&McasCtx=4): Use of Digital Scotland Design system has changed some global styles.

## Changes

- remove the -`/all-base` scss import from the Digital Scotland pattern library, as described in the [Getting started instructions](https://designsystem.gov.scot/get-started/css), and replace it with imports for helpers, settings, tools and utilities stylesheets. These contain helpers, variables and mixins used in the component, but no styles.
- Manually apply the `ds_link` style as per the [core link styles](https://github.com/scottish-government-design-system/design-system/blob/main/src/base/core/links/_links.scss). This is required to ensure that the same styles are not applied to the `a` tag.
- Import the `box-sizing` styles as the component appears incorrectly on small screens with JavaScript turned off without this. This does not seem to negatively affect other components, but we may need to keep an eye on this. 
- Remove our extension of the Side Navigation styles to add left alignment for nested links on smaller screens, as the button first styles applied using JavaScript result in the link target area being cut off on the left of the text. 

## Screenshots of UI changes

### Before

Screenshot of search page showing unwanted Digital Scotland hover style on links
![](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/38f1f443-7327-4aca-9191-c469b9e03b62)

Screenshot of collapsed side-navigation with cut-off target area
![](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/115ffffa-8d70-4642-a421-6cf40b1e97fc)

### After

Screenshot of search page showing GOV.UK hover style on links
<img width="1440" alt="" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/e05dc600-b9c0-4629-91ef-6e82545b99d7">

Screenshot of collapsed side-navigation with Digital Scotland's horizontal nesting - allowing full target area
![](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/019a47cc-88ae-40c8-a931-be3c4b21a390)


## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
