### PR TITLE
Remove address properties which are not populated in the database

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/AcademiesDbContext.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/AcademiesDbContext.cs
@@ -39,12 +39,6 @@ public class AcademiesDbContext : DbContext, IAcademiesDbContext
             entity.Property(e => e.CompaniesHouseNumber)
                 .IsUnicode(false)
                 .HasColumnName("Companies House Number");
-            entity.Property(e => e.GroupContactAddress3)
-                .IsUnicode(false)
-                .HasColumnName("Group Contact Address 3");
-            entity.Property(e => e.GroupContactCounty)
-                .IsUnicode(false)
-                .HasColumnName("Group Contact County");
             entity.Property(e => e.GroupContactLocality)
                 .IsUnicode(false)
                 .HasColumnName("Group Contact Locality");

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Group.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Group.cs
@@ -27,11 +27,7 @@ public class Group
 
     public string? GroupContactLocality { get; set; }
 
-    public string? GroupContactAddress3 { get; set; }
-
     public string? GroupContactTown { get; set; }
-
-    public string? GroupContactCounty { get; set; }
 
     public string? GroupContactPostcode { get; set; }
 

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustHelper.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustHelper.cs
@@ -16,7 +16,6 @@ public class TrustHelper : ITrustHelper
             group.GroupContactStreet,
             group.GroupContactLocality,
             group.GroupContactTown,
-            group.GroupContactCounty,
             group.GroupContactPostcode
         }.Where(s => !string.IsNullOrWhiteSpace(s)));
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GroupFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GroupFaker.cs
@@ -18,7 +18,6 @@ public class GroupFaker
             .RuleFor(td => td.GroupContactStreet, f => $"{f.Address.BuildingNumber()} {f.Address.StreetName()}")
             .RuleFor(td => td.GroupContactLocality, f => f.PickRandom(f.Address.StreetName(), string.Empty))
             .RuleFor(td => td.GroupContactTown, f => f.PickRandom(f.Address.City(), string.Empty))
-            .RuleFor(td => td.GroupContactCounty, f => f.PickRandom(f.Address.County(), "Not recorded"))
             .RuleFor(td => td.GroupContactPostcode, f => f.Address.ZipCode());
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustHelperTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustHelperTests.cs
@@ -14,10 +14,9 @@ public class TrustHelperTests
             GroupContactStreet = "12 Abbey Road",
             GroupContactLocality = "Dorthy Inlet",
             GroupContactTown = "East Park",
-            GroupContactCounty = "Kingston upon Hull",
             GroupContactPostcode = "JY36 9VC"
         };
-        var expected = "12 Abbey Road, Dorthy Inlet, East Park, Kingston upon Hull, JY36 9VC";
+        var expected = "12 Abbey Road, Dorthy Inlet, East Park, JY36 9VC";
         var result = _sut.BuildAddressString(group);
 
         result.Should().Be(expected);
@@ -39,7 +38,6 @@ public class TrustHelperTests
             GroupContactStreet = string.Empty,
             GroupContactLocality = string.Empty,
             GroupContactTown = string.Empty,
-            GroupContactCounty = string.Empty,
             GroupContactPostcode = string.Empty
         };
         var result = _sut.BuildAddressString(group);


### PR DESCRIPTION
addressline3 and county properties removed from model and address builder
## Changes
these values are always stored as 'not recorded' in the academies db for trusts. we have removed these properties so that the not recorded string is never returned in our address builders. 
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/143064
## Screenshots of UI changes
### Before
<img width="447" alt="image" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/123379894/24220a0a-f3b0-4e86-a826-7b35549be856">
### After
<img width="301" alt="image" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/123379894/724d5902-5d40-4ac1-95d9-a4a9150777d5">

