### PR TITLE
Enable app insights on the client 

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Layout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Layout.cshtml
@@ -14,6 +14,9 @@
   <link rel="apple-touch-icon" sizes="152x152" href="~/dist/images/govuk-apple-touch-icon-152x152.png">
   <link rel="apple-touch-icon" href="~/dist/images/govuk-apple-touch-icon.png">
   <link rel="stylesheet" href="~/dist/main.css"/>
+  <script asp-add-nonce>
+    @Html.Raw(AppInsightsSnippet.ScriptBody)
+  </script>
 </head>
 
 <body class="govuk-template__body ">

--- a/DfE.FindInformationAcademiesTrusts/Pages/_ViewImports.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/_ViewImports.cshtml
@@ -1,4 +1,6 @@
 ﻿@using DfE.FindInformationAcademiesTrusts
+@using Microsoft.ApplicationInsights.AspNetCore
 @namespace DfE.FindInformationAcademiesTrusts.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, NetEscapades.AspNetCore.SecurityHeaders.TagHelpers
+@inject JavaScriptSnippet AppInsightsSnippet

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -110,7 +110,12 @@ internal static class Program
                 cspBuilder.AddScriptSrc()
                     .Self()
                     .UnsafeInline()
-                    .WithNonce();
+                    .WithNonce()
+                    .From("https://js.monitor.azure.com/scripts/b/ai.2.min.js");
+                cspBuilder.AddConnectSrc()
+                    .Self()
+                    .WithNonce()
+                    .From("https://*.in.applicationinsights.azure.com//v2/track");
                 cspBuilder.AddObjectSrc().None();
                 cspBuilder.AddBlockAllMixedContent();
                 cspBuilder.AddImgSrc().Self();

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -32,6 +32,7 @@ internal static class Program
 
             builder.Services.AddRazorPages();
             builder.Services.AddHealthChecks();
