### PR TITLE
contact page added with UI tests

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
@@ -4,3 +4,86 @@
 @{
   Layout = "_TrustLayout";
 }
+
+<section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9" data-testid="dfe-contacts">
+  <div class="govuk-summary-card">
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title">Dfe Contacts</h2>
+    </div>
+    <div class="govuk-summary-card__content">
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Trust relationship manager
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Keyshawn Hermiston
+            <p class="govuk-body">
+              <a class="govuk-link" href="#">Keyshawn.Hermiston@education.gov.uk</a>
+            </p>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            SFSO (Schools financial support and oversight) lead
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Ayana Lueilwitz
+            <p class="govuk-body">
+              <a class="govuk-link" href="#">Ayana.Lueilwitz@education.gov.uk</a>
+            </p>
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+</section>
+
+<section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9" data-testid="trust-contacts">
+  <div class="govuk-summary-card">
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title">Trust Contacts</h2>
+      </div>
+      <div class="govuk-summary-card__content">
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Accounting officer
+            </dt>
+            <dd class="govuk-summary-list__value">
+              Tyler Welch
+              <p class="govuk-body">
+                <a class="govuk-link" href="#">Tyler.Welch@abbeylaneacademiestrust.co.uk</a>
+              </p>
+              Telephone: 027 5395 0525
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Chair of trustees
+            </dt>
+            <dd class="govuk-summary-list__value">
+              Courtney Pacocha
+              <p class="govuk-body">
+                <a class="govuk-link" href="#">Courtney.Pacocha@abbeylaneacademiestrust.co.uk</a>
+              </p>
+              Telephone: 0500 544079
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Chief financial officer
+            </dt>
+            <dd class="govuk-summary-list__value">
+              Lowell Hoppe
+              <p class="govuk-body">
+                <a class="govuk-link" href="#">Lowell.Hoppe@abbeylaneacademiestrust.co.uk</a>
+              </p>
+              Telephone: 01289 72558
+            </dd>
+          </div>
+
+        </dl>
+      </div>
+    </div>
+</section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
@@ -24,13 +24,13 @@
           </a>
         </li>
         <li class="ds_side-navigation__item app-side-navigation-highlight-item">
-          <a asp-page="./Overview" asp-route-uid="@Model.Trust.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Overview")">
-            <span class="visually-hidden">Trust</span>Overview
+          <a asp-page="./Contacts" asp-route-uid="@Model.Trust.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Contacts")">
+            <span class="visually-hidden">Trust</span>Contacts
           </a>
         </li>
         <li class="ds_side-navigation__item app-side-navigation-highlight-item">
-          <a asp-page="./Contacts" asp-route-uid="@Model.Trust.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Contacts")">
-            <span class="visually-hidden">Trust</span>Contacts
+          <a asp-page="./Overview" asp-route-uid="@Model.Trust.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Overview")">
+            <span class="visually-hidden">Trust</span>Overview
           </a>
         </li>
       </ul>

--- a/tests/playwright/accessibility-tests/trusts/contact-page.spec.ts
+++ b/tests/playwright/accessibility-tests/trusts/contact-page.spec.ts
@@ -1,0 +1,15 @@
+import { test } from '../a11y-test'
+import { ContactsPage } from '../../page-object-model/trust/contacts-page'
+import { FakeTestData } from '../../fake-data/fake-test-data'
+
+test.describe('Contacts page', () => {
+  test('should not have any automatically detectable accessibility issues', async ({ expectNoAccessibilityViolations, page }) => {
+    const contactsPage = new ContactsPage(page, new FakeTestData())
+    await contactsPage.goTo()
+    await contactsPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
+    await contactsPage.trustNavigation.expect.toBeVisible()
+    await contactsPage.expect.toSeeCorrectDfeContacts()
+    await contactsPage.expect.toSeeCorrectTrustContacts()
+    await expectNoAccessibilityViolations()
+  })
+})

