### PR TITLE
Fix Faker generating different date every day

### DIFF
--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GroupFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GroupFaker.cs
@@ -20,7 +20,9 @@ public class GroupFaker
             .RuleFor(g => g.GroupContactLocality, f => f.PickRandom(f.Address.StreetName(), string.Empty))
             .RuleFor(g => g.GroupContactTown, f => f.PickRandom(f.Address.City(), string.Empty))
             .RuleFor(g => g.GroupContactPostcode, f => f.Address.ZipCode())
-            .RuleFor(g => g.IncorporatedOnOpenDate, f => f.Date.Past(10).ToString("dd/MM/yyyy"))
+            .RuleFor(g => g.IncorporatedOnOpenDate,
+                f => f.Date.Past(10, new DateTime(2023, 11, 9))
+                    .ToString("dd/MM/yyyy")) //Need a ref date for `Date.Past` so the data generated doesn't change every day
             .RuleFor(g => g.CompaniesHouseNumber, f => f.Random.Int(1100000, 09999999).ToString("D8"));
     }
 

--- a/tests/playwright/fake-data/trusts.json
+++ b/tests/playwright/fake-data/trusts.json
@@ -6,7 +6,7 @@
     "ukprn": "10034481",
     "type": "Multi-academy trust",
     "address": "99627 Mathilde Way, YN0 5GP",
-    "openedDate": "2019-03-01T00:00:00",
+    "openedDate": "2019-03-02T00:00:00",
     "companiesHouseNumber": "02851944",
     "regionAndTerritory": "North West"
   },
@@ -39,7 +39,7 @@
     "ukprn": "10052495",
     "type": "Multi-academy trust",
     "address": "25575 Rupert Valley, Conn Fall, SV3 7SF",
-    "openedDate": "2015-01-23T00:00:00",
+    "openedDate": "2015-01-24T00:00:00",
     "companiesHouseNumber": "04316208",
     "regionAndTerritory": "South East"
   },
@@ -50,7 +50,7 @@
     "ukprn": "10084820",
     "type": "Multi-academy trust",
     "address": "61300 Emilio Gardens, Crooks Ports, FZ6 0VG",
-    "openedDate": "2022-10-23T00:00:00",
+    "openedDate": "2022-10-24T00:00:00",
     "companiesHouseNumber": "02094128",
     "regionAndTerritory": "North East"
   },
@@ -61,7 +61,7 @@
     "ukprn": "10086065",
     "type": "Multi-academy trust",
     "address": "832 Sven Springs, Mylene Summit, Goyetteview, EM96 0ZZ",
-    "openedDate": "2019-08-05T00:00:00",
+    "openedDate": "2019-08-06T00:00:00",
     "companiesHouseNumber": "08295189",
     "regionAndTerritory": "South West"
   },
@@ -83,7 +83,7 @@
     "ukprn": "10030562",
     "type": "Multi-academy trust",
     "address": "96920 Gaylord Knolls, Douglas Stravenue, QN2 9IJ",
-    "openedDate": "2021-11-13T00:00:00",
+    "openedDate": "2021-11-14T00:00:00",
     "companiesHouseNumber": "05185253",
     "regionAndTerritory": "South West"
   },
@@ -105,7 +105,7 @@
     "ukprn": "10040183",
     "type": "Multi-academy trust",
     "address": "47738 Pfannerstill Club, Fisher Route, Alenefort, OY5 3SZ",
-    "openedDate": "2021-07-27T00:00:00",
+    "openedDate": "2021-07-28T00:00:00",
     "companiesHouseNumber": "06657230",
     "regionAndTerritory": "London"
   },
@@ -116,7 +116,7 @@
     "ukprn": "10078024",
     "type": "Multi-academy trust",
     "address": "71074 Mayer Shore, Hilpert Greens, JL42 5TF",
-    "openedDate": "2014-02-17T00:00:00",
+    "openedDate": "2014-02-18T00:00:00",
     "companiesHouseNumber": "04238039",
     "regionAndTerritory": "South East"
   },
@@ -149,7 +149,7 @@
     "ukprn": "10001631",
     "type": "Multi-academy trust",
     "address": "91973 Kenyon Drive, Port Brant, WO5 9MS",
