### PR TITLE
Switch to using a re-usable workflow

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -26,8 +26,6 @@ jobs:
     outputs:
       environment: ${{ steps.var.outputs.environment }}
       branch: ${{ steps.var.outputs.branch }}
-      release: ${{ steps.var.outputs.release }}
-      sha: ${{ steps.var.outputs.sha }}
     steps:
       - id: var
         run: |
@@ -35,84 +33,24 @@ jobs:
           GIT_BRANCH=${GIT_REF##*/}
           INPUT=${{ github.event.inputs.environment }}
           ENVIRONMENT=${INPUT:-"development"}
-          RELEASE=${ENVIRONMENT,,}-`date +%Y-%m-%d`.${{ github.run_number }}
           echo "environment=${ENVIRONMENT,,}" >> $GITHUB_OUTPUT
           echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
-          echo "release=${RELEASE}" >> $GITHUB_OUTPUT
-          echo "sha=${GITHUB_SHA}" >> $GITHUB_OUTPUT
-
-  build-and-push-image:
-    name: Build and push to ACR
-    needs: set-env
-    runs-on: ubuntu-22.04
-    environment: ${{ needs.set-env.outputs.environment }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Azure Container Registry login
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.AZURE_ACR_CLIENTID }}
-          password: ${{ secrets.AZURE_ACR_SECRET }}
-          registry: ${{ secrets.AZURE_ACR_URL }}
-
-      - name: Build and push docker image
-        uses: docker/build-push-action@v5
-        with:
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-          context: .
-          file: docker/Dockerfile
-          tags: |
-            ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.branch }}
-            ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.sha }}
-            ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:latest
-          push: true
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   deploy-image:
-    name: Deploy to ${{ needs.set-env.outputs.environment }} (${{ needs.set-env.outputs.sha }})
-    needs: [ build-and-push-image, set-env ]
-    runs-on: ubuntu-22.04
-    environment: ${{ needs.set-env.outputs.environment }}
-    steps:
-      - name: Azure login with ACA credentials
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_ACA_CREDENTIALS }}
-
-      - name: Update Azure Container Apps Revision
-        uses: azure/CLI@v1
-        id: azure
-        with:
-          azcliversion: 2.50.0
-          inlineScript: |
-            az config set extension.use_dynamic_install=yes_without_prompt
-            az containerapp update \
-              --name ${{ secrets.AZURE_ACA_NAME }} \
-              --resource-group ${{ secrets.AZURE_ACA_RESOURCE_GROUP }} \
-              --image ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.sha }} \
-              --output none
+    name: Deploy to environment
+    needs: [ set-env ]
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@main
+    with:
+      docker-image-name: ${{ env.DOCKER_IMAGE }}
+      docker-build-file-name: 'docker/Dockerfile'
+      environment: ${{ needs.set-env.outputs.environment }}
+    secrets:
+      azure-acr-client-id: ${{ secrets.AZURE_ACR_CLIENTID }}
+      azure-acr-secret: ${{ secrets.AZURE_ACR_SECRET }}
+      azure-acr-url: ${{ secrets.AZURE_ACR_URL }}
+      azure-aca-credentials: ${{ secrets.AZURE_ACA_CREDENTIALS }}
+      azure-aca-name: ${{ secrets.AZURE_ACA_NAME }}
+      azure-aca-resource-group: ${{ secrets.AZURE_ACA_RESOURCE_GROUP }}
 
   run-deployment-tests:
      name: Run deployment tests


### PR DESCRIPTION
Switching to a re-usable GitHub Action for deploying to Azure helps reduce duplication of code across multiple RSD service repos.

## Changes

- Removed the build, push and deployment steps within the workflow and replaced it with a reference to a re-usable workflow hosted in a different DFE Repository. It does essentially the same job.
