### PR TITLE
Academies db connection/update faker to generate trusts json

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustHelper.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustHelper.cs
@@ -5,10 +5,23 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb;
 public interface ITrustHelper
 {
     string BuildAddressString(Group group);
+    Trust CreateTrustFromGroup(Group group);
 }
 
 public class TrustHelper : ITrustHelper
 {
+    public Trust CreateTrustFromGroup(Group group)
+    {
+        return new Trust(
+            group.GroupUid!,
+            group.GroupName ?? string.Empty,
+            group.GroupId ?? string.Empty,
+            group.Ukprn,
+            group.GroupType ?? string.Empty,
+            BuildAddressString(group)
+        );
+    }
+
     public string BuildAddressString(Group group)
     {
         return string.Join(", ", new[]

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
@@ -6,15 +6,18 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb;
 public class TrustProvider : ITrustProvider
 {
     private readonly IAcademiesDbContext _academiesDbContext;
+    private readonly ITrustHelper _trustHelper;
 
     [ExcludeFromCodeCoverage]
-    public TrustProvider(AcademiesDbContext academiesDbContext) : this((IAcademiesDbContext)academiesDbContext)
+    public TrustProvider(AcademiesDbContext academiesDbContext, ITrustHelper trustHelper) : this(
+        (IAcademiesDbContext)academiesDbContext, trustHelper)
     {
     }
 
-    public TrustProvider(IAcademiesDbContext academiesDbContext)
+    public TrustProvider(IAcademiesDbContext academiesDbContext, ITrustHelper trustHelper)
     {
         _academiesDbContext = academiesDbContext;
+        _trustHelper = trustHelper;
     }
 
     public async Task<Trust?> GetTrustByUidAsync(string uid)
@@ -24,12 +27,7 @@ public class TrustProvider : ITrustProvider
         var group = await _academiesDbContext.Groups.SingleOrDefaultAsync(g => g.GroupUid == uid);
         if (group is not null)
         {
-            trust = new Trust(
-                group.GroupUid!,
-                group.GroupName ?? string.Empty,
-                group.Ukprn,
-                group.GroupType ?? string.Empty
-            );
+            trust = _trustHelper.CreateTrustFromGroup(group);
         }
 
         return trust;

--- a/DfE.FindInformationAcademiesTrusts.Data/Trust.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Trust.cs
@@ -1,3 +1,3 @@
 namespace DfE.FindInformationAcademiesTrusts.Data;
 
-public record Trust(string Uid, string Name, string? Ukprn, string Type);
+public record Trust(string Uid, string Name, string GroupId, string? Ukprn, string Type, string Address);

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GroupFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GroupFaker.cs
@@ -11,14 +11,15 @@ public class GroupFaker
     public GroupFaker(TrustToGenerate trustToGenerate)
     {
         _groupFaker = new Faker<Group>("en_GB")
-            .RuleFor(t => t.GroupName, trustToGenerate.Name)
-            .RuleFor(t => t.GroupUid, f => $"{f.Random.Int(1000, 9999)}")
-            .RuleFor(td => td.GroupId, f => $"TR{f.Random.Int(0, 9999)}")
-            .RuleFor(td => td.GroupType, trustToGenerate.TrustType)
-            .RuleFor(td => td.GroupContactStreet, f => $"{f.Address.BuildingNumber()} {f.Address.StreetName()}")
-            .RuleFor(td => td.GroupContactLocality, f => f.PickRandom(f.Address.StreetName(), string.Empty))
-            .RuleFor(td => td.GroupContactTown, f => f.PickRandom(f.Address.City(), string.Empty))
-            .RuleFor(td => td.GroupContactPostcode, f => f.Address.ZipCode());
+            .RuleFor(g => g.GroupName, trustToGenerate.Name)
+            .RuleFor(g => g.GroupUid, f => $"{f.Random.Int(1000, 9999)}")
+            .RuleFor(g => g.GroupId, f => $"TR{f.Random.Int(0, 9999)}")
+            .RuleFor(g => g.Ukprn, f => $"100{f.Random.Int(0, 99999):D5}")
+            .RuleFor(g => g.GroupType, trustToGenerate.TrustType)
+            .RuleFor(g => g.GroupContactStreet, f => $"{f.Address.BuildingNumber()} {f.Address.StreetName()}")
+            .RuleFor(g => g.GroupContactLocality, f => f.PickRandom(f.Address.StreetName(), string.Empty))
+            .RuleFor(g => g.GroupContactTown, f => f.PickRandom(f.Address.City(), string.Empty))
+            .RuleFor(g => g.GroupContactPostcode, f => f.Address.ZipCode());
     }
 
     public Group Generate()

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/JsonGenerator.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/JsonGenerator.cs
@@ -10,7 +10,9 @@ public static class JsonGenerator
         var serializeOptions = new JsonSerializerOptions
             { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
-        var jsonisisedTrusts = JsonSerializer.Serialize(fakeGroups, serializeOptions);
-        File.WriteAllText(outputFilePath, jsonisisedTrusts);
+        var trustHelper = new TrustHelper();
+        var trusts = fakeGroups.OrderBy(g => g.GroupName).Select(g => trustHelper.CreateTrustFromGroup(g));
+
+        File.WriteAllText(outputFilePath, JsonSerializer.Serialize(trusts, serializeOptions));
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/JsonGenerator.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/JsonGenerator.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker;
+
+public static class JsonGenerator
+{
+    public static void GenerateAndSaveTrustsJson(Group[] fakeGroups, string outputFilePath)
+    {
+        var serializeOptions = new JsonSerializerOptions
+            { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+        var jsonisisedTrusts = JsonSerializer.Serialize(fakeGroups, serializeOptions);
+        File.WriteAllText(outputFilePath, jsonisisedTrusts);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Program.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Program.cs
@@ -1,10 +1,7 @@
-﻿using System.Reflection;
-using System.Text.Json;
-using Bogus;
+﻿using Bogus;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Fakers;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Helpers;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models;
-using Microsoft.EntityFrameworkCore;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker;
 
@@ -14,29 +11,15 @@ public static class Program
     {
         try
         {
-            var dbContextOptions = new DbContextOptionsBuilder<AcademiesDbContext>().UseSqlServer();
-            using var context = new AcademiesDbContext(dbContextOptions.Options);
-            var createScript = context.Database.GenerateCreateScript();
-
-            Directory.CreateDirectory("data");
-            File.WriteAllText("data/createScript.sql", createScript);
-
             //The randomizer seed enables us to generate slightly repeatable data sets
+            //The data sets will only change when changes are made to the generator
             Randomizer.Seed = new Random(28698);
 
             var fakeGroups = Data.TrustsToGenerate
                 .Select(GenerateGroup).ToArray();
 
-            var serializeOptions = new JsonSerializerOptions { WriteIndented = true };
-            var jsonisisedTrusts = JsonSerializer.Serialize(fakeGroups, serializeOptions);
-            File.WriteAllText("data/output.json", jsonisisedTrusts);
-
-            var groupProperties = typeof(Group).GetProperties();
-            var valuesStrings = fakeGroups.Select(group => $"({GetEntityValues(group, groupProperties)})");
-
-            var insertScript =
-                $"INSERT INTO [gias].[Group] ({GetEntityProperties(groupProperties, context)}) VALUES {string.Join(',', valuesStrings)}";
-            File.WriteAllText("data/insertScript.sql", insertScript);
+            SqlScriptGenerator.GenerateAndSaveSqlScripts(fakeGroups, "data/createScript.sql", "data/insertScript.sql");
+            JsonGenerator.GenerateAndSaveTrustsJson(fakeGroups, "data/output.json");
         }
         catch (Exception e)
         {
@@ -48,49 +31,5 @@ public static class Program
     {
         var fakeGroup = new GroupFaker(trustToGenerate);
         return fakeGroup.Generate();
-    }
-
-    private static string GetEntityValues<T>(T obj, PropertyInfo[] entityProperties)
-    {
-        var list = entityProperties
-            .Select(pi => GetValueAsString(pi.GetValue(obj), pi.PropertyType));
-
-        return string.Join(", ", list);
-    }
-
-    private static string GetEntityProperties(PropertyInfo[] propertyInfos, AcademiesDbContext context)
-    {
-        var entityProperties = context.Model.FindEntityTypes(typeof(Group)).FirstOrDefault()!.GetProperties();
-        var columnNames =
-            propertyInfos.Select(pi =>
-            {
-                var columnName = entityProperties.FirstOrDefault(ep => ep.Name == pi.Name)!.GetColumnName();
-                return $"[{columnName}]";
-            });
-        return string.Join(',', columnNames);
-    }
-
-    private static string GetValueAsString(object? value, Type propertyType)
-    {
-        if (value is null)
-            return "NULL";
-        if (propertyType == typeof(string))
-        {
-            return TransformIntoSqlSafeString(value.ToString());
-        }
-
-        if (propertyType == typeof(int))
-        {
-            return value.ToString()!;
-        }
-
-        throw new Exception("unknown type");
-    }
-
-    private static string TransformIntoSqlSafeString(string? unsantisedString)
-    {
-        if (string.IsNullOrEmpty(unsantisedString))
-            return "''";
-        return $"'{unsantisedString.Replace("'", @"''")}'";
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/SqlScriptGenerator.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/SqlScriptGenerator.cs
@@ -1,0 +1,80 @@
+using System.Reflection;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker;
+
+public static class SqlScriptGenerator
+{
+    public static void GenerateAndSaveSqlScripts(Group[] fakeGroups, string createScriptOutputFilePath,
+        string insertScriptOutputFilePath)
+    {
+        var dbContextOptions = new DbContextOptionsBuilder<AcademiesDbContext>().UseSqlServer();
+        using var context = new AcademiesDbContext(dbContextOptions.Options);
+
+        GenerateSqlCreateScript(context, createScriptOutputFilePath);
+        GenerateSqlInsertScript(fakeGroups, context, insertScriptOutputFilePath);
+    }
+
+    private static void GenerateSqlCreateScript(AcademiesDbContext context, string outputFilePath)
+    {
+        var createScript = context.Database.GenerateCreateScript();
+
+        Directory.CreateDirectory("data");
+        File.WriteAllText(outputFilePath, createScript);
+    }
+
+    private static void GenerateSqlInsertScript(Group[] fakeGroups, AcademiesDbContext context, string ouputFilePath)
+    {
+        var groupProperties = typeof(Group).GetProperties();
+        var valuesStrings = fakeGroups.Select(group => $"({GetEntityValues(group, groupProperties)})");
+
+        var insertScript =
+            $"INSERT INTO [gias].[Group] ({GetEntityProperties(groupProperties, context)}) VALUES {string.Join(',', valuesStrings)}";
+        File.WriteAllText(ouputFilePath, insertScript);
+    }
+
+    private static string GetEntityValues<T>(T obj, PropertyInfo[] entityProperties)
+    {
+        var list = entityProperties
+            .Select(pi => GetValueAsString(pi.GetValue(obj), pi.PropertyType));
+
+        return string.Join(", ", list);
+    }
+
+    private static string GetEntityProperties(PropertyInfo[] propertyInfos, AcademiesDbContext context)
+    {
+        var entityProperties = context.Model.FindEntityTypes(typeof(Group)).FirstOrDefault()!.GetProperties();
+        var columnNames =
+            propertyInfos.Select(pi =>
+            {
+                var columnName = entityProperties.FirstOrDefault(ep => ep.Name == pi.Name)!.GetColumnName();
+                return $"[{columnName}]";
+            });
+        return string.Join(',', columnNames);
+    }
+
+    private static string GetValueAsString(object? value, Type propertyType)
+    {
+        if (value is null)
+            return "NULL";
+        if (propertyType == typeof(string))
+        {
+            return TransformIntoSqlSafeString(value.ToString());
+        }
+
+        if (propertyType == typeof(int))
+        {
+            return value.ToString()!;
+        }
+
+        throw new Exception("unknown type");
+    }
+
+    private static string TransformIntoSqlSafeString(string? unsantisedString)
+    {
+        if (string.IsNullOrEmpty(unsantisedString))
+            return "''";
+        return $"'{unsantisedString.Replace("'", @"''")}'";
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
@@ -11,14 +12,14 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.12.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
         <PackageReference Include="Moq" Version="4.20.69"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
@@ -26,6 +27,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj"/>
+        <ProjectReference Include="..\DfE.FindInformationAcademiesTrusts.UnitTests\DfE.FindInformationAcademiesTrusts.UnitTests.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustHelperTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustHelperTests.cs
@@ -7,6 +7,30 @@ public class TrustHelperTests
     private readonly TrustHelper _sut = new();
 
     [Fact]
+    public void CreateTrustFromGroup_should_transform_a_group_into_a_trust()
+    {
+        var group = new Group
+        {
+            GroupName = "trust 1", GroupUid = "1234", GroupType = "Multi-academy trust", Ukprn = "my ukprn",
+            GroupId = "my groupId",
+            GroupContactStreet = "12 Abbey Road",
+            GroupContactLocality = "Dorthy Inlet",
+            GroupContactTown = "East Park",
+            GroupContactPostcode = "JY36 9VC"
+        };
+
+        var result = _sut.CreateTrustFromGroup(group);
+
+        result.Should().BeEquivalentTo(new Trust(
+            "1234",
+            "trust 1",
+            "my groupId",
+            "my ukprn",
+            "Multi-academy trust",
+            "12 Abbey Road, Dorthy Inlet, East Park, JY36 9VC"));
+    }
+
+    [Fact]
     public void BuildAddressString_should_return_full_address_as_string()
     {
         var group = new Group

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
@@ -4,28 +4,22 @@
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
         <IsPackable>false</IsPackable>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <IsTestProject>true</IsTestProject>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="Moq" Version="4.20.69" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/DummyTrustFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/DummyTrustFactory.cs
@@ -1,0 +1,19 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+
+public class DummyTrustFactory
+{
+    private int _numberTrustsGenerated;
+
+    public Trust GetDummyTrust()
+    {
+        _numberTrustsGenerated++;
+        return GetDummyTrust(_numberTrustsGenerated.ToString("0000"));
+    }
+
+    public Trust GetDummyTrust(string uid)
+    {
+        return new Trust(uid, $"Trust {uid}", "test", "test", "test", "test");
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/SearchModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/SearchModelTests.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Pages;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
@@ -18,14 +19,15 @@ public class SearchModelTests
         new("trust 3", "Abbott Turnpike, East Riding of Yorkshire, BI86 4LZ", "2044", "")
     };
 
-    private readonly Trust _fakeTrust =
-        new("2044", "trust 1", "100123456", "Multi-academy trust");
+    private readonly Trust _fakeTrust;
 
     public SearchModelTests()
     {
         Mock<ITrustProvider> mockTrustProvider = new();
         _mockTrustSearch = new Mock<ITrustSearch>();
 
+        var dummyTrustFactory = new DummyTrustFactory();
+        _fakeTrust = dummyTrustFactory.GetDummyTrust();
         mockTrustProvider.Setup(s => s.GetTrustByUidAsync(_fakeTrust.Uid).Result)
             .Returns(_fakeTrust);
         _mockTrustSearch.Setup(s => s.SearchAsync(SearchTermThatMatchesAllFakeTrusts).Result).Returns(_fakeTrusts);
@@ -81,8 +83,8 @@ public class SearchModelTests
     public async Task OnGetAsync_should_not_redirect_to_trust_details_if_trustId_does_not_match_query()
     {
         var differentFakeTrust = new TrustSearchEntry("other trust", "Some address", "987", "TR0987");
-        _mockTrustSearch.Setup(s => s.SearchAsync(differentFakeTrust.Name).Result)
-            .Returns(new[] { differentFakeTrust });
+        _mockTrustSearch.Setup(s => s.SearchAsync(differentFakeTrust.Name))
+            .ReturnsAsync(new[] { differentFakeTrust });
 
         _sut.KeyWords = differentFakeTrust.Name;
         _sut.Uid = _fakeTrust.Uid;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
@@ -7,10 +8,12 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
 public class ContactsModelTests
 {
     private readonly Mock<ITrustProvider> _mockTrustProvider;
+    private readonly DummyTrustFactory _dummyTrustFactory;
     private readonly ContactsModel _sut;
 
     public ContactsModelTests()
     {
+        _dummyTrustFactory = new DummyTrustFactory();
         _mockTrustProvider = new Mock<ITrustProvider>();
         _sut = new ContactsModel(_mockTrustProvider.Object);
     }
@@ -18,11 +21,12 @@ public class ContactsModelTests
     [Fact]
     public async void OnGetAsync_should_fetch_a_trust_by_Uid()
     {
-        _mockTrustProvider.Setup(s => s.GetTrustByUidAsync("1234").Result)
-            .Returns(new Trust("test", "test", "test", "Multi-academy trust"));
-        _sut.Uid = "1234";
+        var dummyTrust = _dummyTrustFactory.GetDummyTrust("1234");
+        _mockTrustProvider.Setup(s => s.GetTrustByUidAsync(dummyTrust.Uid))
+            .ReturnsAsync(dummyTrust);
+        _sut.Uid = dummyTrust.Uid;
         await _sut.OnGetAsync();
-        _sut.Trust.Should().BeEquivalentTo(new Trust("test", "test", "test", "Multi-academy trust"));
+        _sut.Trust.Should().BeEquivalentTo(dummyTrust);
     }
 
     [Fact]
@@ -47,8 +51,8 @@ public class ContactsModelTests
     [Fact]
     public async void OnGetAsync_should_return_not_found_result_if_trust_is_not_found()
     {
-        _mockTrustProvider.Setup(s => s.GetTrustByUidAsync("1111").Result)
-            .Returns((Trust?)null);
+        _mockTrustProvider.Setup(s => s.GetTrustByUidAsync("1111"))
+            .ReturnsAsync((Trust?)null);
 
         _sut.Uid = "1111";
 


### PR DESCRIPTION
Export `Trust`s rather than `Group`s in the fake data json from the fake data generator.

## Changes

- Export `Trust`s rather than `Group`s in the fake data json
- Move `Trust` creation to the `TrustHelper`
- Update unit test nuget package references
- Use a `DummyTrustFactory` in unit tests