-    "openedDate": "2019-09-07T00:00:00",
+    "openedDate": "2019-09-08T00:00:00",
     "companiesHouseNumber": "09999948",
     "regionAndTerritory": "West Midlands"
   },
@@ -160,7 +160,7 @@
     "ukprn": "10011539",
     "type": "Multi-academy trust",
     "address": "446 Wilbert Wall, Jamil Fords, Orionport, CW3 7OY",
-    "openedDate": "2018-10-18T00:00:00",
+    "openedDate": "2018-10-19T00:00:00",
     "companiesHouseNumber": "06963381",
     "regionAndTerritory": "North East"
   },
@@ -171,7 +171,7 @@
     "ukprn": "10000707",
     "type": "Multi-academy trust",
     "address": "99030 Bechtelar Crossroad, XB36 8BS",
-    "openedDate": "2022-04-09T00:00:00",
+    "openedDate": "2022-04-10T00:00:00",
     "companiesHouseNumber": "07561251",
     "regionAndTerritory": "Yorkshire and the Humber"
   },
@@ -193,7 +193,7 @@
     "ukprn": "10077980",
     "type": "Multi-academy trust",
     "address": "4948 Cummerata Glens, Gregoria Coves, YR7 7MT",
-    "openedDate": "2015-01-20T00:00:00",
+    "openedDate": "2015-01-21T00:00:00",
     "companiesHouseNumber": "02048801",
     "regionAndTerritory": "North East"
   },
@@ -215,7 +215,7 @@
     "ukprn": "10098627",
     "type": "Multi-academy trust",
     "address": "2926 Metz Mall, Okey Points, Daviston, ZR50 7CA",
-    "openedDate": "2019-09-26T00:00:00",
+    "openedDate": "2019-09-27T00:00:00",
     "companiesHouseNumber": "01833958",
     "regionAndTerritory": ""
   },
@@ -226,7 +226,7 @@
     "ukprn": "10082763",
     "type": "Multi-academy trust",
     "address": "034 Brooke Drive, Rohan Neck, SO65 5OU",
-    "openedDate": "2016-06-11T00:00:00",
+    "openedDate": "2016-06-12T00:00:00",
     "companiesHouseNumber": "08482727",
     "regionAndTerritory": "North West"
   },
@@ -248,7 +248,7 @@
     "ukprn": "10094503",
     "type": "Multi-academy trust",
     "address": "584 Jenkins Road, MX4 3XC",
-    "openedDate": "2019-01-24T00:00:00",
+    "openedDate": "2019-01-25T00:00:00",
     "companiesHouseNumber": "03005016",
     "regionAndTerritory": "North West"
   },
@@ -270,7 +270,7 @@
     "ukprn": "10073223",
     "type": "Multi-academy trust",
     "address": "38700 Tromp Tunnel, Hoegerfurt, ZP8 7YA",
-    "openedDate": "2020-10-13T00:00:00",
+    "openedDate": "2020-10-14T00:00:00",
     "companiesHouseNumber": "01890178",
     "regionAndTerritory": "East of England"
   },
@@ -281,7 +281,7 @@
     "ukprn": "10031072",
     "type": "Multi-academy trust",
     "address": "0762 Justice Row, Braeden Turnpike, YG6 5HP",
-    "openedDate": "2022-07-13T00:00:00",
+    "openedDate": "2022-07-14T00:00:00",
     "companiesHouseNumber": "09699456",
     "regionAndTerritory": "South East"
   },
@@ -314,7 +314,7 @@
     "ukprn": "10097862",
     "type": "Multi-academy trust",
     "address": "60611 Della Plaza, TH17 1RI",
-    "openedDate": "2015-05-18T00:00:00",
+    "openedDate": "2015-05-19T00:00:00",
     "companiesHouseNumber": "09521072",
     "regionAndTerritory": "Yorkshire and the Humber"
   },
@@ -358,7 +358,7 @@
     "ukprn": "10081058",
     "type": "Multi-academy trust",
     "address": "480 Murray Tunnel, FJ5 3GS",
