### PR TITLE
Add UI template for Academies in this trust Ofsted ratings table

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
@@ -24,7 +24,7 @@
         <td class="govuk-body govuk-table__cell">Nov 2018</td>
         <td class="govuk-body govuk-table__cell">
         </td>
-        <td class="govuk-body govuk-table__cell">
+        <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.NotYetInspected)">
           <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2018, 11, 1), "Not yet inspected", null)"></partial>
         </td>
       </tr>
@@ -33,10 +33,10 @@
           Fay Fort Catholic Primary Academy<br/><span class="govuk-!-font-weight-regular">URN: 109174</span>
         </th>
         <td class="govuk-body govuk-table__cell">Nov 2017</td>
-        <td class="govuk-body govuk-table__cell">
+        <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.NotYetInspected)">
           <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 11, 1), "Not yet inspected", null)"></partial>
         </td>
-        <td class="govuk-body govuk-table__cell">
+        <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.Good)">
           <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 11, 1), "Good", new DateTime(2021, 05, 9))"></partial>
         </td>
       </tr>
@@ -45,10 +45,10 @@
           George Abbey Secondary Academy<br/><span class="govuk-!-font-weight-regular">URN: 109174</span>
         </th>
         <td class="govuk-body govuk-table__cell">Nov 2017</td>
-        <td class="govuk-body govuk-table__cell">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 10, 1), "Good", new DateTime(2014, 11, 30));"></partial>
+        <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.RequiresImprovement)">
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 10, 1), "Requires improvement", new DateTime(2014, 11, 30));"></partial>
         </td>
-        <td class="govuk-body govuk-table__cell">
+        <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.Outstanding)">
           <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 10, 1), "Outstanding", new DateTime(2020, 11, 1))"></partial>
         </td>
       </tr>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
@@ -23,10 +23,10 @@
         </th>
         <td class="govuk-body govuk-table__cell">Nov 2018</td>
         <td class="govuk-body govuk-table__cell">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2018, 11, 1), "Not yet inspected", null)"></partial>
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2018, 11, 1, 0, 0, 0, DateTimeKind.Utc), "Not yet inspected", null)"></partial>
         </td>
         <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.NotYetInspected)">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2018, 11, 1), "Not yet inspected", null)"></partial>
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2018, 11, 1, 0, 0, 0, DateTimeKind.Utc), "Not yet inspected", null)"></partial>
         </td>
       </tr>
       <tr class="govuk-table__row" data-testid="academy-row">
@@ -35,10 +35,10 @@
         </th>
         <td class="govuk-body govuk-table__cell">Nov 2017</td>
         <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.NotYetInspected)">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 11, 1), "Not yet inspected", null)"></partial>
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 11, 1, 0, 0, 0, DateTimeKind.Utc), "Not yet inspected", null)"></partial>
         </td>
         <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.Good)">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 11, 1), "Good", new DateTime(2021, 05, 9))"></partial>
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 11, 1, 0, 0, 0, DateTimeKind.Utc), "Good", new DateTime(2021, 05, 9, 0, 0, 0, DateTimeKind.Utc))"></partial>
         </td>
       </tr>
       <tr class="govuk-table__row" data-testid="academy-row">
@@ -47,10 +47,10 @@
         </th>
         <td class="govuk-body govuk-table__cell">Nov 2017</td>
         <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.RequiresImprovement)">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 10, 1), "Requires improvement", new DateTime(2014, 11, 30));"></partial>
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 10, 1, 0, 0, 0, DateTimeKind.Utc), "Requires improvement", new DateTime(2014, 11, 30, 0, 0, 0, DateTimeKind.Utc))"></partial>
         </td>
         <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.Outstanding)">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 10, 1), "Outstanding", new DateTime(2020, 11, 1))"></partial>
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 10, 1, 0, 0, 0, DateTimeKind.Utc), "Outstanding", new DateTime(2020, 11, 1, 0, 0, 0, DateTimeKind.Utc))"></partial>
         </td>
       </tr>
     </tbody>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
@@ -5,3 +5,26 @@
 @{
   Layout = "Academies/_AcademiesLayout";
 }
