### PR TITLE
search hint text changed to not include reference numbers

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
@@ -54,7 +54,7 @@
                 <dt class="govuk-summary-list__key app-search-results-summary-list__key app-search-results-summary-list__item">
                   UID:
                 </dt>
-                <dd class="govuk-summary-list__value app-search-results-summary-list__item" data-testid="uid" >
+                <dd class="govuk-summary-list__value app-search-results-summary-list__item" data-testid="uid">
                   @Html.DisplayFor(modelItem => trust.Uid)
                 </dd>
               </div>
@@ -66,16 +66,7 @@
     }
     else
     {
-      <p class="govuk-body">Check the spelling of the trust name.</p>
-
-      <p class="govuk-body">Enter a reference number in the right format. For example:</p>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <li>TRN (trust reference number) or Group ID - TR00123</li>
-        <li>UID (unique identifier) - 2034</li>
-        <li>UKPRN (UK provider number) - 100023456</li>
-        <li>Companies House number - 00123456</li>
-      </ul>
+      <p class="govuk-body">Check the spelling of the trust name. Make sure you include the right punctuation.</p>
     }
 
   </section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_SearchForm.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_SearchForm.cshtml
@@ -1,7 +1,7 @@
 @model ISearchFormModel
 <div data-testid="app-search-form">
   <div class="govuk-hint">
-    Enter trust name, TRN, group ID, UID, UKPRN or Companies House number
+    Enter trust name. Include the right punctuation.
   </div>
 
   @* This is used by the no javascript users *@

--- a/tests/playwright/page-object-model/search-page.ts
+++ b/tests/playwright/page-object-model/search-page.ts
@@ -112,7 +112,7 @@ class SearchPageAssertions {
   async toSeeNoResultsMessage (): Promise<void> {
     await expect(this.searchPage._searchResultsListHeaderLocator).toContainText(`0 ${this.searchPage._searchResultsHeadingName}`)
     await expect(this.searchPage._searchResultsSectionLocator).toContainText(
-      'Check the spelling of the trust name. Enter a reference number in the right format'
+      'Check the spelling of the trust name. Make sure you include the right punctuation.'
     )
   }
 }


### PR DESCRIPTION
## Changes
we now don't provide search filtering on reference numbers. the hint text now matches that. UI tests also updated.

[User Story 144967](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/144967): Build: Update search text on homepage and search page**

## Screenshots of UI changes

### Before
<img width="633" alt="Screenshot 2023-11-01 114547" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/123379894/cbccdafe-f078-4639-ab61-b4e4fab89c0e">
<img width="658" alt="Screenshot 2023-11-01 114558" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/123379894/10474572-b5f6-4067-b91d-cad1bb9f2eaf">
### After
<img width="605" alt="Screenshot 2023-11-01 113356" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/123379894/7b83cbc8-3a1e-42ca-a6ee-71bfa63bef1c">
<img width="709" alt="Screenshot 2023-11-01 113409" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/123379894/68736876-6672-4362-86ba-3a517f650e84">

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps

