### PR TITLE
Update contacts UI

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
@@ -55,7 +55,6 @@
             <p class="govuk-body">
               <a class="govuk-link" href="#">Tyler.Welch@abbeylaneacademiestrust.co.uk</a>
             </p>
-            Telephone: 027 5395 0525
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -67,7 +66,6 @@
             <p class="govuk-body">
               <a class="govuk-link" href="#">Courtney.Pacocha@abbeylaneacademiestrust.co.uk</a>
             </p>
-            Telephone: 0500 544079
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -79,7 +77,6 @@
             <p class="govuk-body">
               <a class="govuk-link" href="#">Lowell.Hoppe@abbeylaneacademiestrust.co.uk</a>
             </p>
-            Telephone: 01289 72558
           </dd>
         </div>
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
@@ -17,7 +17,7 @@
             Trust relationship manager
           </dt>
           <dd class="govuk-summary-list__value">
-            Keyshawn Hermiston
+            <p class="govuk-body">Keyshawn Hermiston</p>
             <p class="govuk-body">
               <a class="govuk-link" href="#">Keyshawn.Hermiston@education.gov.uk</a>
             </p>
@@ -28,7 +28,7 @@
             SFSO (Schools financial support and oversight) lead
           </dt>
           <dd class="govuk-summary-list__value">
-            Ayana Lueilwitz
+            <p class="govuk-body">Ayana Lueilwitz</p>
             <p class="govuk-body">
               <a class="govuk-link" href="#">Ayana.Lueilwitz@education.gov.uk</a>
             </p>
@@ -51,7 +51,7 @@
             Accounting officer
           </dt>
           <dd class="govuk-summary-list__value">
-            Tyler Welch
+            <p class="govuk-body">Tyler Welch</p>
             <p class="govuk-body">
               <a class="govuk-link" href="#">Tyler.Welch@abbeylaneacademiestrust.co.uk</a>
             </p>
@@ -62,7 +62,7 @@
             Chair of trustees
           </dt>
           <dd class="govuk-summary-list__value">
-            Courtney Pacocha
+            <p class="govuk-body">Courtney Pacocha</p>
             <p class="govuk-body">
               <a class="govuk-link" href="#">Courtney.Pacocha@abbeylaneacademiestrust.co.uk</a>
             </p>
@@ -73,7 +73,7 @@
             Chief financial officer
           </dt>
           <dd class="govuk-summary-list__value">
-            Lowell Hoppe
+            <p class="govuk-body">Lowell Hoppe</p>
             <p class="govuk-body">
               <a class="govuk-link" href="#">Lowell.Hoppe@abbeylaneacademiestrust.co.uk</a>
             </p>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
@@ -8,7 +8,7 @@
 <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9" data-testid="dfe-contacts">
   <div class="govuk-summary-card">
     <div class="govuk-summary-card__title-wrapper">
-      <h2 class="govuk-summary-card__title">Dfe Contacts</h2>
+      <h2 class="govuk-summary-card__title">DfE contacts</h2>
     </div>
     <div class="govuk-summary-card__content">
       <dl class="govuk-summary-list">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
@@ -5,7 +5,7 @@
   Layout = "_TrustLayout";
 }
 
-<section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9" data-testid="dfe-contacts">
+<section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
   <div class="govuk-summary-card">
     <div class="govuk-summary-card__title-wrapper">
       <h2 class="govuk-summary-card__title">DfE contacts</h2>
@@ -39,7 +39,7 @@
   </div>
 </section>
 
-<section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9" data-testid="trust-contacts">
+<section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
   <div class="govuk-summary-card">
     <div class="govuk-summary-card__title-wrapper">
       <h2 class="govuk-summary-card__title">Trust Contacts</h2>

--- a/tests/playwright/page-object-model/trust/contacts-page.ts
+++ b/tests/playwright/page-object-model/trust/contacts-page.ts
@@ -10,8 +10,8 @@ export class ContactsPage extends BaseTrustPage {
   constructor (readonly page: Page, fakeTestData: FakeTestData) {
     super(page, fakeTestData, '/trusts/contacts')
     this.expect = new ContactsPageAssertions(this)
-    this.dfeContactsCard = page.locator('[data-testid="dfe-contacts"]')
-    this.trustContactsCard = page.locator('[data-testid="trust-contacts"]')
+    this.dfeContactsCard = page.getByText('DfE contacts Trust relationship manager')
+    this.trustContactsCard = page.getByText('Trust Contacts Accounting officer')
   }
 }
 

--- a/tests/playwright/page-object-model/trust/contacts-page.ts
+++ b/tests/playwright/page-object-model/trust/contacts-page.ts
@@ -34,12 +34,9 @@ class ContactsPageAssertions extends BaseTrustPageAssertions {
   async toSeeCorrectTrustContacts (): Promise<void> {
     await expect(this.contactsPage.trustContactsCard).toContainText('Tyler Welch')
     await expect(this.contactsPage.trustContactsCard).toContainText('Tyler.Welch@abbeylaneacademiestrust.co.uk')
-    await expect(this.contactsPage.trustContactsCard).toContainText('Telephone: 027 5395 0525')
     await expect(this.contactsPage.trustContactsCard).toContainText('Courtney Pacocha')
     await expect(this.contactsPage.trustContactsCard).toContainText('Courtney.Pacocha@abbeylaneacademiestrust.co.uk')
-    await expect(this.contactsPage.trustContactsCard).toContainText('Telephone: 0500 544079')
     await expect(this.contactsPage.trustContactsCard).toContainText('Lowell Hoppe')
     await expect(this.contactsPage.trustContactsCard).toContainText('Lowell.Hoppe@abbeylaneacademiestrust.co.uk')
-    await expect(this.contactsPage.trustContactsCard).toContainText('Telephone: 01289 72558')
   }
 }


### PR DESCRIPTION
We have added the Contacts page html template and UI tests in #227, but a few small discrepancies were found against the acceptance criteria during manual testing:

- DfE should be in the correct case
- Contacts will not have phone numbers

This change fixes these issues, and also slightly improves the html template and locator used during UI tests.

## Changes

- Fix casing on DfE card title
- Remove phone numbers from contacts
- Add missing `<p>` tags
- Change locator used for cards in UI tests

## Screenshots of UI changes

### Before

DfE was in the wrong case in the DfE contacts card title:
![](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/90d48f7a-36e8-4adb-b5ca-6453b3b9c193)

Trust contacts had a telephone number:
![](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/c22e3436-7c3e-49a1-95c8-1d42a7c57954)

### After

Casing on DfE contacts card title is correct:
![](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/56793b69-85ce-4a38-bd9b-1f7367b6203f)

Trust contacts no longer have a telephone number:
![](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/dc14bf1d-e7cc-464a-b3bd-29b204d7e704)

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