+
+<section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9 app-table-container">
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="academies-details-link">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">School name</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Date joined</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Previous Ofsted rating</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Current Ofsted rating</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row" data-testid="academy-row">
+        <th scope="row" class="govuk-body govuk-table__header" data-sort-value="Barr and Community R.C. School">
+          Barr and Community R.C. School<br/><span class="govuk-!-font-weight-regular">URN: 109174</span>
+        </th>
+        <td class="govuk-body govuk-table__cell">Nov 2018</td>
+        <td class="govuk-body govuk-table__cell">Not yet inspected</td>
+        <td class="govuk-body govuk-table__cell">Not yet inspected</td>
+      </tr>
+    </tbody>
+  </table>
+</section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
@@ -23,6 +23,7 @@
         </th>
         <td class="govuk-body govuk-table__cell">Nov 2018</td>
         <td class="govuk-body govuk-table__cell">
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2018, 11, 1), "Not yet inspected", null)"></partial>
         </td>
         <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.NotYetInspected)">
           <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2018, 11, 1), "Not yet inspected", null)"></partial>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
@@ -22,8 +22,35 @@
           Barr and Community R.C. School<br/><span class="govuk-!-font-weight-regular">URN: 109174</span>
         </th>
         <td class="govuk-body govuk-table__cell">Nov 2018</td>
-        <td class="govuk-body govuk-table__cell">Not yet inspected</td>
-        <td class="govuk-body govuk-table__cell">Not yet inspected</td>
+        <td class="govuk-body govuk-table__cell">
+        </td>
+        <td class="govuk-body govuk-table__cell">
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2018, 11, 1), "Not yet inspected", null)"></partial>
+        </td>
+      </tr>
+      <tr class="govuk-table__row" data-testid="academy-row">
+        <th scope="row" class="govuk-body govuk-table__header" data-sort-value="Fay Fort Catholic Primary Academy">
+          Fay Fort Catholic Primary Academy<br/><span class="govuk-!-font-weight-regular">URN: 109174</span>
+        </th>
+        <td class="govuk-body govuk-table__cell">Nov 2017</td>
+        <td class="govuk-body govuk-table__cell">
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 11, 1), "Not yet inspected", null)"></partial>
+        </td>
+        <td class="govuk-body govuk-table__cell">
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 11, 1), "Good", new DateTime(2021, 05, 9))"></partial>
+        </td>
+      </tr>
+      <tr class="govuk-table__row" data-testid="academy-row">
+        <th scope="row" class="govuk-body govuk-table__header" data-sort-value="Fay Fort Catholic Primary Academy">
+          George Abbey Secondary Academy<br/><span class="govuk-!-font-weight-regular">URN: 109174</span>
+        </th>
+        <td class="govuk-body govuk-table__cell">Nov 2017</td>
+        <td class="govuk-body govuk-table__cell">
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 10, 1), "Good", new DateTime(2014, 11, 30));"></partial>
+        </td>
+        <td class="govuk-body govuk-table__cell">
+          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 10, 1), "Outstanding", new DateTime(2020, 11, 1))"></partial>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml.cs
@@ -2,6 +2,15 @@ using DfE.FindInformationAcademiesTrusts.Data;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
+public enum OfstedRatings
+{
+    NotYetInspected,
+    Inadequate,
+    RequiresImprovement,
+    Good,
+    Outstanding
+}
+
 public class OfstedRatingsModel : TrustsAreaModel, IAcademiesAreaModel
 {
     public OfstedRatingsModel(ITrustProvider trustProvider) : base(trustProvider, "Academies in this trust")
@@ -10,7 +19,7 @@ public class OfstedRatingsModel : TrustsAreaModel, IAcademiesAreaModel
     }
 
     public string TabName => "Ofsted ratings";
-    
+
     public OfstedRatingCellModel GetOfstedRatingCellModel(DateTime academyJoinedDate, string rating,
         DateTime? ratingDate)
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml.cs
@@ -10,4 +10,15 @@ public class OfstedRatingsModel : TrustsAreaModel, IAcademiesAreaModel
     }
 
     public string TabName => "Ofsted ratings";
+    
+    public OfstedRatingCellModel GetOfstedRatingCellModel(DateTime academyJoinedDate, string rating,
+        DateTime? ratingDate)
+    {
+        return new OfstedRatingCellModel
+        {
+            AcademyJoinedDate = academyJoinedDate,
+            Rating = rating,
+            RatingDate = ratingDate
+        };
+    }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml
@@ -1,0 +1,14 @@
+@model OfstedRatingCellModel
+
+<span class="govuk-!-font-weight-bold">@Model.Rating</span>
+<span>
+  @if (Model.HasRating() && Model.RatingDate is not null)
+  {
+    <br/>
+    @Model.RatingDate.Value.ToString(ViewConstants.ViewDateFormat)
+    <br/>
+    <strong class="@Model.GetTagClasses() govuk-!-margin-top-2 govuk-!-margin-bottom-1">
+      @Model.GetTagText()
+    </strong>
+  }
+</span>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml.cs
@@ -1,0 +1,35 @@
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
+
+internal static class OfstedRatingConstants
+{
+    public const string NotYetInspected = "Not yet inspected";
+}
+
+public class OfstedRatingCellModel
+{
+    public required DateTime? AcademyJoinedDate { get; init; }
+    public required string Rating { get; init; }
+    public required DateTime? RatingDate { get; init; }
+
+    public bool HasRating()
+    {
+        return Rating != OfstedRatingConstants.NotYetInspected;
+    }
+
+    public bool IsAfterJoining()
+    {
+        return RatingDate >= AcademyJoinedDate;
+    }
+
+    public string GetTagClasses()
+    {
+        var tag = "govuk-tag";
+        if (!IsAfterJoining()) tag += " govuk-tag--grey";
+        return tag;
+    }
+
+    public string GetTagText()
+    {
+        return IsAfterJoining() ? "After joining" : "Before joining";
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
@@ -10,4 +10,6 @@ public static class ViewConstants
 
     public const string FeedbackFormLink =
         "https://forms.office.com.mcas.ms/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-VCFjdIWb7BPh79bON_K__tUOTdJMlZZUzBMMFhHV1lHNERFM041U0dUUy4u";
+
+    public const string ViewDateFormat = "d MMM yyyy";
 }

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
@@ -1,8 +1,21 @@
 .app-table-container {
   overflow: auto;
 
-  // Fix sort icons provided by MOJ design system overlapping slightly on Chrome and Edge
-  [aria-sort] button::before {
-    top: 11px;
+  [aria-sort] button {
+    // increase padding slightly to add space between the column header and the sort icon
+    // as we have removed the negative position below
+    padding-right: 1rem;
+
+    // Fix sort icons provided by MOJ design system overlapping slightly on Chrome and Edge
+    &::before {
+      top: 11px;
+    }
+
+    // Fix sort icons causing content to always overflow container
+    // this causes horizontal scroll to always visible when using overflow:auto
+    &::before,
+    &::after {
+      right: 0;
+    }
   }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingCellModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingCellModelTests.cs
@@ -1,0 +1,134 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies;
+
+public class OfstedRatingCellModelTests
+{
+    private readonly OfstedRatingCellModel _sut;
+
+    public OfstedRatingCellModelTests()
+    {
+        _sut = new OfstedRatingCellModel
+        {
+            AcademyJoinedDate = new DateTime(),
+            Rating = "Good",
+            RatingDate = new DateTime()
+        };
+    }
+
+    [Fact]
+    public void HasRating_returns_true_if_rating_is_not_NotYetInspected()
+    {
+        var result = _sut.HasRating();
+        result.Should().Be(true);
+    }
+
+    [Fact]
+    public void HasRating_returns_false_if_rating_is_NotYetInspected()
+    {
+        var sut = GetSutWithNotYetInspectedRating();
+
+        var result = sut.HasRating();
+        result.Should().Be(false);
+    }
+
+    [Fact]
+    public void IsAfterJoining_returns_true_if_RatingDate_is_after_AcademyJoinedDate()
+    {
+        var sut = GetSutWithOfstedRatingDateAfterJoining();
+
+        var result = sut.IsAfterJoining();
+        result.Should().Be(true);
+    }
+
+    [Fact]
+    public void IsAfterJoining_returns_true_if_RatingDate_is_same_as_AcademyJoinedDate()
+    {
+        var result = _sut.IsAfterJoining();
+        result.Should().Be(true);
+    }
+
+    [Fact]
+    public void IsAfterJoining_returns_false_if_RatingDate_is_before_AcademyJoinedDate()
+    {
+        var sut = GetSutWithOfstedRatingDateBeforeJoining();
+
+        var result = sut.IsAfterJoining();
+        result.Should().Be(false);
+    }
+
+    [Fact]
+    public void IsAfterJoining_returns_false_if_RatingDate_is_null()
+    {
+        var sut = GetSutWithNotYetInspectedRating();
+
+        var result = sut.IsAfterJoining();
+        result.Should().Be(false);
+    }
+
+    [Fact]
+    public void GetTagClasses_returns_default_tag_class_if_IsAfterJoining()
+    {
+        var sut = GetSutWithOfstedRatingDateAfterJoining();
+
+        var result = sut.GetTagClasses();
+        result.Should().Be("govuk-tag");
+    }
+
+    [Fact]
+    public void GetTagClasses_returns_grey_tag_class_variant_if_IsAfterJoining_is_false()
+    {
+        var sut = GetSutWithOfstedRatingDateBeforeJoining();
+
+        var result = sut.GetTagClasses();
+        result.Should().Be("govuk-tag govuk-tag--grey");
+    }
+
+    [Fact]
+    public void GetTagText_returns_AfterJoining_If_Rating_Is_AfterJoining()
+    {
+        var sut = GetSutWithOfstedRatingDateAfterJoining();
+
+        var result = sut.GetTagText();
+        result.Should().Be("After joining");
+    }
+
+    [Fact]
+    public void GetTagText_returns_BeforeJoining_If_Rating_Is_Not_AfterJoining()
+    {
+        var sut = GetSutWithOfstedRatingDateBeforeJoining();
+
+        var result = sut.GetTagText();
+        result.Should().Be("Before joining");
+    }
+
+    private static OfstedRatingCellModel GetSutWithOfstedRatingDateAfterJoining()
+    {
+        return new OfstedRatingCellModel
+        {
+            AcademyJoinedDate = new DateTime(2020, 11, 1),
+            Rating = "Good",
+            RatingDate = new DateTime(2022, 3, 2)
+        };
+    }
+
+    private static OfstedRatingCellModel GetSutWithOfstedRatingDateBeforeJoining()
+    {
+        return new OfstedRatingCellModel
+        {
+            AcademyJoinedDate = new DateTime(2022, 3, 2),
+            Rating = "Good",
+            RatingDate = new DateTime(2020, 11, 1)
+        };
+    }
+
+    private static OfstedRatingCellModel GetSutWithNotYetInspectedRating()
+    {
+        return new OfstedRatingCellModel
+        {
+            AcademyJoinedDate = new DateTime(2022, 3, 2),
+            Rating = "Not yet inspected",
+            RatingDate = null
+        };
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingsModelTests.cs
@@ -24,4 +24,19 @@ public class OfstedRatingsModelTests
     {
         _sut.TabName.Should().Be("Ofsted ratings");
     }
+
+    [Fact]
+    public void GetOfstedRatingCellModel_returns_an_OfstedRatingCellModel()
+    {
+        OfstedRatingCellModel expected = new()
+        {
+            AcademyJoinedDate = new DateTime(2018, 11, 1),
+            Rating = "Not yet inspected",
+            RatingDate = null
+        };
+
+        var result = _sut.GetOfstedRatingCellModel(
+            new DateTime(2018, 11, 1), "Not yet inspected", null);
+        result.Should().BeEquivalentTo(expected);
+    }
 }

--- a/tests/playwright/page-object-model/shared/table-component.ts
+++ b/tests/playwright/page-object-model/shared/table-component.ts
@@ -1,0 +1,29 @@
+import { Locator } from '@playwright/test'
+
+export class TableComponent {
+  readonly locator: Locator
+  readonly rowsLocator: Locator
+
+  constructor (locator: Locator) {
+    this.locator = locator
+    this.rowsLocator = this.locator.locator('tr')
+  }
+
+  getRowComponentAt (rowNumber: number): RowComponent {
+    return new RowComponent(this.rowsLocator.nth(rowNumber))
+  }
+}
+
+export class RowComponent {
+  readonly locator: Locator
+  readonly rowHeaderLocator: Locator
+
+  constructor (locator: Locator) {
+    this.locator = locator
+    this.rowHeaderLocator = this.locator.locator('th')
+  }
+
+  cellLocator (columnNumber: number): Locator {
+    return this.locator.locator('td').nth(columnNumber)
+  }
+}

--- a/tests/playwright/page-object-model/trust/academies/base-academies-page.ts
+++ b/tests/playwright/page-object-model/trust/academies/base-academies-page.ts
@@ -1,6 +1,6 @@
 import { Locator, Page, expect } from '@playwright/test'
 import { FakeTestData } from '../../../fake-data/fake-test-data'
-import { BaseTrustPage } from '../base-trust-page'
+import { BaseTrustPage, BaseTrustPageAssertions } from '../base-trust-page'
 import { NavigationComponent } from '../../shared/navigation-component'
 
 export class BaseAcademiesPage extends BaseTrustPage {
@@ -18,8 +18,10 @@ export class BaseAcademiesPage extends BaseTrustPage {
   }
 }
 
-export class BaseAcademiesPageAssertions {
-  constructor (readonly academiesPage: BaseAcademiesPage) {}
+export class BaseAcademiesPageAssertions extends BaseTrustPageAssertions {
+  constructor (readonly academiesPage: BaseAcademiesPage) {
+    super(academiesPage)
+  }
 
   async toBeOnAcademiesInTrustPages (): Promise<void> {
     await expect(this.academiesPage.pageHeadingLocator).toHaveText('Academies in this trust')

--- a/tests/playwright/page-object-model/trust/academies/base-academies-page.ts
+++ b/tests/playwright/page-object-model/trust/academies/base-academies-page.ts
@@ -2,18 +2,19 @@ import { Locator, Page, expect } from '@playwright/test'
 import { FakeTestData } from '../../../fake-data/fake-test-data'
 import { BaseTrustPage, BaseTrustPageAssertions } from '../base-trust-page'
 import { NavigationComponent } from '../../shared/navigation-component'
+import { TableComponent } from '../../shared/table-component'
 
 export class BaseAcademiesPage extends BaseTrustPage {
   readonly expect: BaseAcademiesPageAssertions
-  readonly academiesTableLocator: Locator
+  readonly academiesTable: TableComponent
   readonly academiesRowLocator: Locator
   readonly subNavigation: NavigationComponent
 
   constructor (readonly page: Page, fakeTestData: FakeTestData, pageUrl: string) {
     super(page, fakeTestData, pageUrl)
     this.expect = new BaseAcademiesPageAssertions(this)
-    this.academiesTableLocator = this.page.getByRole('table')
-    this.academiesRowLocator = this.academiesTableLocator.getByTestId('academy-row')
+    this.academiesTable = new TableComponent(this.page.getByRole('table'))
+    this.academiesRowLocator = this.academiesTable.locator.getByTestId('academy-row')
     this.subNavigation = new NavigationComponent(page, 'Academies tabs')
   }
 }

--- a/tests/playwright/page-object-model/trust/academies/details-page.ts
+++ b/tests/playwright/page-object-model/trust/academies/details-page.ts
@@ -22,10 +22,10 @@ export class AcademiesDetailsPageAssertions extends BaseAcademiesPageAssertions 
   }
 
   async toDisplayCorrectInformationAboutAcademiesInThatTrust (): Promise<void> {
-    await expect(this.detailsPage.academiesTableLocator).toContainText('Barr and Community R.C. SchoolURN: 109174')
-    await expect(this.detailsPage.academiesTableLocator).toContainText('URN: 109174')
-    await expect(this.detailsPage.academiesTableLocator).toContainText('Kingston upon Hull, City of')
-    await expect(this.detailsPage.academiesTableLocator).toContainText('Academy converter')
-    await expect(this.detailsPage.academiesTableLocator).toContainText('Urban minor conurbation')
+    await expect(this.detailsPage.academiesTable.locator).toContainText('Barr and Community R.C. SchoolURN: 109174')
+    await expect(this.detailsPage.academiesTable.locator).toContainText('URN: 109174')
+    await expect(this.detailsPage.academiesTable.locator).toContainText('Kingston upon Hull, City of')
+    await expect(this.detailsPage.academiesTable.locator).toContainText('Academy converter')
+    await expect(this.detailsPage.academiesTable.locator).toContainText('Urban minor conurbation')
   }
 }

--- a/tests/playwright/page-object-model/trust/academies/ofsted-ratings-page.ts
+++ b/tests/playwright/page-object-model/trust/academies/ofsted-ratings-page.ts
@@ -32,7 +32,7 @@ class AcademiesOfstedRatingsPageAssertions extends BaseAcademiesPageAssertions {
     await expect(firstRowComponent.rowHeaderLocator).toContainText('Barr and Community R.C. School')
     await expect(firstRowComponent.rowHeaderLocator).toContainText('URN: 109174')
     await expect(firstRowComponent.cellLocator(ColumnHeading.DateJoined)).toContainText('Nov 2018')
-    await expect(firstRowComponent.cellLocator(ColumnHeading.PreviousOfstedRatings)).not.toContainText('Not yet inspected')
+    await expect(firstRowComponent.cellLocator(ColumnHeading.PreviousOfstedRatings)).toContainText('Not yet inspected')
     await expect(firstRowComponent.cellLocator(ColumnHeading.CurrentOfstedRatings)).toContainText('Not yet inspected')
 
     const secondRowComponent = this.ofstedRatingsPage.academiesTable.getRowComponentAt(2)

--- a/tests/playwright/page-object-model/trust/academies/ofsted-ratings-page.ts
+++ b/tests/playwright/page-object-model/trust/academies/ofsted-ratings-page.ts
@@ -2,10 +2,16 @@ import { Page, expect } from '@playwright/test'
 import { FakeTestData } from '../../../fake-data/fake-test-data'
 import { BaseAcademiesPage, BaseAcademiesPageAssertions } from './base-academies-page'
 
+enum ColumnHeading {
+  DateJoined,
+  PreviousOfstedRatings,
+  CurrentOfstedRatings
+}
+
 export class AcademiesOfstedRatingsPage extends BaseAcademiesPage {
   readonly expect: AcademiesOfstedRatingsPageAssertions
   constructor (readonly page: Page, fakeTestData: FakeTestData) {
-    super(page, fakeTestData, '/trusts/academies/ofsted-data')
+    super(page, fakeTestData, '/trusts/academies/ofsted-ratings')
     this.expect = new AcademiesOfstedRatingsPageAssertions(this)
   }
 }
@@ -18,5 +24,44 @@ class AcademiesOfstedRatingsPageAssertions extends BaseAcademiesPageAssertions {
   async toBeOnTheRightPage (): Promise<void> {
     await this.toBeOnAcademiesInTrustPages()
     await expect(this.ofstedRatingsPage.page).toHaveTitle(/Ofsted ratings/)
+  }
+
+  async toDisplayCorrectInformationAboutAcademiesInThatTrust (): Promise<void> {
+    // start at 1 (rather than 0) because the first row will be the header
+    const firstRowComponent = this.ofstedRatingsPage.academiesTable.getRowComponentAt(1)
+    await expect(firstRowComponent.rowHeaderLocator).toContainText('Barr and Community R.C. School')
+    await expect(firstRowComponent.rowHeaderLocator).toContainText('URN: 109174')
+    await expect(firstRowComponent.cellLocator(ColumnHeading.DateJoined)).toContainText('Nov 2018')
+    await expect(firstRowComponent.cellLocator(ColumnHeading.PreviousOfstedRatings)).not.toContainText('Not yet inspected')
+    await expect(firstRowComponent.cellLocator(ColumnHeading.CurrentOfstedRatings)).toContainText('Not yet inspected')
+
+    const secondRowComponent = this.ofstedRatingsPage.academiesTable.getRowComponentAt(2)
+    await expect(secondRowComponent.rowHeaderLocator).toContainText('Fay Fort Catholic Primary Academy')
+    await expect(secondRowComponent.rowHeaderLocator).toContainText('URN: 109174')
+    await expect(secondRowComponent.cellLocator(ColumnHeading.DateJoined)).toContainText('Nov 2017')
+    await expect(secondRowComponent.cellLocator(ColumnHeading.PreviousOfstedRatings)).toContainText('Not yet inspected')
+    await expect(secondRowComponent.cellLocator(ColumnHeading.CurrentOfstedRatings)).toContainText('Good')
+    await expect(secondRowComponent.cellLocator(ColumnHeading.CurrentOfstedRatings)).toContainText('9 May 2021')
+
+    const thirdRowComponent = this.ofstedRatingsPage.academiesTable.getRowComponentAt(2)
+    await expect(thirdRowComponent.rowHeaderLocator).toContainText('Fay Fort Catholic Primary Academy')
+    await expect(thirdRowComponent.rowHeaderLocator).toContainText('URN: 109174')
+    await expect(thirdRowComponent.cellLocator(ColumnHeading.DateJoined)).toContainText('Nov 2017')
+    await expect(thirdRowComponent.cellLocator(ColumnHeading.PreviousOfstedRatings)).toContainText('Not yet inspected')
+    await expect(thirdRowComponent.cellLocator(ColumnHeading.CurrentOfstedRatings)).toContainText('Good')
+    await expect(thirdRowComponent.cellLocator(ColumnHeading.CurrentOfstedRatings)).toContainText('9 May 2021')
+  }
+
+  async toDisplayTheCorrectTagsForEachOfstedRating (): Promise<void> {
+    const secondRowComponent = this.ofstedRatingsPage.academiesTable.getRowComponentAt(2)
+    const currentOfstedRatingCell = secondRowComponent.cellLocator(ColumnHeading.CurrentOfstedRatings)
+    await expect(currentOfstedRatingCell).toContainText('After joining')
+
+    const thirdRowComponent = this.ofstedRatingsPage.academiesTable.getRowComponentAt(3)
+    const thirdRowPreviousOfstedRatingsCell = thirdRowComponent.cellLocator(ColumnHeading.PreviousOfstedRatings)
+    const thirdRowCurrentOfstedRatingsCell = thirdRowComponent.cellLocator(ColumnHeading.CurrentOfstedRatings)
+
+    await expect(thirdRowPreviousOfstedRatingsCell).toContainText('Before joining')
+    await expect(thirdRowCurrentOfstedRatingsCell).toContainText('After joining')
   }
 }

--- a/tests/playwright/ui-tests/trusts/academies/ofsted-ratings-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/academies/ofsted-ratings-page.spec.ts
@@ -1,0 +1,14 @@
+import { test } from '@playwright/test'
+import { FakeTestData } from '../../../fake-data/fake-test-data'
+import { AcademiesOfstedRatingsPage } from '../../../page-object-model/trust/academies/ofsted-ratings-page'
+
+test.describe('Academies in trust ofsted ratings page', () => {
+  test('user should see the right information about a trust', async ({ page }) => {
+    const ofstedRatingsPage = new AcademiesOfstedRatingsPage(page, new FakeTestData())
+    await ofstedRatingsPage.goTo()
+    await ofstedRatingsPage.expect.toBeOnTheRightPage()
+    await ofstedRatingsPage.expect.toDisplayInformationForAllAcademiesInThatTrust()
+    await ofstedRatingsPage.expect.toDisplayCorrectInformationAboutAcademiesInThatTrust()
+    await ofstedRatingsPage.expect.toDisplayTheCorrectTagsForEachOfstedRating()
+  })
+})


### PR DESCRIPTION
This change adds the html template and styles for the 'Ofsted ratings' tab on the 'Academies in this trust' page, when a user is looking at information about a trust.

On this tab, a user will be able to see information about the Ofsted ratings history for all of the academies within the trust they have searched for. This information will help them determine whether joining the trust has helped a school/academy improve their Ofsted rating or not.

We are working on getting all data we need for About the trust pages (#249) so this page currently contains static fake text. We will add dynamic data from the Academies database in a later pull request. 

Although we are using static text, the change does include logic for how to display the previous and latest Ofsted ratings for an academy - by comparing the academy joined date and rating date to display a 'before joining' or 'after joining' tag next to the rating. 

Related to [User Story 134805](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/134805?McasTsid=26110&McasCtx=4): Build: Academies in Trust Page - Ofsted ratings: UI

## Changes

- Add html template for Ofsted ratings table
- Create partial and model for building the previous and current Ofsted rating table cell values
- Create Page Object models for a table and table row, to make locating and testing data in table cells easier in UI tests.

## Screenshots of UI changes

Academies in Trust Ofsted ratings table with static data:
![](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/f0cab4ac-7d61-42ab-9ac0-1bca772d7c31)


## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
