### PR TITLE
anti forgery tokens added to all search forms

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Index.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Index.cshtml
@@ -9,7 +9,7 @@
     <div class="dfe-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half">
-          <form class="govuk-form-group app-search" asp-page="Search" method="get" role="search" aria-label="sitewide">
+          <form class="govuk-form-group app-search" asp-page="Search" method="get" role="search" aria-label="sitewide" asp-antiforgery="true">
             <h1 class="govuk-label-wrapper">
               <label class="govuk-label govuk-label--xl app-banner--heading govuk-!-margin-bottom-8" for="@Model.InputId">
                 Find information about academies and trusts

--- a/DfE.FindInformationAcademiesTrusts/Pages/Index.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Index.cshtml
@@ -9,7 +9,8 @@
     <div class="dfe-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half">
-          <form class="govuk-form-group app-search" asp-page="Search" method="get" role="search" aria-label="sitewide" asp-antiforgery="true">
+          <form class="govuk-form-group app-search" asp-page="Search" method="get" role="search" aria-label="sitewide">
+            @Html.AntiForgeryToken()
             <h1 class="govuk-label-wrapper">
               <label class="govuk-label govuk-label--xl app-banner--heading govuk-!-margin-bottom-8" for="@Model.InputId">
                 Find information about academies and trusts

--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
@@ -7,12 +7,12 @@
 }
 
 @section reportProblem {
-    <partial name="_ReportProblemLink"/>
+  <partial name="_ReportProblemLink"/>
 }
 
 <div class="govuk-grid-row govuk-!-margin-bottom-6">
   <div class="govuk-grid-column-one-half">
-    <form class="govuk-form-group app-search" role="search" aria-label="sitewide">
+    <form class="govuk-form-group app-search" role="search" aria-label="sitewide" asp-antiforgery="true">
       <h1 class="govuk-label-wrapper">
         <label class="govuk-label govuk-label--l" for="@Model.InputId">
           Search

--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
@@ -12,7 +12,8 @@
 
 <div class="govuk-grid-row govuk-!-margin-bottom-6">
   <div class="govuk-grid-column-one-half">
-    <form class="govuk-form-group app-search" role="search" aria-label="sitewide" asp-antiforgery="true">
+    <form class="govuk-form-group app-search" role="search" aria-label="sitewide">
+      @Html.AntiForgeryToken()
       <h1 class="govuk-label-wrapper">
         <label class="govuk-label govuk-label--l" for="@Model.InputId">
           Search

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_SearchForm.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_SearchForm.cshtml
@@ -9,7 +9,6 @@
     <div id="@Model.InputId-no-js-search-container">
       <input class="govuk-input app-search__input" id="@Model.InputId" type="search" asp-for="KeyWords" name="keywords">
     </div>
-    @Html.AntiForgeryToken()
     <button class="govuk-button app-search__button app-search__button--blue" type="submit">
       <svg class="app-search__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_SearchForm.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_SearchForm.cshtml
@@ -9,7 +9,7 @@
     <div id="@Model.InputId-no-js-search-container">
       <input class="govuk-input app-search__input" id="@Model.InputId" type="search" asp-for="KeyWords" name="keywords">
     </div>
-
+    @Html.AntiForgeryToken()
     <button class="govuk-button app-search__button app-search__button--blue" type="submit">
       <svg class="app-search__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -158,6 +158,39 @@ TEST_USER_ACCOUNT_PASSWORD="<insert here>" #
  npm run test:integration
 ```
 
+### Owasp Zap security tests
+
+To run the owasp zap security scanner locally on the test or dev environments.
+
+1. Run the owasp zap api in docker, please note the post scan test report will be sent to wherever you run this command from. Always stop and restart the owasp zap api in docker before evey test run to ensure you get a clean test report. 
+
+```bash
+docker run --rm -v ${PWD}:/zap/wrk/:rw -u zap -p 8083:8083 -i owasp/zap2docker-stable zap.sh -daemon -host 0.0.0.0 -port 8083 -config api.disablekey=true -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true
+```
+
+2. Add these environment variables to the .env file in the playwright folder.
+
+```bash
+cd tests/playwright/.env
+
+# add these environmental variable to .env file
+
+PLAYWRIGHT_BASEURL="https://dev.find-information-academies-trusts.education.gov.uk/"
+TEST_USER_ACCOUNT_NAME="<test user>"
+TEST_USER_ACCOUNT_PASSWORD="<test users password>"
+HTTP_PROXY="http://localhost:8083/"
+ZAP=true
+ZAP_PORT=8083
+```
+3. run the tests
+
+```bash
+cd tests/playwright
+
+npx playwright test --project=zap-tests --trace=on
+```
+
+
 ## Supercharge your dev environment
 
 We recommend using Rider or Visual Studio with ReSharper.


### PR DESCRIPTION
anti forgery tokens added to the search forms to enhance security as suggested by the owasp zap scanner. this will help prevent cross site security attacks..i have tried implementing a global solution but it owasp zap still asks that anti forgery tokens be added to each form. you can see a similar implementation in the 'external' code base for prepare


https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/136824

## Changes

anti forgery tags added to forms 

## Screenshots of UI changes

## Checklist