--- a/tests/playwright/page-object-model/trust/contacts-page.ts
+++ b/tests/playwright/page-object-model/trust/contacts-page.ts
@@ -8,6 +8,8 @@ export class ContactsPage {
   readonly trustHeading: TrustHeaderComponent
   readonly trustNavigation: TrustNavigationComponent
   readonly pageHeadingLocator: Locator
+  readonly dfeContactsCard: Locator
+  readonly trustContactsCard: Locator
 
   fakeTestData: FakeTestData
   currentTrust: FakeTrust
@@ -18,6 +20,8 @@ export class ContactsPage {
     this.trustHeading = new TrustHeaderComponent(page)
     this.trustNavigation = new TrustNavigationComponent(page)
     this.pageHeadingLocator = page.locator('h1')
+    this.dfeContactsCard = page.locator('[data-testid="dfe-contacts"]')
+    this.trustContactsCard = page.locator('[data-testid="trust-contacts"]')
   }
 
   async goTo (): Promise<void> {
@@ -44,5 +48,24 @@ class ContactsPageAssertions {
   async toSeeCorrectTrustNameAndTypeInHeader (): Promise<void> {
     const { name, type } = this.contactsPage.fakeTestData.getFirstTrust()
     await this.contactsPage.trustHeading.expect.toSeeCorrectTrustNameAndType(name, type)
+  }
+
+  async toSeeCorrectDfeContacts (): Promise<void> {
+    await expect(this.contactsPage.dfeContactsCard).toContainText('Keyshawn Hermiston')
+    await expect(this.contactsPage.dfeContactsCard).toContainText('Keyshawn.Hermiston@education.gov.uk')
+    await expect(this.contactsPage.dfeContactsCard).toContainText('Ayana Lueilwitz')
+    await expect(this.contactsPage.dfeContactsCard).toContainText('Ayana.Lueilwitz@education.gov.uk')
+  }
+
+  async toSeeCorrectTrustContacts (): Promise<void> {
+    await expect(this.contactsPage.trustContactsCard).toContainText('Tyler Welch')
+    await expect(this.contactsPage.trustContactsCard).toContainText('Tyler.Welch@abbeylaneacademiestrust.co.uk')
+    await expect(this.contactsPage.trustContactsCard).toContainText('Telephone: 027 5395 0525')
+    await expect(this.contactsPage.trustContactsCard).toContainText('Courtney Pacocha')
+    await expect(this.contactsPage.trustContactsCard).toContainText('Courtney.Pacocha@abbeylaneacademiestrust.co.uk')
+    await expect(this.contactsPage.trustContactsCard).toContainText('Telephone: 0500 544079')
+    await expect(this.contactsPage.trustContactsCard).toContainText('Lowell Hoppe')
+    await expect(this.contactsPage.trustContactsCard).toContainText('Lowell.Hoppe@abbeylaneacademiestrust.co.uk')
+    await expect(this.contactsPage.trustContactsCard).toContainText('Telephone: 01289 72558')
   }
 }

--- a/tests/playwright/ui-tests/trusts/contacts-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/contacts-page.spec.ts
@@ -16,6 +16,11 @@ test.describe('Contacts page', () => {
     await contactsPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
   })
 
+  test('user should see the correct contact information', async () => {
+    await contactsPage.expect.toSeeCorrectDfeContacts()
+    await contactsPage.expect.toSeeCorrectTrustContacts()
+  })
+
   test.describe('given a user tries to visit the url without an existing trust', () => {
     test.beforeEach(({ page }) => {
       notFoundPage = new NotFoundPage(page)


### PR DESCRIPTION
## Changes

contact page added with UI test update and accessibility test added. trust navigation changes as per the Heroku prototype

[User Story 146343](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/146343): Build: Contacts Page UI

## Screenshots of UI changes

![image](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/123379894/e270f27d-79bd-4637-a009-ad377777a052)



## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
