### PR TITLE
Academies db connection: update integration and deployment tests

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -195,18 +195,6 @@ internal static class Program
             });
     }
 
-    private static bool ShouldSkipAuthentication(WebApplicationBuilder builder)
-    {
-        if (!builder.Environment.IsLocalDevelopment() && !builder.Environment.IsContinuousIntegration())
-            return false;
-
-        //We need to be sure that this is actually an isolated environment with no access to production data
-        var databaseConnectionString = builder.Configuration.GetConnectionString("AcademiesDb")?.ToLower();
-        return string.IsNullOrWhiteSpace(databaseConnectionString)
-               || databaseConnectionString.Contains("testdb")
-               || databaseConnectionString.Contains("localhost");
-    }
-
     private static void ReconfigureLogging(WebApplicationBuilder builder)
     {
         if (builder.Environment.IsLocalDevelopment() || builder.Environment.IsContinuousIntegration())

--- a/docs/run-tests-locally.md
+++ b/docs/run-tests-locally.md
@@ -81,15 +81,21 @@ For more information on running and debugging Playwright tests it is worth famil
 
 ### Integration and Deployment tests
 
-[Integration and Deployment tests](./test-approach.md) are also run in [Playwright](https://playwright.dev/), but do not have dependencies mocked. If you wish to run these locally you will need to run the app locally before running your tests. Alternatively you can run them against deployed dev or test environments.
+[Integration and Deployment tests](./test-approach.md) are also run in [Playwright](https://playwright.dev/), but do not have dependencies mocked. In the pipeline these will be run against deployed environments, but if you wish to run these locally you will need to run the app locally, as you will not be able to run these tests against the docker containers.
 
-1. Run the .NET application using your preferred IDE or by running `dotnet run`
+1. Update the dotnet user-secrets for the application to bypass authentication:
+
+```bash
+cd DfE.FindInformationAcademiesTrusts
+dotnet user-secrets set "TestOverride:PlaywrightTestSecret" "TestSuperSecret"
+```
+
+2. Run the .NET application using your preferred IDE or by running `dotnet run`
 2. Configure/create `tests/playwright/.env` and add the following:
 
 ```dotenv
 PLAYWRIGHT_BASEURL="http://localhost:5163" # This should be the localhost port the application is running on, or the deployed application url you wish to test against
-TEST_USER_ACCOUNT_NAME="<insert here>" # Include the domain name
-TEST_USER_ACCOUNT_PASSWORD="<insert here>" # 
+AUTH_BYPASS_SECRET="TestSuperSecret"
 ```
 
 3. Open a terminal to run your tests
@@ -97,7 +103,9 @@ TEST_USER_ACCOUNT_PASSWORD="<insert here>" #
 ```shell
  cd DfE.FindInformationAcademiesTrusts.UnitTests/playwright
  npm install
+ npx playwright install
  npm run test:integration
+ npm run test:deployment
 ```
 
 ### Owasp Zap security tests

--- a/docs/run-tests-locally.md
+++ b/docs/run-tests-locally.md
@@ -27,17 +27,23 @@ Accessibility and UI tests are written using [Playwright](https://playwright.dev
 **If running tests against the docker instance of the app:**
 ```dotenv
 PLAYWRIGHT_BASEURL="http://localhost/"
+AUTH_BYPASS_SECRET="TestSuperSecret"
 ```
 
 **If running tests in your local environment**
 ```dotenv
 PLAYWRIGHT_BASEURL="http://localhost:{port} # e.g. http://localhost:5163
+AUTH_BYPASS_SECRET="TestSuperSecret"
 ```
 
-For your local environment you will also need to change your database connection string (dotnet user secrets) to point to the docker instance:
+For your local environment you will also need to update your dotnet user secrets with the following: 
 
-```
+```bash
+# add testdb connection string
 dotnet user-secrets set "ConnectionStrings:AcademiesDb" "Server=localhost;User Id=sa;Password=mySuperStrong_pa55word!!!;TrustServerCertificate=true"
+
+# add authorization header for tests - which matches the auth bypass secret set in the playwright .env file
+dotnet user-secrets set "TestOverride:PlaywrightTestSecret" "TestSuperSecret"
 ```
 
 2. Open a terminal in your repository and run:

--- a/tests/playwright/deployment-tests/deployment.spec.ts
+++ b/tests/playwright/deployment-tests/deployment.spec.ts
@@ -1,14 +1,15 @@
 import { test } from '@playwright/test'
 import { HomePage } from '../page-object-model/home-page'
 import { SearchPage } from '../page-object-model/search-page'
+import { CurrentSearch } from '../page-object-model/shared/search-form-component'
 
 test('is deployed', async ({ page }) => {
-  const homePage = new HomePage(page)
-  const searchPage = new SearchPage(page)
+  const homePage = new HomePage(page, new CurrentSearch())
+  const searchPage = new SearchPage(page, new CurrentSearch())
   await homePage.goTo()
   await homePage.expect.toBeOnTheRightPage()
 
-  await homePage.searchForm.typeSearchTerm('education')
+  await homePage.searchForm.typeASearchTerm()
   await homePage.searchForm.submitSearch()
   await searchPage.expect.toShowResults()
 })

--- a/tests/playwright/integration-tests/database-connection.spec.ts
+++ b/tests/playwright/integration-tests/database-connection.spec.ts
@@ -1,26 +1,28 @@
 import { test } from '@playwright/test'
 import { HomePage } from '../page-object-model/home-page'
 import { SearchPage } from '../page-object-model/search-page'
+import { CurrentSearch } from '../page-object-model/shared/search-form-component'
 
 test.describe('search for trusts', () => {
   let homePage: HomePage
   let searchPage: SearchPage
 
   test.beforeEach(({ page }) => {
-    homePage = new HomePage(page)
-    searchPage = new SearchPage(page)
+    const currentSearch = new CurrentSearch()
+    homePage = new HomePage(page, currentSearch)
+    searchPage = new SearchPage(page, currentSearch)
   })
 
   test('returns results', async () => {
     await homePage.goTo()
-    await homePage.searchForm.typeSearchTerm('education')
+    await homePage.searchForm.typeASearchTerm()
     await homePage.searchForm.submitSearch()
     await searchPage.expect.toShowResults()
   })
 
   test('returns empty results', async () => {
     await homePage.goTo()
-    await homePage.searchForm.typeSearchTerm('trust that does not exist')
+    await homePage.searchForm.typeASearchTermWithNoMatches()
     await homePage.searchForm.submitSearch()
     await searchPage.expect.toSeeNoResultsMessage()
   })

--- a/tests/playwright/integration-tests/log-in.spec.ts
+++ b/tests/playwright/integration-tests/log-in.spec.ts
@@ -2,6 +2,7 @@ import { test } from '@playwright/test'
 import { HomePage } from '../page-object-model/home-page'
 import { LogInPage } from '../page-object-model/log-in-page'
 import { SearchPage } from '../page-object-model/search-page'
+import { CurrentSearch } from '../page-object-model/shared/search-form-component'
 
 test.describe('Log in to application', () => {
   let homePage: HomePage
@@ -9,9 +10,10 @@ test.describe('Log in to application', () => {
   let searchPage: SearchPage
 
   test.beforeEach(({ page }) => {
-    homePage = new HomePage(page)
+    const currentSearch = new CurrentSearch()
+    homePage = new HomePage(page, currentSearch)
     logInPage = new LogInPage(page)
-    searchPage = new SearchPage(page)
+    searchPage = new SearchPage(page, currentSearch)
   })
 
   test.describe('Given the user is authenticated', () => {

--- a/tests/playwright/page-object-model/search-page.ts
+++ b/tests/playwright/page-object-model/search-page.ts
@@ -14,8 +14,11 @@ export class SearchPage {
   testData: FakeTestData
   numberOfResultsOnOnePage = 20
 
-  constructor (readonly page: Page, currentSearch: CurrentSearch, fakeTestData: FakeTestData) {
-    this.testData = fakeTestData
+  constructor (readonly page: Page, currentSearch: CurrentSearch, fakeTestData?: FakeTestData) {
+    if (fakeTestData !== undefined) {
+      this.testData = fakeTestData
+    }
+
     this.expect = new SearchPageAssertions(this)
     this.searchForm = new SearchFormComponent(
       page,


### PR DESCRIPTION
This change integrates some parallel changes from main, particularly the new method to bypass authentication in tests, and the reintroduction of integration and deployment tests in the CI pipeline, introduced in #209 .

## Changes

- Remove `ShouldSkipAuthentication` method in application start up: this was the previous method to bypass authentication for tests run in the CI environment, and was removed in #209 - Auth bypass for tests feature. 
- Fix integration and deployment tests: these were not updated during the changes to our Page Object Models in #202 , and are currently failing in the pipeline.
- Update documentation: ensure steps to run UI and accessibility tests include both the testdb connection string and authentication header environment variables, and clarify how integration and deployment tests can be run locally. 

## Screenshots of UI changes

N/A

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
