### PR TITLE
Enable app insights client telemetry

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Layout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Layout.cshtml
@@ -14,6 +14,9 @@
   <link rel="apple-touch-icon" sizes="152x152" href="~/dist/images/govuk-apple-touch-icon-152x152.png">
   <link rel="apple-touch-icon" href="~/dist/images/govuk-apple-touch-icon.png">
   <link rel="stylesheet" href="~/dist/main.css"/>
+  <script asp-add-nonce>
+    @Html.Raw(AppInsightsSnippet.ScriptBody)
+  </script>
 </head>
 
 <body class="govuk-template__body ">

--- a/DfE.FindInformationAcademiesTrusts/Pages/_ViewImports.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/_ViewImports.cshtml
@@ -1,4 +1,6 @@
 ﻿@using DfE.FindInformationAcademiesTrusts
+@using Microsoft.ApplicationInsights.AspNetCore
 @namespace DfE.FindInformationAcademiesTrusts.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, NetEscapades.AspNetCore.SecurityHeaders.TagHelpers
+@inject JavaScriptSnippet AppInsightsSnippet

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -32,6 +32,7 @@ internal static class Program
 
             builder.Services.AddRazorPages();
             builder.Services.AddHealthChecks();
+            builder.Services.AddApplicationInsightsTelemetry();
             AddAuthenticationServices(builder);
 
             builder.Services.Configure<RouteOptions>(options =>
@@ -212,7 +213,6 @@ internal static class Program
         }
         else
         {
-            builder.Services.AddApplicationInsightsTelemetry();
             builder.Host.UseSerilog((_, services, loggerConfiguration) => loggerConfiguration
                 .ReadFrom.Configuration(builder.Configuration)
                 .WriteTo.ApplicationInsights(services.GetRequiredService<TelemetryConfiguration>(),

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -110,7 +110,11 @@ internal static class Program
                 cspBuilder.AddScriptSrc()
                     .Self()
                     .UnsafeInline()
-                    .WithNonce();
+                    .WithNonce()
+                    .From("https://js.monitor.azure.com/scripts/b/ai.2.min.js");
+                cspBuilder.AddConnectSrc()
+                    .Self()
+                    .From("https://*.in.applicationinsights.azure.com//v2/track");
                 cspBuilder.AddObjectSrc().None();
                 cspBuilder.AddBlockAllMixedContent();
                 cspBuilder.AddImgSrc().Self();

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -221,8 +221,8 @@ npm run lint:fix ## to scan and fix issues
 
 App insights is the platform we are using for measuring telemetry. By default app insights is on in dev and test environments and off when running locally or building in a pipeline.
 
-App insights can be enabled locally by including the conncection string in your secrets file. The format should be `"APPLICATIONINSIGHTS_CONNECTION_STRING": "<Connection string here"`
-You can copy the connection string from Azure. Always use the development environment when testing locally.
+App insights can be enabled locally by including the conncection string in your secrets file. The format should be `"APPLICATIONINSIGHTS_CONNECTION_STRING": "<Connection String here>"`
+You can copy the connection string from Azure. Go the the app insights instance (Current instance name is `s184d01-fiat-insights`) and on the overview panel you can copy the connection string. Always use the development environment when testing locally.
 
 ### Tracking events
 We are tracking page views and requests automatically. If you would like to track your own events then us the TrackEvent method.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,7 @@ Use this documentation to configure your local development environment.
   - [Set up continuous testing](#set-up-continuous-testing)
   - [Analyse test coverage](#analyse-test-coverage)
   - [Configure linting and code cleanup](#configure-linting-and-code-cleanup)
+- [Application Insights](#application-insights)
 
 ## Get it working (without Docker)
 
@@ -215,3 +216,16 @@ cd DfE.FindInformationAcademiesTrusts
 npm run lint ## for a list of issues
 npm run lint:fix ## to scan and fix issues
 ```
+
+## Application Insights
+
+App insights is the platform we are using for measuring telemetry. By default app insights is on in dev and test environments and off when running locally or building in a pipeline.
+
+App insights can be enabled locally by including the conncection string in your secrets file. The format should be `"APPLICATIONINSIGHTS_CONNECTION_STRING": "<Connection string here"`
+You can copy the connection string from Azure. Always use the development environment when testing locally.
+
+### Tracking events
+We are tracking page views and requests automatically. If you would like to track your own events then us the TrackEvent method.
+You can track events in the client using javascript or on the server using the app insights module.
+
+More info can be found here https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview


### PR DESCRIPTION
RECREATED PR

[User Story 139068](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/139068): Build: connect App Insights to our Test or Dev environment
Enable client side telemetry to be sent to application insights. We are now tracking page view in addition to the requests we were already tracking.

## Changes
Moved App insights initializer so it can be enabled in development mode. This means that developers can track events when running locally. This can be enabled or disabled by putting the connection string into the secrets file or by setting is as an environment variable.
Updated the Content security policy to allow for app insights script to load and for telemetry to be sent back to app insights.
Add the snippet to the layout to load it onto all files.

## Checklist
- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed