### PR TITLE
Mark `GetDummyTrust` method as static

### DIFF
--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
@@ -9,13 +9,11 @@ public class TrustProviderTests
     private readonly TrustProvider _sut;
     private readonly List<Group> _groups;
     private readonly Mock<ITrustHelper> _mockTrustHelper;
-    private readonly DummyTrustFactory _dummyTrustFactory;
 
     public TrustProviderTests()
     {
         var mockAcademiesDbContext = new MockAcademiesDbContext();
         _groups = mockAcademiesDbContext.SetupMockDbContextGroups(5);
-        _dummyTrustFactory = new DummyTrustFactory();
         _mockTrustHelper = new Mock<ITrustHelper>();
 
         _sut = new TrustProvider(mockAcademiesDbContext.Object, _mockTrustHelper.Object);
@@ -27,7 +25,7 @@ public class TrustProviderTests
         var group = new Group
             { GroupName = "trust 1", GroupUid = "1234", GroupType = "Multi-academy trust", Ukprn = "my ukprn" };
         _groups.Add(group);
-        var expectedTrust = _dummyTrustFactory.GetDummyTrust(group.GroupUid);
+        var expectedTrust = DummyTrustFactory.GetDummyTrust(group.GroupUid);
 
         _mockTrustHelper.Setup(t => t.CreateTrustFromGroup(group)).Returns(expectedTrust);
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/DummyTrustFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/DummyTrustFactory.cs
@@ -12,7 +12,7 @@ public class DummyTrustFactory
         return GetDummyTrust(_numberTrustsGenerated.ToString("0000"));
     }
 
-    public Trust GetDummyTrust(string uid)
+    public static Trust GetDummyTrust(string uid)
     {
         return new Trust(uid, $"Trust {uid}", "test", "test", "test", "test");
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
@@ -8,12 +8,10 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
 public class ContactsModelTests
 {
     private readonly Mock<ITrustProvider> _mockTrustProvider;
-    private readonly DummyTrustFactory _dummyTrustFactory;
     private readonly ContactsModel _sut;
 
     public ContactsModelTests()
     {
-        _dummyTrustFactory = new DummyTrustFactory();
         _mockTrustProvider = new Mock<ITrustProvider>();
         _sut = new ContactsModel(_mockTrustProvider.Object);
     }
@@ -21,7 +19,7 @@ public class ContactsModelTests
     [Fact]
     public async void OnGetAsync_should_fetch_a_trust_by_Uid()
     {
-        var dummyTrust = _dummyTrustFactory.GetDummyTrust("1234");
+        var dummyTrust = DummyTrustFactory.GetDummyTrust("1234");
         _mockTrustProvider.Setup(s => s.GetTrustByUidAsync(dummyTrust.Uid))
             .ReturnsAsync(dummyTrust);
         _sut.Uid = dummyTrust.Uid;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/DetailsModelTests.cs
@@ -9,11 +9,9 @@ public class DetailsModelTests
 {
     private readonly Mock<ITrustProvider> _mockTrustProvider;
     private readonly DetailsModel _sut;
-    private readonly DummyTrustFactory _dummyTrustFactory;
 
     public DetailsModelTests()
     {
-        _dummyTrustFactory = new DummyTrustFactory();
         _mockTrustProvider = new Mock<ITrustProvider>();
         _sut = new DetailsModel(_mockTrustProvider.Object);
     }
@@ -21,7 +19,7 @@ public class DetailsModelTests
     [Fact]
     public async void OnGetAsync_should_fetch_a_trust_by_uid()
     {
-        var dummyTrust = _dummyTrustFactory.GetDummyTrust("1234");
+        var dummyTrust = DummyTrustFactory.GetDummyTrust("1234");
         _mockTrustProvider.Setup(s => s.GetTrustByUidAsync(dummyTrust.Uid))
             .ReturnsAsync(dummyTrust);
         _sut.Uid = dummyTrust.Uid;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/OverviewModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/OverviewModelTests.cs
@@ -9,12 +9,10 @@ public class OverviewModelTests
 {
     private readonly Mock<ITrustProvider> _mockTrustProvider;
     private readonly OverviewModel _sut;
-    private readonly DummyTrustFactory _dummyTrustFactory;
 
 
     public OverviewModelTests()
     {
-        _dummyTrustFactory = new DummyTrustFactory();
         _mockTrustProvider = new Mock<ITrustProvider>();
         _sut = new OverviewModel(_mockTrustProvider.Object);
     }
@@ -22,7 +20,7 @@ public class OverviewModelTests
     [Fact]
     public async void OnGetAsync_should_fetch_a_trust_by_Uid()
     {
-        var dummyTrust = _dummyTrustFactory.GetDummyTrust("1234");
+        var dummyTrust = DummyTrustFactory.GetDummyTrust("1234");
         _mockTrustProvider.Setup(s => s.GetTrustByUidAsync(dummyTrust.Uid))
             .ReturnsAsync(dummyTrust);
         _sut.Uid = dummyTrust.Uid;


### PR DESCRIPTION
Member 'GetDummyTrust' does not access instance data and can be marked as static.

Resolving [sonarcloud consistency warning](https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&pullRequest=216&id=DFE-Digital_find-information-about-academies-and-trusts&open=AYuGdMMOM2o2aWCfsDjy) related to #216 

## Changes

- Mark `GetDummyTrust` method used to generate dummy Trusts instances for unit test assertions as static, and update relevant tests.

## Screenshots of UI changes

N/A

## Checklist

- N/A Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- N/A Update the ADR decision log if needed