-    "openedDate": "2018-09-09T00:00:00",
+    "openedDate": "2018-09-10T00:00:00",
     "companiesHouseNumber": "02786329",
     "regionAndTerritory": ""
   },
@@ -369,7 +369,7 @@
     "ukprn": "10076510",
     "type": "Multi-academy trust",
     "address": "540 Fay Ford, South Adelleberg, QM6 2CI",
-    "openedDate": "2018-03-12T00:00:00",
+    "openedDate": "2018-03-13T00:00:00",
     "companiesHouseNumber": "02476236",
     "regionAndTerritory": "London"
   },
@@ -380,7 +380,7 @@
     "ukprn": "10030337",
     "type": "Multi-academy trust",
     "address": "283 Jovany Greens, Janiya Ports, East Rozella, TP00 5JK",
-    "openedDate": "2019-02-28T00:00:00",
+    "openedDate": "2019-03-01T00:00:00",
     "companiesHouseNumber": "07991197",
     "regionAndTerritory": "South West"
   },
@@ -391,7 +391,7 @@
     "ukprn": "10077751",
     "type": "Multi-academy trust",
     "address": "35021 Lukas Parkways, North Aishaside, AU12 7RU",
-    "openedDate": "2021-06-11T00:00:00",
+    "openedDate": "2021-06-12T00:00:00",
     "companiesHouseNumber": "01459899",
     "regionAndTerritory": "London"
   },
@@ -402,7 +402,7 @@
     "ukprn": "10081792",
     "type": "Multi-academy trust",
     "address": "98547 Fletcher Radial, EL00 0MB",
-    "openedDate": "2021-02-24T00:00:00",
+    "openedDate": "2021-02-25T00:00:00",
     "companiesHouseNumber": "01402379",
     "regionAndTerritory": "East Midlands"
   },
@@ -413,7 +413,7 @@
     "ukprn": "10054945",
     "type": "Multi-academy trust",
     "address": "7451 Little Springs, GV15 9OD",
-    "openedDate": "2023-03-12T00:00:00",
+    "openedDate": "2023-03-13T00:00:00",
     "companiesHouseNumber": "04139461",
     "regionAndTerritory": "North East"
   },
@@ -435,7 +435,7 @@
     "ukprn": "10003508",
     "type": "Multi-academy trust",
     "address": "834 Nelle Road, Sipes Roads, ER23 9LM",
-    "openedDate": "2019-05-30T00:00:00",
+    "openedDate": "2019-05-31T00:00:00",
     "companiesHouseNumber": "06152538",
     "regionAndTerritory": ""
   },
@@ -468,7 +468,7 @@
     "ukprn": "10082880",
     "type": "Multi-academy trust",
     "address": "71250 Alfredo Orchard, PD5 9PP",
-    "openedDate": "2017-05-04T00:00:00",
+    "openedDate": "2017-05-05T00:00:00",
     "companiesHouseNumber": "05658617",
     "regionAndTerritory": "East of England"
   },
@@ -490,7 +490,7 @@
     "ukprn": "10078208",
     "type": "Multi-academy trust",
     "address": "9841 Loma Parkway, Wilbert Valley, JU6 5NM",
-    "openedDate": "2017-04-06T00:00:00",
+    "openedDate": "2017-04-07T00:00:00",
     "companiesHouseNumber": "05398515",
     "regionAndTerritory": "North West"
   },
@@ -501,7 +501,7 @@
     "ukprn": "10077868",
     "type": "Single-academy trust",
     "address": "36740 Mozelle Square, Matt Isle, South Teresaland, LU8 9DI",
-    "openedDate": "2021-06-27T00:00:00",
+    "openedDate": "2021-06-28T00:00:00",
     "companiesHouseNumber": "01189440",
     "regionAndTerritory": "South East"
   },
@@ -512,7 +512,7 @@
     "ukprn": "10065549",
     "type": "Single-academy trust",
     "address": "77600 Blaise Meadow, Hunterburgh, GM42 0KY",
-    "openedDate": "2014-02-18T00:00:00",
+    "openedDate": "2014-02-19T00:00:00",
     "companiesHouseNumber": "04503965",
     "regionAndTerritory": "North East"
   },
