### PR TITLE
Get the email address for governors from the mstr schema

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/GovernorFactory.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/GovernorFactory.cs
@@ -6,12 +6,12 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
 
 public interface IGovernorFactory
 {
-    Governor CreateFrom(GiasGovernance giasGovernance, MstrTrustGovernance? mstrGovernance);
+    Governor CreateFrom(GiasGovernance giasGovernance, MstrTrustGovernance mstrGovernance);
 }
 
 public class GovernorFactory : IGovernorFactory
 {
-    public Governor CreateFrom(GiasGovernance giasGovernance, MstrTrustGovernance? mstrGovernance)
+    public Governor CreateFrom(GiasGovernance giasGovernance, MstrTrustGovernance mstrGovernance)
     {
         return new Governor(
             giasGovernance.Gid!,
@@ -21,7 +21,7 @@ public class GovernorFactory : IGovernorFactory
             giasGovernance.AppointingBody,
             giasGovernance.DateOfAppointment.ParseAsNullableDate(),
             giasGovernance.DateTermOfOfficeEndsEnded.ParseAsNullableDate(),
-            mstrGovernance?.Email
+            mstrGovernance.Email
         );
     }
 

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/GovernorFactory.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/GovernorFactory.cs
@@ -1,16 +1,17 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Extensions;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
 
 public interface IGovernorFactory
 {
-    Governor CreateFrom(GiasGovernance giasGovernance);
+    Governor CreateFrom(GiasGovernance giasGovernance, MstrTrustGovernance? mstrGovernance);
 }
 
 public class GovernorFactory : IGovernorFactory
 {
-    public Governor CreateFrom(GiasGovernance giasGovernance)
+    public Governor CreateFrom(GiasGovernance giasGovernance, MstrTrustGovernance? mstrGovernance)
     {
         return new Governor(
             giasGovernance.Gid!,
@@ -20,7 +21,7 @@ public class GovernorFactory : IGovernorFactory
             giasGovernance.AppointingBody,
             giasGovernance.DateOfAppointment.ParseAsNullableDate(),
             giasGovernance.DateTermOfOfficeEndsEnded.ParseAsNullableDate(),
-            null
+            mstrGovernance?.Email
         );
     }
 

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
@@ -43,7 +43,7 @@ public class TrustProvider : ITrustProvider
     {
         return await _academiesDbContext.GiasGovernances
             .Where(g => g.Uid == uid)
-            .Select(g => _governorFactory.CreateFrom(g))
+            .Select(g => _governorFactory.CreateFrom(g, null))
             .ToArrayAsync();
     }
 

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
@@ -43,7 +43,10 @@ public class TrustProvider : ITrustProvider
     {
         return await _academiesDbContext.GiasGovernances
             .Where(g => g.Uid == uid)
-            .Select(g => _governorFactory.CreateFrom(g, null))
+            .Join(_academiesDbContext.MstrTrustGovernances,
+                gg => gg.Gid!,
+                mtg => mtg.Gid,
+                (gg, mtg) => _governorFactory.CreateFrom(gg, mtg))
             .ToArrayAsync();
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/GovernorFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/GovernorFactoryTests.cs
@@ -8,6 +8,12 @@ public class GovernorFactoryTests
 {
     private readonly GovernorFactory _sut = new();
 
+    private readonly MstrTrustGovernance _mstrTrustGovernance = new()
+    {
+        Gid = "1011111",
+        Email = "ms.governor@thetrust.com"
+    };
+
     [Fact]
     public void CreateFrom_should_transform_a_giasGovernance_into_a_governor()
     {
@@ -18,44 +24,23 @@ public class GovernorFactoryTests
             AppointingBody = "Appointed by GB/board",
             DateOfAppointment = "01/09/2023",
             DateTermOfOfficeEndsEnded = "01/09/2024",
-            Forename1 = "Oliver",
-            Forename2 = "Jane",
-            Surname = "Wood",
-            Role = "Trustee",
-            Title = "Mr"
+            Role = "Trustee"
         };
 
-        var result = _sut.CreateFrom(giasGovernance, null);
+        var result = _sut.CreateFrom(giasGovernance, _mstrTrustGovernance);
 
-        result.Should().BeEquivalentTo(new Governor(
-                "1011111",
-                "1234",
-                "Oliver Jane Wood",
-                "Trustee",
-                "Appointed by GB/board",
-                new DateTime(2023, 09, 01),
-                new DateTime(2024, 09, 01),
-                null
-            )
-        );
+        result.GID.Should().Be("1011111");
+        result.UID.Should().Be("1234");
+        result.Role.Should().Be("Trustee");
+        result.AppointingBody.Should().Be("Appointed by GB/board");
+        result.DateOfAppointment.Should().Be(new DateTime(2023, 09, 01));
+        result.DateOfTermEnd.Should().Be(new DateTime(2024, 09, 01));
     }
 
-    [Fact]
-    public void CreateFrom_should_default_email_to_null_if_no_mstrTrustGovernance()
-    {
-        var giasGovernance = new GiasGovernance
-        {
-            Gid = "1011111",
-            Uid = "1234"
-        };
-
-        var result = _sut.CreateFrom(giasGovernance, null);
-
-        result.Email.Should().BeNull();
-    }
-
-    [Fact]
-    public void CreateFrom_should_use_email_from_mstrTrustGovernance_if_present()
+    [Theory]
+    [InlineData("ms.governor@thetrust.com")]
+    [InlineData("")]
+    public void CreateFrom_should_use_email_from_mstrTrustGovernance(string email)
     {
         var giasGovernance = new GiasGovernance
         {
@@ -65,12 +50,12 @@ public class GovernorFactoryTests
         var mstrTrustGovernance = new MstrTrustGovernance
         {
             Gid = "1011111",
-            Email = "ms.governor@thetrust.com"
+            Email = email
         };
 
         var result = _sut.CreateFrom(giasGovernance, mstrTrustGovernance);
 
-        result.Email.Should().Be("ms.governor@thetrust.com");
+        result.Email.Should().Be(email);
     }
 
     [Theory]
@@ -94,7 +79,7 @@ public class GovernorFactoryTests
             Title = "not used"
         };
 
-        var result = _sut.CreateFrom(giasGovernance, null);
+        var result = _sut.CreateFrom(giasGovernance, _mstrTrustGovernance);
 
         result.FullName.Should().Be(expectedFullName);
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/GovernorFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/GovernorFactoryTests.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Factories;
 
@@ -24,7 +25,7 @@ public class GovernorFactoryTests
             Title = "Mr"
         };
 
-        var result = _sut.CreateFrom(giasGovernance);
+        var result = _sut.CreateFrom(giasGovernance, null);
 
         result.Should().BeEquivalentTo(new Governor(
                 "1011111",
@@ -37,6 +38,39 @@ public class GovernorFactoryTests
                 null
             )
         );
+    }
+
+    [Fact]
+    public void CreateFrom_should_default_email_to_null_if_no_mstrTrustGovernance()
+    {
+        var giasGovernance = new GiasGovernance
+        {
+            Gid = "1011111",
+            Uid = "1234"
+        };
+
+        var result = _sut.CreateFrom(giasGovernance, null);
+
+        result.Email.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateFrom_should_use_email_from_mstrTrustGovernance_if_present()
+    {
+        var giasGovernance = new GiasGovernance
+        {
+            Gid = "1011111",
+            Uid = "1234"
+        };
+        var mstrTrustGovernance = new MstrTrustGovernance
+        {
+            Gid = "1011111",
+            Email = "ms.governor@thetrust.com"
+        };
+
+        var result = _sut.CreateFrom(giasGovernance, mstrTrustGovernance);
+
+        result.Email.Should().Be("ms.governor@thetrust.com");
     }
 
     [Theory]
@@ -60,7 +94,7 @@ public class GovernorFactoryTests
             Title = "not used"
         };
 
-        var result = _sut.CreateFrom(giasGovernance);
+        var result = _sut.CreateFrom(giasGovernance, null);
 
         result.FullName.Should().Be(expectedFullName);
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -53,9 +53,21 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
             i => new GiasGovernance
             {
                 Uid = groupUid,
+                Gid = i.ToString(),
                 Forename1 = $"Governor {i}"
             },
             academiesDbContext => academiesDbContext.GiasGovernances);
+    }
+
+    public List<MstrTrustGovernance> SetupMockDbContextMstrTrustGovernance(int numMatches)
+    {
+        return SetupMockDbContext(numMatches,
+            i => new MstrTrustGovernance
+            {
+                Gid = i.ToString(),
+                Forename1 = $"Governor {i}"
+            },
+            academiesDbContext => academiesDbContext.MstrTrustGovernances);
     }
 
     private List<T> SetupMockDbContext<T>(int numMatches, Func<int, T> itemCreator,

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
@@ -196,7 +196,7 @@ public class TrustProviderTests
         foreach (var giasGovernance in newGiasGovernances)
         {
             var dummyGovernor = dummyGovernorFactory.GetDummyGovernor(groupUid);
-            _mockGovernorFactory.Setup(g => g.CreateFrom(giasGovernance))
+            _mockGovernorFactory.Setup(g => g.CreateFrom(giasGovernance, null))
                 .Returns(dummyGovernor);
             governorsLinkedToTrust.Add(dummyGovernor);
         }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
@@ -13,6 +13,7 @@ public class TrustProviderTests
     private readonly List<MstrTrust> _mstrTrusts;
     private readonly List<GiasEstablishment> _giasEstablishments;
     private readonly List<GiasGovernance> _giasGovernances;
+    private readonly List<MstrTrustGovernance> _mstrTrustGovernances;
     private readonly Mock<ITrustFactory> _mockTrustFactory = new();
     private readonly Mock<IAcademyFactory> _mockAcademyFactory = new();
     private readonly Mock<IGovernorFactory> _mockGovernorFactory = new();
@@ -24,6 +25,7 @@ public class TrustProviderTests
         _mstrTrusts = _mockAcademiesDbContext.SetupMockDbContextMstrTrust(5);
         _giasEstablishments = _mockAcademiesDbContext.SetupMockDbContextGiasEstablishment(15);
         _giasGovernances = _mockAcademiesDbContext.SetupMockDbContextGiasGovernance(20, "Some other trust");
+        _mstrTrustGovernances = _mockAcademiesDbContext.SetupMockDbContextMstrTrustGovernance(20);
 
         _sut = new TrustProvider(_mockAcademiesDbContext.Object, _mockTrustFactory.Object, _mockAcademyFactory.Object,
             _mockGovernorFactory.Object);
@@ -130,10 +132,6 @@ public class TrustProviderTests
 
         var expectedGovernors = SetUpGovernorsLinkedToTrust(5, groupUid);
 
-        _mockTrustFactory
-            .Setup(t => t.CreateTrustFrom(giasGroup, mstrTrust, Array.Empty<Academy>(), It.IsAny<Governor[]>()))
-            .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
-
         await _sut.GetTrustByUidAsync(groupUid);
 
         _mockTrustFactory.Verify(t =>
@@ -178,25 +176,30 @@ public class TrustProviderTests
 
     private List<Governor> SetUpGovernorsLinkedToTrust(int num, string groupUid)
     {
-        var newGiasGovernances = new List<GiasGovernance>();
-        for (var i = 0; i < num; i++)
-        {
-            newGiasGovernances.Add(new GiasGovernance
-            {
-                Uid = groupUid,
-                Forename1 = $"Governor {i}"
-            });
-        }
-
-        _giasGovernances.AddRange(newGiasGovernances);
-
+        var numExistingGovernances = _giasGovernances.Count;
         var governorsLinkedToTrust = new List<Governor>();
 
-        var dummyGovernorFactory = new DummyGovernorFactory();
-        foreach (var giasGovernance in newGiasGovernances)
+        for (var i = 0; i < num; i++)
         {
-            var dummyGovernor = dummyGovernorFactory.GetDummyGovernor(groupUid);
-            _mockGovernorFactory.Setup(g => g.CreateFrom(giasGovernance, null))
+            var gid = (i + numExistingGovernances).ToString();
+            var giasGovernance = new GiasGovernance
+            {
+                Gid = gid,
+                Uid = groupUid,
+                Forename1 = $"Governor {i}"
+            };
+            var mstrTrustGovernance = new MstrTrustGovernance
+            {
+                Gid = gid,
+                Forename1 = $"Governor {i}",
+                Email = $"governor{i}@trust{groupUid}.com"
+            };
+
+            _giasGovernances.Add(giasGovernance);
+            _mstrTrustGovernances.Add(mstrTrustGovernance);
+
+            var dummyGovernor = DummyGovernorFactory.GetDummyGovernor(gid, groupUid);
+            _mockGovernorFactory.Setup(g => g.CreateFrom(giasGovernance, mstrTrustGovernance))
                 .Returns(dummyGovernor);
             governorsLinkedToTrust.Add(dummyGovernor);
         }


### PR DESCRIPTION
Get the email address for governors from the mstr schema

[User Story 146083](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/146083): Build: Get all the data we need from Academies DB for MVP

## Changes

- Amend GovernorFactory to pull email address from MstrTrustGovernance
- Amend TrustProvider to get MstrTrustGovernance from the db and give to `GovernorFactory`

## Checklist

- [n/a] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [n/a] Update the ADR decision log if needed
