### PR TITLE
Privacy pages added with footer and ui tests

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Footer.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Footer.cshtml
@@ -1,2 +1,24 @@
 <footer class="govuk-footer " role="contentinfo">
+  <div class="govuk-width-container ">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <h2 class="govuk-visually-hidden">Support links</h2>
+        <ul class="govuk-footer__inline-list">
+          <li class="govuk-footer__inline-list-item">
+            <a asp-page="/Privacy" class="govuk-footer__link" data-testid="privacy-policy-link">Privacy policy</a>
+          </li>
+        </ul>
+        <svg class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+          <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"/>
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+
+      </div>
+      <div class="govuk-footer__meta-item">
+      </div>
+    </div>
+  </div>
 </footer>

--- a/DfE.FindInformationAcademiesTrusts/Pages/privacy.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/privacy.cshtml
@@ -1,0 +1,152 @@
+@page
+
+@{
+  Layout = "_ContentLayout";
+  ViewData["Title"] = "Privacy notice";
+}
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">
+          Privacy notice for Find information about academies and trusts
+        </h1>
+        <p class="govuk-body">
+          The Department for Education (DfE) owns ‘Find information about academies and trusts’ and is also the data controller for the personal data processed as part of the product.
+        </p>
+        <p class="govuk-body">
+          This notice explains why we use personal information and how.
+        </p>
+        <h3 class="govuk-heading-m">
+          What data is collected
+        </h3>
+        <p class="govuk-body">
+          We may use the following personal information:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>trust and school managers and governance roles name and email addresses</li>
+          <li>authorised and public user’s internet protocol address (IP)</li>
+          <li>DfE SFSO lead and trust relationship manager names and email addresses</li>
+        </ul>
+        <h3 class="govuk-heading-m">
+          Why we use it
+        </h3>
+        <p class="govuk-body">
+          DfE processes data to compile and maintain a register of academies and trusts in England and Wales. This product is a tool for everyone in DfE to find information which is collated from multiple sources about academies and trusts to inform their assessments, decisions and support activities.
+        </p>
+        <h3 class="govuk-heading-m">
+          Our legal basis for processing your data
+        </h3>
+        <p class="govuk-body">
+          The law says that we can use the data you provide to:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>in the exercise of our functions as a government department</li>
+          <li>perform a task in the public interest</li>
+        </ul>
+        <h3 class="govuk-heading-m">
+          Where your data is stored and processed
+        </h3>
+        <p class="govuk-body">
+          The DfE holds and processes personal information within the United Kingdom (UK) and under contracted services, within the European Economic Area (EEA).
+        </p>
+        <p class="govuk-body">
+          Your personal data may be transferred outside the United Kingdom while being processed by DfE. If this happens, we’ll make sure you’re given the same level of technical and legal protection as you are within the United Kingdom.
+        </p>
+        <h3 class="govuk-heading-m">
+          How long we keep your data
+        </h3>
+        <p class="govuk-body">
+          We will only keep your personal data for as long as:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>the law requires us to</li>
+          <li>we need for the purposes listed under ‘Why we use it’</li>
+        </ul>
+        <p class="govuk-body">
+          Under law, personal data can be kept for longer periods of time when processed purely for archiving purposes in the public interest, scientific or historical research, and statistical purposes.
+        </p>
+        <p class="govuk-body">
+          We can keep non-public personal data for 6 years. It is then reviewed annually.
+        </p>
+        <h3 class="govuk-heading-m">
+          Who we share your data with
+        </h3>
+        <p class="govuk-body">
+          We may share information we hold about you with certain organisations where the law allows it, or if we have a legal obligation to do so. We may share information with other organisations, including the following:
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>national and local agencies who look after children</li>
+          <li>local authorities</li>
+          <li>professionals who work in early years, schools and further and higher education institutions, children’s services and health services</li>
+          <li>other government departments and related public-sector bodies</li>
+          <li>research institutions</li>
+          <li>organisations contracted with us and/or by the above organisations to undertake work for them, requiring them to manage your information</li>
+        </ul>
+        <p class="govuk-body">
+          We will share your data if we’re required to do so by law — for example, by court order, or to prevent fraud or other crime.
+        </p>
+        <h3 class="govuk-heading-m">
+          Your rights
+        </h3>
+        <p class="govuk-body">
+          By law you are entitled to:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>ask to see a copy of any information we hold about you - this is called a Subject Access Request (SAR)</li>
+          <li>ask us to correct mistakes in your data</li>
+          <li>ask us to stop processing it</li>
+          <li>ask us to delete it</li>
+        </ul>
+        <p class="govuk-body">
+          If you ask us to delete or stop processing data from an ongoing application, we may not be able to continue with it.
+        </p>
+        <p class="govuk-body">
+          You may also want to:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            <a href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter" class="govuk-link">read DfE’s Personal Information Charter</a>
+            for more information on the data it holds, and how to make an SAR
+          </li>
+          <li>
+            <a href="https://ico.org.uk/" class="govuk-link" target="_blank">visit the Information Commissioner’s Office website (opens in new tab)</a> to learn more about your rights
+          </li>
+        </ul>
+        <h3 class="govuk-heading-m">
+          Contact us or make a complaint
+        </h3>
+        <p class="govuk-body">
+          If you have any questions about the way we use your data, or if you want to make a complaint, you can:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            <a href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen">use the DfE contact form</a>, or
+          </li>
+          <li>
+            write to our Data Protection Officer (DPO) at
+          </li>
+        </ul>
+        <p class="govuk-body-m">
+          Data Protection Officer<br>
+          Department for Education (B2.28)<br>
+          7 & 8 Wellington Place<br>
+          Wellington Street<br>
+          Leeds<br>
+          LS1 4AW
+        </p>
+        <h3 class="govuk-heading-m">
+          Changes to this policy
+        </h3>
+        <p class="govuk-body-m">
+          We recommend that you come back to this page from time to time as we sometimes need to update this information.
+        </p>
+        <p class="govuk-body-m">
+          Last updated October 2023.
+        </p>
+      </div>
+    </div>
+  </main>
+</div>