+            builder.Services.AddApplicationInsightsTelemetry();
             AddAuthenticationServices(builder);
 
             builder.Services.Configure<RouteOptions>(options =>
@@ -212,7 +213,6 @@ internal static class Program
         }
         else
         {
-            builder.Services.AddApplicationInsightsTelemetry();
             builder.Host.UseSerilog((_, services, loggerConfiguration) => loggerConfiguration
                 .ReadFrom.Configuration(builder.Configuration)
                 .WriteTo.ApplicationInsights(services.GetRequiredService<TelemetryConfiguration>(),

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -114,7 +114,6 @@ internal static class Program
                     .From("https://js.monitor.azure.com/scripts/b/ai.2.min.js");
                 cspBuilder.AddConnectSrc()
                     .Self()
-                    .WithNonce()
                     .From("https://*.in.applicationinsights.azure.com//v2/track");
                 cspBuilder.AddObjectSrc().None();
                 cspBuilder.AddBlockAllMixedContent();

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,7 @@ Use this documentation to configure your local development environment.
   - [Set up continuous testing](#set-up-continuous-testing)
   - [Analyse test coverage](#analyse-test-coverage)
   - [Configure linting and code cleanup](#configure-linting-and-code-cleanup)
+- [Application Insights](#application-insights)
 
 ## Get it working (without Docker)
 
@@ -215,3 +216,16 @@ cd DfE.FindInformationAcademiesTrusts
 npm run lint ## for a list of issues
 npm run lint:fix ## to scan and fix issues
 ```
+
+## Application Insights
+
+App insights is the platform we are using for measuring telemetry. By default app insights is on in dev and test environments and off when running locally or building in a pipeline.
+
+App insights can be enabled locally by including the conncection string in your secrets file. The format should be `"APPLICATIONINSIGHTS_CONNECTION_STRING": "<Connection string here"`
+You can copy the connection string from Azure. Always use the development environment when testing locally.
+
+### Tracking events
+We are tracking page views and requests automatically. If you would like to track your own events then us the TrackEvent method.
+You can track events in the client using javascript or on the server using the app insights module.
+
+More info can be found here https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -126,8 +126,9 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.1 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.73.0 |
+| <a name="requirement_statuscake"></a> [statuscake](#requirement\_statuscake) | >= 2.1.0 |
 
 ## Providers
 
@@ -141,7 +142,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 |------|--------|---------|
 | <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v1.1.0 |
 | <a name="module_azurerm_key_vault"></a> [azurerm\_key\_vault](#module\_azurerm\_key\_vault) | github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars | v0.2.1 |
-| <a name="module_statuscake-tls-monitor"></a> [statuscake-tls-monitor](#module\_statuscake-tls-monitor) | github.com/dfe-digital/terraform-statuscake-tls-monitor | v0.1.1 |
+| <a name="module_statuscake-tls-monitor"></a> [statuscake-tls-monitor](#module\_statuscake-tls-monitor) | github.com/dfe-digital/terraform-statuscake-tls-monitor | v0.1.2 |
 
 ## Resources
 
@@ -202,9 +203,11 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_redis_cache_capacity"></a> [redis\_cache\_capacity](#input\_redis\_cache\_capacity) | Redis Cache Capacity | `number` | n/a | yes |
 | <a name="input_redis_cache_sku"></a> [redis\_cache\_sku](#input\_redis\_cache\_sku) | Redis Cache SKU | `string` | n/a | yes |
-| <a name="input_statuscake_api_token"></a> [statuscake\_api\_token](#input\_statuscake\_api\_token) | API token for StatusCake | `string` | n/a | yes |
+| <a name="input_statuscake_api_token"></a> [statuscake\_api\_token](#input\_statuscake\_api\_token) | API token for StatusCake | `string` | `"00000000000000000000000000000"` | no |
+| <a name="input_statuscake_contact_group_email_addresses"></a> [statuscake\_contact\_group\_email\_addresses](#input\_statuscake\_contact\_group\_email\_addresses) | List of email address that should receive notifications from StatusCake | `list(string)` | `[]` | no |
 | <a name="input_statuscake_contact_group_integrations"></a> [statuscake\_contact\_group\_integrations](#input\_statuscake\_contact\_group\_integrations) | List of Integration IDs to connect to your Contact Group | `list(string)` | `[]` | no |
 | <a name="input_statuscake_contact_group_name"></a> [statuscake\_contact\_group\_name](#input\_statuscake\_contact\_group\_name) | Name of the contact group in StatusCake | `string` | `""` | no |
+| <a name="input_statuscake_monitored_resource_addresses"></a> [statuscake\_monitored\_resource\_addresses](#input\_statuscake\_monitored\_resource\_addresses) | The URLs to perform TLS checks on | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | n/a | yes |
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | tfvars filename. This file is uploaded and stored encrypted within Key Vault, to ensure that the latest tfvars are stored in a shared place. | `string` | n/a | yes |
 | <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual network address space CIDR | `string` | n/a | yes |

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -49,8 +49,8 @@ locals {
   key_vault_access_users                       = var.key_vault_access_users
   key_vault_access_ipv4                        = var.key_vault_access_ipv4
   tfvars_filename                              = var.tfvars_filename
-  statuscake_api_token                         = var.statuscake_api_token
-  statuscake_monitored_resource_address        = "https://${local.dns_zone_domain_name}${local.monitor_endpoint_healthcheck}"
+  statuscake_monitored_resource_addresses      = var.statuscake_monitored_resource_addresses
   statuscake_contact_group_name                = var.statuscake_contact_group_name
   statuscake_contact_group_integrations        = var.statuscake_contact_group_integrations
+  statuscake_contact_group_email_addresses     = var.statuscake_contact_group_email_addresses
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -2,3 +2,7 @@ provider "azurerm" {
   features {}
   skip_provider_registration = true
 }
+
+provider "statuscake" {
+  api_token = var.statuscake_api_token
+}

--- a/terraform/statuscake-tls-monitor.tf
+++ b/terraform/statuscake-tls-monitor.tf
@@ -1,12 +1,11 @@
 module "statuscake-tls-monitor" {
-  source = "github.com/dfe-digital/terraform-statuscake-tls-monitor?ref=v0.1.1"
+  source = "github.com/dfe-digital/terraform-statuscake-tls-monitor?ref=v0.1.2"
 
-  statuscake_api_token                  = local.statuscake_api_token
-  statuscake_monitored_resource_address = local.statuscake_monitored_resource_address
+  statuscake_monitored_resource_addresses = local.statuscake_monitored_resource_addresses
   statuscake_alert_at = [ # days to alert on
     14, 7, 3
   ]
   statuscake_contact_group_name            = local.statuscake_contact_group_name
   statuscake_contact_group_integrations    = local.statuscake_contact_group_integrations
-  statuscake_contact_group_email_addresses = local.monitor_email_receivers
+  statuscake_contact_group_email_addresses = local.statuscake_contact_group_email_addresses
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -282,6 +282,7 @@ variable "statuscake_api_token" {
   description = "API token for StatusCake"
   type        = string
   sensitive   = true
+  default     = "00000000000000000000000000000"
 }
 
 variable "statuscake_contact_group_name" {
@@ -292,6 +293,18 @@ variable "statuscake_contact_group_name" {
 
 variable "statuscake_contact_group_integrations" {
   description = "List of Integration IDs to connect to your Contact Group"
+  type        = list(string)
+  default     = []
+}
+
+variable "statuscake_monitored_resource_addresses" {
+  description = "The URLs to perform TLS checks on"
+  type        = list(string)
+  default     = []
+}
+
+variable "statuscake_contact_group_email_addresses" {
+  description = "List of email address that should receive notifications from StatusCake"
   type        = list(string)
   default     = []
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,9 +1,13 @@
 terraform {
-  required_version = ">= 1.5.7"
+  required_version = ">= 1.6.1"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.73.0"
+    }
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = ">= 2.1.0"
     }
   }
 }


### PR DESCRIPTION
[User Story 139068](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/139068): Build: connect App Insights to our Test or Dev environment
Enable client side telemetry to be sent to application insights. We are now tracking page view in addition to the requests we were already tracking.

## Changes

Moved App insights initializer so it can be enabled in development mode. This means that developers can track events when running locally. This can be enabled or disabled by putting the connection string into the secrets file or by setting is as an environment variable.
Updated the Content security policy to allow for app insights script to load and for telemetry to be sent back to app insights.
Add the snippet to the layout to load it onto all files.

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
