### PR TITLE
Removal of references to ukprn from code base

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
@@ -17,7 +17,7 @@ public class TrustProvider : ITrustProvider
         _academiesDbContext = academiesDbContext;
     }
 
-    public async Task<Trust?> GetTrustByUkprnAsync(string groupUid)
+    public async Task<Trust?> GetTrustByGroupUidAsync(string groupUid)
     {
         Trust? trust = null;
 
@@ -25,7 +25,8 @@ public class TrustProvider : ITrustProvider
         if (group is not null)
         {
             trust = new Trust(
-                group.GroupName,
+                group.GroupUid!,
+                group.GroupName ?? string.Empty,
                 group.Ukprn,
                 group.GroupType ?? string.Empty
             );

--- a/DfE.FindInformationAcademiesTrusts.Data/ITrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/ITrustProvider.cs
@@ -2,5 +2,5 @@ namespace DfE.FindInformationAcademiesTrusts.Data;
 
 public interface ITrustProvider
 {
-    public Task<Trust?> GetTrustByUkprnAsync(string groupUid);
+    public Task<Trust?> GetTrustByGroupUidAsync(string groupUid);
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Trust.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Trust.cs
@@ -1,3 +1,3 @@
 namespace DfE.FindInformationAcademiesTrusts.Data;
 
-public record Trust(string Name, string? Ukprn, string Type);
+public record Trust(string GroupUid, string Name, string? Ukprn, string Type);

--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml.cs
@@ -27,7 +27,7 @@ public class SearchModel : PageModel, ISearchFormModel
     {
         if (!string.IsNullOrWhiteSpace(TrustId))
         {
-            var trust = await _trustProvider.GetTrustByUkprnAsync(TrustId);
+            var trust = await _trustProvider.GetTrustByGroupUidAsync(TrustId);
             if (trust != null && string.Equals(trust.Name, KeyWords, StringComparison.CurrentCultureIgnoreCase))
             {
                 return RedirectToPage("/Trusts/Details", new { Uid = TrustId });

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml.cs
@@ -20,7 +20,7 @@ public class ContactsModel : PageModel, ITrustsAreaModel
 
     public async Task<IActionResult> OnGetAsync()
     {
-        var trust = await _trustProvider.GetTrustByUkprnAsync(Uid);
+        var trust = await _trustProvider.GetTrustByGroupUidAsync(Uid);
 
         if (trust == null)
         {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Details.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Details.cshtml.cs
@@ -21,7 +21,7 @@ public class DetailsModel : PageModel, ITrustsAreaModel
 
     public async Task<IActionResult> OnGetAsync()
     {
-        var trust = await _trustProvider.GetTrustByUkprnAsync(Uid);
+        var trust = await _trustProvider.GetTrustByGroupUidAsync(Uid);
 
         if (trust == null)
         {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
@@ -19,12 +19,12 @@
       <div class="govuk-caption-m app-side-navigation__title">@ViewConstants.AboutTheTrustSectionName</div>
       <ul class="ds_side-navigation__list app-side-navigation__list">
         <li class="ds_side-navigation__item app-side-navigation-highlight-item">
-          <a asp-page="./Details" asp-route-ukprn="@Model.Trust.Ukprn" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Details")">
+          <a asp-page="./Details" asp-route-uid="@Model.Trust.GroupUid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Details")">
             <span class="visually-hidden">Trust</span>Details
           </a>
         </li>
         <li class="ds_side-navigation__item app-side-navigation-highlight-item">
-          <a asp-page="./Contacts" asp-route-ukprn="@Model.Trust.Ukprn" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Contacts")">
+          <a asp-page="./Contacts" asp-route-uid="@Model.Trust.GroupUid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Contacts")">
             <span class="visually-hidden">Trust</span>Contacts
           </a>
         </li>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
@@ -16,22 +16,22 @@ public class TrustProviderTests
     }
 
     [Fact]
-    public async Task GetTrustsByUkprnAsync_should_return_a_trust_if_group_found()
+    public async Task GetTrustsByGroupUidAsync_should_return_a_trust_if_group_found()
     {
         _groups.Add(new Group
             { GroupName = "trust 1", GroupUid = "1234", GroupType = "Multi-academy trust", Ukprn = "my ukprn" });
 
-        var result = await _sut.GetTrustByUkprnAsync("1234");
+        var result = await _sut.GetTrustByGroupUidAsync("1234");
 
-        result.Should().BeEquivalentTo(new Trust("trust 1",
+        result.Should().BeEquivalentTo(new Trust("1234", "trust 1",
             "my ukprn",
             "Multi-academy trust"));
     }
 
     [Fact]
-    public async Task GetTrustsByUkprnAsync_should_return_null_when_group_not_found()
+    public async Task GetTrustsByGroupUidAsync_should_return_null_when_group_not_found()
     {
-        var result = await _sut.GetTrustByUkprnAsync("987654321");
+        var result = await _sut.GetTrustByGroupUidAsync("987654321");
         result.Should().BeNull();
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/SearchModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/SearchModelTests.cs
@@ -27,9 +27,9 @@ public class SearchModelTests
     };
 
     private readonly Trust _fakeTrust =
-        new("trust 1", "2044", "Multi-academy trust");
+        new("123", "trust 1", "2044", "Multi-academy trust");
 
-    private const string _trustId = "1234";
+    private const string TrustId = "1234";
 
     [Fact]
     public async Task OnGetAsync_should_search_if_query_parameter()
@@ -55,9 +55,9 @@ public class SearchModelTests
     [Fact]
     public async Task OnGetAsync_should_redirect_to_trust_details_if_given_trustId()
     {
-        _sut.TrustId = _trustId;
+        _sut.TrustId = TrustId;
         _sut.KeyWords = "trust 1";
-        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync(_trustId).Result)
+        _mockTrustProvider.Setup(s => s.GetTrustByGroupUidAsync(TrustId).Result)
             .Returns(_fakeTrust);
 
         var result = await _sut.OnGetAsync();
@@ -70,16 +70,16 @@ public class SearchModelTests
     [Fact]
     public async Task OnGetAsync_should_pass_trustId_to_trust_details_if_given_trustId()
     {
-        _sut.TrustId = _trustId;
+        _sut.TrustId = TrustId;
         _sut.KeyWords = "trust 1";
-        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync(_trustId).Result)
+        _mockTrustProvider.Setup(s => s.GetTrustByGroupUidAsync(TrustId).Result)
             .Returns(_fakeTrust);
 
         var result = await _sut.OnGetAsync();
 
         result.Should().BeOfType<RedirectToPageResult>();
         var redirectResult = (RedirectToPageResult)result;
-        redirectResult.RouteValues.Should().ContainKey("Uid").WhoseValue.Should().Be(_trustId);
+        redirectResult.RouteValues.Should().ContainKey("Uid").WhoseValue.Should().Be(TrustId);
     }
 
     [Fact]
@@ -88,12 +88,12 @@ public class SearchModelTests
         const string query = "trust 3";
 
         _mockTrustSearch.Setup(s => s.SearchAsync(query).Result).Returns(_fakeTrusts);
-        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync(_trustId).Result)
+        _mockTrustProvider.Setup(s => s.GetTrustByGroupUidAsync(TrustId).Result)
             .Returns(_fakeTrust);
 
         _mockTrustSearch.Setup(s => s.SearchAsync(query).Result).Returns(_fakeTrusts);
         _sut.KeyWords = query;
-        _sut.TrustId = _trustId;
+        _sut.TrustId = TrustId;
 
         var result = await _sut.OnGetAsync();
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
@@ -16,17 +16,17 @@ public class ContactsModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_should_fetch_a_trust_by_ukprn()
+    public async void OnGetAsync_should_fetch_a_trust_by_GroupUid()
     {
-        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1234").Result)
-            .Returns(new Trust("test", "test", "Multi-academy trust"));
+        _mockTrustProvider.Setup(s => s.GetTrustByGroupUidAsync("1234").Result)
+            .Returns(new Trust("test", "test", "test", "Multi-academy trust"));
         _sut.Uid = "1234";
         await _sut.OnGetAsync();
-        _sut.Trust.Should().BeEquivalentTo(new Trust("test", "test", "Multi-academy trust"));
+        _sut.Trust.Should().BeEquivalentTo(new Trust("test", "test", "test", "Multi-academy trust"));
     }
 
     [Fact]
-    public async void Ukprn_should_be_empty_string_by_default()
+    public async void GroupUid_should_be_empty_string_by_default()
     {
         await _sut.OnGetAsync();
         _sut.Uid.Should().BeEquivalentTo(string.Empty);
@@ -47,7 +47,7 @@ public class ContactsModelTests
     [Fact]
     public async void OnGetAsync_should_return_not_found_result_if_trust_is_not_found()
     {
-        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1111").Result)
+        _mockTrustProvider.Setup(s => s.GetTrustByGroupUidAsync("1111").Result)
             .Returns((Trust?)null);
 
         _sut.Uid = "1111";
@@ -57,7 +57,7 @@ public class ContactsModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_should_return_not_found_result_if_Ukprn_is_not_provided()
+    public async void OnGetAsync_should_return_not_found_result_if_GroupUid_is_not_provided()
     {
         var result = await _sut.OnGetAsync();
         result.Should().BeOfType<NotFoundResult>();

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/DetailsModelTests.cs
@@ -16,18 +16,18 @@ public class DetailsModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_should_fetch_a_trust_by_ukprn()
+    public async void OnGetAsync_should_fetch_a_trust_by_groupUid()
     {
-        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1234").Result)
-            .Returns(new Trust("test", "test", "Multi-academy trust"));
+        _mockTrustProvider.Setup(s => s.GetTrustByGroupUidAsync("1234").Result)
+            .Returns(new Trust("test", "test", "test", "Multi-academy trust"));
         _sut.Uid = "1234";
 
         await _sut.OnGetAsync();
-        _sut.Trust.Should().BeEquivalentTo(new Trust("test", "test", "Multi-academy trust"));
+        _sut.Trust.Should().BeEquivalentTo(new Trust("test", "test", "test", "Multi-academy trust"));
     }
 
     [Fact]
-    public async void Ukprn_should_be_empty_string_by_default()
+    public async void GroupUid_should_be_empty_string_by_default()
     {
         await _sut.OnGetAsync();
         _sut.Uid.Should().BeEquivalentTo(string.Empty);
@@ -48,7 +48,7 @@ public class DetailsModelTests
     [Fact]
     public async void OnGetAsync_should_return_not_found_result_if_trust_is_not_found()
     {
-        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1111").Result)
+        _mockTrustProvider.Setup(s => s.GetTrustByGroupUidAsync("1111").Result)
             .Returns((Trust?)null);
 
         _sut.Uid = "1111";


### PR DESCRIPTION
the GroupUid will be used as the primary reference number when retrieving trusts. ukprn will still be a value returned and references to it will remain, just not used as the main identifier for the trust object


## Changes

all references to the ukprn as a main identifier for the trust object will be changed to GroupUid



- this branch will be added as a pull request into the feature branch 'academies-db-connection/trust-provider' rather than main
