### PR TITLE
Trust details page feature

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Details.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Details.cshtml
@@ -3,3 +3,102 @@
 @{
   Layout = "_TrustLayout";
 }
+
+<section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
+  <div class="govuk-summary-card">
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title">Trust details</h2>
+    </div>
+    <div class="govuk-summary-card__content">
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Address
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Dorthy Inlet, Kingston upon Hull, City of, JY36 9VC
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Opened on
+          </dt>
+          <dd class="govuk-summary-list__value">
+            30 Dec 2013
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Region and territory
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Yorkshire and the Humber
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Information from other services (opens in a new tab)
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p class="govuk-body">
+              <a class="govuk-link" href="#">Companies House</a>
+            </p>
+            <p class="govuk-body">
+              <a class="govuk-link" href="#">Get information about schools</a>
+            </p>
+            <p class="govuk-body">
+              <a class="govuk-link" href="#">Schools financial benchmarking</a>
+            </p>
+            <p class="govuk-body">
+              <a class="govuk-link" href="#">Find school college and performance data in England</a>
+            </p>
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+</section>
+
+<section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
+  <div class="govuk-summary-card">
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title">Reference numbers</h2>
+    </div>
+    <div class="govuk-summary-card__content">
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            UID (Unique group identifier)
+          </dt>
+          <dd class="govuk-summary-list__value">
+            2412
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Group ID (identifier) and TRN (trust reference number)
+          </dt>
+          <dd class="govuk-summary-list__value">
+            TR3971
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            UKPRN (UK provider reference number)
+          </dt>
+          <dd class="govuk-summary-list__value">
+            10013796
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Companies House number
+          </dt>
+          <dd class="govuk-summary-list__value">
+            03080547
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+</section>

--- a/tests/playwright/accessibility-tests/trusts/details-page.spec.ts
+++ b/tests/playwright/accessibility-tests/trusts/details-page.spec.ts
@@ -7,7 +7,8 @@ test.describe('Details page', () => {
     await detailsPage.goTo()
     await detailsPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
     await detailsPage.trustNavigation.expect.toBeVisible()
-
+    await detailsPage.expect.toSeeCorrectTrustDetails()
+    await detailsPage.expect.toSeeCorrectTrustReferenceNumbers()
     await expectNoAccessibilityViolations()
   })
 })

--- a/tests/playwright/page-object-model/trust/details-page.ts
+++ b/tests/playwright/page-object-model/trust/details-page.ts
@@ -8,12 +8,16 @@ export class DetailsPage {
   readonly trustHeading: TrustHeaderComponent
   readonly trustNavigation: TrustNavigationComponent
   readonly pageHeadingLocator: Locator
+  readonly trustDetailsCardLocator: Locator
+  readonly referenceNumbersCardLocator: Locator
 
   constructor (readonly page: Page) {
     this.expect = new DetailsPageAssertions(this)
     this.trustHeading = new TrustHeaderComponent(page)
     this.trustNavigation = new TrustNavigationComponent(page)
     this.pageHeadingLocator = page.locator('h1')
+    this.trustDetailsCardLocator = this.page.getByText('Trust details Address')
+    this.referenceNumbersCardLocator = this.page.getByText('Reference numbers UID')
   }
 
   async goTo (
@@ -39,5 +43,18 @@ class DetailsPageAssertions {
   async toSeeCorrectTrustNameAndTypeInHeader (): Promise<void> {
     const { name, type } = MockTrustsProvider.expectedFormattedTrustResult
     await this.detailsPage.trustHeading.expect.toSeeCorrectTrustNameAndType(name, type)
+  }
+
+  async toSeeCorrectTrustDetails (): Promise<void> {
+    await expect(this.detailsPage.trustDetailsCardLocator).toContainText('Address Dorthy Inlet, Kingston upon Hull, City of, JY36 9VC')
+    await expect(this.detailsPage.trustDetailsCardLocator).toContainText('Opened on 30 Dec 2013')
+    await expect(this.detailsPage.trustDetailsCardLocator).toContainText('Region and territory Yorkshire and the Humber')
+  }
+
+  async toSeeCorrectTrustReferenceNumbers (): Promise<void> {
+    await expect(this.detailsPage.referenceNumbersCardLocator).toContainText('UID (Unique group identifier) 2412')
+    await expect(this.detailsPage.referenceNumbersCardLocator).toContainText('Group ID (identifier) and TRN (trust reference number) TR3971')
+    await expect(this.detailsPage.referenceNumbersCardLocator).toContainText('UKPRN (UK provider reference number) 10013796')
+    await expect(this.detailsPage.referenceNumbersCardLocator).toContainText('Companies House number 03080547')
   }
 }

--- a/tests/playwright/ui-tests/trusts/details-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/details-page.spec.ts
@@ -16,6 +16,11 @@ test.describe('Details page', () => {
     await detailsPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
   })
 
+  test('user should see the correct trust information', async () => {
+    await detailsPage.expect.toSeeCorrectTrustDetails()
+    await detailsPage.expect.toSeeCorrectTrustReferenceNumbers()
+  })
+
   test.describe('given a user tries to visit the url without an existing trust', () => {
     test.beforeEach(({ page }) => {
       notFoundPage = new NotFoundPage(page)


### PR DESCRIPTION
This change adds the UI template for the trust details page as part of [User Story 143960](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/143960?McasTsid=26110&McasCtx=4): Build: Trust details page - UI

We have separated out the UI template work from the data integration, so the page is currently displaying static (hard-coded) dummy data about the trust. Our UI tests test against this same dummy data, and so are expected to fail when we add the integration to the academies db.

**Related work required to complete this page:** [User Story 127514](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/127514?McasTsid=26110&McasCtx=4): Build: Trust details page - data

## Changes

- Add summary cards components for trust details page, containing dummy text
- Update details page Page Object Model(playwright) to include same dummy data to test against
- Add UI test for the expected trust information to be displayed on the page
- Update accessibility test to ensure the cards are showing before scanning for WCAG violations

## Screenshots of UI changes

![Screenshot with new summary card components](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/d2e5c8e1-43d2-4f99-b2bb-e640b945bdfb) 

![Screenshot of trust details page template](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/b4cc28d7-0ae6-40f6-acf6-3c8536bd8102)

## Checklist

- [x] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
