### PR TITLE
Fix: Specified name of file for upload

### DIFF
--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -29,9 +29,8 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Set SHA environment variable
-        if: ${{ github.event_name == 'push' }}
         run: |
-          echo "LAST_COMMIT_SHA=${GITHUB_SHA}" >> $GITHUB_ENV
+          echo "LAST_COMMIT_SHA=${GITHUB_SHA:(-7)}" >> $GITHUB_ENV
 
       - uses: actions/setup-node@v3
         name: Set up Node.js
@@ -86,10 +85,12 @@ jobs:
         with:
           azcliversion: 2.53.0
           inlineScript: |
+            GIT_REF=${{ github.base_ref }}
+            GIT_BRANCH=${GIT_REF//\//-}
             az storage blob upload \
               --container-name ${{ secrets.CI_REPORTS_STORAGE_CONTAINER_NAME }} \
               --account-name ${{ secrets.CI_REPORTS_STORAGE_ACCOUNT_NAME }} \
               --file "./tests/playwright/${{ inputs.environment }}-${{ env.LAST_COMMIT_SHA }}.zip" \
-              --name "Dfe.FindInformationAcademiesTrusts/playwright-report/" \
+              --name "Dfe.FindInformationAcademiesTrusts/$GIT_BRANCH/test-deployment-${{ env.LAST_COMMIT_SHA }}.zip" \
               --auth-mode login \
               --overwrite


### PR DESCRIPTION
When reports were being uploaded to Azure, they didn't have a filename which, generally, breaks lots of things.

The new destination file path will be in the format of:

```
"Dfe.FindInformationAcademiesTrusts/$GIT_BRANCH/$CI_FILE_NAME-$LAST_COMMIT_SHA.zip"
```