### PR TITLE
Fix app displaying GDS Transport font

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/assets/index.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/index.scss
@@ -6,28 +6,3 @@
 .govuk-width-container {
   max-width: 1200px;
 }
-
-body,
-p,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-a,
-span,
-div,
-input,
-table,
-th,
-td,
-blockquote,
-ol,
-li,
-dt,
-dd,
-tr {
-  font-family: BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu,
-    Cantarell, "Helvetica Neue", sans-serif !important; // stylelint-disable-line declaration-no-important
-}

--- a/DfE.FindInformationAcademiesTrusts/assets/index.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/index.scss
@@ -2,7 +2,3 @@
 @import "./sass/imports";
 @import "./sass/resets";
 @import "./sass/components";
-
-.govuk-width-container {
-  max-width: 1200px;
-}

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_imports.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_imports.scss
@@ -1,6 +1,9 @@
 $govuk-assets-path: "/node_modules/govuk-frontend/govuk/assets/";
+
+// Add DfE design system styles
 $govuk-font-family: blinkmacsystemfont, "Segoe UI", roboto, oxygen-sans, ubuntu,
   cantarell, "Helvetica Neue", sans-serif;
+$govuk-page-width: 1200px;
 
 @import "govuk-frontend/govuk/all";
 @import "accessible-autocomplete";

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_imports.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_imports.scss
@@ -1,4 +1,7 @@
 $govuk-assets-path: "/node_modules/govuk-frontend/govuk/assets/";
+$govuk-font-family: blinkmacsystemfont, "Segoe UI", roboto, oxygen-sans, ubuntu,
+  cantarell, "Helvetica Neue", sans-serif;
+
 @import "govuk-frontend/govuk/all";
 @import "accessible-autocomplete";
 @import "./imports/digital-scotland";


### PR DESCRIPTION
The title on the home page of our application is using GDS Transport font rather than the system font. We cannot use GDS Transport fonts on applications which are not hosted on `service.gov.uk` due to licensing issues.

The issue is caused by the use of a nested `label` element within the `h1` tag as suggested in the GOV.UK Design system guidance for the [text input component](https://design-system.service.gov.uk/components/text-input/).

To resolve the issue, I have opted to change the method of overriding the GDS Transport font—rather than overriding the font for every html tag we might use using the `!important` tag (which is not recommended), have instead set the `$govuk-font-family` variable to the DfE font before importing the GOV.UK styles. This is an easier method, and means we shouldn't need to keep updating the element list.

This is related to [Bug 140961](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/140961?McasTsid=26110&McasCtx=4): Label elements use GOV.UK Transport font

## Changes

- Remove font override code from index.scss
- Set the value of `$govuk-font-family` to be the required fonts for DfE products.

## Screenshots of UI changes

### Before

Screenshot showing GDS transport font used on the app title
![](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/c9c0e3c0-c4b7-4cde-ab51-a40c992de01c)

### After

Screenshot showing system font used in app title
<img width="1438" alt="" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/8cfe450a-b7d5-4da9-a26f-312a3375ffb0">

## Checklist

- [x] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
