### PR TITLE
Deploy multiple SSL Checks from using StatusCake

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -126,8 +126,9 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.1 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.73.0 |
+| <a name="requirement_statuscake"></a> [statuscake](#requirement\_statuscake) | >= 2.1.0 |
 
 ## Providers
 
@@ -141,7 +142,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 |------|--------|---------|
 | <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v1.1.0 |
 | <a name="module_azurerm_key_vault"></a> [azurerm\_key\_vault](#module\_azurerm\_key\_vault) | github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars | v0.2.1 |
-| <a name="module_statuscake-tls-monitor"></a> [statuscake-tls-monitor](#module\_statuscake-tls-monitor) | github.com/dfe-digital/terraform-statuscake-tls-monitor | v0.1.1 |
+| <a name="module_statuscake-tls-monitor"></a> [statuscake-tls-monitor](#module\_statuscake-tls-monitor) | github.com/dfe-digital/terraform-statuscake-tls-monitor | v0.1.2 |
 
 ## Resources
 
@@ -202,9 +203,11 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_redis_cache_capacity"></a> [redis\_cache\_capacity](#input\_redis\_cache\_capacity) | Redis Cache Capacity | `number` | n/a | yes |
 | <a name="input_redis_cache_sku"></a> [redis\_cache\_sku](#input\_redis\_cache\_sku) | Redis Cache SKU | `string` | n/a | yes |
-| <a name="input_statuscake_api_token"></a> [statuscake\_api\_token](#input\_statuscake\_api\_token) | API token for StatusCake | `string` | n/a | yes |
+| <a name="input_statuscake_api_token"></a> [statuscake\_api\_token](#input\_statuscake\_api\_token) | API token for StatusCake | `string` | `"00000000000000000000000000000"` | no |
+| <a name="input_statuscake_contact_group_email_addresses"></a> [statuscake\_contact\_group\_email\_addresses](#input\_statuscake\_contact\_group\_email\_addresses) | List of email address that should receive notifications from StatusCake | `list(string)` | `[]` | no |
 | <a name="input_statuscake_contact_group_integrations"></a> [statuscake\_contact\_group\_integrations](#input\_statuscake\_contact\_group\_integrations) | List of Integration IDs to connect to your Contact Group | `list(string)` | `[]` | no |
 | <a name="input_statuscake_contact_group_name"></a> [statuscake\_contact\_group\_name](#input\_statuscake\_contact\_group\_name) | Name of the contact group in StatusCake | `string` | `""` | no |
+| <a name="input_statuscake_monitored_resource_addresses"></a> [statuscake\_monitored\_resource\_addresses](#input\_statuscake\_monitored\_resource\_addresses) | The URLs to perform TLS checks on | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | n/a | yes |
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | tfvars filename. This file is uploaded and stored encrypted within Key Vault, to ensure that the latest tfvars are stored in a shared place. | `string` | n/a | yes |
 | <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual network address space CIDR | `string` | n/a | yes |

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -49,8 +49,8 @@ locals {
   key_vault_access_users                       = var.key_vault_access_users
   key_vault_access_ipv4                        = var.key_vault_access_ipv4
   tfvars_filename                              = var.tfvars_filename
-  statuscake_api_token                         = var.statuscake_api_token
-  statuscake_monitored_resource_address        = "https://${local.dns_zone_domain_name}${local.monitor_endpoint_healthcheck}"
+  statuscake_monitored_resource_addresses      = var.statuscake_monitored_resource_addresses
   statuscake_contact_group_name                = var.statuscake_contact_group_name
   statuscake_contact_group_integrations        = var.statuscake_contact_group_integrations
+  statuscake_contact_group_email_addresses     = var.statuscake_contact_group_email_addresses
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -2,3 +2,7 @@ provider "azurerm" {
   features {}
   skip_provider_registration = true
 }
+
+provider "statuscake" {
+  api_token = var.statuscake_api_token
+}

--- a/terraform/statuscake-tls-monitor.tf
+++ b/terraform/statuscake-tls-monitor.tf
@@ -1,12 +1,11 @@
 module "statuscake-tls-monitor" {
-  source = "github.com/dfe-digital/terraform-statuscake-tls-monitor?ref=v0.1.1"
+  source = "github.com/dfe-digital/terraform-statuscake-tls-monitor?ref=v0.1.2"
 
-  statuscake_api_token                  = local.statuscake_api_token
-  statuscake_monitored_resource_address = local.statuscake_monitored_resource_address
+  statuscake_monitored_resource_addresses = local.statuscake_monitored_resource_addresses
   statuscake_alert_at = [ # days to alert on
     14, 7, 3
   ]
   statuscake_contact_group_name            = local.statuscake_contact_group_name
   statuscake_contact_group_integrations    = local.statuscake_contact_group_integrations
-  statuscake_contact_group_email_addresses = local.monitor_email_receivers
+  statuscake_contact_group_email_addresses = local.statuscake_contact_group_email_addresses
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -282,6 +282,7 @@ variable "statuscake_api_token" {
   description = "API token for StatusCake"
   type        = string
   sensitive   = true
+  default     = "00000000000000000000000000000"
 }
 
 variable "statuscake_contact_group_name" {
@@ -292,6 +293,18 @@ variable "statuscake_contact_group_name" {
 
 variable "statuscake_contact_group_integrations" {
   description = "List of Integration IDs to connect to your Contact Group"
+  type        = list(string)
+  default     = []
+}
+
+variable "statuscake_monitored_resource_addresses" {
+  description = "The URLs to perform TLS checks on"
+  type        = list(string)
+  default     = []
+}
+
+variable "statuscake_contact_group_email_addresses" {
+  description = "List of email address that should receive notifications from StatusCake"
   type        = list(string)
   default     = []
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,9 +1,13 @@
 terraform {
-  required_version = ">= 1.5.7"
+  required_version = ">= 1.6.1"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.73.0"
+    }
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = ">= 2.1.0"
     }
   }
 }


### PR DESCRIPTION
- The StatusCake module requires us to specify the minimum terraform of 1.6.1
- Updating to version 0.1.2 of StatusCake module allows us to associate multiple SSL checks with a single contact group, rather than having a 1:1 relationship.
- Setting the API token to `00000000000000000000000000000` means that we can skip the validation that requires us to specify this. Essentially, this makes the StatusCake module conditionally deployable.
- Specifying `statuscake_contact_group_email_addresses` instead of using the email addresses used for infrastructure monitoring ensures that the list doesnt change per environment. e.g. In Production, there are more email receivers for infra monitoring compared to Dev. Whereas we want everyone to be notified about TLS certs expiry.
