### PR TITLE
Only run .NET tests if project files have changed

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -3,9 +3,21 @@ name: Build, analyse and test .NET code
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'DfE.FindInformationAcademiesTrusts/**'
+      - 'DfE.FindInformationAcademiesTrusts.Data/**'
+      - 'DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/**'
+      - 'tests/**'
+      - '!tests/playwright/**'
   pull_request:
     branches: [ main, '**-feature' ]
     types: [ opened, synchronize, reopened]
+    paths:
+      - 'DfE.FindInformationAcademiesTrusts/**'
+      - 'DfE.FindInformationAcademiesTrusts.Data/**'
+      - 'DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/**'
+      - 'tests/**'
+      - '!tests/playwright/**'
 
 env:
   JAVA_VERSION: '17'


### PR DESCRIPTION
* This will mean we no longer have to wait for this test to pass when changing things that are not .NET
* We would have to change the GitHub repo settings to make the .NET test optional
