### PR TITLE
Lint Markdown files

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -1,0 +1,25 @@
+name: Lint markdown
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened]
+    paths:
+      - 'docs/**'
+
+jobs:
+  mdlint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout
+        with:
+          ref: ${{ github.ref }}
+
+      - uses: articulate/actions-markdownlint@v1
+        with:
+          files: 'docs/**/*.md'
+          config: './docs/.markdownlint.json'
+
+      - uses: articulate/actions-markdownlint@v1
+        with:
+          files: 'docs/*.md'
+          config: './docs/.markdownlint.json'

--- a/docs/.markdownlint.json
+++ b/docs/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "default": true,
+  "line-length": false
+}

--- a/docs/application-insights.md
+++ b/docs/application-insights.md
@@ -5,8 +5,9 @@ App insights is the platform we are using for measuring telemetry. By default ap
 App insights can be enabled locally by including the conncection string in your secrets file. The format should be `"APPLICATIONINSIGHTS_CONNECTION_STRING": "<Connection String here>"`
 You can copy the connection string from Azure. Go the the app insights instance (Current instance name is `s184d01-fiat-insights`) and on the overview panel you can copy the connection string. Always use the development environment when testing locally.
 
-### Tracking events
+## Tracking events
+
 We are tracking page views and requests automatically. If you would like to track your own events then us the TrackEvent method.
 You can track events in the client using javascript or on the server using the app insights module.
 
-More info can be found here https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
+More info about app insights can be found [on learn.microsoft.com](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)

--- a/docs/update-test-data.md
+++ b/docs/update-test-data.md
@@ -1,6 +1,6 @@
 # Update test data
 
-Accessibility and UI tests are written using Playwright, with external dependencies (e.g. APIs) mocked using a fake database. 
+Accessibility and UI tests are written using Playwright, with external dependencies (e.g. APIs) mocked using a fake database.
 
 We use a console application to generate test data, which is added to a fake version of the Academies database before [running the tests](run-tests-locally.md#accessibility-and-ui-tests).
 
@@ -11,6 +11,7 @@ When developing you may need to update and replace this test data—particularly
 3. Navigate to the project's run location  (e.g. `bin/Debug/net7.0`) and copy all json files in the new `data/` folder into `~/tests/playwright/fake-data`
 4. Commit both the update to the Faker project and the new fake data in the playwright directory
 5. If you are already running your tests locally you will need to stop and start the docker container to recreate the test database:
+
 ```bash
 cd tests/playwright
 npm run docker:stop


### PR DESCRIPTION


## Changes

Add a new github action that scans for `.md` files and lints them.

We can customise the lint configuration with a [config file](https://github.com/DavidAnson/markdownlint#optionsconfig) if we need to

[Task 145737](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/145737): Add markdown linting to pipeline

- [x] Attach this pull request to the appropriate user story in Azure DevOps