@@ -556,7 +556,7 @@
     "ukprn": "10091329",
     "type": "Single-academy trust",
     "address": "94687 Ruecker Drive, Macifort, YP5 4GC",
-    "openedDate": "2020-07-05T00:00:00",
+    "openedDate": "2020-07-06T00:00:00",
     "companiesHouseNumber": "03434646",
     "regionAndTerritory": "South West"
   },
@@ -567,7 +567,7 @@
     "ukprn": "10028937",
     "type": "Single-academy trust",
     "address": "828 Marielle Rest, Waters Flats, JN69 5UM",
-    "openedDate": "2021-11-17T00:00:00",
+    "openedDate": "2021-11-18T00:00:00",
     "companiesHouseNumber": "06224280",
     "regionAndTerritory": "North West"
   },
@@ -578,7 +578,7 @@
     "ukprn": "10036478",
     "type": "Single-academy trust",
     "address": "633 Skiles Island, YB06 4TL",
-    "openedDate": "2016-08-29T00:00:00",
+    "openedDate": "2016-08-30T00:00:00",
     "companiesHouseNumber": "08468944",
     "regionAndTerritory": "South East"
   },
@@ -589,7 +589,7 @@
     "ukprn": "10091049",
     "type": "Multi-academy trust",
     "address": "930 Marjorie Harbor, Bauchfurt, AO8 5DW",
-    "openedDate": "2014-07-14T00:00:00",
+    "openedDate": "2014-07-15T00:00:00",
     "companiesHouseNumber": "05915255",
     "regionAndTerritory": ""
   },
@@ -600,7 +600,7 @@
     "ukprn": "10049762",
     "type": "Single-academy trust",
     "address": "91264 Thomas Plains, Urban Spurs, Sanfordshire, AH0 9II",
-    "openedDate": "2019-08-27T00:00:00",
+    "openedDate": "2019-08-28T00:00:00",
     "companiesHouseNumber": "02584157",
     "regionAndTerritory": "East of England"
   },
@@ -611,7 +611,7 @@
     "ukprn": "10097767",
     "type": "Single-academy trust",
     "address": "898 Schuster Mission, Lake Billie, MF09 8DL",
-    "openedDate": "2017-08-17T00:00:00",
+    "openedDate": "2017-08-18T00:00:00",
     "companiesHouseNumber": "05655575",
     "regionAndTerritory": "South East"
   },
@@ -644,7 +644,7 @@
     "ukprn": "10054354",
     "type": "Single-academy trust",
     "address": "29635 Lehner Glens, Schoen Street, New Earnestland, XY65 5WS",
-    "openedDate": "2019-03-02T00:00:00",
+    "openedDate": "2019-03-03T00:00:00",
     "companiesHouseNumber": "07727951",
     "regionAndTerritory": "South East"
   },
@@ -666,7 +666,7 @@
     "ukprn": "10065784",
     "type": "Single-academy trust",
     "address": "18963 Jess Circles, Craig Mountain, ZJ60 9CJ",
-    "openedDate": "2023-10-16T00:00:00",
+    "openedDate": "2023-10-17T00:00:00",
     "companiesHouseNumber": "03109883",
     "regionAndTerritory": ""
   },
@@ -688,7 +688,7 @@
     "ukprn": "10072268",
     "type": "Multi-academy trust",
     "address": "7176 Marge Parkways, North Bethchester, DT9 4AY",
-    "openedDate": "2016-10-15T00:00:00",
+    "openedDate": "2016-10-16T00:00:00",
     "companiesHouseNumber": "09186752",
     "regionAndTerritory": "North East"
   },
@@ -699,7 +699,7 @@
     "ukprn": "10002695",
     "type": "Multi-academy trust",
     "address": "66616 Mariana Ferry, Pagac Rest, Port Kevon, YC73 7XW",
-    "openedDate": "2019-06-12T00:00:00",
+    "openedDate": "2019-06-13T00:00:00",
     "companiesHouseNumber": "01895143",
     "regionAndTerritory": "East Midlands"
   },
@@ -710,7 +710,7 @@
     "ukprn": "10037344",
     "type": "Multi-academy trust",
     "address": "243 Jed View, LQ81 4XO",