--- a/tests/playwright/accessibility-tests/privacy-page.spec.ts
+++ b/tests/playwright/accessibility-tests/privacy-page.spec.ts
@@ -1,0 +1,15 @@
+import { test } from './a11y-test'
+import { PrivacyPage } from '../page-object-model/privacy-page'
+
+test.describe('Page not found', () => {
+    let privacyPage: PrivacyPage
+
+    test.beforeEach(async ({ page }) => {
+        privacyPage = new PrivacyPage(page)
+    })
+
+    test('Privacy page should have no automatically detectable accessibility issues', async ({ expectNoAccessibilityViolations }) => {
+        await privacyPage.goTo()
+        await expectNoAccessibilityViolations()
+    })
+})

--- a/tests/playwright/page-object-model/home-page.ts
+++ b/tests/playwright/page-object-model/home-page.ts
@@ -1,14 +1,17 @@
 import { Locator, Page, expect } from '@playwright/test'
 import { CurrentSearch, SearchFormComponent } from './shared/search-form-component'
+import { FooterNavigationComponent } from '../page-object-model/shared/footer-navigation-component'
 
 export class HomePage {
   readonly expect: HomePageAssertions
   readonly searchForm: SearchFormComponent
+  readonly footerNavigation: FooterNavigationComponent
   readonly _searchBoxLocator: Locator
   readonly _searchButtonLocator: Locator
 
   constructor (readonly page: Page, currentSearch: CurrentSearch) {
     this.expect = new HomePageAssertions(this)
+    this.footerNavigation = new FooterNavigationComponent(page)
     this.searchForm = new SearchFormComponent(
       page,
       'Find information about academies and trusts',

--- a/tests/playwright/page-object-model/privacy-page.ts
+++ b/tests/playwright/page-object-model/privacy-page.ts
@@ -1,0 +1,22 @@
+import { Locator, Page, expect } from '@playwright/test'
+export class PrivacyPage {
+    readonly expect: PrivacyPageAssertions
+    readonly body: Locator
+
+    constructor (readonly page: Page) {
+        this.expect = new PrivacyPageAssertions(this)
+        this.body = page.locator('body')
+    }
+
+    async goTo (): Promise<void> {
+        await this.page.goto('/privacy')
+    }
+}
+
+class PrivacyPageAssertions {
+    constructor (readonly privacyPage: PrivacyPage) { }
+    async toBeOnTheRightPage(): Promise<void> {
+        
+        await expect(this.privacyPage.body).toContainText('Privacy notice for Find information about academies and trusts')
+    }
+}

--- a/tests/playwright/page-object-model/shared/footer-navigation-component.ts
+++ b/tests/playwright/page-object-model/shared/footer-navigation-component.ts
@@ -1,0 +1,22 @@
+import { Locator, Page, expect } from '@playwright/test'
+
+export class FooterNavigationComponent {
+    readonly expect: FooterNavigationComponentAssertions
+    readonly locator: Locator
+    readonly privacyPolicyLinkLocator: Locator
+    constructor(readonly page: Page) {
+        this.expect = new FooterNavigationComponentAssertions(this)
+        this.privacyPolicyLinkLocator = page.getByTestId('privacy-policy-link')
+    }
+
+    async clickPrivacyPolicy () {
+        await this.privacyPolicyLinkLocator.click()
+    }
+}
+    class FooterNavigationComponentAssertions {
+        constructor(readonly footerNavigation: FooterNavigationComponent) {
+        }
+        async isVisible(): Promise<void> {
+            await expect(this.footerNavigation.locator).toContainText('All content is available under the Open Government Licence v3.0, except where otherwise stated')
+        }
+    }

--- a/tests/playwright/ui-tests/navigation.spec.ts
+++ b/tests/playwright/ui-tests/navigation.spec.ts
@@ -1,19 +1,28 @@
 import { test } from '@playwright/test'
+import { CurrentSearch } from '../../page-object-model/shared/search-form-component'
+import { HomePage } from '../../page-object-model/home-page'
 import { DetailsPage } from '../../page-object-model/trust/details-page'
 import { ContactsPage } from '../../page-object-model/trust/contacts-page'
 import { FakeTestData } from '../../fake-data/fake-test-data'
 import { OverviewPage } from '../../page-object-model/trust/overview-page'
+import { PrivacyPage } from '../../page-object-model/privacy-page'
 
 test.describe('Trust navigation', () => {
+  let homePage : HomePage
+  let currentSearch : CurrentSearch
   let detailsPage: DetailsPage
   let contactsPage: ContactsPage
   let overviewPage: OverviewPage
+  let privacyPage: PrivacyPage
 
   test.beforeEach(async ({ page }) => {
     const fakeTestData = new FakeTestData()
+    currentSearch = new CurrentSearch()
+    homePage = new HomePage(page, currentSearch)
     detailsPage = new DetailsPage(page, fakeTestData)
     contactsPage = new ContactsPage(page, fakeTestData)
     overviewPage = new OverviewPage(page, fakeTestData)
+    privacyPage = new PrivacyPage(page)
   })
 
   test('user should be able to navigate between different sections about a trust', async () => {
@@ -38,4 +47,12 @@ test.describe('Trust navigation', () => {
     await overviewPage.trustNavigation.clickOn('Details')
     await detailsPage.expect.toBeOnTheRightPage()
   })
+
+
+test('user should be able to navigate to the different links within the footer', async () => {
+  //Footer Via HomePage => Privacy
+  await homePage.goTo()
+  await homePage.footerNavigation.clickPrivacyPolicy()
+  await privacyPage.expect.toBeOnTheRightPage()
+})
 })


### PR DESCRIPTION

## Changes

A basic footer has been added to access the privacy policy page. Ui tests have been added also to verify accessibility and navigation

## Screenshots of UI changes

### Before

![image](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/123379894/fd306328-415f-499a-a2c8-86e36c6bc910)


### After

![image](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/123379894/38e2169d-ca88-4828-b082-5e1ed5695443)

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
