### PR TITLE
Add Pagination to the search page

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data/IPageStatus.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/IPageStatus.cs
@@ -1,0 +1,10 @@
+﻿namespace DfE.FindInformationAcademiesTrusts.Data;
+
+public interface IPageStatus
+{
+    int PageIndex { get; }
+    int TotalPages { get; }
+    int TotalResults { get; }
+    bool HasPreviousPage { get; }
+    bool HasNextPage { get; }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/IPagintatedList.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/IPagintatedList.cs
@@ -1,0 +1,6 @@
+﻿namespace DfE.FindInformationAcademiesTrusts.Data;
+
+public interface IPaginatedList<T> : IList<T>
+{
+    public PageStatus PageStatus { get; }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/ITrustSearch.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/ITrustSearch.cs
@@ -2,5 +2,5 @@ namespace DfE.FindInformationAcademiesTrusts.Data;
 
 public interface ITrustSearch
 {
-    public Task<TrustSearchEntry[]> SearchAsync(string searchTerm);
+    public Task<IPaginatedList<TrustSearchEntry>> SearchAsync(string searchTerm, int page = 1);
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/PageStatus.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/PageStatus.cs
@@ -1,0 +1,17 @@
+﻿namespace DfE.FindInformationAcademiesTrusts.Data;
+
+public class PageStatus : IPageStatus
+{
+    public PageStatus(int pageIndex, int totalPages, int totalResults)
+    {
+        PageIndex = pageIndex;
+        TotalPages = totalPages;
+        TotalResults = totalResults;
+    }
+
+    public int PageIndex { get; }
+    public int TotalPages { get; }
+    public int TotalResults { get; }
+    public bool HasPreviousPage => PageIndex > 1;
+    public bool HasNextPage => PageIndex < TotalPages;
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/PaginatedList.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/PaginatedList.cs
@@ -1,0 +1,18 @@
+﻿namespace DfE.FindInformationAcademiesTrusts.Data;
+
+public class PaginatedList<T> : List<T>, IPaginatedList<T>
+{
+    public PageStatus PageStatus { get; }
+
+    public PaginatedList(IEnumerable<T> items, int count, int pageIndex, int pageSize)
+    {
+        var totalPages = (int)Math.Ceiling(count / (double)pageSize);
+        PageStatus = new PageStatus(pageIndex, totalPages, count);
+        AddRange(items);
+    }
+
+    public static PaginatedList<T> Empty()
+    {
+        return new PaginatedList<T>(Array.Empty<T>(), 0, 0, 1);
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts.sln
+++ b/DfE.FindInformationAcademiesTrusts.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademie
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker", "tests\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.csproj", "{CE03C6BD-0160-4265-A287-3EC70103E4C9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademiesTrusts.Data.UnitTests", "tests\DfE.FindInformationAcademiesTrusts.Data.UnitTests\DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj", "{90AA9D53-B5B0-489F-AEC1-23551EA04BC5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,10 +46,15 @@ Global
 		{CE03C6BD-0160-4265-A287-3EC70103E4C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CE03C6BD-0160-4265-A287-3EC70103E4C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CE03C6BD-0160-4265-A287-3EC70103E4C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90AA9D53-B5B0-489F-AEC1-23551EA04BC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90AA9D53-B5B0-489F-AEC1-23551EA04BC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90AA9D53-B5B0-489F-AEC1-23551EA04BC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90AA9D53-B5B0-489F-AEC1-23551EA04BC5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0A3416F9-33DB-4870-97EA-7CFF8D828031} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}
 		{E20D30CB-8EB1-453B-8C49-77CAFBF16A13} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}
 		{CE03C6BD-0160-4265-A287-3EC70103E4C9} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}
+		{90AA9D53-B5B0-489F-AEC1-23551EA04BC5} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}
 	EndGlobalSection
 EndGlobal

--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
@@ -3,7 +3,7 @@
 
 @{
   Layout = "_ContentLayout";
-  ViewData["Title"] = Model.Title();
+  ViewData["Title"] = Model.Title;
 }
 
 @section reportProblem {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml
@@ -3,7 +3,7 @@
 
 @{
   Layout = "_ContentLayout";
-  ViewData["Title"] = string.IsNullOrWhiteSpace(Model.KeyWords) ? "Search" : $"{Model.KeyWords} - Search";
+  ViewData["Title"] = Model.Title();
 }
 
 @section reportProblem {
@@ -24,7 +24,7 @@
 </div>
 <div class="govuk-grid-row">
   <section aria-labelledby="results-details" class="govuk-grid-column-three-quarters">
-    <h2 id="results-details" class="govuk-heading-m">@Model.Trusts.Count() results for "@Model.KeyWords"</h2>
+    <h2 id="results-details" class="govuk-heading-m">@Model.PageStatus.TotalResults result@(Model.PageStatus.TotalResults != 1 ? "s" : "") for "@Model.KeyWords"</h2>
     @if (Model.Trusts.Any())
     {
       <ul class="govuk-list">
@@ -70,3 +70,7 @@
 
   </section>
 </div>
+@if (Model.PageStatus.TotalResults > 0)
+{
+  <partial name="Shared/_Pagination"/>
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml.cs
@@ -70,18 +70,21 @@ public class SearchModel : PageModel, ISearchFormModel, IPaginationModel
                 )));
     }
 
-    public string Title()
+    public string Title
     {
-        if (string.IsNullOrWhiteSpace(KeyWords))
+        get
         {
-            return "Search";
-        }
+            if (string.IsNullOrWhiteSpace(KeyWords))
+            {
+                return "Search";
+            }
 
-        if (PageStatus.TotalPages > 1)
-        {
-            return $"Search (page {PageStatus.PageIndex} of {PageStatus.TotalPages}) - {KeyWords}";
-        }
+            if (PageStatus.TotalPages > 1)
+            {
+                return $"Search (page {PageStatus.PageIndex} of {PageStatus.TotalPages}) - {KeyWords}";
+            }
 
-        return $"Search - {KeyWords}";
+            return $"Search - {KeyWords}";
+        }
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml.cs
@@ -5,24 +5,29 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages;
 
-public class SearchModel : PageModel, ISearchFormModel
+public class SearchModel : PageModel, ISearchFormModel, IPaginationModel
 {
     public record AutocompleteEntry(string Address, string Name, string? TrustId);
 
     private readonly ITrustProvider _trustProvider;
     private readonly ITrustSearch _trustSearch;
+    public string PageName { get; } = "Search";
+    public IPageStatus PageStatus { get; set; }
+    public Dictionary<string, string> PaginationRouteData { get; set; } = new();
+    public string InputId => "search";
+    [BindProperty(SupportsGet = true)] public string KeyWords { get; set; } = string.Empty;
+    [BindProperty(SupportsGet = true)] public string Uid { get; set; } = string.Empty;
+    [BindProperty(SupportsGet = true)] public int PageNumber { get; set; } = 1;
+
+    public IPaginatedList<TrustSearchEntry> Trusts { get; set; } =
+        PaginatedList<TrustSearchEntry>.Empty();
 
     public SearchModel(ITrustProvider trustProvider, ITrustSearch trustSearch)
     {
         _trustProvider = trustProvider;
         _trustSearch = trustSearch;
+        PageStatus = Trusts.PageStatus;
     }
-
-    public string InputId => "search";
-    [BindProperty(SupportsGet = true)] public string KeyWords { get; set; } = string.Empty;
-    [BindProperty(SupportsGet = true)] public string Uid { get; set; } = string.Empty;
-    public IEnumerable<TrustSearchEntry> Trusts { get; set; } = Array.Empty<TrustSearchEntry>();
-
 
     public IActionResult OnPost()
     {
@@ -41,14 +46,17 @@ public class SearchModel : PageModel, ISearchFormModel
         }
 
         Trusts = await GetTrustsForKeywords();
+
+        PageStatus = Trusts.PageStatus;
+        PaginationRouteData = new Dictionary<string, string> { { "Keywords", KeyWords } };
         return new PageResult();
     }
 
-    private async Task<IEnumerable<TrustSearchEntry>> GetTrustsForKeywords()
+    private async Task<IPaginatedList<TrustSearchEntry>> GetTrustsForKeywords()
     {
         return !string.IsNullOrEmpty(KeyWords)
-            ? await _trustSearch.SearchAsync(KeyWords)
-            : Array.Empty<TrustSearchEntry>();
+            ? await _trustSearch.SearchAsync(KeyWords, PageNumber)
+            : PaginatedList<TrustSearchEntry>.Empty();
     }
 
     public async Task<IActionResult> OnGetPopulateAutocompleteAsync()
@@ -60,5 +68,20 @@ public class SearchModel : PageModel, ISearchFormModel
                     trust.Name,
                     trust.Uid
                 )));
+    }
+
+    public string Title()
+    {
+        if (string.IsNullOrWhiteSpace(KeyWords))
+        {
+            return "Search";
+        }
+
+        if (PageStatus.TotalPages > 1)
+        {
+            return $"Search (page {PageStatus.PageIndex} of {PageStatus.TotalPages}) - {KeyWords}";
+        }
+
+        return $"Search - {KeyWords}";
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/IPaginationModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/IPaginationModel.cs
@@ -1,0 +1,11 @@
+﻿using DfE.FindInformationAcademiesTrusts.Data;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Shared;
+
+public interface IPaginationModel
+{
+    public string PageName { get; }
+    public IPageStatus PageStatus { get; }
+    public int PageNumber { get; }
+    public Dictionary<string, string> PaginationRouteData { get; }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Pagination.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Pagination.cshtml
@@ -1,0 +1,82 @@
+﻿@model IPaginationModel
+
+<nav class="govuk-pagination" role="navigation" aria-label="results">
+  @* Previous link *@
+  @if (Model.PageStatus.HasPreviousPage)
+  {
+    <div class="govuk-pagination__prev">
+      <a class="govuk-link govuk-pagination__link" asp-page="@("/" + Model.PageName)" asp-all-route-data="@Model.PaginationRouteData" asp-route-PageNumber="@(Model.PageStatus.PageIndex - 1)" rel="prev">
+        <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+          <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+        </svg>
+        <span class="govuk-pagination__link-title">Previous</span>
+      </a>
+    </div>
+  }
+  <ul class="govuk-pagination__PageStatus">
+    @* First Page *@
+    @if (Model.PageStatus.PageIndex != 1)
+    {
+      <li class="govuk-pagination__item">
+        <a class="govuk-link govuk-pagination__link" asp-page="@("/" + Model.PageName)" asp-all-route-data="@Model.PaginationRouteData" asp-route-PageNumber="1" aria-label="Page 1">
+          1
+        </a>
+      </li>
+    }
+    @* Skipped pages *@
+    @if (Model.PageStatus.HasPreviousPage && Model.PageStatus.PageIndex - 1 > 2)
+    {
+      <li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>
+    }
+    @* previous page *@
+    @if (Model.PageStatus.HasPreviousPage && Model.PageStatus.PageIndex - 1 != 1)
+    {
+      <li class="govuk-pagination__item">
+        <a class="govuk-link govuk-pagination__link" asp-page="@("/" + Model.PageName)" asp-all-route-data="@Model.PaginationRouteData" asp-route-PageNumber="@(Model.PageStatus.PageIndex - 1)" aria-label="Page @(Model.PageStatus.PageIndex - 1)">
+          @(Model.PageStatus.PageIndex - 1)
+        </a>
+      </li>
+    }
+    @* Current page *@
+    <li class="govuk-pagination__item govuk-pagination__item--current">
+      <a class="govuk-link govuk-pagination__link" href="#" aria-label="Page @Model.PageStatus.PageIndex" aria-current="page">
+        @Model.PageStatus.PageIndex
+      </a>
+    </li>
+    @* Next Page *@
+    @if (Model.PageStatus.PageIndex != Model.PageStatus.TotalPages && Model.PageStatus.PageIndex + 1 != Model.PageStatus.TotalPages)
+    {
+      <li class="govuk-pagination__item">
+        <a class="govuk-link govuk-pagination__link" asp-page="@("/" + Model.PageName)" asp-all-route-data="@Model.PaginationRouteData" asp-route-PageNumber="@(Model.PageStatus.PageIndex + 1)" aria-label="Page @(Model.PageStatus.PageIndex + 1)">
+          @(Model.PageStatus.PageIndex + 1)
+        </a>
+      </li>
+    }
+    @* skipped pages *@
+    @if (Model.PageStatus.HasNextPage && Model.PageStatus.PageIndex + 2 < Model.PageStatus.TotalPages)
+    {
+      <li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>
+    }
+    @* last page *@
+    @if (Model.PageStatus.PageIndex != Model.PageStatus.TotalPages)
+    {
+      <li class="govuk-pagination__item">
+        <a class="govuk-link govuk-pagination__link" asp-page="@("/" + Model.PageName)" asp-all-route-data="@Model.PaginationRouteData" asp-route-PageNumber="@(Model.PageStatus.TotalPages)" aria-label="Page @(Model.PageStatus.TotalPages)">
+          @(Model.PageStatus.TotalPages)
+        </a>
+      </li>
+    }
+  </ul>
+  @* next link *@
+  @if (Model.PageStatus.HasNextPage)
+  {
+    <div class="govuk-pagination__next">
+      <a class="govuk-link govuk-pagination__link" asp-page="@("/" + Model.PageName)" asp-all-route-data="@Model.PaginationRouteData" asp-route-PageNumber="@(Model.PageStatus.PageIndex + 1)">
+        <span class="govuk-pagination__link-title">Next</span>
+        <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+          <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+        </svg>
+      </a>
+    </div>
+  }
+</nav>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
@@ -31,6 +31,26 @@ public class TrustSearchTests
     }
 
     [Fact]
+    public async Task SearchAsync_should_return_the_correct_results_page_when_there_are_more_than_20_matches()
+    {
+        const int matches = 60;
+        var groups = _mockAcademiesDbContext.SetupMockDbContextGroups(matches);
+        for (var i = 0; i < groups.Count; i++)
+        {
+            groups[i].GroupName = "Page " + Math.Ceiling((double)(i + 1) / 20);
+        }
+
+        var result = await _sut.SearchAsync("Page");
+        result.All(entry => entry.Name == "Page 1").Should().Be(true);
+
+        result = await _sut.SearchAsync("Page", 2);
+        result.All(entry => entry.Name == "Page 2").Should().Be(true);
+
+        result = await _sut.SearchAsync("Page", 3);
+        result.All(entry => entry.Name == "Page 3").Should().Be(true);
+    }
+
+    [Fact]
     public async Task SearchAsync_should_return_all_results_when_there_are_less_than_20_matches()
     {
         _mockAcademiesDbContext.SetupMockDbContextGroups(19);
@@ -117,7 +137,7 @@ public class TrustSearchTests
     [InlineData(null)]
     public async Task SearchAsync_should_not_call_database_if_empty_search_term(string term)
     {
-        _ = await _sut.SearchAsync(term);
+        await _sut.SearchAsync(term);
         _mockAcademiesDbContext.Verify(academiesDbContext => academiesDbContext.Groups, Times.Never);
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <RootNamespace>DfE.FindInformationAcademiesTrusts.Data.UnitTests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.12.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1"/>
+        <PackageReference Include="Moq" Version="4.20.69"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\DfE.FindInformationAcademiesTrusts.Data\DfE.FindInformationAcademiesTrusts.Data.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/GlobalUsings.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using Xunit;
+global using FluentAssertions;
+global using Moq;

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/PaginatedListTest.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/PaginatedListTest.cs
@@ -1,0 +1,105 @@
+﻿namespace DfE.FindInformationAcademiesTrusts.Data.UnitTests;
+
+public class PaginatedListTest
+{
+    private const int PageSize = 5;
+    private PaginatedList<string> _list = new(Array.Empty<string>(), 0, 0, PageSize);
+
+    private readonly string[] _testNames =
+    {
+        "Evergreen Academy Trust", "Pinnacle Educational Foundation", "Horizon Learning Group",
+        "Unity Educational Services", "Starlight Schools Consortium"
+    };
+
+
+    private void SetupList(int page)
+    {
+        _list = new PaginatedList<string>(_testNames, 20, page, PageSize);
+    }
+
+    [Fact]
+    public void PageIndex_property_is_0_by_default()
+    {
+        _list.PageStatus.PageIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public void PageIndex_property_is_correct_when_on_firstPage()
+    {
+        SetupList(1);
+        _list.PageStatus.PageIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void PageIndex_property_is_correct_when_on_another_page()
+    {
+        SetupList(3);
+        _list.PageStatus.PageIndex.Should().Be(3);
+    }
+
+    [Fact]
+    public void TotalPages_property_is_0_by_default()
+    {
+        _list.PageStatus.TotalPages.Should().Be(0);
+    }
+
+    [Fact]
+    public void TotalPages_property_is_correct_when_on_first_page()
+    {
+        SetupList(1);
+        _list.PageStatus.TotalPages.Should().Be(4);
+    }
+
+    [Fact]
+    public void TotalResults_property_is_0_by_default()
+    {
+        _list.PageStatus.TotalResults.Should().Be(0);
+    }
+
+    [Fact]
+    public void TotalResults_property_is_correct_when_setup()
+    {
+        SetupList(1);
+        _list.PageStatus.TotalResults.Should().Be(20);
+    }
+
+    [Fact]
+    public void HasPreviousPage_property_is_false_by_default()
+    {
+        _list.PageStatus.HasPreviousPage.Should().Be(false);
+    }
+
+    [Fact]
+    public void HasPreviousPage_property_is_false_when_on_first_page()
+    {
+        SetupList(1);
+        _list.PageStatus.HasPreviousPage.Should().Be(false);
+    }
+
+    [Fact]
+    public void HasPreviousPage_property_is_true_when_on_last_page()
+    {
+        SetupList(4);
+        _list.PageStatus.HasPreviousPage.Should().Be(true);
+    }
+
+    [Fact]
+    public void HasNextPage_property_is_false_by_default()
+    {
+        _list.PageStatus.HasNextPage.Should().Be(false);
+    }
+
+    [Fact]
+    public void HasNextPage_property_is_true_when_on_first_page()
+    {
+        SetupList(1);
+        _list.PageStatus.HasNextPage.Should().Be(true);
+    }
+
+    [Fact]
+    public void HasNextPage_property_is_false_when_on_first_page()
+    {
+        SetupList(4);
+        _list.PageStatus.HasNextPage.Should().Be(false);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/SearchModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/SearchModelTests.cs
@@ -193,14 +193,14 @@ public class SearchModelTests
     [Fact]
     public void Title_Should_Be_Search_When_Keywords_Are_Empty()
     {
-        _sut.Title().Should().BeEquivalentTo("Search");
+        _sut.Title.Should().BeEquivalentTo("Search");
     }
 
     [Fact]
     public void Title_Should_Include_The_Keywords_When_they_Are_Set()
     {
         _sut.KeyWords = "Test";
-        _sut.Title().Should().BeEquivalentTo("Search - Test");
+        _sut.Title.Should().BeEquivalentTo("Search - Test");
     }
 
     [Fact]
@@ -208,7 +208,7 @@ public class SearchModelTests
     {
         _sut.KeyWords = "Test";
         _sut.PageStatus = new PageStatus(1, 1, 1);
-        _sut.Title().Should().BeEquivalentTo("Search - Test");
+        _sut.Title.Should().BeEquivalentTo("Search - Test");
     }
 
     [Fact]
@@ -216,6 +216,6 @@ public class SearchModelTests
     {
         _sut.KeyWords = "Test";
         _sut.PageStatus = new PageStatus(1, 2, 3);
-        _sut.Title().Should().BeEquivalentTo("Search (page 1 of 2) - Test");
+        _sut.Title.Should().BeEquivalentTo("Search (page 1 of 2) - Test");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/SearchModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/SearchModelTests.cs
@@ -30,7 +30,8 @@ public class SearchModelTests
         _fakeTrust = dummyTrustFactory.GetDummyTrust();
         mockTrustProvider.Setup(s => s.GetTrustByUidAsync(_fakeTrust.Uid).Result)
             .Returns(_fakeTrust);
-        _mockTrustSearch.Setup(s => s.SearchAsync(SearchTermThatMatchesAllFakeTrusts).Result).Returns(_fakeTrusts);
+        _mockTrustSearch.Setup(s => s.SearchAsync(SearchTermThatMatchesAllFakeTrusts, It.IsAny<int>()).Result)
+            .Returns(new PaginatedList<TrustSearchEntry>(_fakeTrusts, _fakeTrusts.Length, 1, 1));
 
         _sut = new SearchModel(mockTrustProvider.Object, _mockTrustSearch.Object);
     }
@@ -83,8 +84,8 @@ public class SearchModelTests
     public async Task OnGetAsync_should_not_redirect_to_trust_details_if_trustId_does_not_match_query()
     {
         var differentFakeTrust = new TrustSearchEntry("other trust", "Some address", "987", "TR0987");
-        _mockTrustSearch.Setup(s => s.SearchAsync(differentFakeTrust.Name))
-            .ReturnsAsync(new[] { differentFakeTrust });
+        _mockTrustSearch.Setup(s => s.SearchAsync(differentFakeTrust.Name, It.IsAny<int>()))
+            .ReturnsAsync(new PaginatedList<TrustSearchEntry>(new[] { differentFakeTrust }, 1, 1, 1));
 
         _sut.KeyWords = differentFakeTrust.Name;
         _sut.Uid = _fakeTrust.Uid;
@@ -138,5 +139,83 @@ public class SearchModelTests
     public void InputId_should_have_a_fixed_value()
     {
         _sut.InputId.Should().Be("search");
+    }
+
+    [Fact]
+    public void SearchPageNumber_should_default_to_1()
+    {
+        _sut.PageNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public void PageName_should_be_search()
+    {
+        _sut.PageName.Should().Be("Search");
+    }
+
+    [Fact]
+    public void PaginationRouteData_should_default_to_empty()
+    {
+        _sut.PaginationRouteData.Should().BeEquivalentTo(new Dictionary<string, string>());
+    }
+
+    [Fact]
+    public void PageStatus_should_default_to_empty()
+    {
+        _sut.PageStatus.Should().BeEquivalentTo(new PageStatus(0, 0, 0));
+    }
+
+    [Fact]
+    public async Task When_a_different_page_is_requested_return_a_different_page()
+    {
+        _mockTrustSearch.Setup(s => s.SearchAsync(SearchTermThatMatchesAllFakeTrusts, 1))
+            .ReturnsAsync(new PaginatedList<TrustSearchEntry>(_fakeTrusts, 4, 1, 3));
+        var differentFakeTrust =
+            new TrustSearchEntry(SearchTermThatMatchesAllFakeTrusts, "Some address", "987", "TR0987");
+        _mockTrustSearch.Setup(s => s.SearchAsync(differentFakeTrust.Name, 2))
+            .ReturnsAsync(new PaginatedList<TrustSearchEntry>(new[] { differentFakeTrust }, 4, 2, 3));
+
+        _sut.KeyWords = SearchTermThatMatchesAllFakeTrusts;
+        _sut.PageNumber = 1;
+
+        var result = await _sut.OnGetAsync();
+        result.Should().BeOfType<PageResult>();
+        _sut.Trusts.Should().BeEquivalentTo(_fakeTrusts);
+        _sut.PaginationRouteData["Keywords"].Should().Be(SearchTermThatMatchesAllFakeTrusts);
+
+        _sut.PageNumber = 2;
+        result = await _sut.OnGetAsync();
+        result.Should().BeOfType<PageResult>();
+        _sut.Trusts.Should().ContainSingle(t => t == differentFakeTrust);
+        _sut.PaginationRouteData["Keywords"].Should().Be(SearchTermThatMatchesAllFakeTrusts);
+    }
+
+    [Fact]
+    public void Title_Should_Be_Search_When_Keywords_Are_Empty()
+    {
+        _sut.Title().Should().BeEquivalentTo("Search");
+    }
+
+    [Fact]
+    public void Title_Should_Include_The_Keywords_When_they_Are_Set()
+    {
+        _sut.KeyWords = "Test";
+        _sut.Title().Should().BeEquivalentTo("Search - Test");
+    }
+
+    [Fact]
+    public void Title_Should_Include_The_Keywords_When_they_Are_Set_And_There_Is_Only_one_page()
+    {
+        _sut.KeyWords = "Test";
+        _sut.PageStatus = new PageStatus(1, 1, 1);
+        _sut.Title().Should().BeEquivalentTo("Search - Test");
+    }
+
+    [Fact]
+    public void Title_Should_Include_The_Keywords_And_Page_Number_When_They_Are_Set()
+    {
+        _sut.KeyWords = "Test";
+        _sut.PageStatus = new PageStatus(1, 2, 3);
+        _sut.Title().Should().BeEquivalentTo("Search (page 1 of 2) - Test");
     }
 }

--- a/tests/playwright/accessibility-tests/search-page.spec.ts
+++ b/tests/playwright/accessibility-tests/search-page.spec.ts
@@ -16,8 +16,8 @@ test.describe('search page should not have any automatically detectable accessib
     await expectNoAccessibilityViolations()
   })
 
-  test('when going to a search page with a search term', async ({ expectNoAccessibilityViolations }) => {
-    await searchPage.goToPageWithResults()
+  test('when going to a search page with a search term that returns one page of results', async ({ expectNoAccessibilityViolations }) => {
+    await searchPage.goToSearchWithResults()
     await searchPage.expect.toBeOnPageWithMatchingResults()
     await searchPage.expect.toShowResults()
 
@@ -29,6 +29,14 @@ test.describe('search page should not have any automatically detectable accessib
     await searchPage.searchForm.typeASearchTerm()
     await searchPage.searchForm.expect.toShowAnySuggestionInAutocomplete()
 
+    await expectNoAccessibilityViolations()
+  })
+
+  test('when there are multiple pages of results', async ({ expectNoAccessibilityViolations }) => {
+    // Go to second page as this has all the pagination buttons visible
+    await searchPage.goToSearchWithManyPagesOfResults()
+    await searchPage.pagination.selectNextPage()
+    await searchPage.pagination.expect.toBeOnSpecificPage(2)
     await expectNoAccessibilityViolations()
   })
 

--- a/tests/playwright/fake-data/search-terms.ts
+++ b/tests/playwright/fake-data/search-terms.ts
@@ -2,5 +2,7 @@ export const SearchTerms = {
   First: 'trust',
   Second: 'education',
   CommonName: 'mary',
+  OnePage: 'lane',
+  ManyPages: 'trust',
   NoMatches: 'nonexistingtrustname'
 } as const

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -14,7 +14,8 @@
     "test:deployment": "npx playwright test --project=\"deployment-tests\"",
     "test:integration": "npx playwright test --project=\"integration-tests\"",
     "docker:start": "docker compose -f ../../docker/docker-compose.ci.yml up -d --build",
-    "docker:stop": "docker compose -f ../../docker/docker-compose.ci.yml down"
+    "docker:stop": "docker compose -f ../../docker/docker-compose.ci.yml down",
+    "docker:restart": "npm run docker:stop && npm run docker:start"
   },
   "keywords": [],
   "author": "",

--- a/tests/playwright/page-object-model/search-page.ts
+++ b/tests/playwright/page-object-model/search-page.ts
@@ -2,10 +2,12 @@ import { Locator, Page, expect } from '@playwright/test'
 import { CurrentSearch, SearchFormComponent } from './shared/search-form-component'
 import { FakeTestData, FakeTrust } from '../fake-data/fake-test-data'
 import { SearchTerms } from '../fake-data/search-terms'
+import { PaginationComponent } from './shared/pagination-component'
 
 export class SearchPage {
   readonly expect: SearchPageAssertions
   readonly searchForm: SearchFormComponent
+  readonly pagination: PaginationComponent
   readonly _headerLocator: Locator
   readonly _searchResultsListHeaderLocator: Locator
   readonly _searchResultsSectionLocator: Locator
@@ -26,6 +28,7 @@ export class SearchPage {
       currentSearch
     )
     this.currentSearch = currentSearch
+    this.pagination = new PaginationComponent(page)
     this._headerLocator = this.page.locator('h1')
     this._searchResultsListHeaderLocator = this.page.getByRole('heading', {
       name: this._searchResultsHeadingName
@@ -45,11 +48,19 @@ export class SearchPage {
     await this.page.goto(`/search?keywords=${searchTerm}`)
   }
 
-  async goToPageWithResults (): Promise<void> {
+  async goToSearchWithResults (): Promise<void> {
     await this.goToSearchFor(SearchTerms.CommonName)
   }
 
-  async goToPageWithNoResults (): Promise<void> {
+  async goToSearchWithOnePageOfResults (): Promise<void> {
+    await this.goToSearchFor(SearchTerms.OnePage)
+  }
+
+  async goToSearchWithManyPagesOfResults (): Promise<void> {
+    await this.goToSearchFor(SearchTerms.ManyPages)
+  }
+
+  async goToSearchWithNoResults (): Promise<void> {
     await this.goToSearchFor(SearchTerms.NoMatches)
   }
 

--- a/tests/playwright/page-object-model/search-page.ts
+++ b/tests/playwright/page-object-model/search-page.ts
@@ -97,9 +97,9 @@ class SearchPageAssertions {
     await expect(this.searchPage._searchResultsListItemLocator).not.toHaveCount(0)
   }
 
-  async toSeeInformationForEachResult (): Promise<void> {
+  async toSeeInformationForUpToMaximumNumberOfResultsPerPage (): Promise<void> {
     const resultsCount = await this.searchPage._searchResultsListItemLocator.count()
-    expect(resultsCount, `should be a maxium of ${this.searchPage.numberOfResultsOnOnePage} results per page`)
+    expect(resultsCount, `should be a maximum of ${this.searchPage.numberOfResultsOnOnePage} results per page`)
       .toBeLessThanOrEqual(this.searchPage.numberOfResultsOnOnePage)
 
     for (let resultNumber = 0; resultNumber < resultsCount; resultNumber++) {

--- a/tests/playwright/page-object-model/shared/pagination-component.ts
+++ b/tests/playwright/page-object-model/shared/pagination-component.ts
@@ -1,0 +1,61 @@
+import { Locator, Page, expect } from '@playwright/test'
+
+export class PaginationComponent {
+  readonly expect: PaginationComponentAssertions
+  readonly previousButtonLocator: Locator
+  readonly nextButtonLocator: Locator
+
+  constructor (readonly page: Page) {
+    this.expect = new PaginationComponentAssertions(this)
+    this.previousButtonLocator = page.getByRole('link', { name: 'Previous' })
+    this.nextButtonLocator = page.getByRole('link', { name: 'Next' })
+  }
+
+  async selectNextPage (): Promise<void> {
+    await this.nextButtonLocator.click()
+  }
+
+  async selectPreviousPage (): Promise<void> {
+    await this.previousButtonLocator.click()
+  }
+
+  async selectPage (pageNumber: number): Promise<void> {
+    await this.locatePageNumber(pageNumber).click()
+  }
+
+  locatePageNumber (pageNumber: number): Locator {
+    return this.page.getByRole('link', { name: `${pageNumber}` })
+  }
+}
+
+class PaginationComponentAssertions {
+  constructor (readonly pagination: PaginationComponent) {}
+
+  async toShowNextPageLink (): Promise<void> {
+    await expect(this.pagination.nextButtonLocator).toBeVisible()
+  }
+
+  async toNotShowNextPageLink (): Promise<void> {
+    await expect(this.pagination.nextButtonLocator).not.toBeVisible()
+  }
+
+  async toShowPreviousPageLink (): Promise<void> {
+    await expect(this.pagination.previousButtonLocator).toBeVisible()
+  }
+
+  async toNotShowPreviousPageLink (): Promise<void> {
+    await expect(this.pagination.previousButtonLocator).not.toBeVisible()
+  }
+
+  async toShowPageNumber (pageNumber: number): Promise<void> {
+    await expect(this.pagination.locatePageNumber(pageNumber)).toBeVisible()
+  }
+
+  async toBeOnSpecificPage (pageNumber: number): Promise<void> {
+    // First page does not always contain page number in the url
+    if (pageNumber !== 1) {
+      expect(this.pagination.page.url().toLocaleLowerCase()).toContain(`pagenumber=${pageNumber}`)
+    }
+    await expect(this.pagination.locatePageNumber(pageNumber)).toHaveAttribute('aria-current', 'page')
+  }
+}

--- a/tests/playwright/ui-tests/search-page.spec.ts
+++ b/tests/playwright/ui-tests/search-page.spec.ts
@@ -38,7 +38,7 @@ test.describe('Search page', () => {
         })
 
         test('then it displays a list of results with information about each trust', async () => {
-          await searchPage.expect.toDisplayNumberOfResultsFound()
+          await searchPage.expect.toDisplayTotalNumberOfResultsFound()
           await searchPage.expect.toSeeInformationForEachResult()
         })
 
@@ -70,6 +70,11 @@ test.describe('Search page', () => {
           await searchPage.pagination.expect.toBeOnSpecificPage(1)
         })
 
+        test('the correct number of results are returned', async () => {
+          await searchPage.expect.toDisplayTotalNumberOfResultsFound()
+          await searchPage.expect.toSeeInformationForEachResult()
+        })
+
         test('the next page link is visible when there is another page', async () => {
           await searchPage.pagination.expect.toShowNextPageLink()
           await searchPage.pagination.selectPage(4)
@@ -88,6 +93,11 @@ test.describe('Search page', () => {
       test.describe('given that there is only 1 page of results', () => {
         test.beforeEach(async () => {
           await searchPage.goToSearchWithOnePageOfResults()
+        })
+
+        test('the correct number of results are returned', async () => {
+          await searchPage.expect.toDisplayTotalNumberOfResultsFound()
+          await searchPage.expect.toSeeInformationForEachResult()
         })
 
         test('the next and previous page links are not visible', async () => {

--- a/tests/playwright/ui-tests/search-page.spec.ts
+++ b/tests/playwright/ui-tests/search-page.spec.ts
@@ -33,7 +33,7 @@ test.describe('Search page', () => {
 
       test.describe('Given a user searches for a term that returns results', () => {
         test.beforeEach(async () => {
-          await searchPage.goToPageWithResults()
+          await searchPage.goToSearchWithResults()
           await searchPage.expect.toBeOnPageWithMatchingResults()
         })
 
@@ -57,20 +57,54 @@ test.describe('Search page', () => {
           await searchPage.clickOnSearchResultLink(1)
           await detailsPage.expect.toBeOnTheRightPageFor(currentSearch.selectedTrustName)
 
-          await searchPage.goToPageWithResults()
+          await searchPage.goToSearchWithResults()
           await searchPage.clickOnSearchResultLink(2)
           await detailsPage.expect.toBeOnTheRightPageFor(currentSearch.selectedTrustName)
         })
       })
 
+      test.describe('given that there are multiple pages of results', () => {
+        test.beforeEach(async () => {
+          await searchPage.goToSearchWithManyPagesOfResults()
+          await searchPage.expect.toBeOnPageWithMatchingResults()
+          await searchPage.pagination.expect.toBeOnSpecificPage(1)
+        })
+
+        test('the next page link is visible when there is another page', async () => {
+          await searchPage.pagination.expect.toShowNextPageLink()
+          await searchPage.pagination.selectPage(4)
+          await searchPage.pagination.expect.toBeOnSpecificPage(4)
+          await searchPage.pagination.expect.toNotShowNextPageLink()
+        })
+
+        test('the previous page link is visible when there is another page', async () => {
+          await searchPage.pagination.expect.toNotShowPreviousPageLink()
+          await searchPage.pagination.selectNextPage()
+          await searchPage.pagination.expect.toBeOnSpecificPage(2)
+          await searchPage.pagination.expect.toShowPreviousPageLink()
+        })
+      })
+
+      test.describe('given that there is only 1 page of results', () => {
+        test.beforeEach(async () => {
+          await searchPage.goToSearchWithOnePageOfResults()
+        })
+
+        test('the next and previous page links are not visible', async () => {
+          await searchPage.pagination.expect.toBeOnSpecificPage(1)
+          await searchPage.pagination.expect.toNotShowNextPageLink()
+          await searchPage.pagination.expect.toNotShowPreviousPageLink()
+        })
+      })
+
       test.describe('Given a user searches for a term that returns no results', () => {
         test('then they can see an input containing the search term so they can edit it', async () => {
-          await searchPage.goToPageWithNoResults()
+          await searchPage.goToSearchWithNoResults()
           await searchPage.searchForm.expect.inputToContainSearchTerm()
         })
 
         test('they see a helpful message to help them change their search', async () => {
-          await searchPage.goToPageWithNoResults()
+          await searchPage.goToSearchWithNoResults()
           await searchPage.expect.toSeeNoResultsMessage()
         })
       })
@@ -80,7 +114,7 @@ test.describe('Search page', () => {
   test.describe('Only with JavaScript enabled', () => {
     test.describe('Given a user searches for a term that returns results', () => {
       test.beforeEach(async () => {
-        await searchPage.goToPageWithResults()
+        await searchPage.goToSearchWithResults()
         await searchPage.expect.toBeOnPageWithMatchingResults()
       })
 

--- a/tests/playwright/ui-tests/search-page.spec.ts
+++ b/tests/playwright/ui-tests/search-page.spec.ts
@@ -27,7 +27,7 @@ test.describe('Search page', () => {
           await searchPage.searchForm.expect.inputToContainNoSearchTerm()
           await searchPage.expect.toSeeNoResultsMessage()
           await searchPage.searchForm.searchForATrust()
-          await searchPage.expect.toSeeInformationForEachResult()
+          await searchPage.expect.toSeeInformationForUpToMaximumNumberOfResultsPerPage()
         })
       })
 
@@ -39,7 +39,7 @@ test.describe('Search page', () => {
 
         test('then it displays a list of results with information about each trust', async () => {
           await searchPage.expect.toDisplayTotalNumberOfResultsFound()
-          await searchPage.expect.toSeeInformationForEachResult()
+          await searchPage.expect.toSeeInformationForUpToMaximumNumberOfResultsPerPage()
         })
 
         test('the user can edit their search and search again', async ({ browserName }) => {
@@ -50,7 +50,7 @@ test.describe('Search page', () => {
           await searchPage.searchForm.searchForADifferentTrust()
           await searchPage.searchForm.expect.inputToContainSearchTerm()
           await searchPage.expect.toBeOnPageWithMatchingResults()
-          await searchPage.expect.toSeeInformationForEachResult()
+          await searchPage.expect.toSeeInformationForUpToMaximumNumberOfResultsPerPage()
         })
 
         test('when the user clicks on different results they are taken to different trust details pages', async () => {
@@ -70,9 +70,9 @@ test.describe('Search page', () => {
           await searchPage.pagination.expect.toBeOnSpecificPage(1)
         })
 
-        test('the correct number of results are returned', async () => {
+        test('the correct total number of results are displayed and infomation is only shown for one page of results', async () => {
           await searchPage.expect.toDisplayTotalNumberOfResultsFound()
-          await searchPage.expect.toSeeInformationForEachResult()
+          await searchPage.expect.toSeeInformationForUpToMaximumNumberOfResultsPerPage()
         })
 
         test('the next page link is visible when there is another page', async () => {
@@ -95,9 +95,10 @@ test.describe('Search page', () => {
           await searchPage.goToSearchWithOnePageOfResults()
         })
 
-        test('the correct number of results are returned', async () => {
-          await searchPage.expect.toDisplayTotalNumberOfResultsFound()
-          await searchPage.expect.toSeeInformationForEachResult()
+        test('only 1 result is shown', async () => {
+          await searchPage.expect.toDisplayOneResultFound()
+          await searchPage.expect.toBeOnPageWithMatchingResults()
+          await searchPage.expect.toSeeInformationForUpToMaximumNumberOfResultsPerPage()
         })
 
         test('the next and previous page links are not visible', async () => {
@@ -158,7 +159,7 @@ test.describe('Search page', () => {
         await searchPage.searchForm.typeADifferentSearchTerm()
         await searchPage.searchForm.submitSearch()
         await searchPage.expect.toBeOnPageWithMatchingResults()
-        await searchPage.expect.toSeeInformationForEachResult()
+        await searchPage.expect.toSeeInformationForUpToMaximumNumberOfResultsPerPage()
       })
 
       test('then they should be able to change their selection after clicking a result', async ({ browserName }) => {


### PR DESCRIPTION
[User Story 137382](https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/137382): Build: search results on search page should be paginated

Add pagination to the search page. Search results are now split into separate pages, 20 results at a time. Users can navigate through these pages using the controls at the bottom of the page. The pagination control always shows the first, last, current and adjacent page numbers. It also shows the previous and next page links when there is an appropriate page.

## Changes

- Added a class to handle paginated lists returned from the database
- Added a class to hold pagination details
- Added a partial to keep the page navigation controls
- Edited the search request to return a paginated list
- Changed the search page to use the pagination navigation, inherit from the new pagination model so it can have the correct fields, use the correct results number and fix the pluralisation when there is only one result.
- Created a test project for the AcademiesDb.Data project so the Pagination list can be tested
- Added tests to the search page to handle pagination navigation
- Added unit tests to the search model to handle the added pagination fields
- Updated the title of the search page to be in line with other pages in FIAT

## Screenshots of UI changes

### Before
![image](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/128540970/f27b0353-bf4e-4b74-8372-062f31276a69)

### After
![image](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/128540970/7a4c1632-e0d1-4114-a7ee-9da9c05c203d)
![image](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/128540970/17e867fc-331c-457e-ad1c-cb6b0dcff356)
![image](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/128540970/1ae1bb4b-d5dc-4b1f-9175-26cb309279b8)

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
