### PR TITLE
Trust overview page UI

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
@@ -88,7 +88,6 @@
                 </tr>
               </tbody>
             </table>
-            <div aria-live="polite" role="status" aria-atomic="true" class="govuk-visually-hidden"></div>
           </div>
         </section>
       </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
@@ -9,7 +9,7 @@
   <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-1">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
-        <section class="govuk-summary-card" aria-labelledby="trust-information">
+        <section class="govuk-summary-card">
           <div class="govuk-summary-card__title-wrapper">
             <h2 class="govuk-summary-card__title" id="trust-information">Trust summary</h2>
           </div>
@@ -53,7 +53,7 @@
         </section>
       </div>
       <div class="govuk-grid-column-one-half">
-        <section class="govuk-summary-card" aria-labelledby="ofsted-ratings">
+        <section class="govuk-summary-card">
           <div class="govuk-summary-card__title-wrapper">
             <h2 class="govuk-summary-card__title" id="ofsted-ratings">Ofsted ratings</h2>
           </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "{ukprn}"
 @model OverviewModel
 
 @{

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
@@ -58,7 +58,7 @@
             <h2 class="govuk-summary-card__title" id="ofsted-ratings">Ofsted ratings</h2>
           </div>
           <div class="govuk-summary-card__content">
-            <table class="govuk-table" data-module="moj-sortable-table">
+            <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="ofsted-ratings">
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                   <th scope="col" class="govuk-table__header" aria-sort="ascending">Rating</th>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
@@ -1,0 +1,97 @@
+﻿@page
+@model OverviewModel
+
+@{
+  Layout = "_TrustLayout";
+}
+
+<section>
+  <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-1">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <section class="govuk-summary-card" aria-labelledby="trust-information">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title" id="trust-information">Trust summary</h2>
+          </div>
+          <div class="govuk-summary-card__content">
+            <dl class="govuk-summary-list">
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                  Total academies
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  4
+                </dd>
+              </div>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                  Academies in each local authority
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  <p class="govuk-!-margin-bottom-1">3 in North Lincolnshire</p>
+                  <p class="govuk-!-margin-bottom-1">1 in North East Lincolnshire</p>
+                </dd>
+              </div>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                  Pupil numbers
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  4,896
+                </dd>
+              </div>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key govuk-!-width-one-half">
+                  Pupil capacity <br>(% full)
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  6,463<br>(76%)
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </section>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <section class="govuk-summary-card" aria-labelledby="ofsted-ratings">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title" id="ofsted-ratings">Ofsted ratings</h2>
+          </div>
+          <div class="govuk-summary-card__content">
+            <table class="govuk-table" data-module="moj-sortable-table">
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header" aria-sort="ascending">Rating</th>
+                  <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-width-one-third" aria-sort="none">Number of schools</th>
+                </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell" data-sort-value="1">Outstanding</td>
+                  <td class="govuk-table__cell govuk-table__cell--numeric">3</td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell" data-sort-value="2">Good</td>
+                  <td class="govuk-table__cell govuk-table__cell--numeric">5</td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell" data-sort-value="3">Requires improvement</td>
+                  <td class="govuk-table__cell govuk-table__cell--numeric">2</td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell" data-sort-value="4">Inadequate</td>
+                  <td class="govuk-table__cell govuk-table__cell--numeric">3</td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell" data-sort-value="5">Not yet inspected</td>
+                  <td class="govuk-table__cell govuk-table__cell--numeric">4</td>
+                </tr>
+              </tbody>
+            </table>
+            <div aria-live="polite" role="status" aria-atomic="true" class="govuk-visually-hidden"></div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
@@ -9,7 +9,7 @@
   <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-1">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
-        <section class="govuk-summary-card">
+        <section class="govuk-summary-card" data-testid="trust-summary">
           <div class="govuk-summary-card__title-wrapper">
             <h2 class="govuk-summary-card__title" id="trust-information">Trust summary</h2>
           </div>
@@ -53,7 +53,7 @@
         </section>
       </div>
       <div class="govuk-grid-column-one-half">
-        <section class="govuk-summary-card">
+        <section class="govuk-summary-card" data-testid="ofsted-ratings">
           <div class="govuk-summary-card__title-wrapper">
             <h2 class="govuk-summary-card__title" id="ofsted-ratings">Ofsted ratings</h2>
           </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
@@ -28,8 +28,8 @@
                   Academies in each local authority
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  <p class="govuk-!-margin-bottom-1">3 in North Lincolnshire</p>
-                  <p class="govuk-!-margin-bottom-1">1 in North East Lincolnshire</p>
+                  <p class="govuk-body govuk-!-margin-bottom-1">3 in North Lincolnshire</p>
+                  <p class="govuk-body govuk-!-margin-bottom-1">1 in North East Lincolnshire</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
@@ -61,30 +61,30 @@
             <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="ofsted-ratings">
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                  <th scope="col" class="govuk-table__header" aria-sort="ascending">Rating</th>
-                  <th scope="col" class="govuk-table__header govuk-table__header--numeric govuk-!-width-one-third" aria-sort="none">Number of schools</th>
+                  <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Rating</th>
+                  <th scope="col" class="govuk-body govuk-table__header govuk-table__header--numeric govuk-!-width-one-third" aria-sort="none">Number of schools</th>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
-                  <td class="govuk-table__cell" data-sort-value="1">Outstanding</td>
-                  <td class="govuk-table__cell govuk-table__cell--numeric">3</td>
+                  <td class="govuk-body govuk-table__cell" data-sort-value="1">Outstanding</td>
+                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">3</td>
                 </tr>
                 <tr class="govuk-table__row">
-                  <td class="govuk-table__cell" data-sort-value="2">Good</td>
-                  <td class="govuk-table__cell govuk-table__cell--numeric">5</td>
+                  <td class="govuk-body govuk-table__cell" data-sort-value="2">Good</td>
+                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">5</td>
                 </tr>
                 <tr class="govuk-table__row">
-                  <td class="govuk-table__cell" data-sort-value="3">Requires improvement</td>
-                  <td class="govuk-table__cell govuk-table__cell--numeric">2</td>
+                  <td class="govuk-body govuk-table__cell" data-sort-value="3">Requires improvement</td>
+                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">2</td>
                 </tr>
                 <tr class="govuk-table__row">
-                  <td class="govuk-table__cell" data-sort-value="4">Inadequate</td>
-                  <td class="govuk-table__cell govuk-table__cell--numeric">3</td>
+                  <td class="govuk-body govuk-table__cell" data-sort-value="4">Inadequate</td>
+                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">3</td>
                 </tr>
                 <tr class="govuk-table__row">
-                  <td class="govuk-table__cell" data-sort-value="5">Not yet inspected</td>
-                  <td class="govuk-table__cell govuk-table__cell--numeric">4</td>
+                  <td class="govuk-body govuk-table__cell" data-sort-value="5">Not yet inspected</td>
+                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">4</td>
                 </tr>
               </tbody>
             </table>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+
+public class OverviewModel : PageModel, ITrustsAreaModel
+{
+    private readonly ITrustProvider _trustProvider;
+
+    public OverviewModel(ITrustProvider trustProvider)
+    {
+        _trustProvider = trustProvider;
+    }
+
+    [BindProperty(SupportsGet = true)] public string Ukprn { get; set; } = "";
+    public Trust Trust { get; set; } = default!;
+    public string PageName => "Overview";
+    public string Section => ViewConstants.AboutTheTrustSectionName;
+
+
+    public async Task<IActionResult> OnGetAsync()
+    {
+        var trust = await _trustProvider.GetTrustByUkprnAsync(Ukprn);
+
+        if (trust == null)
+        {
+            return new NotFoundResult();
+        }
+
+        Trust = trust;
+        return Page();
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
@@ -24,6 +24,11 @@
           </a>
         </li>
         <li class="ds_side-navigation__item app-side-navigation-highlight-item">
+          <a asp-page="./Overview" asp-route-ukprn="@Model.Trust.Ukprn" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Overview")">
+            <span class="visually-hidden">Trust</span>Overview
+          </a>
+        </li>
+        <li class="ds_side-navigation__item app-side-navigation-highlight-item">
           <a asp-page="./Contacts" asp-route-ukprn="@Model.Trust.Ukprn" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Contacts")">
             <span class="visually-hidden">Trust</span>Contacts
           </a>

--- a/DfE.FindInformationAcademiesTrusts/assets/index.js
+++ b/DfE.FindInformationAcademiesTrusts/assets/index.js
@@ -1,8 +1,20 @@
 import GOVUKFrontend from 'govuk-frontend/govuk/all'
 import { Autocomplete } from './javascripts/autocomplete'
 import SideNavigation from '@scottish-government/pattern-library/src/components/side-navigation/side-navigation'
+import $ from 'jquery'
+import { SortableTable, nodeListForEach } from '@ministryofjustice/frontend'
+
+window.$ = $
 
 GOVUKFrontend.initAll()
+
+// Sortable table initialisation from the MOJ Frontend library
+const sortableTables = document.querySelectorAll('[data-module="moj-sortable-table"]')
+nodeListForEach(sortableTables, table =>
+  new SortableTable({
+    table
+  })
+)
 
 const sideNavs = [].slice.call(document.querySelectorAll('[data-module="ds-side-navigation"]'))
 sideNavs.forEach(accordion =>

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_imports.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_imports.scss
@@ -8,3 +8,4 @@ $govuk-page-width: 1200px;
 @import "govuk-frontend/govuk/all";
 @import "accessible-autocomplete";
 @import "./imports/digital-scotland";
+@import "@ministryofjustice/frontend/moj/components/sortable-table/sortable-table";

--- a/DfE.FindInformationAcademiesTrusts/package-lock.json
+++ b/DfE.FindInformationAcademiesTrusts/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@ministryofjustice/frontend": "^1.8.0",
         "accessible-autocomplete": "^2.0.4",
-        "govuk-frontend": "^4.6.0"
+        "govuk-frontend": "^4.6.0",
+        "jquery": "^3.7.1"
       },
       "devDependencies": {
         "@babel/core": "^7.21.8",
@@ -1968,6 +1970,21 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
+    },
+    "node_modules/@ministryofjustice/frontend": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-1.8.0.tgz",
+      "integrity": "sha512-N4791HcFoqJNLNrK6EN4oMaTJjeFp9ileavCpXkda3qvpEWQByxZUsOd6sDA69FuLRpB6jBFL2C2bqfYbcTdqg==",
+      "dependencies": {
+        "govuk-frontend": "^3.0.0 || ^4.0.0",
+        "moment": "^2.27.0"
+      },
+      "engines": {
+        "node": ">= 4.2.0"
+      },
+      "peerDependencies": {
+        "jquery": "^3.6.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5132,6 +5149,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5563,6 +5585,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -9871,6 +9901,15 @@
         }
       }
     },
+    "@ministryofjustice/frontend": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-1.8.0.tgz",
+      "integrity": "sha512-N4791HcFoqJNLNrK6EN4oMaTJjeFp9ileavCpXkda3qvpEWQByxZUsOd6sDA69FuLRpB6jBFL2C2bqfYbcTdqg==",
+      "requires": {
+        "govuk-frontend": "^3.0.0 || ^4.0.0",
+        "moment": "^2.27.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -12222,6 +12261,11 @@
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
     },
+    "jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12551,6 +12595,11 @@
         "is-plain-obj": "^1.1.0",
         "kind-of": "^6.0.3"
       }
