### PR TITLE
Fix Overview Page UI tests

### DIFF
--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/OverviewModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/OverviewModelTests.cs
@@ -20,7 +20,7 @@ public class OverviewModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_should_fetch_a_trust_by_ukprn()
+    public async void OnGetAsync_should_fetch_a_trust_by_Uid()
     {
         var dummyTrust = _dummyTrustFactory.GetDummyTrust("1234");
         _mockTrustProvider.Setup(s => s.GetTrustByUidAsync(dummyTrust.Uid))
@@ -32,7 +32,7 @@ public class OverviewModelTests
     }
 
     [Fact]
-    public async void Ukprn_should_be_empty_string_by_default()
+    public async void Uid_should_be_empty_string_by_default()
     {
         await _sut.OnGetAsync();
         _sut.Uid.Should().BeEquivalentTo(string.Empty);
@@ -62,7 +62,7 @@ public class OverviewModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_should_return_not_found_result_if_Ukprn_is_not_provided()
+    public async void OnGetAsync_should_return_not_found_result_if_Uid_is_not_provided()
     {
         var result = await _sut.OnGetAsync();
         result.Should().BeOfType<NotFoundResult>();

--- a/tests/playwright/accessibility-tests/trusts/overview-page.spec.ts
+++ b/tests/playwright/accessibility-tests/trusts/overview-page.spec.ts
@@ -1,9 +1,10 @@
 import { test } from '../a11y-test'
 import { OverviewPage } from '../../page-object-model/trust/overview-page'
+import { FakeTestData } from '../../fake-data/fake-test-data'
 
 test.describe('Overview page', () => {
   test('should not have any automatically detectable accessibility issues', async ({ expectNoAccessibilityViolations, page }) => {
-    const overviewPage = new OverviewPage(page)
+    const overviewPage = new OverviewPage(page, new FakeTestData())
     await overviewPage.goTo()
     await overviewPage.expect.toBeOnTheRightPage()
     await overviewPage.expect.toSeeCorrectTrustNameAndTypeInHeader()

--- a/tests/playwright/ui-tests/trusts/navigation.spec.ts
+++ b/tests/playwright/ui-tests/trusts/navigation.spec.ts
@@ -2,28 +2,40 @@ import { test } from '@playwright/test'
 import { DetailsPage } from '../../page-object-model/trust/details-page'
 import { ContactsPage } from '../../page-object-model/trust/contacts-page'
 import { FakeTestData } from '../../fake-data/fake-test-data'
+import { OverviewPage } from '../../page-object-model/trust/overview-page'
 
 test.describe('Trust navigation', () => {
   let detailsPage: DetailsPage
   let contactsPage: ContactsPage
+  let overviewPage: OverviewPage
 
   test.beforeEach(async ({ page }) => {
     const fakeTestData = new FakeTestData()
     detailsPage = new DetailsPage(page, fakeTestData)
     contactsPage = new ContactsPage(page, fakeTestData)
+    overviewPage = new OverviewPage(page, fakeTestData)
   })
 
-  test.describe('Given a user navigates to trust details', () => {
-    test.beforeEach(async () => {
-      await detailsPage.goTo()
-    })
-
-    test('user should be able to navigate between different sections about a trust', async () => {
-      await detailsPage.trustNavigation.expect.toBeVisible()
-      await detailsPage.trustNavigation.clickOn('Contacts')
-      await contactsPage.expect.toBeOnTheRightPage()
-      await contactsPage.trustNavigation.clickOn('Details')
-      await detailsPage.expect.toBeOnTheRightPage()
-    })
+  test('user should be able to navigate between different sections about a trust', async () => {
+    await detailsPage.goTo()
+    await detailsPage.trustNavigation.expect.toBeVisible()
+    // Details => Contacts
+    await detailsPage.trustNavigation.clickOn('Contacts')
+    await contactsPage.expect.toBeOnTheRightPage()
+    // Contacts => Details
+    await contactsPage.trustNavigation.clickOn('Details')
+    await detailsPage.expect.toBeOnTheRightPage()
+    // Details => Overview
+    await detailsPage.trustNavigation.clickOn('Overview')
+    await overviewPage.expect.toBeOnTheRightPage()
+    // Overview => Contacts
+    await overviewPage.trustNavigation.clickOn('Contacts')
+    await contactsPage.expect.toBeOnTheRightPage()
+    // Contacts => Overview
+    await contactsPage.trustNavigation.clickOn('Overview')
+    await overviewPage.expect.toBeOnTheRightPage()
+    // Overview => Details
+    await overviewPage.trustNavigation.clickOn('Details')
+    await detailsPage.expect.toBeOnTheRightPage()
   })
 })

--- a/tests/playwright/ui-tests/trusts/overview-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/overview-page.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test'
 import { OverviewPage } from '../../page-object-model/trust/overview-page'
 import { NotFoundPage } from '../../page-object-model/not-found-page'
-import { MockTrustsProvider } from '../../mocks/mock-trusts-provider'
+import { FakeTestData } from '../../fake-data/fake-test-data'
 import { javaScriptContexts } from '../../helpers'
 
 test.describe('Overview page', () => {
@@ -9,7 +9,7 @@ test.describe('Overview page', () => {
   let notFoundPage: NotFoundPage
 
   test.beforeEach(async ({ page }) => {
-    overviewPage = new OverviewPage(page)
+    overviewPage = new OverviewPage(page, new FakeTestData())
     await overviewPage.goTo()
   })
 
@@ -33,10 +33,10 @@ test.describe('Overview page', () => {
         })
 
         test('then they should see a not found message', async () => {
-          await overviewPage.goTo('')
+          await overviewPage.goToPageWithoutUid()
           await notFoundPage.expect.toBeShownNotFoundMessage()
 
-          await overviewPage.goTo(MockTrustsProvider.nonExistingTrustUkprn)
+          await overviewPage.goToPageWithUidThatDoesNotExist()
           await notFoundPage.expect.toBeShownNotFoundMessage()
         })
       })


### PR DESCRIPTION
[Task 145799](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/145799): Fix Overview page UI tests
Change the Overview tests to use the new fake data instead of the old mock trust.
Add in a test for the navigation panel to move to and from the overview page, along with some other refactoring.
Also rename the Unit tests from Ukprn to Uid since they no longer use Ukprn.

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
