### PR TITLE
Add `target=ES6` to TypeScript compiler options

### DIFF
--- a/tests/playwright/tsconfig.json
+++ b/tests/playwright/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "compilerOptions": {
     "strictNullChecks": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "target": "ES6",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   }
 }


### PR DESCRIPTION
We were experiencing local type checking errors, so adding recommended target language to our tsconfig.json in our playwright test suite. As a result, we also needed to declare `module` and `moduleResolution` properties, as these were defaulting to 'classic' which is not compatible with `resolveJsonModule`.

Set using recommended options at https://www.typescriptlang.org/tsconfig

## Changes

- Update tsconfig.json

## Screenshots of UI changes

N/A

## Checklist

- [ ] N/A Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] N/A Attach this pull request to the appropriate user story in Azure DevOps
- [ ] N/A Update the ADR decision log if needed