+    },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2",

--- a/DfE.FindInformationAcademiesTrusts/package.json
+++ b/DfE.FindInformationAcademiesTrusts/package.json
@@ -30,8 +30,10 @@
     "webpack-cli": "^5.1.1"
   },
   "dependencies": {
+    "@ministryofjustice/frontend": "^1.8.0",
     "accessible-autocomplete": "^2.0.4",
-    "govuk-frontend": "^4.6.0"
+    "govuk-frontend": "^4.6.0",
+    "jquery": "^3.7.1"
   },
   "standard": {
     "ignore": [

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/OverviewModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/OverviewModelTests.cs
@@ -1,0 +1,64 @@
+﻿using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
+
+public class OverviewModelTests
+{
+    private readonly Mock<ITrustProvider> _mockTrustProvider;
+    private readonly OverviewModel _sut;
+
+    public OverviewModelTests()
+    {
+        _mockTrustProvider = new Mock<ITrustProvider>();
+        _sut = new OverviewModel(_mockTrustProvider.Object);
+    }
+
+    [Fact]
+    public async void OnGetAsync_should_fetch_a_trust_by_ukprn()
+    {
+        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1234").Result)
+            .Returns(new Trust("test", "test", "Multi-academy trust"));
+        _sut.Ukprn = "1234";
+
+        await _sut.OnGetAsync();
+        _sut.Trust.Should().BeEquivalentTo(new Trust("test", "test", "Multi-academy trust"));
+    }
+
+    [Fact]
+    public async void Ukprn_should_be_empty_string_by_default()
+    {
+        await _sut.OnGetAsync();
+        _sut.Ukprn.Should().BeEquivalentTo(string.Empty);
+    }
+
+    [Fact]
+    public void PageName_should_be_Overview()
+    {
+        _sut.PageName.Should().Be("Overview");
+    }
+
+    [Fact]
+    public void PageSection_should_be_AboutTheTrust()
+    {
+        _sut.Section.Should().Be("About the trust");
+    }
+
+    [Fact]
+    public async void OnGetAsync_should_return_not_found_result_if_trust_is_not_found()
+    {
+        _mockTrustProvider.Setup(s => s.GetTrustByUkprnAsync("1111").Result)
+            .Returns((Trust?)null);
+
+        _sut.Ukprn = "1111";
+        var result = await _sut.OnGetAsync();
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async void OnGetAsync_should_return_not_found_result_if_Ukprn_is_not_provided()
+    {
+        var result = await _sut.OnGetAsync();
+        result.Should().BeOfType<NotFoundResult>();
+    }
+}

--- a/tests/playwright/accessibility-tests/trusts/overview-page.spec.ts
+++ b/tests/playwright/accessibility-tests/trusts/overview-page.spec.ts
@@ -1,0 +1,15 @@
+import { test } from '../a11y-test'
+import { OverviewPage } from '../../page-object-model/trust/overview-page'
+
+test.describe('Overview page', () => {
+  test('should not have any automatically detectable accessibility issues', async ({ expectNoAccessibilityViolations, page }) => {
+    const overviewPage = new OverviewPage(page)
+    await overviewPage.goTo()
+    await overviewPage.expect.toBeOnTheRightPage()
+    await overviewPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
+    await overviewPage.trustNavigation.expect.toBeVisible()
+    await overviewPage.expect.toSeeCorrectTrustSummary()
+    await overviewPage.expect.toSeeCorrectOfstedRatings()
+    await expectNoAccessibilityViolations()
+  })
+})

--- a/tests/playwright/page-object-model/trust/overview-page.ts
+++ b/tests/playwright/page-object-model/trust/overview-page.ts
@@ -1,0 +1,43 @@
+import { Locator, Page, expect } from '@playwright/test'
+import { TrustHeaderComponent } from '../shared/trust-header-component'
+import { TrustNavigationComponent } from '../shared/trust-navigation-component'
+import { MockTrustsProvider } from '../../mocks/mock-trusts-provider'
+
+export class OverviewPage {
+  readonly expect: OverviewPageAssertions
+  readonly trustHeading: TrustHeaderComponent
+  readonly trustNavigation: TrustNavigationComponent
+  readonly pageHeadingLocator: Locator
+
+  constructor (readonly page: Page) {
+    this.expect = new OverviewPageAssertions(this)
+    this.trustHeading = new TrustHeaderComponent(page)
+    this.trustNavigation = new TrustNavigationComponent(page)
+    this.pageHeadingLocator = page.locator('h1')
+  }
+
+  async goTo (
+    ukprn: string = MockTrustsProvider.expectedFormattedTrustResult.ukprn
+  ): Promise<void> {
+    await this.page.goto(`/trusts/overview/${ukprn}`)
+  }
+}
+
+class OverviewPageAssertions {
+  constructor (readonly OverviewPage: OverviewPage) {}
+
+  async toBeOnTheRightPageFor (trust: string): Promise<void> {
+    await this.OverviewPage.trustHeading.expect.toContain(trust)
+    await expect(this.OverviewPage.pageHeadingLocator).toHaveText('Overview')
+  }
+
+  async toBeOnTheRightPage (): Promise<void> {
+    const { name } = MockTrustsProvider.expectedFormattedTrustResult
+    await this.toBeOnTheRightPageFor(name)
+  }
+
+  async toSeeCorrectTrustNameAndTypeInHeader (): Promise<void> {
+    const { name, type } = MockTrustsProvider.expectedFormattedTrustResult
+    await this.OverviewPage.trustHeading.expect.toSeeCorrectTrustNameAndType(name, type)
+  }
+}

--- a/tests/playwright/page-object-model/trust/overview-page.ts
+++ b/tests/playwright/page-object-model/trust/overview-page.ts
@@ -16,8 +16,8 @@ export class OverviewPage {
     this.trustHeading = new TrustHeaderComponent(page)
     this.trustNavigation = new TrustNavigationComponent(page)
     this.pageHeadingLocator = page.locator('h1')
-    this.trustSummaryCard = page.locator('[aria-labelledby="trust-information"]')
-    this.trustOfstedTable = page.locator('[aria-labelledby="ofsted-ratings"]')
+    this.trustSummaryCard = page.locator('[data-testid="trust-summary"]')
+    this.trustOfstedTable = page.locator('[data-testid="ofsted-ratings"]')
   }
 
   async goTo (

--- a/tests/playwright/page-object-model/trust/overview-page.ts
+++ b/tests/playwright/page-object-model/trust/overview-page.ts
@@ -8,12 +8,16 @@ export class OverviewPage {
   readonly trustHeading: TrustHeaderComponent
   readonly trustNavigation: TrustNavigationComponent
   readonly pageHeadingLocator: Locator
+  readonly trustSummaryCard: Locator
+  readonly trustOfstedTable: Locator
 
   constructor (readonly page: Page) {
     this.expect = new OverviewPageAssertions(this)
     this.trustHeading = new TrustHeaderComponent(page)
     this.trustNavigation = new TrustNavigationComponent(page)
     this.pageHeadingLocator = page.locator('h1')
+    this.trustSummaryCard = page.locator('[aria-labelledby="trust-information"]')
+    this.trustOfstedTable = page.locator('[aria-labelledby="ofsted-ratings"]')
   }
 
   async goTo (
@@ -24,11 +28,11 @@ export class OverviewPage {
 }
 
 class OverviewPageAssertions {
-  constructor (readonly OverviewPage: OverviewPage) {}
+  constructor (readonly overviewPage: OverviewPage) {}
 
   async toBeOnTheRightPageFor (trust: string): Promise<void> {
-    await this.OverviewPage.trustHeading.expect.toContain(trust)
-    await expect(this.OverviewPage.pageHeadingLocator).toHaveText('Overview')
+    await this.overviewPage.trustHeading.expect.toContain(trust)
+    await expect(this.overviewPage.pageHeadingLocator).toHaveText('Overview')
   }
 
   async toBeOnTheRightPage (): Promise<void> {
@@ -38,6 +42,21 @@ class OverviewPageAssertions {
 
   async toSeeCorrectTrustNameAndTypeInHeader (): Promise<void> {
     const { name, type } = MockTrustsProvider.expectedFormattedTrustResult
-    await this.OverviewPage.trustHeading.expect.toSeeCorrectTrustNameAndType(name, type)
+    await this.overviewPage.trustHeading.expect.toSeeCorrectTrustNameAndType(name, type)
+  }
+
+  async toSeeCorrectTrustSummary (): Promise<void> {
+    await expect(this.overviewPage.trustSummaryCard).toContainText('Total academies  4')
+    await expect(this.overviewPage.trustSummaryCard).toContainText('Academies in each local authority  3 in North Lincolnshire  1 in North East Lincolnshire')
+    await expect(this.overviewPage.trustSummaryCard).toContainText('Pupil numbers  4,896')
+    await expect(this.overviewPage.trustSummaryCard).toContainText('Pupil capacity (% full)  6,463(76%)')
+  }
+
+  async toSeeCorrectOfstedRatings (): Promise<void> {
+    await expect(this.overviewPage.trustOfstedTable).toContainText('Outstanding  3')
+    await expect(this.overviewPage.trustOfstedTable).toContainText('Good  5')
+    await expect(this.overviewPage.trustOfstedTable).toContainText('Requires improvement  2')
+    await expect(this.overviewPage.trustOfstedTable).toContainText('Inadequate  3')
+    await expect(this.overviewPage.trustOfstedTable).toContainText('Not yet inspected  4')
   }
 }

--- a/tests/playwright/ui-tests/trusts/overview-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/overview-page.spec.ts
@@ -2,6 +2,7 @@ import { test } from '@playwright/test'
 import { OverviewPage } from '../../page-object-model/trust/overview-page'
 import { NotFoundPage } from '../../page-object-model/not-found-page'
 import { MockTrustsProvider } from '../../mocks/mock-trusts-provider'
+import { javaScriptContexts } from '../../helpers'
 
 test.describe('Overview page', () => {
   let overviewPage: OverviewPage
@@ -12,27 +13,33 @@ test.describe('Overview page', () => {
     await overviewPage.goTo()
   })
 
-  test('user should see trust name and type', async () => {
-    await overviewPage.expect.toBeOnTheRightPage()
-    await overviewPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
-  })
+  for (const javaScriptContext of javaScriptContexts) {
+    test.describe(`With JavaScript ${javaScriptContext.name}`, () => {
+      test.use({ javaScriptEnabled: javaScriptContext.isEnabled })
 
-  test('user should see the correct trust information', async () => {
-    await overviewPage.expect.toSeeCorrectTrustSummary()
-    await overviewPage.expect.toSeeCorrectOfstedRatings()
-  })
+      test('user should see trust name and type', async () => {
+        await overviewPage.expect.toBeOnTheRightPage()
+        await overviewPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
+      })
 
-  test.describe('given a user tries to visit the url without an existing trust', () => {
-    test.beforeEach(({ page }) => {
-      notFoundPage = new NotFoundPage(page)
+      test('user should see the correct trust information', async () => {
+        await overviewPage.expect.toSeeCorrectTrustSummary()
+        await overviewPage.expect.toSeeCorrectOfstedRatings()
+      })
+
+      test.describe('given a user tries to visit the url without an existing trust', () => {
+        test.beforeEach(({ page }) => {
+          notFoundPage = new NotFoundPage(page)
+        })
+
+        test('then they should see a not found message', async () => {
+          await overviewPage.goTo('')
+          await notFoundPage.expect.toBeShownNotFoundMessage()
+
+          await overviewPage.goTo(MockTrustsProvider.nonExistingTrustUkprn)
+          await notFoundPage.expect.toBeShownNotFoundMessage()
+        })
+      })
     })
-
-    test('then they should see a not found message', async () => {
-      await overviewPage.goTo('')
-      await notFoundPage.expect.toBeShownNotFoundMessage()
-
-      await overviewPage.goTo(MockTrustsProvider.nonExistingTrustUkprn)
-      await notFoundPage.expect.toBeShownNotFoundMessage()
-    })
-  })
+  }
 })

--- a/tests/playwright/ui-tests/trusts/overview-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/overview-page.spec.ts
@@ -18,7 +18,7 @@ test.describe('Overview page', () => {
   })
 
   test('user should see the correct trust information', async () => {
-    await overviewPage.expect.toSeeCorrectOfstedRatings()
+    await overviewPage.expect.toSeeCorrectTrustSummary()
     await overviewPage.expect.toSeeCorrectOfstedRatings()
   })
 

--- a/tests/playwright/ui-tests/trusts/overview-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/overview-page.spec.ts
@@ -4,16 +4,16 @@ import { NotFoundPage } from '../../page-object-model/not-found-page'
 import { MockTrustsProvider } from '../../mocks/mock-trusts-provider'
 
 test.describe('Overview page', () => {
-  let detailsPage: OverviewPage
+  let overviewPage: OverviewPage
   let notFoundPage: NotFoundPage
 
   test.beforeEach(async ({ page }) => {
-    detailsPage = new OverviewPage(page)
-    await detailsPage.goTo()
+    overviewPage = new OverviewPage(page)
+    await overviewPage.goTo()
   })
 
   test('user should see trust name and type', async () => {
-    await detailsPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
+    await overviewPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
   })
 
   test.describe('given a user tries to visit the url without an existing trust', () => {
@@ -22,10 +22,10 @@ test.describe('Overview page', () => {
     })
 
     test('then they should see a not found message', async () => {
-      await detailsPage.goTo('')
+      await overviewPage.goTo('')
       await notFoundPage.expect.toBeShownNotFoundMessage()
 
-      await detailsPage.goTo(MockTrustsProvider.nonExistingTrustUkprn)
+      await overviewPage.goTo(MockTrustsProvider.nonExistingTrustUkprn)
       await notFoundPage.expect.toBeShownNotFoundMessage()
     })
   })

--- a/tests/playwright/ui-tests/trusts/overview-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/overview-page.spec.ts
@@ -13,7 +13,13 @@ test.describe('Overview page', () => {
   })
 
   test('user should see trust name and type', async () => {
+    await overviewPage.expect.toBeOnTheRightPage()
     await overviewPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
+  })
+
+  test('user should see the correct trust information', async () => {
+    await overviewPage.expect.toSeeCorrectOfstedRatings()
+    await overviewPage.expect.toSeeCorrectOfstedRatings()
   })
 
   test.describe('given a user tries to visit the url without an existing trust', () => {

--- a/tests/playwright/ui-tests/trusts/overview-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/overview-page.spec.ts
@@ -1,0 +1,32 @@
+import { test } from '@playwright/test'
+import { OverviewPage } from '../../page-object-model/trust/overview-page'
+import { NotFoundPage } from '../../page-object-model/not-found-page'
+import { MockTrustsProvider } from '../../mocks/mock-trusts-provider'
+
+test.describe('Overview page', () => {
+  let detailsPage: OverviewPage
+  let notFoundPage: NotFoundPage
+
+  test.beforeEach(async ({ page }) => {
+    detailsPage = new OverviewPage(page)
+    await detailsPage.goTo()
+  })
+
+  test('user should see trust name and type', async () => {
+    await detailsPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
+  })
+
+  test.describe('given a user tries to visit the url without an existing trust', () => {
+    test.beforeEach(({ page }) => {
+      notFoundPage = new NotFoundPage(page)
+    })
+
+    test('then they should see a not found message', async () => {
+      await detailsPage.goTo('')
+      await notFoundPage.expect.toBeShownNotFoundMessage()
+
+      await detailsPage.goTo(MockTrustsProvider.nonExistingTrustUkprn)
+      await notFoundPage.expect.toBeShownNotFoundMessage()
+    })
+  })
+})


### PR DESCRIPTION
[User Story 134799](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/134799): Build: Trust Overview page - UI

Adds the new page to the UI for Trust overviews. Uses dummy data to fill the table until we have the connection to Academies DB work merged. 

We have added dependencies to the MOJ frontend library for use of the sortable table component. 

## Changes

- Added new dependencies to MOJ frontend Library and jQuery (needed for MOJ frontend library)
- Created Trust overview page and model
- Added Overview link to trust navigation
- Created UI automation tests for the Overview page

## Screenshots of UI changes

### Before - No overview link
<img width="634" alt="image" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/128540970/11d772d7-3b25-4ea6-ad07-9ef97c727d3f">

### After
<img width="629" alt="image" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/128540970/33d05e2e-a938-4615-8ce1-9d2ab061a26f">

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
