### PR TITLE
privacy link changed on footer

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Footer.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Footer.cshtml
@@ -7,9 +7,6 @@
           <li class="govuk-footer__inline-list-item">
             <a asp-page="/Privacy" class="govuk-footer__link" data-testid="privacy-policy-link">Privacy</a>
           </li>
-          <li class="govuk-footer__inline-list-item">
-            <a asp-page="/Cookies" class="govuk-footer__link" data-testid="privacy-policy-link" asp-route-returnUrl="/Cookies">Cookies</a>
-          </li>
         </ul>
         <svg class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
           <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"/>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Footer.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Footer.cshtml
@@ -5,7 +5,10 @@
         <h2 class="govuk-visually-hidden">Support links</h2>
         <ul class="govuk-footer__inline-list">
           <li class="govuk-footer__inline-list-item">
-            <a asp-page="/Privacy" class="govuk-footer__link" data-testid="privacy-policy-link">Privacy policy</a>
+            <a asp-page="/Privacy" class="govuk-footer__link" data-testid="privacy-policy-link">Privacy</a>
+          </li>
+          <li class="govuk-footer__inline-list-item">
+            <a asp-page="/Cookies" class="govuk-footer__link" data-testid="privacy-policy-link" asp-route-returnUrl="/Cookies">Cookies</a>
           </li>
         </ul>
         <svg class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
@@ -15,7 +18,6 @@
           All content is available under the
           <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
         </span>
-
       </div>
       <div class="govuk-footer__meta-item">
       </div>


### PR DESCRIPTION
## Changes

privacy policy link is now called privacy as in line with other products within the program

[User Story 134800](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/134800): Build: Privacy notice

## Screenshots of UI changes

### Before

<img width="552" alt="image" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/123379894/59288c42-9839-4817-9039-a855ba73e5da">

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps

