### PR TITLE
Get all mvp data - Add governors

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/GovernorFactory.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/GovernorFactory.cs
@@ -1,0 +1,39 @@
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Extensions;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
+
+public interface IGovernorFactory
+{
+    Governor CreateFrom(Governance g);
+}
+
+public class GovernorFactory : IGovernorFactory
+{
+    public Governor CreateFrom(Governance governance)
+    {
+        return new Governor(
+            governance.Gid!,
+            governance.Uid!,
+            GetFullName(governance),
+            governance.Role,
+            governance.AppointingBody,
+            governance.DateOfAppointment.ParseAsNullableDate(),
+            governance.DateTermOfOfficeEndsEnded.ParseAsNullableDate(),
+            null
+        );
+    }
+
+    private static string GetFullName(Governance governance)
+    {
+        var fullName = governance.Forename1!; //Forename1 is always populated
+
+        if (!string.IsNullOrWhiteSpace(governance.Forename2))
+            fullName += $" {governance.Forename2}";
+
+        if (!string.IsNullOrWhiteSpace(governance.Surname))
+            fullName += $" {governance.Surname}";
+
+        return fullName;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/TrustFactory.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/TrustFactory.cs
@@ -5,12 +5,12 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
 
 public interface ITrustFactory
 {
-    Trust CreateTrustFrom(Group group, MstrTrust? mstrTrust, Academy[] academies);
+    Trust CreateTrustFrom(Group group, MstrTrust? mstrTrust, Academy[] academies, Governor[] governors);
 }
 
 public class TrustFactory : ITrustFactory
 {
-    public Trust CreateTrustFrom(Group group, MstrTrust? mstrTrust, Academy[] academies)
+    public Trust CreateTrustFrom(Group group, MstrTrust? mstrTrust, Academy[] academies, Governor[] governors)
     {
         return new Trust(
             group.GroupUid!,
@@ -23,7 +23,7 @@ public class TrustFactory : ITrustFactory
             group.CompaniesHouseNumber ?? string.Empty,
             mstrTrust?.GORregion ?? string.Empty,
             academies,
-            Array.Empty<Governor>(),
+            governors,
             null,
             null
         );

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
@@ -33,7 +33,7 @@ public class TrustProvider : ITrustProvider
         var mstrTrust = await _academiesDbContext.MstrTrusts.SingleOrDefaultAsync(m => m.GroupUid == uid);
         var academies = await GetAcademiesLinkedTo(uid);
 
-        return _trustFactory.CreateTrustFrom(group, mstrTrust, academies);
+        return _trustFactory.CreateTrustFrom(group, mstrTrust, academies, Array.Empty<Governor>());
     }
 
     private async Task<Academy[]> GetAcademiesLinkedTo(string uid)

--- a/DfE.FindInformationAcademiesTrusts.Data/Governor.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Governor.cs
@@ -7,4 +7,5 @@ public record Governor(
     string? Role,
     string? AppointingBody,
     DateTime? DateOfAppointment,
+    DateTime? DateOfTermEnd,
     string? Email) : Person(FullName, Email);

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -160,6 +160,7 @@ internal static class Program
         builder.Services.AddScoped<ITrustProvider, TrustProvider>();
         builder.Services.AddScoped<ITrustFactory, TrustFactory>();
         builder.Services.AddScoped<IAcademyFactory, AcademyFactory>();
+        builder.Services.AddScoped<IGovernorFactory, GovernorFactory>();
         builder.Services.AddScoped<IAuthorizationHandler, HeaderRequirementHandler>();
         builder.Services.AddHttpContextAccessor();
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/JsonGenerator.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/JsonGenerator.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
-using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Fakers;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker;
 
@@ -16,7 +15,7 @@ public static class JsonGenerator
             .OrderBy(g => g.GroupName)
             .Select(g => trustHelper
                 .CreateTrustFrom(g, fakeData.MstrTrusts.FirstOrDefault(t => t.GroupUid == g.GroupUid)!,
-                    Array.Empty<Academy>())
+                    Array.Empty<Academy>(), Array.Empty<Governor>())
             );
 
         File.WriteAllText(outputFilePath, JsonSerializer.Serialize(trusts, serializeOptions));

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/GovernorFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/GovernorFactoryTests.cs
@@ -1,0 +1,67 @@
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Factories;
+
+public class GovernorFactoryTests
+{
+    private readonly GovernorFactory _sut = new();
+
+    [Fact]
+    public void CreateFrom_should_transform_a_governance_into_a_governor()
+    {
+        var governance = new Governance
+        {
+            Gid = "1011111",
+            Uid = "1234",
+            AppointingBody = "Appointed by GB/board",
+            DateOfAppointment = "01/09/2023",
+            DateTermOfOfficeEndsEnded = "01/09/2024",
+            Forename1 = "Oliver",
+            Forename2 = "Jane",
+            Surname = "Wood",
+            Role = "Trustee",
+            Title = "Mr"
+        };
+
+        var result = _sut.CreateFrom(governance);
+
+        result.Should().BeEquivalentTo(new Governor(
+                "1011111",
+                "1234",
+                "Oliver Jane Wood",
+                "Trustee",
+                "Appointed by GB/board",
+                new DateTime(2023, 09, 01),
+                new DateTime(2024, 09, 01),
+                null
+            )
+        );
+    }
+
+    [Theory]
+    [InlineData("Oliver", "", "Wood", "Oliver Wood")]
+    [InlineData("Oliver", "", "", "Oliver")]
+    [InlineData("Oliver", "James", "Wood", "Oliver James Wood")]
+    public void GetFullName_should_return_full_name(string forename1, string forename2, string surname,
+        string expectedFullName)
+    {
+        var governance = new Governance
+        {
+            Gid = "1011111",
+            Uid = "1234",
+            AppointingBody = "Appointed by GB/board",
+            DateOfAppointment = "01/09/2023",
+            DateTermOfOfficeEndsEnded = "01/09/2024",
+            Forename1 = forename1,
+            Forename2 = forename2,
+            Surname = surname,
+            Role = "Trustee",
+            Title = "not used"
+        };
+
+        var result = _sut.CreateFrom(governance);
+
+        result.FullName.Should().Be(expectedFullName);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/TrustFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/TrustFactoryTests.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Factories;
 
@@ -7,27 +8,27 @@ public class TrustFactoryTests
 {
     private readonly TrustFactory _sut = new();
 
-    [Fact]
-    public void CreateTrustFromGroup_should_transform_a_group_and_mstrTrust_into_a_trust()
+    private readonly Group _testGroup = new()
     {
-        var group = new Group
-        {
-            GroupName = "trust 1", GroupUid = "1234", GroupType = "Multi-academy trust", Ukprn = "my ukprn",
-            GroupId = "my groupId",
-            GroupContactStreet = "12 Abbey Road",
-            GroupContactLocality = "Dorthy Inlet",
-            GroupContactTown = "East Park",
-            GroupContactPostcode = "JY36 9VC",
-            IncorporatedOnOpenDate = "20/12/1990",
-            CompaniesHouseNumber = "00123444"
-        };
+        GroupName = "trust 1", GroupUid = "1234", GroupType = "Multi-academy trust", Ukprn = "my ukprn",
+        GroupId = "my groupId",
+        GroupContactStreet = "12 Abbey Road",
+        GroupContactLocality = "Dorthy Inlet",
+        GroupContactTown = "East Park",
+        GroupContactPostcode = "JY36 9VC",
+        IncorporatedOnOpenDate = "20/12/1990",
+        CompaniesHouseNumber = "00123444"
+    };
 
+    [Fact]
+    public void CreateTrustFrom_should_transform_a_group_and_mstrTrust_into_a_trust()
+    {
         var mstrTrust = new MstrTrust
         {
             GroupUid = "1234", GORregion = "North East"
         };
 
-        var result = _sut.CreateTrustFrom(group, mstrTrust, Array.Empty<Academy>());
+        var result = _sut.CreateTrustFrom(_testGroup, mstrTrust, Array.Empty<Academy>(), Array.Empty<Governor>());
 
         result.Should().BeEquivalentTo(new Trust(
                 "1234",
@@ -47,23 +48,10 @@ public class TrustFactoryTests
         );
     }
 
-
     [Fact]
-    public void CreateTrustFromGroup_should_transform_a_group_without_mstrTrust_into_a_trust()
+    public void CreateTrustFrom_should_transform_a_group_without_mstrTrust_into_a_trust()
     {
-        var group = new Group
-        {
-            GroupName = "trust 1", GroupUid = "1234", GroupType = "Multi-academy trust", Ukprn = "my ukprn",
-            GroupId = "my groupId",
-            GroupContactStreet = "12 Abbey Road",
-            GroupContactLocality = "Dorthy Inlet",
-            GroupContactTown = "East Park",
-            GroupContactPostcode = "JY36 9VC",
-            IncorporatedOnOpenDate = "20/12/1990",
-            CompaniesHouseNumber = "00123444"
-        };
-
-        var result = _sut.CreateTrustFrom(group, null, Array.Empty<Academy>());
+        var result = _sut.CreateTrustFrom(_testGroup, null, Array.Empty<Academy>(), Array.Empty<Governor>());
 
         result.Should().BeEquivalentTo(new Trust(
                 "1234",
@@ -83,12 +71,32 @@ public class TrustFactoryTests
         );
     }
 
+    [Fact]
+    public void CreateTrustFrom_should_set_academies_from_parameters()
+    {
+        var academies = new[] { DummyAcademyFactory.GetDummyAcademy(1234546) };
+
+        var result = _sut.CreateTrustFrom(_testGroup, null, academies, Array.Empty<Governor>());
+
+        result.Academies.Should().Equal(academies);
+    }
+
+    [Fact]
+    public void CreateTrustFrom_should_set_governors_from_parameters()
+    {
+        var governors = new[] { DummyGovernorFactory.GetDummyGovernor("1234546") };
+
+        var result = _sut.CreateTrustFrom(_testGroup, null, Array.Empty<Academy>(), governors);
+
+        result.Governors.Should().Equal(governors);
+    }
+
     [Theory]
     [MemberData(nameof(EmptyData))]
     public void CreateTrustFromGroup_Should_Include_Empty_string_values_if_properties_have_no_value(
         Group group, MstrTrust mstrTrust, Trust expected)
     {
-        var result = _sut.CreateTrustFrom(group, mstrTrust, Array.Empty<Academy>());
+        var result = _sut.CreateTrustFrom(group, mstrTrust, Array.Empty<Academy>(), Array.Empty<Governor>());
         result.Should().BeEquivalentTo(expected);
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/TrustFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/TrustFactoryTests.cs
@@ -84,7 +84,7 @@ public class TrustFactoryTests
     [Fact]
     public void CreateTrustFrom_should_set_governors_from_parameters()
     {
-        var governors = new[] { DummyGovernorFactory.GetDummyGovernor("1234546") };
+        var governors = new[] { DummyGovernorFactory.GetDummyGovernor("1234546", "1234") };
 
         var result = _sut.CreateTrustFrom(_testGroup, null, Array.Empty<Academy>(), governors);
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -46,6 +46,17 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
             academiesDbContext => academiesDbContext.Establishments);
     }
 
+    public List<Governance> SetupMockDbContextGovernance(int numMatches, string groupUid)
+    {
+        return SetupMockDbContext(numMatches,
+            i => new Governance
+            {
+                Uid = groupUid,
+                Forename1 = $"Governor {i}"
+            },
+            academiesDbContext => academiesDbContext.Governances);
+    }
+
     private List<T> SetupMockDbContext<T>(int numMatches, Func<int, T> itemCreator,
         Expression<Func<IAcademiesDbContext, DbSet<T>>> dbContextTable) where T : class
     {

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
@@ -32,7 +32,8 @@ public class TrustProviderTests
         var mstrTrust = CreateMstrTrust(groupUid);
         var expectedTrust = DummyTrustFactory.GetDummyTrust(groupUid);
 
-        _mockTrustHelper.Setup(t => t.CreateTrustFrom(group, mstrTrust, It.IsAny<Academy[]>())).Returns(expectedTrust);
+        _mockTrustHelper.Setup(t => t.CreateTrustFrom(group, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>()))
+            .Returns(expectedTrust);
 
         var result = await _sut.GetTrustByUidAsync(groupUid);
 
@@ -56,7 +57,8 @@ public class TrustProviderTests
         var group = CreateGroup(groupUid);
         var expectedTrust = DummyTrustFactory.GetDummyTrust(groupUid);
 
-        _mockTrustHelper.Setup(t => t.CreateTrustFrom(group, It.IsAny<MstrTrust>(), It.IsAny<Academy[]>()))
+        _mockTrustHelper.Setup(t =>
+                t.CreateTrustFrom(group, It.IsAny<MstrTrust>(), It.IsAny<Academy[]>(), Array.Empty<Governor>()))
             .Returns(expectedTrust);
 
         var result = await _sut.GetTrustByUidAsync(groupUid);
@@ -82,14 +84,14 @@ public class TrustProviderTests
         SetUpAcademiesLinkedToTrust(_establishments.Skip(5).Take(3), CreateGroup("Some other trust"));
 
         _mockTrustHelper
-            .Setup(t => t.CreateTrustFrom(group, mstrTrust, It.IsAny<Academy[]>()))
+            .Setup(t => t.CreateTrustFrom(group, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>()))
             .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
 
         await _sut.GetTrustByUidAsync(groupUid);
 
         _mockTrustHelper.Verify(t =>
             t.CreateTrustFrom(group, mstrTrust,
-                It.Is<Academy[]>(a => expectedAcademies.SequenceEqual(a)))
+                It.Is<Academy[]>(a => expectedAcademies.SequenceEqual(a)), Array.Empty<Governor>())
         );
     }
 
@@ -104,12 +106,13 @@ public class TrustProviderTests
         SetUpAcademiesLinkedToTrust(_establishments.Skip(5).Take(3), CreateGroup("Some other trust"));
 
         _mockTrustHelper
-            .Setup(t => t.CreateTrustFrom(group, mstrTrust, It.IsAny<Academy[]>()))
+            .Setup(t => t.CreateTrustFrom(group, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>()))
             .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
 
         await _sut.GetTrustByUidAsync(groupUid);
 
-        _mockTrustHelper.Verify(t => t.CreateTrustFrom(group, mstrTrust, It.Is<Academy[]>(a => !a.Any())));
+        _mockTrustHelper.Verify(t =>
+            t.CreateTrustFrom(group, mstrTrust, It.Is<Academy[]>(a => !a.Any()), Array.Empty<Governor>()));
     }
 
     private List<Academy> SetUpAcademiesLinkedToTrust(IEnumerable<Establishment> establishmentsLinkedToTrust,

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
@@ -11,8 +11,10 @@ public class TrustProviderTests
     private readonly List<Group> _groups;
     private readonly List<MstrTrust> _mstrTrusts;
     private readonly List<Establishment> _establishments;
-    private readonly Mock<ITrustFactory> _mockTrustHelper = new();
-    private readonly Mock<IAcademyFactory> _mockAcademyHelper = new();
+    private readonly List<Governance> _governances;
+    private readonly Mock<ITrustFactory> _mockTrustFactory = new();
+    private readonly Mock<IAcademyFactory> _mockAcademyFactory = new();
+    private readonly Mock<IGovernorFactory> _mockGovernorFactory = new();
     private readonly MockAcademiesDbContext _mockAcademiesDbContext = new();
 
     public TrustProviderTests()
@@ -20,8 +22,11 @@ public class TrustProviderTests
         _groups = _mockAcademiesDbContext.SetupMockDbContextGroups(5);
         _mstrTrusts = _mockAcademiesDbContext.SetupMockDbContextMstrTrust(5);
         _establishments = _mockAcademiesDbContext.SetupMockDbContextEstablishment(15);
+        _governances = _mockAcademiesDbContext.SetupMockDbContextGovernance(20, "Some other trust");
 
-        _sut = new TrustProvider(_mockAcademiesDbContext.Object, _mockTrustHelper.Object, _mockAcademyHelper.Object);
+
+        _sut = new TrustProvider(_mockAcademiesDbContext.Object, _mockTrustFactory.Object, _mockAcademyFactory.Object,
+            _mockGovernorFactory.Object);
     }
 
     [Fact]
@@ -32,7 +37,8 @@ public class TrustProviderTests
         var mstrTrust = CreateMstrTrust(groupUid);
         var expectedTrust = DummyTrustFactory.GetDummyTrust(groupUid);
 
-        _mockTrustHelper.Setup(t => t.CreateTrustFrom(group, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>()))
+        _mockTrustFactory
+            .Setup(t => t.CreateTrustFrom(group, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>()))
             .Returns(expectedTrust);
 
         var result = await _sut.GetTrustByUidAsync(groupUid);
@@ -57,7 +63,7 @@ public class TrustProviderTests
         var group = CreateGroup(groupUid);
         var expectedTrust = DummyTrustFactory.GetDummyTrust(groupUid);
 
-        _mockTrustHelper.Setup(t =>
+        _mockTrustFactory.Setup(t =>
                 t.CreateTrustFrom(group, It.IsAny<MstrTrust>(), It.IsAny<Academy[]>(), Array.Empty<Governor>()))
             .Returns(expectedTrust);
 
@@ -74,7 +80,7 @@ public class TrustProviderTests
     }
 
     [Fact]
-    public async Task GetTrustByUidAsync_should_only_give_academies_linked_to_trust_to_trustHelper()
+    public async Task GetTrustByUidAsync_should_only_give_academies_linked_to_trust_to_trustFactory()
     {
         const string groupUid = "1234";
         var group = CreateGroup(groupUid);
@@ -83,13 +89,13 @@ public class TrustProviderTests
         var expectedAcademies = SetUpAcademiesLinkedToTrust(_establishments.Take(3), group);
         SetUpAcademiesLinkedToTrust(_establishments.Skip(5).Take(3), CreateGroup("Some other trust"));
 
-        _mockTrustHelper
+        _mockTrustFactory
             .Setup(t => t.CreateTrustFrom(group, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>()))
             .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
 
         await _sut.GetTrustByUidAsync(groupUid);
 
-        _mockTrustHelper.Verify(t =>
+        _mockTrustFactory.Verify(t =>
             t.CreateTrustFrom(group, mstrTrust,
                 It.Is<Academy[]>(a => expectedAcademies.SequenceEqual(a)), Array.Empty<Governor>())
         );
@@ -97,7 +103,7 @@ public class TrustProviderTests
 
     [Fact]
     public async Task
-        GetTrustByUidAsync_should_give_empty_academies_array_to_trustHelper_when_no_academies_linked_to_trust()
+        GetTrustByUidAsync_should_give_empty_academies_array_to_trustFactory_when_no_academies_linked_to_trust()
     {
         const string groupUid = "1234";
         var group = CreateGroup(groupUid);
@@ -105,14 +111,52 @@ public class TrustProviderTests
 
         SetUpAcademiesLinkedToTrust(_establishments.Skip(5).Take(3), CreateGroup("Some other trust"));
 
-        _mockTrustHelper
+        _mockTrustFactory
             .Setup(t => t.CreateTrustFrom(group, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>()))
             .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
 
         await _sut.GetTrustByUidAsync(groupUid);
 
-        _mockTrustHelper.Verify(t =>
+        _mockTrustFactory.Verify(t =>
             t.CreateTrustFrom(group, mstrTrust, It.Is<Academy[]>(a => !a.Any()), Array.Empty<Governor>()));
+    }
+
+    [Fact]
+    public async Task GetTrustByUidAsync_should_only_give_governors_linked_to_trust_to_trustFactory()
+    {
+        const string groupUid = "1234";
+        var group = CreateGroup(groupUid);
+        var mstrTrust = CreateMstrTrust(groupUid);
+
+        var expectedGovernors = SetUpGovernorsLinkedToTrust(5, groupUid);
+
+        _mockTrustFactory
+            .Setup(t => t.CreateTrustFrom(group, mstrTrust, Array.Empty<Academy>(), It.IsAny<Governor[]>()))
+            .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
+
+        await _sut.GetTrustByUidAsync(groupUid);
+
+        _mockTrustFactory.Verify(t =>
+            t.CreateTrustFrom(group, mstrTrust, Array.Empty<Academy>(),
+                It.Is<Governor[]>(g => expectedGovernors.SequenceEqual(g)))
+        );
+    }
+
+    [Fact]
+    public async Task
+        GetTrustByUidAsync_should_give_empty_governors_array_to_trustFactory_when_no_governors_linked_to_trust()
+    {
+        const string groupUid = "1234";
+        var group = CreateGroup(groupUid);
+
+        _mockTrustFactory
+            .Setup(t => t.CreateTrustFrom(group, null, Array.Empty<Academy>(), Array.Empty<Governor>()))
+            .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
+
+        await _sut.GetTrustByUidAsync(groupUid);
+
+        _mockTrustFactory.Verify(t =>
+            t.CreateTrustFrom(group, null, It.IsAny<Academy[]>(), It.Is<Governor[]>(g => !g.Any())));
     }
 
     private List<Academy> SetUpAcademiesLinkedToTrust(IEnumerable<Establishment> establishmentsLinkedToTrust,
@@ -124,12 +168,40 @@ public class TrustProviderTests
         foreach (var (establishment, groupLink) in establishmentGroupLinks)
         {
             var dummyAcademy = DummyAcademyFactory.GetDummyAcademy(establishment.Urn);
-            _mockAcademyHelper.Setup(a => a.CreateAcademyFrom(groupLink, establishment))
+            _mockAcademyFactory.Setup(a => a.CreateAcademyFrom(groupLink, establishment))
                 .Returns(dummyAcademy);
             academiesLinkedToTrust.Add(dummyAcademy);
         }
 
         return academiesLinkedToTrust;
+    }
+
+    private List<Governor> SetUpGovernorsLinkedToTrust(int num, string groupUid)
+    {
+        var newGovernances = new List<Governance>();
+        for (var i = 0; i < num; i++)
+        {
+            newGovernances.Add(new Governance
+            {
+                Uid = groupUid,
+                Forename1 = $"Governor {i}"
+            });
+        }
+
+        _governances.AddRange(newGovernances);
+
+        var governorsLinkedToTrust = new List<Governor>();
+
+        var dummyGovernorFactory = new DummyGovernorFactory();
+        foreach (var governance in newGovernances)
+        {
+            var dummyGovernor = dummyGovernorFactory.GetDummyGovernor(groupUid);
+            _mockGovernorFactory.Setup(g => g.CreateFrom(governance))
+                .Returns(dummyGovernor);
+            governorsLinkedToTrust.Add(dummyGovernor);
+        }
+
+        return governorsLinkedToTrust;
     }
 
     private MstrTrust CreateMstrTrust(string groupUid)

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/DummyGovernorFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/DummyGovernorFactory.cs
@@ -6,16 +6,16 @@ public class DummyGovernorFactory
 {
     private int _numberGenerated;
 
-    public Governor GetDummyGovernor()
+    public Governor GetDummyGovernor(string uid)
     {
         _numberGenerated++;
-        return GetDummyGovernor(_numberGenerated.ToString());
+        return GetDummyGovernor(_numberGenerated.ToString(), uid);
     }
 
-    public static Governor GetDummyGovernor(string gid)
+    public static Governor GetDummyGovernor(string gid, string uid)
     {
         return new Governor(gid,
-            "uid",
+            uid,
             $"Governor {gid}",
             "test",
             "test",

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/DummyGovernorFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/DummyGovernorFactory.cs
@@ -1,0 +1,25 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+
+public class DummyGovernorFactory
+{
+    private int _numberGenerated;
+
+    public Governor GetDummyGovernor()
+    {
+        _numberGenerated++;
+        return GetDummyGovernor(_numberGenerated.ToString());
+    }
+
+    public static Governor GetDummyGovernor(string gid)
+    {
+        return new Governor(gid,
+            "uid",
+            $"Governor {gid}",
+            "test",
+            "test",
+            null,
+            "test");
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/DummyGovernorFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/DummyGovernorFactory.cs
@@ -20,6 +20,7 @@ public class DummyGovernorFactory
             "test",
             "test",
             null,
+            null,
             "test");
     }
 }


### PR DESCRIPTION
Gets data on governors and adds it to the trust returned by the `TrustProvider`

[User Story 146083](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/146083): Build: Get all the data we need from Academies DB for MVP

## Changes

- Add `GovernorFactory`
- Use `GovernorFactory` in `TrustProvider` to populate a Trust's governors
- Add missing `DateOfTermEnd` property to Governor

## Checklist

- [n/a] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [n/a] Update the ADR decision log if needed
