### PR TITLE
Delete CI reports after 14 days

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -134,7 +134,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.77.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.79.0 |
 
 ## Modules
 
@@ -151,6 +151,7 @@ If everything looks good, answer `yes` and wait for the new infrastructure to be
 | [azurerm_monitor_diagnostic_setting.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_storage_account.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [azurerm_storage_container.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_management_policy.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
 | [azurerm_storage_account_blob_container_sas.ci-test-reports](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account_blob_container_sas) | data source |
 
 ## Inputs

--- a/terraform/ci-storage.tf
+++ b/terraform/ci-storage.tf
@@ -39,6 +39,32 @@ resource "azurerm_monitor_diagnostic_setting" "ci-test-reports" {
   }
 }
 
+resource "azurerm_storage_management_policy" "ci-test-reports" {
+  count = local.enable_ci_report_storage_container ? 1 : 0
+
+  storage_account_id = azurerm_storage_account.ci-test-reports[0].id
+
+  rule {
+    name    = "ci-report-cool-off"
+    enabled = true
+
+    filters {
+      blob_types = ["blockBlob"]
+    }
+
+    actions {
+      base_blob {
+        tier_to_cool_after_days_since_creation_greater_than = 7
+        delete_after_days_since_creation_greater_than       = 14
+      }
+
+      snapshot {
+        delete_after_days_since_creation_greater_than = 14
+      }
+    }
+  }
+}
+
 data "azurerm_storage_account_blob_container_sas" "ci-test-reports" {
   count = local.enable_ci_report_storage_container ? 1 : 0
 


### PR DESCRIPTION
In order to not hoard CI report files forever, we should delete them after a set number of days.

## Changes

Adds a lifecycle to the files within the storage account. They will move from 'hot' (frequently accessed) tier to 'cool' (infrequently accessed) after 7 days from the point of creation. After 14 days from the point of creation, the blobs will be deleted.