-    "openedDate": "2019-05-07T00:00:00",
+    "openedDate": "2019-05-08T00:00:00",
     "companiesHouseNumber": "09149912",
     "regionAndTerritory": "North East"
   },
@@ -721,7 +721,7 @@
     "ukprn": "10081748",
     "type": "Multi-academy trust",
     "address": "677 Casper Grove, Damaris Fall, Willside, WD7 0XV",
-    "openedDate": "2022-05-24T00:00:00",
+    "openedDate": "2022-05-25T00:00:00",
     "companiesHouseNumber": "05098138",
     "regionAndTerritory": "North East"
   },
@@ -732,7 +732,7 @@
     "ukprn": "10023481",
     "type": "Multi-academy trust",
     "address": "997 Iliana Union, Welch Shores, East Cesarborough, OC78 2IP",
-    "openedDate": "2017-03-14T00:00:00",
+    "openedDate": "2017-03-15T00:00:00",
     "companiesHouseNumber": "03818997",
     "regionAndTerritory": "South East"
   },
@@ -743,7 +743,7 @@
     "ukprn": "10026208",
     "type": "Multi-academy trust",
     "address": "152 Hayes Drive, Jamey Loop, Baileyburgh, GQ9 6RW",
-    "openedDate": "2022-03-30T00:00:00",
+    "openedDate": "2022-03-31T00:00:00",
     "companiesHouseNumber": "06281348",
     "regionAndTerritory": "North East"
   },
@@ -754,7 +754,7 @@
     "ukprn": "10010147",
     "type": "Multi-academy trust",
     "address": "7530 Hartmann Port, EJ16 6GZ",
-    "openedDate": "2020-08-24T00:00:00",
+    "openedDate": "2020-08-25T00:00:00",
     "companiesHouseNumber": "01254059",
     "regionAndTerritory": "London"
   },
@@ -765,7 +765,7 @@
     "ukprn": "10048763",
     "type": "Multi-academy trust",
     "address": "0099 Abernathy Lodge, Cole Isle, Gaylordport, LI0 6SH",
-    "openedDate": "2014-03-01T00:00:00",
+    "openedDate": "2014-03-02T00:00:00",
     "companiesHouseNumber": "02884439",
     "regionAndTerritory": "South West"
   },
@@ -787,7 +787,7 @@
     "ukprn": "10067538",
     "type": "Multi-academy trust",
     "address": "88707 Jakubowski Garden, Cassie Cove, Lake Elmirafort, OW20 5VE",
-    "openedDate": "2021-01-05T00:00:00",
+    "openedDate": "2021-01-06T00:00:00",
     "companiesHouseNumber": "06193174",
     "regionAndTerritory": "London"
   },
@@ -798,7 +798,7 @@
     "ukprn": "10064331",
     "type": "Multi-academy trust",
     "address": "8130 Effertz Village, Kunze Drive, Juliannetown, UW9 2OX",
-    "openedDate": "2020-09-02T00:00:00",
+    "openedDate": "2020-09-03T00:00:00",
     "companiesHouseNumber": "08348193",
     "regionAndTerritory": "South West"
   },
@@ -809,7 +809,7 @@
     "ukprn": "10023922",
     "type": "Multi-academy trust",
     "address": "5658 Arjun Pass, Reilly Loop, Port Eunaview, TG4 2AS",
-    "openedDate": "2019-12-31T00:00:00",
+    "openedDate": "2020-01-01T00:00:00",
     "companiesHouseNumber": "01290370",
     "regionAndTerritory": "East of England"
   },
@@ -853,7 +853,7 @@
     "ukprn": "10063631",
     "type": "Multi-academy trust",
     "address": "810 Viola Parkways, Gerardberg, QX2 0DC",
-    "openedDate": "2020-03-26T00:00:00",
+    "openedDate": "2020-03-27T00:00:00",
     "companiesHouseNumber": "03057358",
     "regionAndTerritory": "South West"
   },


### PR DESCRIPTION
Faker was using a relative date generation method which meant that dates generated depended on both the seed and the current date. This broke the UI tests because the `trusts.json` is manually created and copied into playwright `fake-data` but the dockerised db uses a fresh generation

[Bug 147058](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/147058): Faker generating different date every day