### PR TITLE
Get all mvp data - add academies fakers

### DIFF
--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/AcademiesDbData.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/AcademiesDbData.cs
@@ -3,6 +3,11 @@ using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker;
 
-public record AcademiesDbData(GiasEstablishment[] GiasEstablishments, GiasGovernance[] GiasGovernances,
-    GiasGroupLink[] GiasGroupLinks,
-    GiasGroup[] GiasGroups, MstrTrust[] MstrTrusts);
+public class AcademiesDbData
+{
+    public List<GiasEstablishment> GiasEstablishments { get; } = new();
+    public List<GiasGovernance> GiasGovernances { get; } = new();
+    public List<GiasGroupLink> GiasGroupLinks { get; } = new();
+    public List<GiasGroup> GiasGroups { get; } = new();
+    public List<MstrTrust> MstrTrusts { get; } = new();
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Data.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Data.cs
@@ -116,4 +116,59 @@ public static class Data
         "Yorkshire and the Humber",
         "South West"
     };
+
+    public static string[] LocalAuthorities { get; } =
+    {
+        "Barnsley",
+        "Bradford",
+        "Calderdale",
+        "Doncaster",
+        "East Riding of Yorkshire",
+        "Kingston upon Hull, City of",
+        "Kirklees",
+        "Leeds",
+        "North East Lincolnshire",
+        "North Lincolnshire",
+        "North Yorkshire",
+        "Rotherham",
+        "Sheffield",
+        "Wakefield",
+        "York"
+    };
+
+    public static string[] Schools { get; } =
+    {
+        "St. Mary's",
+        "St. Marys",
+        "St. John's",
+        "St. Peter's",
+        "St. Joseph's",
+        "St. Paul's",
+        "St. James'",
+        "St. James's",
+        "St. Anne's",
+        "St. Catherine's",
+        "Momentum Community",
+        "Barr and Community",
+        "Beacon",
+        "Co-op",
+        "George Abbey",
+        "Glyn",
+        "Greensward",
+        "Halewood",
+        "Harris",
+        "Holly Lodge Girls'",
+        "Lampton",
+        "Limehurst",
+        "Longhill",
+        "Malbank",
+        "Meridian",
+        "Mulberry",
+        "Northwood",
+        "Oasis",
+        "Horizon",
+        "Peacehaven Community",
+        "Queen Elizabeth's",
+        "Queensbridge"
+    };
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
@@ -8,24 +8,34 @@ public class AcademiesDbFaker
 {
     private int _counter = 1233;
     private readonly string?[] _regions;
+    private readonly string?[] _localAuthorities;
+    private readonly GiasGroupLinkFaker _giasGroupLinkFaker = new();
+    private readonly Bogus.Faker _generalFaker = new();
+    private readonly GiasEstablishmentFaker _establishmentFaker;
 
-    public AcademiesDbFaker(string?[] regions)
+    public AcademiesDbFaker(string?[] regions, string?[] localAuthorities, string[] fakeSchoolNames)
     {
         _regions = regions;
+        _localAuthorities = localAuthorities;
+        _establishmentFaker = new GiasEstablishmentFaker(fakeSchoolNames);
     }
 
     public AcademiesDbData Generate(TrustToGenerate[] trustsToGenerate)
     {
-        var groups = trustsToGenerate
-            .Select(GenerateGroup).ToArray();
-        var mstrTrusts = groups.Select(GenerateMstrTrust).ToArray();
+        var academiesDbData = new AcademiesDbData();
 
-        return new AcademiesDbData(
-            Array.Empty<GiasEstablishment>(),
-            Array.Empty<GiasGovernance>(),
-            Array.Empty<GiasGroupLink>(),
-            groups,
-            mstrTrusts);
+        foreach (var trustToGenerate in trustsToGenerate)
+        {
+            var group = GenerateGroup(trustToGenerate);
+            academiesDbData.GiasGroups.Add(group);
+            academiesDbData.MstrTrusts.Add(GenerateMstrTrust(group.GroupUid));
+
+            var academies = GenerateAcademies(trustToGenerate, group.GroupUid!).ToArray();
+            academiesDbData.GiasEstablishments.AddRange(academies);
+            academiesDbData.GiasGroupLinks.AddRange(academies.Select(academy => GenerateGroupLink(academy, group)));
+        }
+
+        return academiesDbData;
     }
 
     private GiasGroup GenerateGroup(TrustToGenerate trustToGenerate)
@@ -34,8 +44,29 @@ public class AcademiesDbFaker
         return fakeGroup.Generate();
     }
 
-    private MstrTrust GenerateMstrTrust(GiasGroup giasGroup)
+    private MstrTrust GenerateMstrTrust(string? uid)
     {
-        return new MstrTrustFaker(giasGroup.GroupUid!, _regions).Generate();
+        return new MstrTrustFaker(uid!, _regions).Generate();
+    }
+
+    private GiasGroupLink GenerateGroupLink(GiasEstablishment establishment, GiasGroup giasGroup)
+    {
+        return _giasGroupLinkFaker
+            .SetGiasGroupOpenedDate(giasGroup.IncorporatedOnOpenDate)
+            .Generate(giasGroup.GroupUid!,
+                establishment.Urn.ToString());
+    }
+
+    private IEnumerable<GiasEstablishment> GenerateAcademies(TrustToGenerate trustToGenerate, string uid)
+    {
+        _establishmentFaker.SetUid(uid).SetLocalAuthoritiesSelection(
+            _generalFaker.PickRandom(_localAuthorities, _generalFaker.Random.Int(1, 4)).ToArray());
+
+        if (trustToGenerate.Schools.Any())
+        {
+            return _establishmentFaker.Generate(trustToGenerate.Schools);
+        }
+
+        return _establishmentFaker.Generate(_generalFaker.Random.Int(0, 11));
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
@@ -7,21 +7,24 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Fakers;
 public class AcademiesDbFaker
 {
     private int _counter = 1233;
-    private readonly string?[] _regions;
+    private readonly Bogus.Faker _generalFaker = new();
+
     private readonly string?[] _localAuthorities;
     private readonly GiasGroupLinkFaker _giasGroupLinkFaker;
-    private readonly Bogus.Faker _generalFaker = new();
     private readonly GiasEstablishmentFaker _giasEstablishmentFaker;
+    private readonly GiasGroupFaker _giasGroupFaker;
+    private readonly MstrTrustFaker _mstrTrustFaker;
 
     public AcademiesDbFaker(string?[] regions, string?[] localAuthorities, string[] fakeSchoolNames)
     {
         // Need a ref date for any use of `faker.Date` so the data generated doesn't change every day
         var refDate = new DateTime(2023, 11, 9);
 
-        _regions = regions;
         _localAuthorities = localAuthorities;
+        _giasGroupFaker = new GiasGroupFaker(refDate);
         _giasEstablishmentFaker = new GiasEstablishmentFaker(fakeSchoolNames);
         _giasGroupLinkFaker = new GiasGroupLinkFaker(refDate);
+        _mstrTrustFaker = new MstrTrustFaker(regions);
     }
 
     public AcademiesDbData Generate(TrustToGenerate[] trustsToGenerate)
@@ -44,13 +47,12 @@ public class AcademiesDbFaker
 
     private GiasGroup GenerateGroup(TrustToGenerate trustToGenerate)
     {
-        var fakeGroup = new GiasGroupFaker(trustToGenerate, _counter++);
-        return fakeGroup.Generate();
+        return _giasGroupFaker.Generate(trustToGenerate, _counter++);
     }
 
     private MstrTrust GenerateMstrTrust(string? uid)
     {
-        return new MstrTrustFaker(uid!, _regions).Generate();
+        return _mstrTrustFaker.Generate(uid!);
     }
 
     private GiasGroupLink GenerateGroupLink(GiasEstablishment establishment, GiasGroup giasGroup)

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
@@ -9,15 +9,19 @@ public class AcademiesDbFaker
     private int _counter = 1233;
     private readonly string?[] _regions;
     private readonly string?[] _localAuthorities;
-    private readonly GiasGroupLinkFaker _giasGroupLinkFaker = new();
+    private readonly GiasGroupLinkFaker _giasGroupLinkFaker;
     private readonly Bogus.Faker _generalFaker = new();
-    private readonly GiasEstablishmentFaker _establishmentFaker;
+    private readonly GiasEstablishmentFaker _giasEstablishmentFaker;
 
     public AcademiesDbFaker(string?[] regions, string?[] localAuthorities, string[] fakeSchoolNames)
     {
+        // Need a ref date for any use of `faker.Date` so the data generated doesn't change every day
+        var refDate = new DateTime(2023, 11, 9);
+
         _regions = regions;
         _localAuthorities = localAuthorities;
-        _establishmentFaker = new GiasEstablishmentFaker(fakeSchoolNames);
+        _giasEstablishmentFaker = new GiasEstablishmentFaker(fakeSchoolNames);
+        _giasGroupLinkFaker = new GiasGroupLinkFaker(refDate);
     }
 
     public AcademiesDbData Generate(TrustToGenerate[] trustsToGenerate)
@@ -59,14 +63,14 @@ public class AcademiesDbFaker
 
     private IEnumerable<GiasEstablishment> GenerateAcademies(TrustToGenerate trustToGenerate, string uid)
     {
-        _establishmentFaker.SetUid(uid).SetLocalAuthoritiesSelection(
+        _giasEstablishmentFaker.SetUid(uid).SetLocalAuthoritiesSelection(
             _generalFaker.PickRandom(_localAuthorities, _generalFaker.Random.Int(1, 4)).ToArray());
 
         if (trustToGenerate.Schools.Any())
         {
-            return _establishmentFaker.Generate(trustToGenerate.Schools);
+            return _giasEstablishmentFaker.Generate(trustToGenerate.Schools);
         }
 
-        return _establishmentFaker.Generate(_generalFaker.Random.Int(0, 11));
+        return _giasEstablishmentFaker.Generate(_generalFaker.Random.Int(0, 11));
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasEstablishmentFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasEstablishmentFaker.cs
@@ -38,10 +38,10 @@ public class GiasEstablishmentFaker
                     set.RuleFor(e => e.PhaseOfEducationName, f => f.PickRandom("Primary", "Secondary"))
                         .RuleFor(e => e.EstablishmentName, GenerateSchoolName)
                         .RuleFor(e => e.StatutoryLowAge, (f, e) =>
-                            e.PhaseOfEducationName == "Primary" ? f.PickRandom("4", "5") : "11"
+                            GetMinAge(e.PhaseOfEducationName, f)
                         )
                         .RuleFor(e => e.StatutoryHighAge,
-                            (f, e) => e.PhaseOfEducationName == "Primary" ? "11" : f.PickRandom("16", "18"));
+                            (f, e) => GetMaxAge(e.PhaseOfEducationName, f));
                 })
                 .RuleSet("definedSchoolName",
                     set =>
@@ -55,9 +55,9 @@ public class GiasEstablishmentFaker
                                         ? "Secondary"
                                         : f.PickRandom("Primary", "Secondary"))
                             .RuleFor(e => e.StatutoryLowAge,
-                                (f, e) => e.PhaseOfEducationName == "Primary" ? f.PickRandom("4", "5") : "11")
+                                (f, e) => GetMinAge(e.PhaseOfEducationName, f))
                             .RuleFor(e => e.StatutoryHighAge,
-                                (f, a) => a.PhaseOfEducationName == "Primary" ? "11" : f.PickRandom("16", "18"));
+                                (f, e) => GetMaxAge(e.PhaseOfEducationName, f));
                     })
             ;
     }
@@ -74,6 +74,16 @@ public class GiasEstablishmentFaker
         name = $"{name} {faker.PickRandom("School", "Academy")}";
 
         return name;
+    }
+
+    private string GetMinAge(string? phaseOfEducationName, Bogus.Faker faker)
+    {
+        return phaseOfEducationName == "Primary" ? faker.PickRandom("4", "5") : "11";
+    }
+
+    private string GetMaxAge(string? phaseOfEducationName, Bogus.Faker faker)
+    {
+        return phaseOfEducationName == "Primary" ? "11" : faker.PickRandom("16", "18");
     }
 
     public GiasEstablishmentFaker SetLocalAuthoritiesSelection(IEnumerable<string?> localAuthorities)

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasEstablishmentFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasEstablishmentFaker.cs
@@ -1,0 +1,104 @@
+using Bogus;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Fakers;
+
+public class GiasEstablishmentFaker
+{
+    private IEnumerable<string?> _localAuthorities = Array.Empty<string>();
+    private readonly Faker<GiasEstablishment> _establishmentFaker;
+    private readonly string[] _fakeSchoolNames;
+    private string _uid = "";
+
+    public GiasEstablishmentFaker(string[] fakeSchoolNames)
+    {
+        _fakeSchoolNames = fakeSchoolNames;
+        _establishmentFaker = new Faker<GiasEstablishment>("en_GB")
+                // will this Urn sometimes be a duplicate?
+                .RuleFor(a => a.Urn, f => int.Parse($"{_uid}{f.Random.Int(1000, 9999)}"))
+                .RuleFor(e => e.LaName, f => f.PickRandom(_localAuthorities))
+                .RuleFor(e => e.TypeOfEstablishmentName,
+                    f => f.PickRandom("Academy sponsor led", "Academy converter", "Free school"))
+                .RuleFor(e => e.UrbanRuralName, f => f.PickRandom(
+                    "Urban city and town",
+                    "Rural town and fringe",
+                    "Rural village in a sparse setting",
+                    "Urban major conurbation",
+                    "Urban minor conurbation"))
+                .RuleFor(e => e.SchoolCapacity, f => f.Random.Int(100, 3000).ToString())
+                .RuleFor(e => e.NumberOfPupils, (f, e) =>
+                {
+                    var schoolCapacity = int.Parse(e.SchoolCapacity!);
+                    var noOfPupils = (int)Math.Round(schoolCapacity * f.Random.Double(0.4, 1.3));
+                    return noOfPupils.ToString();
+                })
+                .RuleFor(e => e.PercentageFsm, f => f.Random.Int(1, 30).ToString())
+                .RuleSet("randomSchoolName", set =>
+                {
+                    set.RuleFor(e => e.PhaseOfEducationName, f => f.PickRandom("Primary", "Secondary"))
+                        .RuleFor(e => e.EstablishmentName, GenerateSchoolName)
+                        .RuleFor(e => e.StatutoryLowAge, (f, e) =>
+                            e.PhaseOfEducationName == "Primary" ? f.PickRandom("4", "5") : "11"
+                        )
+                        .RuleFor(e => e.StatutoryHighAge,
+                            (f, e) => e.PhaseOfEducationName == "Primary" ? "11" : f.PickRandom("16", "18"));
+                })
+                .RuleSet("definedSchoolName",
+                    set =>
+                    {
+                        set.RuleFor(e => e.PhaseOfEducationName,
+                                (f, e) => e.EstablishmentName!.Contains("Primary",
+                                    StringComparison.CurrentCultureIgnoreCase)
+                                    ? "Primary"
+                                    : e.EstablishmentName.Contains("Secondary",
+                                        StringComparison.CurrentCultureIgnoreCase)
+                                        ? "Secondary"
+                                        : f.PickRandom("Primary", "Secondary"))
+                            .RuleFor(e => e.StatutoryLowAge,
+                                (f, e) => e.PhaseOfEducationName == "Primary" ? f.PickRandom("4", "5") : "11")
+                            .RuleFor(e => e.StatutoryHighAge,
+                                (f, a) => a.PhaseOfEducationName == "Primary" ? "11" : f.PickRandom("16", "18"));
+                    })
+            ;
+    }
+
+    private string GenerateSchoolName(Bogus.Faker faker, GiasEstablishment establishment)
+    {
+        var name = faker.PickRandom(
+            _fakeSchoolNames.Concat(new[] { establishment.LaName!, faker.Address.StreetName() }));
+        if (name.StartsWith("st", StringComparison.InvariantCultureIgnoreCase) || faker.Random.Bool())
+            name = $"{name} {faker.PickRandom("Church of England", "Cofe", "CE", "Catholic", "C of E", "R.C.")}";
+
+        if (faker.Random.Bool())
+            name = $"{name} {establishment.PhaseOfEducationName}";
+        name = $"{name} {faker.PickRandom("School", "Academy")}";
+
+        return name;
+    }
+
+    public GiasEstablishmentFaker SetLocalAuthoritiesSelection(IEnumerable<string?> localAuthorities)
+    {
+        _localAuthorities = localAuthorities;
+        return this;
+    }
+
+    public GiasEstablishmentFaker SetUid(string uid)
+    {
+        _uid = uid;
+        return this;
+    }
+
+    public IEnumerable<GiasEstablishment> Generate(int num)
+    {
+        return _establishmentFaker.Generate(num, "default,randomSchoolName");
+    }
+
+    public IEnumerable<GiasEstablishment> Generate(IEnumerable<string> schools)
+    {
+        return schools.Select(n =>
+        {
+            _establishmentFaker.RuleFor(e => e.EstablishmentName, n);
+            return _establishmentFaker.Generate("default,definedSchoolName");
+        });
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasGroupFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasGroupFaker.cs
@@ -8,26 +8,28 @@ public class GiasGroupFaker
 {
     private readonly Faker<GiasGroup> _giasGroupFaker;
 
-    public GiasGroupFaker(TrustToGenerate trustToGenerate, int uid)
+    public GiasGroupFaker(DateTime refDate)
     {
         _giasGroupFaker = new Faker<GiasGroup>("en_GB")
-            .RuleFor(g => g.GroupName, trustToGenerate.Name)
-            .RuleFor(g => g.GroupUid, f => $"{uid}")
             .RuleFor(g => g.GroupId, f => $"TR{f.Random.Int(0, 9999)}")
             .RuleFor(g => g.Ukprn, f => $"100{f.Random.Int(0, 99999):D5}")
-            .RuleFor(g => g.GroupType, trustToGenerate.TrustType)
             .RuleFor(g => g.GroupContactStreet, f => $"{f.Address.BuildingNumber()} {f.Address.StreetName()}")
             .RuleFor(g => g.GroupContactLocality, f => f.PickRandom(f.Address.StreetName(), string.Empty))
             .RuleFor(g => g.GroupContactTown, f => f.PickRandom(f.Address.City(), string.Empty))
             .RuleFor(g => g.GroupContactPostcode, f => f.Address.ZipCode())
             .RuleFor(g => g.IncorporatedOnOpenDate,
-                f => f.Date.Past(10, new DateTime(2023, 11, 9))
-                    .ToString("dd/MM/yyyy")) //Need a ref date for `Date.Past` so the data generated doesn't change every day
+                f => f.Date.Past(10, refDate)
+                    .ToString("dd/MM/yyyy"))
             .RuleFor(g => g.CompaniesHouseNumber, f => f.Random.Int(1100000, 09999999).ToString("D8"));
     }
 
-    public GiasGroup Generate()
+    public GiasGroup Generate(TrustToGenerate trustToGenerate, int uid)
     {
-        return _giasGroupFaker.Generate();
+        var fakeGiasGroup = _giasGroupFaker.Generate();
+        fakeGiasGroup.GroupName = trustToGenerate.Name;
+        fakeGiasGroup.GroupType = trustToGenerate.TrustType;
+        fakeGiasGroup.GroupUid = uid.ToString();
+
+        return fakeGiasGroup;
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasGroupLinkFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasGroupLinkFaker.cs
@@ -9,12 +9,12 @@ public class GiasGroupLinkFaker
     private readonly Faker<GiasGroupLink> _groupLinkFaker;
     private string? _giasGroupOpenedDate;
 
-    public GiasGroupLinkFaker()
+    public GiasGroupLinkFaker(DateTime refDate)
     {
         _groupLinkFaker = new Faker<GiasGroupLink>("en_GB")
             .RuleFor(t => t.JoinedDate, f => f.Date.Between(
                     DateTime.ParseExact(_giasGroupOpenedDate!, "dd/MM/yyyy", CultureInfo.InvariantCulture),
-                    new DateTime(2023, 11, 9)).ToString("dd/MM/yyyy")
+                    refDate).ToString("dd/MM/yyyy")
             );
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasGroupLinkFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasGroupLinkFaker.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+using Bogus;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Fakers;
+
+public class GiasGroupLinkFaker
+{
+    private readonly Faker<GiasGroupLink> _groupLinkFaker;
+    private string? _giasGroupOpenedDate;
+
+    public GiasGroupLinkFaker()
+    {
+        _groupLinkFaker = new Faker<GiasGroupLink>("en_GB")
+            .RuleFor(t => t.JoinedDate, f => f.Date.Between(
+                    DateTime.ParseExact(_giasGroupOpenedDate!, "dd/MM/yyyy", CultureInfo.InvariantCulture),
+                    new DateTime(2023, 11, 9)).ToString("dd/MM/yyyy")
+            );
+    }
+
+    public GiasGroupLinkFaker SetGiasGroupOpenedDate(string? giasGroupOpenedDate)
+    {
+        _giasGroupOpenedDate = giasGroupOpenedDate;
+        return this;
+    }
+
+    public GiasGroupLink Generate(string uid, string urn)
+    {
+        var fakeGroupLink = _groupLinkFaker.Generate();
+        fakeGroupLink.GroupUid = uid;
+        fakeGroupLink.Urn = urn;
+        return fakeGroupLink;
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/MstrTrustFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/MstrTrustFaker.cs
@@ -7,15 +7,16 @@ public class MstrTrustFaker
 {
     private readonly Faker<MstrTrust> _mstrTrustFaker;
 
-    public MstrTrustFaker(string uid, string?[] region)
+    public MstrTrustFaker(string?[] region)
     {
         _mstrTrustFaker = new Faker<MstrTrust>()
-            .RuleFor(t => t.GroupUid, uid)
             .RuleFor(t => t.GORregion, f => f.PickRandom(region));
     }
 
-    public MstrTrust Generate()
+    public MstrTrust Generate(string uid)
     {
-        return _mstrTrustFaker.Generate();
+        var fakeMstrTrust = _mstrTrustFaker.Generate();
+        fakeMstrTrust.GroupUid = uid;
+        return fakeMstrTrust;
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Program.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Program.cs
@@ -14,7 +14,7 @@ public static class Program
             Randomizer.Seed = new Random(28698);
 
 
-            var faker = new AcademiesDbFaker(Data.Regions);
+            var faker = new AcademiesDbFaker(Data.Regions, Data.LocalAuthorities, Data.Schools);
             var academiesDbData = faker.Generate(Data.TrustsToGenerate);
 
             SqlScriptGenerator.GenerateAndSaveSqlScripts(academiesDbData, "data/createScript.sql",

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/SqlScriptGenerator.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/SqlScriptGenerator.cs
@@ -34,7 +34,7 @@ public static class SqlScriptGenerator
         File.WriteAllText(outputFilePath, insertScript);
     }
 
-    private static string GenerateSqlInsertScriptSegmentFor<T>(T[] fakeObjects, AcademiesDbContext context)
+    private static string GenerateSqlInsertScriptSegmentFor<T>(List<T> fakeObjects, AcademiesDbContext context)
     {
         var objProperties = typeof(T).GetProperties();
         var entityType = context.Model.FindEntityTypes(typeof(T)).FirstOrDefault()!;

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/SqlScriptGenerator.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/SqlScriptGenerator.cs
@@ -29,7 +29,9 @@ public static class SqlScriptGenerator
     {
         var insertScript = string.Join("; ",
             GenerateSqlInsertScriptSegmentFor(fakeData.GiasGroups, context),
-            GenerateSqlInsertScriptSegmentFor(fakeData.MstrTrusts, context)
+            GenerateSqlInsertScriptSegmentFor(fakeData.MstrTrusts, context),
+            GenerateSqlInsertScriptSegmentFor(fakeData.GiasGroupLinks, context),
+            GenerateSqlInsertScriptSegmentFor(fakeData.GiasEstablishments, context)
         );
         File.WriteAllText(outputFilePath, insertScript);
     }

--- a/tests/playwright/fake-data/trusts.json
+++ b/tests/playwright/fake-data/trusts.json
@@ -8,875 +8,7316 @@
     "address": "99627 Mathilde Way, YN0 5GP",
     "openedDate": "2019-03-02T00:00:00",
     "companiesHouseNumber": "02851944",
-    "regionAndTerritory": "North West"
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12335187,
+        "dateAcademyJoinedTrust": "2022-10-07T00:00:00",
+        "establishmentName": "Halewood Church of England Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "245",
+        "schoolCapacity": "198",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12335729,
+        "dateAcademyJoinedTrust": "2022-10-23T00:00:00",
+        "establishmentName": "St. Marys CE Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1329",
+        "schoolCapacity": "1219",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12339637,
+        "dateAcademyJoinedTrust": "2021-12-31T00:00:00",
+        "establishmentName": "St. Anne\u0027s Church of England Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1091",
+        "schoolCapacity": "1644",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12334923,
+        "dateAcademyJoinedTrust": "2020-12-19T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1400",
+        "schoolCapacity": "1825",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12331100,
+        "dateAcademyJoinedTrust": "2020-10-10T00:00:00",
+        "establishmentName": "St. Paul\u0027s C of E Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1629",
+        "schoolCapacity": "1993",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1250",
     "name": "ACCLIVITY MULTI-ACADEMY TRUST",
-    "groupId": "TR9776",
-    "ukprn": "10058132",
+    "groupId": "TR9610",
+    "ukprn": "10061152",
     "type": "Multi-academy trust",
-    "address": "24755 Donnelly Garden, OY24 1OY",
-    "openedDate": "2014-05-30T00:00:00",
-    "companiesHouseNumber": "03544113",
-    "regionAndTerritory": ""
+    "address": "0401 Juliet Bypass, ZC3 0FK",
+    "openedDate": "2021-08-09T00:00:00",
+    "companiesHouseNumber": "04628262",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12506693,
+        "dateAcademyJoinedTrust": "2021-09-20T00:00:00",
+        "establishmentName": "Northwood Church of England Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1271",
+        "schoolCapacity": "1393",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12504398,
+        "dateAcademyJoinedTrust": "2023-02-03T00:00:00",
+        "establishmentName": "St. James\u0027s Catholic Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1996",
+        "schoolCapacity": "2119",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12505001,
+        "dateAcademyJoinedTrust": "2022-11-15T00:00:00",
+        "establishmentName": "Peacehaven Community Church of England Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3152",
+        "schoolCapacity": "2554",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12503692,
+        "dateAcademyJoinedTrust": "2021-10-18T00:00:00",
+        "establishmentName": "Longhill R.C. School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1880",
+        "schoolCapacity": "1513",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12508690,
+        "dateAcademyJoinedTrust": "2023-03-11T00:00:00",
+        "establishmentName": "Meridian School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1357",
+        "schoolCapacity": "1684",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12504408,
+        "dateAcademyJoinedTrust": "2023-08-16T00:00:00",
+        "establishmentName": "Oasis R.C. School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3532",
+        "schoolCapacity": "2799",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12508253,
+        "dateAcademyJoinedTrust": "2022-03-01T00:00:00",
+        "establishmentName": "Mulberry Cofe Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2960",
+        "schoolCapacity": "2747",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1270",
     "name": "ADEPT ACADEMY TRUST",
-    "groupId": "TR4738",
-    "ukprn": "10051788",
+    "groupId": "TR7224",
+    "ukprn": "10025385",
     "type": "Multi-academy trust",
-    "address": "3065 Bergstrom Summit, Jedidiah Ports, West Gaylord, PQ33 6HH",
-    "openedDate": "2017-12-26T00:00:00",
-    "companiesHouseNumber": "03982040",
-    "regionAndTerritory": "North East"
+    "address": "5368 Torphy Junction, Kirstin Circles, NP06 9NL",
+    "openedDate": "2022-08-29T00:00:00",
+    "companiesHouseNumber": "07564297",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 12701578,
+        "dateAcademyJoinedTrust": "2023-10-29T00:00:00",
+        "establishmentName": "Northwood Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1333",
+        "schoolCapacity": "2978",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12706647,
+        "dateAcademyJoinedTrust": "2023-09-23T00:00:00",
+        "establishmentName": "St. Peter\u0027s CE Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "847",
+        "schoolCapacity": "828",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1277",
     "name": "ADVANTAGE ACADEMY TRUST",
-    "groupId": "TR7879",
-    "ukprn": "10052495",
+    "groupId": "TR7031",
+    "ukprn": "10040879",
     "type": "Multi-academy trust",
-    "address": "25575 Rupert Valley, Conn Fall, SV3 7SF",
-    "openedDate": "2015-01-24T00:00:00",
-    "companiesHouseNumber": "04316208",
-    "regionAndTerritory": "South East"
+    "address": "4573 Hyatt Squares, Haag Cape, Padbergview, ZV1 5CD",
+    "openedDate": "2014-07-16T00:00:00",
+    "companiesHouseNumber": "01652826",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 12774263,
+        "dateAcademyJoinedTrust": "2023-05-12T00:00:00",
+        "establishmentName": "Barr and Community Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "311",
+        "schoolCapacity": "736",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12772526,
+        "dateAcademyJoinedTrust": "2023-06-11T00:00:00",
+        "establishmentName": "Meridian Cofe Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1665",
+        "schoolCapacity": "1495",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12776359,
+        "dateAcademyJoinedTrust": "2018-12-31T00:00:00",
+        "establishmentName": "Beacon Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1115",
+        "schoolCapacity": "1854",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12779418,
+        "dateAcademyJoinedTrust": "2022-09-13T00:00:00",
+        "establishmentName": "Beacon CE Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "140",
+        "schoolCapacity": "231",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12775897,
+        "dateAcademyJoinedTrust": "2018-07-08T00:00:00",
+        "establishmentName": "St. James\u0027s CE School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "241",
+        "schoolCapacity": "265",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12774945,
+        "dateAcademyJoinedTrust": "2016-07-26T00:00:00",
+        "establishmentName": "Barr and Community Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1008",
+        "schoolCapacity": "942",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12777573,
+        "dateAcademyJoinedTrust": "2022-05-06T00:00:00",
+        "establishmentName": "St. James\u0027 Cofe Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1592",
+        "schoolCapacity": "2410",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12777858,
+        "dateAcademyJoinedTrust": "2015-12-04T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "704",
+        "schoolCapacity": "1086",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1244",
     "name": "ASCENDANCY ACADEMY TRUST",
-    "groupId": "TR7909",
-    "ukprn": "10084820",
+    "groupId": "TR3227",
+    "ukprn": "10072217",
     "type": "Multi-academy trust",
-    "address": "61300 Emilio Gardens, Crooks Ports, FZ6 0VG",
-    "openedDate": "2022-10-24T00:00:00",
-    "companiesHouseNumber": "02094128",
-    "regionAndTerritory": "North East"
+    "address": "650 Bosco Brooks, IA5 3PU",
+    "openedDate": "2015-07-30T00:00:00",
+    "companiesHouseNumber": "09147744",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 12446470,
+        "dateAcademyJoinedTrust": "2018-07-06T00:00:00",
+        "establishmentName": "Queensbridge School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1675",
+        "schoolCapacity": "1782",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12445152,
+        "dateAcademyJoinedTrust": "2016-01-27T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2422",
+        "schoolCapacity": "2344",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12441781,
+        "dateAcademyJoinedTrust": "2019-03-30T00:00:00",
+        "establishmentName": "Halewood Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "380",
+        "schoolCapacity": "883",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1263",
     "name": "BRIDGE EDUCATION TRUST",
-    "groupId": "TR9587",
-    "ukprn": "10086065",
+    "groupId": "TR3928",
+    "ukprn": "10073429",
     "type": "Multi-academy trust",
-    "address": "832 Sven Springs, Mylene Summit, Goyetteview, EM96 0ZZ",
-    "openedDate": "2019-08-06T00:00:00",
-    "companiesHouseNumber": "08295189",
-    "regionAndTerritory": "South West"
+    "address": "067 Khalid Causeway, New Jaedenshire, SP69 3RG",
+    "openedDate": "2016-04-24T00:00:00",
+    "companiesHouseNumber": "05019966",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12638706,
+        "dateAcademyJoinedTrust": "2022-02-01T00:00:00",
+        "establishmentName": "Beacon Cofe Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "654",
+        "schoolCapacity": "514",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12632536,
+        "dateAcademyJoinedTrust": "2023-06-01T00:00:00",
+        "establishmentName": "St. James\u0027 C of E Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2263",
+        "schoolCapacity": "2436",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12631776,
+        "dateAcademyJoinedTrust": "2019-02-19T00:00:00",
+        "establishmentName": "St. Joseph\u0027s R.C. Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "682",
+        "schoolCapacity": "609",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12631756,
+        "dateAcademyJoinedTrust": "2020-08-31T00:00:00",
+        "establishmentName": "Barr and Community Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "340",
+        "schoolCapacity": "573",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12635380,
+        "dateAcademyJoinedTrust": "2019-11-10T00:00:00",
+        "establishmentName": "Mulberry Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "651",
+        "schoolCapacity": "863",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12634277,
+        "dateAcademyJoinedTrust": "2019-11-02T00:00:00",
+        "establishmentName": "Harris Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1101",
+        "schoolCapacity": "1070",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12638962,
+        "dateAcademyJoinedTrust": "2016-05-24T00:00:00",
+        "establishmentName": "Harris Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3405",
+        "schoolCapacity": "2797",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12632041,
+        "dateAcademyJoinedTrust": "2022-11-23T00:00:00",
+        "establishmentName": "Kuphal Path C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "868",
+        "schoolCapacity": "723",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12637012,
+        "dateAcademyJoinedTrust": "2016-07-19T00:00:00",
+        "establishmentName": "Limehurst Cofe Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "265",
+        "schoolCapacity": "246",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12634984,
+        "dateAcademyJoinedTrust": "2021-12-16T00:00:00",
+        "establishmentName": "Mulberry Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2597",
+        "schoolCapacity": "2005",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12632657,
+        "dateAcademyJoinedTrust": "2018-01-22T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Church of England Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "527",
+        "schoolCapacity": "1150",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1311",
     "name": "CANTERBURY CROSS EDUCATION TRUST",
-    "groupId": "TR6892",
-    "ukprn": "10011994",
+    "groupId": "TR299",
+    "ukprn": "10078878",
     "type": "Multi-academy trust",
-    "address": "8885 Dietrich Trail, Spinka Brook, PT1 9KV",
-    "openedDate": "2018-08-17T00:00:00",
-    "companiesHouseNumber": "09410190",
-    "regionAndTerritory": "East of England"
+    "address": "385 Reyes Prairie, Jones Terrace, Marvinhaven, ZP83 4BT",
+    "openedDate": "2022-04-19T00:00:00",
+    "companiesHouseNumber": "05443627",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 13117944,
+        "dateAcademyJoinedTrust": "2022-08-13T00:00:00",
+        "establishmentName": "St. Catherine\u0027s R.C. Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "501",
+        "schoolCapacity": "521",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13111130,
+        "dateAcademyJoinedTrust": "2023-08-08T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2171",
+        "schoolCapacity": "2027",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13119303,
+        "dateAcademyJoinedTrust": "2022-10-31T00:00:00",
+        "establishmentName": "St. John\u0027s Cofe Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "652",
+        "schoolCapacity": "620",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13112739,
+        "dateAcademyJoinedTrust": "2023-08-03T00:00:00",
+        "establishmentName": "Northwood Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1178",
+        "schoolCapacity": "1962",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1282",
     "name": "CHALLENGER MULTI-ACADEMY TRUST",
-    "groupId": "TR7589",
-    "ukprn": "10030562",
+    "groupId": "TR9097",
+    "ukprn": "10046583",
     "type": "Multi-academy trust",
-    "address": "96920 Gaylord Knolls, Douglas Stravenue, QN2 9IJ",
-    "openedDate": "2021-11-14T00:00:00",
-    "companiesHouseNumber": "05185253",
-    "regionAndTerritory": "South West"
+    "address": "09914 Lockman Knolls, Wiza Haven, BO0 6DN",
+    "openedDate": "2015-06-28T00:00:00",
+    "companiesHouseNumber": "09498309",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 12823359,
+        "dateAcademyJoinedTrust": "2016-02-26T00:00:00",
+        "establishmentName": "Lampton Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1446",
+        "schoolCapacity": "1534",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12824807,
+        "dateAcademyJoinedTrust": "2017-12-25T00:00:00",
+        "establishmentName": "St. James\u0027s Church of England Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1651",
+        "schoolCapacity": "2284",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12828590,
+        "dateAcademyJoinedTrust": "2017-08-03T00:00:00",
+        "establishmentName": "Oasis Catholic School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1897",
+        "schoolCapacity": "2729",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1254",
     "name": "CHAMPION ACADEMY TRUST",
-    "groupId": "TR1407",
-    "ukprn": "10010535",
+    "groupId": "TR5615",
+    "ukprn": "10098893",
     "type": "Multi-academy trust",
-    "address": "359 Rhiannon Rest, Smith Crossing, AX0 1MZ",
-    "openedDate": "2021-10-30T00:00:00",
-    "companiesHouseNumber": "08089497",
-    "regionAndTerritory": "North West"
+    "address": "0991 Houston Pine, LD2 0FC",
+    "openedDate": "2016-03-08T00:00:00",
+    "companiesHouseNumber": "04962165",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12547934,
+        "dateAcademyJoinedTrust": "2017-02-04T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Church of England Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2275",
+        "schoolCapacity": "2888",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12549532,
+        "dateAcademyJoinedTrust": "2017-04-15T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1225",
+        "schoolCapacity": "1705",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12545894,
+        "dateAcademyJoinedTrust": "2019-02-10T00:00:00",
+        "establishmentName": "Longhill Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "608",
+        "schoolCapacity": "677",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12547264,
+        "dateAcademyJoinedTrust": "2017-06-26T00:00:00",
+        "establishmentName": "Mulberry School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "792",
+        "schoolCapacity": "1511",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12543408,
+        "dateAcademyJoinedTrust": "2023-02-21T00:00:00",
+        "establishmentName": "Co-op Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1600",
+        "schoolCapacity": "1235",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12546472,
+        "dateAcademyJoinedTrust": "2018-02-25T00:00:00",
+        "establishmentName": "George Abbey R.C. School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1261",
+        "schoolCapacity": "2897",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12545857,
+        "dateAcademyJoinedTrust": "2017-12-07T00:00:00",
+        "establishmentName": "Meridian School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2800",
+        "schoolCapacity": "2754",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1260",
     "name": "CORNERSTONE MULTI-ACADEMY TRUST",
-    "groupId": "TR2634",
-    "ukprn": "10040183",
+    "groupId": "TR7616",
+    "ukprn": "10062669",
     "type": "Multi-academy trust",
-    "address": "47738 Pfannerstill Club, Fisher Route, Alenefort, OY5 3SZ",
-    "openedDate": "2021-07-28T00:00:00",
-    "companiesHouseNumber": "06657230",
-    "regionAndTerritory": "London"
+    "address": "1914 Hansen Unions, Schamberger Park, Lake Brennan, KN9 9WI",
+    "openedDate": "2016-07-22T00:00:00",
+    "companiesHouseNumber": "06570508",
+    "regionAndTerritory": "East Midlands",
+    "academies": [
+      {
+        "urn": 12607012,
+        "dateAcademyJoinedTrust": "2018-01-25T00:00:00",
+        "establishmentName": "Northwood Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3088",
+        "schoolCapacity": "2594",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12602116,
+        "dateAcademyJoinedTrust": "2019-05-09T00:00:00",
+        "establishmentName": "Harris Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1720",
+        "schoolCapacity": "1971",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12606191,
+        "dateAcademyJoinedTrust": "2017-10-15T00:00:00",
+        "establishmentName": "Queensbridge Church of England Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "845",
+        "schoolCapacity": "2071",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12607972,
+        "dateAcademyJoinedTrust": "2020-03-24T00:00:00",
+        "establishmentName": "Longhill Catholic Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1366",
+        "schoolCapacity": "1253",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1264",
     "name": "CRESCENDO ACADEMY TRUST",
-    "groupId": "TR276",
-    "ukprn": "10078024",
+    "groupId": "TR3189",
+    "ukprn": "10013508",
     "type": "Multi-academy trust",
-    "address": "71074 Mayer Shore, Hilpert Greens, JL42 5TF",
-    "openedDate": "2014-02-18T00:00:00",
-    "companiesHouseNumber": "04238039",
-    "regionAndTerritory": "South East"
+    "address": "996 Amaya Extension, Celestino Trail, WS4 1FZ",
+    "openedDate": "2018-03-31T00:00:00",
+    "companiesHouseNumber": "08770407",
+    "regionAndTerritory": "South East",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1243",
     "name": "ECHELON EDUCATION TRUST",
-    "groupId": "TR7116",
-    "ukprn": "10003920",
+    "groupId": "TR4877",
+    "ukprn": "10065588",
     "type": "Multi-academy trust",
-    "address": "5490 Karelle Forks, Sporer Flats, YK3 2HG",
-    "openedDate": "2014-06-01T00:00:00",
-    "companiesHouseNumber": "09139155",
-    "regionAndTerritory": "North West"
+    "address": "44348 Nienow Key, Linnie Greens, GY26 6PM",
+    "openedDate": "2022-04-29T00:00:00",
+    "companiesHouseNumber": "07954541",
+    "regionAndTerritory": "North East",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1234",
     "name": "EDIFY MULTI-ACADEMY TRUST",
-    "groupId": "TR3073",
-    "ukprn": "10029064",
+    "groupId": "TR9131",
+    "ukprn": "10068736",
     "type": "Multi-academy trust",
-    "address": "744 Jasmin Wells, AA7 2NX",
-    "openedDate": "2022-10-12T00:00:00",
-    "companiesHouseNumber": "01481711",
-    "regionAndTerritory": "East of England"
+    "address": "5702 Farrell Ferry, Abbott Lodge, KN82 8YU",
+    "openedDate": "2021-08-02T00:00:00",
+    "companiesHouseNumber": "05593282",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 12345999,
+        "dateAcademyJoinedTrust": "2023-11-07T00:00:00",
+        "establishmentName": "Beacon School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "935",
+        "schoolCapacity": "1249",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1240",
     "name": "ELEVATE SCHOOLS TRUST",
-    "groupId": "TR5760",
-    "ukprn": "10001631",
+    "groupId": "TR5063",
+    "ukprn": "10037274",
     "type": "Multi-academy trust",
-    "address": "91973 Kenyon Drive, Port Brant, WO5 9MS",
-    "openedDate": "2019-09-08T00:00:00",
-    "companiesHouseNumber": "09999948",
-    "regionAndTerritory": "West Midlands"
+    "address": "4788 Kessler Tunnel, North Brycehaven, DK81 2JP",
+    "openedDate": "2020-05-20T00:00:00",
+    "companiesHouseNumber": "03426988",
+    "regionAndTerritory": "East Midlands",
+    "academies": [
+      {
+        "urn": 12405527,
+        "dateAcademyJoinedTrust": "2021-09-01T00:00:00",
+        "establishmentName": "Oasis Catholic Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1342",
+        "schoolCapacity": "1290",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12405286,
+        "dateAcademyJoinedTrust": "2021-06-05T00:00:00",
+        "establishmentName": "Meridian C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "882",
+        "schoolCapacity": "1489",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12407280,
+        "dateAcademyJoinedTrust": "2021-04-28T00:00:00",
+        "establishmentName": "Harris C of E School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "928",
+        "schoolCapacity": "2183",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12407418,
+        "dateAcademyJoinedTrust": "2021-07-28T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Cofe Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "170",
+        "schoolCapacity": "170",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12402612,
+        "dateAcademyJoinedTrust": "2022-09-09T00:00:00",
+        "establishmentName": "Barr and Community Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2028",
+        "schoolCapacity": "1874",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12405487,
+        "dateAcademyJoinedTrust": "2023-10-02T00:00:00",
+        "establishmentName": "Northwood Church of England Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1547",
+        "schoolCapacity": "2022",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12404795,
+        "dateAcademyJoinedTrust": "2022-03-04T00:00:00",
+        "establishmentName": "Williamson Throughway Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "605",
+        "schoolCapacity": "1471",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12409161,
+        "dateAcademyJoinedTrust": "2023-09-08T00:00:00",
+        "establishmentName": "St. James\u0027 CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2106",
+        "schoolCapacity": "2559",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12409660,
+        "dateAcademyJoinedTrust": "2021-08-24T00:00:00",
+        "establishmentName": "Glyn Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "198",
+        "schoolCapacity": "180",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1253",
     "name": "ELEVATED SCHOOLS TRUST",
-    "groupId": "TR3436",
-    "ukprn": "10011539",
+    "groupId": "TR5247",
+    "ukprn": "10039717",
     "type": "Multi-academy trust",
-    "address": "446 Wilbert Wall, Jamil Fords, Orionport, CW3 7OY",
-    "openedDate": "2018-10-19T00:00:00",
-    "companiesHouseNumber": "06963381",
-    "regionAndTerritory": "North East"
+    "address": "23563 Claudine Mall, Murray Radial, Asiaside, ZN2 6UT",
+    "openedDate": "2017-04-10T00:00:00",
+    "companiesHouseNumber": "08730124",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 12539436,
+        "dateAcademyJoinedTrust": "2021-11-16T00:00:00",
+        "establishmentName": "Oasis Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3295",
+        "schoolCapacity": "2657",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1280",
     "name": "EMPOWER ACADEMY TRUST",
-    "groupId": "TR340",
-    "ukprn": "10000707",
+    "groupId": "TR2014",
+    "ukprn": "10049042",
     "type": "Multi-academy trust",
-    "address": "99030 Bechtelar Crossroad, XB36 8BS",
-    "openedDate": "2022-04-10T00:00:00",
-    "companiesHouseNumber": "07561251",
-    "regionAndTerritory": "Yorkshire and the Humber"
+    "address": "761 Hayley Drive, TZ8 1IX",
+    "openedDate": "2020-05-18T00:00:00",
+    "companiesHouseNumber": "04993633",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12804753,
+        "dateAcademyJoinedTrust": "2022-09-14T00:00:00",
+        "establishmentName": "Mulberry Cofe School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2028",
+        "schoolCapacity": "1764",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12809048,
+        "dateAcademyJoinedTrust": "2022-04-29T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "738",
+        "schoolCapacity": "1048",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12805453,
+        "dateAcademyJoinedTrust": "2021-02-09T00:00:00",
+        "establishmentName": "Northwood Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2980",
+        "schoolCapacity": "2569",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12804746,
+        "dateAcademyJoinedTrust": "2021-08-29T00:00:00",
+        "establishmentName": "Halewood C of E Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3247",
+        "schoolCapacity": "2774",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12801303,
+        "dateAcademyJoinedTrust": "2023-09-01T00:00:00",
+        "establishmentName": "Horizon R.C. Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "817",
+        "schoolCapacity": "1294",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12802443,
+        "dateAcademyJoinedTrust": "2021-04-18T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Church of England Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2323",
+        "schoolCapacity": "2383",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12803597,
+        "dateAcademyJoinedTrust": "2021-10-01T00:00:00",
+        "establishmentName": "Malbank School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "622",
+        "schoolCapacity": "1540",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12803253,
+        "dateAcademyJoinedTrust": "2020-12-02T00:00:00",
+        "establishmentName": "George Abbey Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "295",
+        "schoolCapacity": "445",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1242",
     "name": "EMPOWERMENT MULTI-ACADEMY TRUST",
-    "groupId": "TR445",
-    "ukprn": "10002002",
+    "groupId": "TR5753",
+    "ukprn": "10071479",
     "type": "Multi-academy trust",
-    "address": "3445 Hermann Stravenue, KI21 3SI",
-    "openedDate": "2023-05-03T00:00:00",
-    "companiesHouseNumber": "05628485",
-    "regionAndTerritory": "London"
+    "address": "447 Abner Parkways, Jerald Loop, Hammesmouth, QH8 5GI",
+    "openedDate": "2014-02-02T00:00:00",
+    "companiesHouseNumber": "02095640",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12425871,
+        "dateAcademyJoinedTrust": "2022-05-29T00:00:00",
+        "establishmentName": "St. Marys CE School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "272",
+        "schoolCapacity": "245",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12421849,
+        "dateAcademyJoinedTrust": "2016-11-16T00:00:00",
+        "establishmentName": "St. Peter\u0027s C of E Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2650",
+        "schoolCapacity": "2813",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1247",
     "name": "EPIC LEARNING TRUST",
-    "groupId": "TR476",
-    "ukprn": "10077980",
+    "groupId": "TR2215",
+    "ukprn": "10006697",
     "type": "Multi-academy trust",
-    "address": "4948 Cummerata Glens, Gregoria Coves, YR7 7MT",
-    "openedDate": "2015-01-21T00:00:00",
-    "companiesHouseNumber": "02048801",
-    "regionAndTerritory": "North East"
+    "address": "05597 Bauch Lock, AT76 2BR",
+    "openedDate": "2020-04-19T00:00:00",
+    "companiesHouseNumber": "07394657",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12471486,
+        "dateAcademyJoinedTrust": "2023-07-29T00:00:00",
+        "establishmentName": "Harris CE Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2033",
+        "schoolCapacity": "2801",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1268",
     "name": "EXCEL MULTI-ACADEMY TRUST",
-    "groupId": "TR7147",
-    "ukprn": "10086247",
+    "groupId": "TR2703",
+    "ukprn": "10012927",
     "type": "Multi-academy trust",
-    "address": "4740 Kuphal Meadows, Alessia Vista, UN2 3ZC",
-    "openedDate": "2017-01-19T00:00:00",
-    "companiesHouseNumber": "08098286",
-    "regionAndTerritory": "South West"
+    "address": "64708 Eileen Lake, Bashirian Prairie, PE8 5XV",
+    "openedDate": "2020-10-16T00:00:00",
+    "companiesHouseNumber": "03420836",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12687775,
+        "dateAcademyJoinedTrust": "2023-01-08T00:00:00",
+        "establishmentName": "St. Catherine\u0027s C of E Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "786",
+        "schoolCapacity": "928",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12688357,
+        "dateAcademyJoinedTrust": "2023-06-09T00:00:00",
+        "establishmentName": "Northwood School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "646",
+        "schoolCapacity": "1297",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1271",
     "name": "EXCELLENCE MULTI-ACADEMY TRUST",
-    "groupId": "TR422",
-    "ukprn": "10098627",
+    "groupId": "TR2945",
+    "ukprn": "10027704",
     "type": "Multi-academy trust",
-    "address": "2926 Metz Mall, Okey Points, Daviston, ZR50 7CA",
-    "openedDate": "2019-09-27T00:00:00",
-    "companiesHouseNumber": "01833958",
-    "regionAndTerritory": ""
+    "address": "09747 Fahey Bypass, JS85 1OZ",
+    "openedDate": "2019-06-02T00:00:00",
+    "companiesHouseNumber": "02786907",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12716208,
+        "dateAcademyJoinedTrust": "2023-01-13T00:00:00",
+        "establishmentName": "St. Paul\u0027s Cofe Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "813",
+        "schoolCapacity": "1545",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12712258,
+        "dateAcademyJoinedTrust": "2021-06-07T00:00:00",
+        "establishmentName": "Queensbridge R.C. Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1227",
+        "schoolCapacity": "1477",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12714898,
+        "dateAcademyJoinedTrust": "2022-05-18T00:00:00",
+        "establishmentName": "Harris Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1264",
+        "schoolCapacity": "1605",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12719172,
+        "dateAcademyJoinedTrust": "2023-09-21T00:00:00",
+        "establishmentName": "Northwood Catholic Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1845",
+        "schoolCapacity": "2875",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12717677,
+        "dateAcademyJoinedTrust": "2022-03-17T00:00:00",
+        "establishmentName": "Northwood School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1951",
+        "schoolCapacity": "2035",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12719177,
+        "dateAcademyJoinedTrust": "2022-03-31T00:00:00",
+        "establishmentName": "St. Anne\u0027s CE Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1743",
+        "schoolCapacity": "2128",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12711985,
+        "dateAcademyJoinedTrust": "2021-10-21T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1414",
+        "schoolCapacity": "2858",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12711963,
+        "dateAcademyJoinedTrust": "2022-12-25T00:00:00",
+        "establishmentName": "Peacehaven Community Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "693",
+        "schoolCapacity": "716",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1275",
     "name": "FORWARD MULTI-ACADEMY TRUST",
-    "groupId": "TR1383",
-    "ukprn": "10082763",
+    "groupId": "TR6319",
+    "ukprn": "10016066",
     "type": "Multi-academy trust",
-    "address": "034 Brooke Drive, Rohan Neck, SO65 5OU",
-    "openedDate": "2016-06-12T00:00:00",
-    "companiesHouseNumber": "08482727",
-    "regionAndTerritory": "North West"
+    "address": "699 Mark Parkway, West Jammie, YE2 1US",
+    "openedDate": "2019-10-06T00:00:00",
+    "companiesHouseNumber": "09832691",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12757687,
+        "dateAcademyJoinedTrust": "2020-12-25T00:00:00",
+        "establishmentName": "Meridian Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2275",
+        "schoolCapacity": "2811",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12759598,
+        "dateAcademyJoinedTrust": "2022-08-21T00:00:00",
+        "establishmentName": "St. Mary\u0027s R.C. School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1356",
+        "schoolCapacity": "2750",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12753388,
+        "dateAcademyJoinedTrust": "2023-10-11T00:00:00",
+        "establishmentName": "Oasis Church of England School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "656",
+        "schoolCapacity": "725",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12757451,
+        "dateAcademyJoinedTrust": "2022-03-24T00:00:00",
+        "establishmentName": "St. James\u0027 C of E Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "974",
+        "schoolCapacity": "992",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12751560,
+        "dateAcademyJoinedTrust": "2019-11-28T00:00:00",
+        "establishmentName": "St. James\u0027 C of E Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1283",
+        "schoolCapacity": "2605",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12752221,
+        "dateAcademyJoinedTrust": "2020-05-15T00:00:00",
+        "establishmentName": "St. John\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "977",
+        "schoolCapacity": "2361",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1279",
     "name": "FUSION EDUCATION TRUST",
-    "groupId": "TR9712",
-    "ukprn": "10014998",
+    "groupId": "TR5365",
+    "ukprn": "10038409",
     "type": "Multi-academy trust",
-    "address": "5263 Pollich Inlet, Lake Idellshire, HG9 8LZ",
-    "openedDate": "2022-04-06T00:00:00",
-    "companiesHouseNumber": "04571230",
-    "regionAndTerritory": "South East"
+    "address": "5441 Kovacek Skyway, Darion Parkways, East Bertha, UL85 3CV",
+    "openedDate": "2017-10-18T00:00:00",
+    "companiesHouseNumber": "06516649",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12798413,
+        "dateAcademyJoinedTrust": "2020-07-26T00:00:00",
+        "establishmentName": "Malbank Church of England School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "230",
+        "schoolCapacity": "446",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12795435,
+        "dateAcademyJoinedTrust": "2020-08-16T00:00:00",
+        "establishmentName": "Greensward Catholic Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1044",
+        "schoolCapacity": "2416",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12794928,
+        "dateAcademyJoinedTrust": "2019-09-09T00:00:00",
+        "establishmentName": "St. Joseph\u0027s CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1709",
+        "schoolCapacity": "1704",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12795915,
+        "dateAcademyJoinedTrust": "2021-08-07T00:00:00",
+        "establishmentName": "Meridian Church of England Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1197",
+        "schoolCapacity": "2833",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12797739,
+        "dateAcademyJoinedTrust": "2017-11-29T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 CE School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1069",
+        "schoolCapacity": "858",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12797326,
+        "dateAcademyJoinedTrust": "2021-06-27T00:00:00",
+        "establishmentName": "St. John\u0027s Church of England Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1061",
+        "schoolCapacity": "1377",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12793752,
+        "dateAcademyJoinedTrust": "2019-08-31T00:00:00",
+        "establishmentName": "St. Mary\u0027s CE Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "668",
+        "schoolCapacity": "1018",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1259",
     "name": "GALVANIZE ACADEMY TRUST",
-    "groupId": "TR2788",
-    "ukprn": "10094503",
+    "groupId": "TR4008",
+    "ukprn": "10018644",
     "type": "Multi-academy trust",
-    "address": "584 Jenkins Road, MX4 3XC",
-    "openedDate": "2019-01-25T00:00:00",
-    "companiesHouseNumber": "03005016",
-    "regionAndTerritory": "North West"
+    "address": "330 Wyatt Pike, Kihn Roads, TZ4 4IO",
+    "openedDate": "2017-08-07T00:00:00",
+    "companiesHouseNumber": "07856980",
+    "regionAndTerritory": "South East",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1239",
     "name": "HORIZON MULTI-ACADEMY TRUST",
-    "groupId": "TR3720",
-    "ukprn": "10077082",
+    "groupId": "TR9910",
+    "ukprn": "10030338",
     "type": "Multi-academy trust",
-    "address": "359 Wuckert Station, Lake Pearlinebury, ME3 1GO",
-    "openedDate": "2019-11-11T00:00:00",
-    "companiesHouseNumber": "09176076",
-    "regionAndTerritory": "North West"
+    "address": "90149 Ozella Plains, FQ45 0IY",
+    "openedDate": "2015-09-19T00:00:00",
+    "companiesHouseNumber": "06896749",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12399338,
+        "dateAcademyJoinedTrust": "2020-08-21T00:00:00",
+        "establishmentName": "St. John\u0027s CE Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2111",
+        "schoolCapacity": "1923",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12393349,
+        "dateAcademyJoinedTrust": "2016-01-14T00:00:00",
+        "establishmentName": "St. Anne\u0027s C of E Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2083",
+        "schoolCapacity": "2567",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12398882,
+        "dateAcademyJoinedTrust": "2016-03-25T00:00:00",
+        "establishmentName": "Glyn R.C. Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "736",
+        "schoolCapacity": "846",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1266",
     "name": "HORIZONS MULTI-ACADEMY TRUST",
-    "groupId": "TR3031",
-    "ukprn": "10073223",
+    "groupId": "TR5949",
+    "ukprn": "10044044",
     "type": "Multi-academy trust",
-    "address": "38700 Tromp Tunnel, Hoegerfurt, ZP8 7YA",
-    "openedDate": "2020-10-14T00:00:00",
-    "companiesHouseNumber": "01890178",
-    "regionAndTerritory": "East of England"
+    "address": "410 Farrell Tunnel, Aufderhar Run, Hellerfort, RB3 4IS",
+    "openedDate": "2018-08-23T00:00:00",
+    "companiesHouseNumber": "08155384",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12661517,
+        "dateAcademyJoinedTrust": "2018-11-01T00:00:00",
+        "establishmentName": "St. John\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1675",
+        "schoolCapacity": "2173",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1281",
     "name": "ILLUMINATE LEARNING TRUST",
-    "groupId": "TR423",
-    "ukprn": "10031072",
+    "groupId": "TR960",
+    "ukprn": "10002923",
     "type": "Multi-academy trust",
-    "address": "0762 Justice Row, Braeden Turnpike, YG6 5HP",
-    "openedDate": "2022-07-14T00:00:00",
-    "companiesHouseNumber": "09699456",
-    "regionAndTerritory": "South East"
+    "address": "614 Sasha Route, Armstrong Villages, Dachshire, BA1 8CM",
+    "openedDate": "2018-12-03T00:00:00",
+    "companiesHouseNumber": "01462188",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12814254,
+        "dateAcademyJoinedTrust": "2023-02-10T00:00:00",
+        "establishmentName": "York Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1105",
+        "schoolCapacity": "1833",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12812933,
+        "dateAcademyJoinedTrust": "2022-06-07T00:00:00",
+        "establishmentName": "Co-op CE School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1474",
+        "schoolCapacity": "1142",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12812442,
+        "dateAcademyJoinedTrust": "2019-10-06T00:00:00",
+        "establishmentName": "Peacehaven Community Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1478",
+        "schoolCapacity": "1436",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12816461,
+        "dateAcademyJoinedTrust": "2022-09-25T00:00:00",
+        "establishmentName": "St. Paul\u0027s Church of England Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1866",
+        "schoolCapacity": "2362",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12819105,
+        "dateAcademyJoinedTrust": "2021-06-09T00:00:00",
+        "establishmentName": "Northwood Church of England School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1676",
+        "schoolCapacity": "2471",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12812820,
+        "dateAcademyJoinedTrust": "2023-07-16T00:00:00",
+        "establishmentName": "St. Anne\u0027s C of E Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1410",
+        "schoolCapacity": "2256",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12814687,
+        "dateAcademyJoinedTrust": "2019-07-16T00:00:00",
+        "establishmentName": "York Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1473",
+        "schoolCapacity": "2005",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12811785,
+        "dateAcademyJoinedTrust": "2019-01-28T00:00:00",
+        "establishmentName": "Beacon Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1119",
+        "schoolCapacity": "1512",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12814730,
+        "dateAcademyJoinedTrust": "2022-11-28T00:00:00",
+        "establishmentName": "St. Peter\u0027s Church of England School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "284",
+        "schoolCapacity": "598",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1278",
     "name": "ILLUMINATE MULTI-ACADEMY TRUST",
-    "groupId": "TR7650",
-    "ukprn": "10048780",
+    "groupId": "TR3561",
+    "ukprn": "10088976",
     "type": "Multi-academy trust",
-    "address": "6033 Joanne Oval, Isabel Station, Geovannyhaven, SZ7 4JS",
-    "openedDate": "2022-12-19T00:00:00",
-    "companiesHouseNumber": "04041940",
-    "regionAndTerritory": "East of England"
+    "address": "23182 Vandervort Pass, Boyle Vista, FZ24 5UG",
+    "openedDate": "2020-11-17T00:00:00",
+    "companiesHouseNumber": "02473158",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12785053,
+        "dateAcademyJoinedTrust": "2021-09-07T00:00:00",
+        "establishmentName": "Halewood School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1446",
+        "schoolCapacity": "2347",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12781095,
+        "dateAcademyJoinedTrust": "2021-04-26T00:00:00",
+        "establishmentName": "St. Joseph\u0027s R.C. Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1168",
+        "schoolCapacity": "1205",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12784083,
+        "dateAcademyJoinedTrust": "2021-10-19T00:00:00",
+        "establishmentName": "Co-op Cofe Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3433",
+        "schoolCapacity": "2755",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12788991,
+        "dateAcademyJoinedTrust": "2021-04-07T00:00:00",
+        "establishmentName": "Longhill Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1843",
+        "schoolCapacity": "2472",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12784455,
+        "dateAcademyJoinedTrust": "2021-09-01T00:00:00",
+        "establishmentName": "St. Peter\u0027s CE School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1956",
+        "schoolCapacity": "1694",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12782844,
+        "dateAcademyJoinedTrust": "2022-03-18T00:00:00",
+        "establishmentName": "Homenick Isle C of E School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1577",
+        "schoolCapacity": "2291",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12784585,
+        "dateAcademyJoinedTrust": "2021-05-15T00:00:00",
+        "establishmentName": "Meridian School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2759",
+        "schoolCapacity": "2992",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12782666,
+        "dateAcademyJoinedTrust": "2022-12-11T00:00:00",
+        "establishmentName": "Glyn C of E Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1272",
+        "schoolCapacity": "2085",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12789653,
+        "dateAcademyJoinedTrust": "2022-03-18T00:00:00",
+        "establishmentName": "St. James\u0027s Church of England Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "347",
+        "schoolCapacity": "591",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1235",
     "name": "INNOVATE ACADEMY TRUST",
-    "groupId": "TR3857",
-    "ukprn": "10076731",
+    "groupId": "TR6318",
+    "ukprn": "10098055",
     "type": "Multi-academy trust",
-    "address": "76320 Bernardo Streets, Vicenta Points, MG92 0WP",
-    "openedDate": "2019-07-15T00:00:00",
-    "companiesHouseNumber": "04979999",
-    "regionAndTerritory": "South West"
+    "address": "047 Altenwerth Streets, Hoppe Lakes, East Erik, OK9 5AG",
+    "openedDate": "2014-08-03T00:00:00",
+    "companiesHouseNumber": "02327386",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12358070,
+        "dateAcademyJoinedTrust": "2017-11-15T00:00:00",
+        "establishmentName": "Queensbridge C of E Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1547",
+        "schoolCapacity": "3000",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12356726,
+        "dateAcademyJoinedTrust": "2022-03-08T00:00:00",
+        "establishmentName": "Peacehaven Community Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "163",
+        "schoolCapacity": "362",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12352450,
+        "dateAcademyJoinedTrust": "2022-08-21T00:00:00",
+        "establishmentName": "George Abbey CE Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "60",
+        "schoolCapacity": "116",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1261",
     "name": "INSPIRE MULTI-ACADEMY TRUST",
-    "groupId": "TR7131",
-    "ukprn": "10097862",
+    "groupId": "TR2798",
+    "ukprn": "10011503",
     "type": "Multi-academy trust",
-    "address": "60611 Della Plaza, TH17 1RI",
-    "openedDate": "2015-05-19T00:00:00",
-    "companiesHouseNumber": "09521072",
-    "regionAndTerritory": "Yorkshire and the Humber"
+    "address": "5251 Hoppe Mountains, Wittington, TY78 2TZ",
+    "openedDate": "2019-01-14T00:00:00",
+    "companiesHouseNumber": "06687377",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12618215,
+        "dateAcademyJoinedTrust": "2020-04-26T00:00:00",
+        "establishmentName": "Longhill Church of England Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1351",
+        "schoolCapacity": "2667",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12619566,
+        "dateAcademyJoinedTrust": "2022-10-06T00:00:00",
+        "establishmentName": "Greensward Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1583",
+        "schoolCapacity": "1771",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12611577,
+        "dateAcademyJoinedTrust": "2021-07-27T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Catholic Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "392",
+        "schoolCapacity": "668",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12617292,
+        "dateAcademyJoinedTrust": "2022-09-06T00:00:00",
+        "establishmentName": "Horizon Catholic Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "596",
+        "schoolCapacity": "1262",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12615510,
+        "dateAcademyJoinedTrust": "2022-12-27T00:00:00",
+        "establishmentName": "Co-op School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1212",
+        "schoolCapacity": "1219",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1255",
     "name": "INTREPID EDUCATION TRUST",
-    "groupId": "TR6187",
-    "ukprn": "10051236",
+    "groupId": "TR773",
+    "ukprn": "10016959",
     "type": "Multi-academy trust",
-    "address": "6589 Lemke Via, ZH53 7GY",
-    "openedDate": "2017-11-23T00:00:00",
-    "companiesHouseNumber": "06286966",
-    "regionAndTerritory": "North East"
+    "address": "80097 Gusikowski Plains, UP6 8SV",
+    "openedDate": "2023-10-19T00:00:00",
+    "companiesHouseNumber": "03998808",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12552918,
+        "dateAcademyJoinedTrust": "2023-11-06T00:00:00",
+        "establishmentName": "Northwood Cofe School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2026",
+        "schoolCapacity": "1953",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12554931,
+        "dateAcademyJoinedTrust": "2023-10-26T00:00:00",
+        "establishmentName": "York CE Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1271",
+        "schoolCapacity": "1515",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1249",
     "name": "LEGACY EDUCATION TRUST",
-    "groupId": "TR3135",
-    "ukprn": "10001404",
+    "groupId": "TR2511",
+    "ukprn": "10035238",
     "type": "Multi-academy trust",
-    "address": "703 Champlin Rapid, East Abbieshire, YU30 5BQ",
-    "openedDate": "2020-11-21T00:00:00",
-    "companiesHouseNumber": "08791528",
-    "regionAndTerritory": "East of England"
+    "address": "6599 Sandy Fall, West Emely, IT9 2KW",
+    "openedDate": "2017-01-07T00:00:00",
+    "companiesHouseNumber": "09698699",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12499083,
+        "dateAcademyJoinedTrust": "2021-07-07T00:00:00",
+        "establishmentName": "Harris School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "799",
+        "schoolCapacity": "899",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12498261,
+        "dateAcademyJoinedTrust": "2017-07-30T00:00:00",
+        "establishmentName": "Limehurst Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1302",
+        "schoolCapacity": "1993",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12495218,
+        "dateAcademyJoinedTrust": "2018-01-06T00:00:00",
+        "establishmentName": "Lampton Cofe School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "449",
+        "schoolCapacity": "585",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12491220,
+        "dateAcademyJoinedTrust": "2022-07-08T00:00:00",
+        "establishmentName": "Lampton School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1408",
+        "schoolCapacity": "1300",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1246",
     "name": "MERIT ACADEMY TRUST",
-    "groupId": "TR7852",
-    "ukprn": "10089550",
+    "groupId": "TR9956",
+    "ukprn": "10008714",
     "type": "Multi-academy trust",
-    "address": "97519 Brandyn Key, Xanderville, YV3 8EH",
-    "openedDate": "2023-11-03T00:00:00",
-    "companiesHouseNumber": "09994759",
-    "regionAndTerritory": "North West"
+    "address": "22984 Cronin Junctions, Batzbury, BD74 5WA",
+    "openedDate": "2018-01-18T00:00:00",
+    "companiesHouseNumber": "08056460",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 12468336,
+        "dateAcademyJoinedTrust": "2020-04-24T00:00:00",
+        "establishmentName": "St. James\u0027s CE Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "966",
+        "schoolCapacity": "2206",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12462126,
+        "dateAcademyJoinedTrust": "2023-07-01T00:00:00",
+        "establishmentName": "Harris Catholic Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1197",
+        "schoolCapacity": "1017",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12463750,
+        "dateAcademyJoinedTrust": "2023-09-10T00:00:00",
+        "establishmentName": "St. James\u0027 C of E Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1598",
+        "schoolCapacity": "2735",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12464847,
+        "dateAcademyJoinedTrust": "2020-04-08T00:00:00",
+        "establishmentName": "Beacon Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1076",
+        "schoolCapacity": "1615",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12467448,
+        "dateAcademyJoinedTrust": "2020-08-06T00:00:00",
+        "establishmentName": "Glyn Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2475",
+        "schoolCapacity": "2227",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12464836,
+        "dateAcademyJoinedTrust": "2021-03-04T00:00:00",
+        "establishmentName": "Meridian School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "322",
+        "schoolCapacity": "473",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12461090,
+        "dateAcademyJoinedTrust": "2020-05-23T00:00:00",
+        "establishmentName": "Halewood CE Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "531",
+        "schoolCapacity": "451",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1258",
     "name": "MILESTONE MULTI-ACADEMY TRUST",
-    "groupId": "TR8469",
-    "ukprn": "10081058",
+    "groupId": "TR8965",
+    "ukprn": "10077712",
     "type": "Multi-academy trust",
-    "address": "480 Murray Tunnel, FJ5 3GS",
-    "openedDate": "2018-09-10T00:00:00",
-    "companiesHouseNumber": "02786329",
-    "regionAndTerritory": ""
+    "address": "5553 Hermina Islands, McClure Mountain, OL98 3GR",
+    "openedDate": "2020-04-01T00:00:00",
+    "companiesHouseNumber": "08342395",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 12589884,
+        "dateAcademyJoinedTrust": "2020-09-23T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Church of England School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2272",
+        "schoolCapacity": "2720",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12587486,
+        "dateAcademyJoinedTrust": "2022-02-01T00:00:00",
+        "establishmentName": "St. Paul\u0027s Catholic Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2612",
+        "schoolCapacity": "2744",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12581589,
+        "dateAcademyJoinedTrust": "2021-09-18T00:00:00",
+        "establishmentName": "Limehurst Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "708",
+        "schoolCapacity": "1039",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1236",
     "name": "MOMENTUM MULTI-ACADEMY TRUST",
-    "groupId": "TR894",
-    "ukprn": "10076510",
+    "groupId": "TR3336",
+    "ukprn": "10009801",
     "type": "Multi-academy trust",
-    "address": "540 Fay Ford, South Adelleberg, QM6 2CI",
-    "openedDate": "2018-03-13T00:00:00",
-    "companiesHouseNumber": "02476236",
-    "regionAndTerritory": "London"
+    "address": "597 Spencer Land, Deondre Drive, BN54 9BA",
+    "openedDate": "2018-06-08T00:00:00",
+    "companiesHouseNumber": "03401075",
+    "regionAndTerritory": "East Midlands",
+    "academies": [
+      {
+        "urn": 12368890,
+        "dateAcademyJoinedTrust": "2019-09-28T00:00:00",
+        "establishmentName": "Horizon Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "777",
+        "schoolCapacity": "1222",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12361532,
+        "dateAcademyJoinedTrust": "2018-08-27T00:00:00",
+        "establishmentName": "Jean Courts Cofe Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1409",
+        "schoolCapacity": "2585",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12368454,
+        "dateAcademyJoinedTrust": "2022-09-09T00:00:00",
+        "establishmentName": "St. James\u0027 CE Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1146",
+        "schoolCapacity": "1042",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12362830,
+        "dateAcademyJoinedTrust": "2023-04-16T00:00:00",
+        "establishmentName": "St. James\u0027 Cofe Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "137",
+        "schoolCapacity": "328",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1257",
     "name": "NEW HORIZONS TRUST",
-    "groupId": "TR82",
-    "ukprn": "10030337",
+    "groupId": "TR8430",
+    "ukprn": "10014617",
     "type": "Multi-academy trust",
-    "address": "283 Jovany Greens, Janiya Ports, East Rozella, TP00 5JK",
-    "openedDate": "2019-03-01T00:00:00",
-    "companiesHouseNumber": "07991197",
-    "regionAndTerritory": "South West"
+    "address": "40264 Pedro Shores, Kaycee Road, Nathanielmouth, RG86 4WJ",
+    "openedDate": "2020-02-07T00:00:00",
+    "companiesHouseNumber": "09304462",
+    "regionAndTerritory": "East Midlands",
+    "academies": [
+      {
+        "urn": 12572319,
+        "dateAcademyJoinedTrust": "2023-04-04T00:00:00",
+        "establishmentName": "Glyn Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2765",
+        "schoolCapacity": "2969",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12578702,
+        "dateAcademyJoinedTrust": "2022-11-05T00:00:00",
+        "establishmentName": "St. Anne\u0027s Catholic Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1989",
+        "schoolCapacity": "2111",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12572649,
+        "dateAcademyJoinedTrust": "2020-05-11T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "274",
+        "schoolCapacity": "398",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12577148,
+        "dateAcademyJoinedTrust": "2022-09-04T00:00:00",
+        "establishmentName": "Mulberry Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "134",
+        "schoolCapacity": "190",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12574038,
+        "dateAcademyJoinedTrust": "2023-09-13T00:00:00",
+        "establishmentName": "St. James\u0027 C of E Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1744",
+        "schoolCapacity": "1698",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12573458,
+        "dateAcademyJoinedTrust": "2020-07-28T00:00:00",
+        "establishmentName": "Oasis Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1881",
+        "schoolCapacity": "1934",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12579064,
+        "dateAcademyJoinedTrust": "2021-08-17T00:00:00",
+        "establishmentName": "Greensward Church of England Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2180",
+        "schoolCapacity": "2162",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12574257,
+        "dateAcademyJoinedTrust": "2020-10-26T00:00:00",
+        "establishmentName": "Horizon Catholic Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "95",
+        "schoolCapacity": "151",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12573564,
+        "dateAcademyJoinedTrust": "2022-06-10T00:00:00",
+        "establishmentName": "St. Paul\u0027s Catholic Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1003",
+        "schoolCapacity": "1070",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12574007,
+        "dateAcademyJoinedTrust": "2021-12-05T00:00:00",
+        "establishmentName": "St. Paul\u0027s Church of England Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3284",
+        "schoolCapacity": "2759",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12577951,
+        "dateAcademyJoinedTrust": "2020-04-01T00:00:00",
+        "establishmentName": "Johnpaul Loop C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "969",
+        "schoolCapacity": "899",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1245",
     "name": "NEXUS MULTI-ACADEMY TRUST",
-    "groupId": "TR3247",
-    "ukprn": "10077751",
+    "groupId": "TR8923",
+    "ukprn": "10040502",
     "type": "Multi-academy trust",
-    "address": "35021 Lukas Parkways, North Aishaside, AU12 7RU",
-    "openedDate": "2021-06-12T00:00:00",
-    "companiesHouseNumber": "01459899",
-    "regionAndTerritory": "London"
+    "address": "5925 Deondre Expressway, Schroeder Shores, Lake Norbertton, LD1 7TO",
+    "openedDate": "2020-05-04T00:00:00",
+    "companiesHouseNumber": "02431960",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 12456520,
+        "dateAcademyJoinedTrust": "2022-01-20T00:00:00",
+        "establishmentName": "Co-op C of E Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2587",
+        "schoolCapacity": "2425",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12459995,
+        "dateAcademyJoinedTrust": "2023-01-15T00:00:00",
+        "establishmentName": "Greensward Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "884",
+        "schoolCapacity": "791",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12458091,
+        "dateAcademyJoinedTrust": "2023-04-19T00:00:00",
+        "establishmentName": "Harris Cofe Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1411",
+        "schoolCapacity": "1571",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12454926,
+        "dateAcademyJoinedTrust": "2021-01-05T00:00:00",
+        "establishmentName": "Northwood Catholic School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1821",
+        "schoolCapacity": "2469",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12454249,
+        "dateAcademyJoinedTrust": "2023-04-03T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Cofe Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1104",
+        "schoolCapacity": "1378",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12455326,
+        "dateAcademyJoinedTrust": "2021-11-19T00:00:00",
+        "establishmentName": "Co-op School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1348",
+        "schoolCapacity": "1058",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1273",
     "name": "PATHFINDER MULTI-ACADEMY TRUST",
-    "groupId": "TR9188",
-    "ukprn": "10081792",
+    "groupId": "TR5338",
+    "ukprn": "10092069",
     "type": "Multi-academy trust",
-    "address": "98547 Fletcher Radial, EL00 0MB",
-    "openedDate": "2021-02-25T00:00:00",
-    "companiesHouseNumber": "01402379",
-    "regionAndTerritory": "East Midlands"
+    "address": "037 Charity Crossroad, Abel Islands, Destineefurt, HQ3 0YG",
+    "openedDate": "2020-09-26T00:00:00",
+    "companiesHouseNumber": "04572847",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12734214,
+        "dateAcademyJoinedTrust": "2022-06-05T00:00:00",
+        "establishmentName": "Halewood CE Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "685",
+        "schoolCapacity": "778",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12738693,
+        "dateAcademyJoinedTrust": "2021-07-16T00:00:00",
+        "establishmentName": "Meridian Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "132",
+        "schoolCapacity": "193",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12735040,
+        "dateAcademyJoinedTrust": "2023-01-16T00:00:00",
+        "establishmentName": "St. Peter\u0027s CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1278",
+        "schoolCapacity": "1642",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12733596,
+        "dateAcademyJoinedTrust": "2021-12-09T00:00:00",
+        "establishmentName": "Horizon School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "363",
+        "schoolCapacity": "466",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12734228,
+        "dateAcademyJoinedTrust": "2023-07-19T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Cofe Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3103",
+        "schoolCapacity": "2424",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12737692,
+        "dateAcademyJoinedTrust": "2022-08-01T00:00:00",
+        "establishmentName": "Northwood School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1404",
+        "schoolCapacity": "2106",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1248",
     "name": "PEAK MULTI-ACADEMY TRUST",
-    "groupId": "TR9768",
-    "ukprn": "10054945",
+    "groupId": "TR7192",
+    "ukprn": "10036830",
     "type": "Multi-academy trust",
-    "address": "7451 Little Springs, GV15 9OD",
-    "openedDate": "2023-03-13T00:00:00",
-    "companiesHouseNumber": "04139461",
-    "regionAndTerritory": "North East"
+    "address": "2584 Medhurst Brooks, Jacobson Trail, CP44 1PQ",
+    "openedDate": "2017-10-16T00:00:00",
+    "companiesHouseNumber": "05821489",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12487416,
+        "dateAcademyJoinedTrust": "2021-02-04T00:00:00",
+        "establishmentName": "St. Paul\u0027s CE Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "309",
+        "schoolCapacity": "297",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12485316,
+        "dateAcademyJoinedTrust": "2018-01-28T00:00:00",
+        "establishmentName": "Glyn Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1024",
+        "schoolCapacity": "860",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12483047,
+        "dateAcademyJoinedTrust": "2018-09-17T00:00:00",
+        "establishmentName": "Harris Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "509",
+        "schoolCapacity": "481",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12487992,
+        "dateAcademyJoinedTrust": "2022-03-14T00:00:00",
+        "establishmentName": "Horizon School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "829",
+        "schoolCapacity": "1212",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12487226,
+        "dateAcademyJoinedTrust": "2018-08-31T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "309",
+        "schoolCapacity": "326",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12481380,
+        "dateAcademyJoinedTrust": "2018-07-12T00:00:00",
+        "establishmentName": "St. John\u0027s CE Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1682",
+        "schoolCapacity": "2538",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12486374,
+        "dateAcademyJoinedTrust": "2023-03-03T00:00:00",
+        "establishmentName": "Longhill Church of England Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "882",
+        "schoolCapacity": "1669",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12489533,
+        "dateAcademyJoinedTrust": "2021-11-18T00:00:00",
+        "establishmentName": "North Yorkshire CE Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3033",
+        "schoolCapacity": "2351",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12489799,
+        "dateAcademyJoinedTrust": "2020-05-08T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s C of E Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3020",
+        "schoolCapacity": "2497",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12485198,
+        "dateAcademyJoinedTrust": "2020-04-09T00:00:00",
+        "establishmentName": "St. James\u0027 Catholic Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1326",
+        "schoolCapacity": "2482",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1251",
     "name": "PINNACLE EDUCATION TRUST",
-    "groupId": "TR6610",
-    "ukprn": "10042464",
+    "groupId": "TR3298",
+    "ukprn": "10057900",
     "type": "Multi-academy trust",
-    "address": "01145 Curt Plains, Boyer Springs, OH47 9KR",
-    "openedDate": "2014-10-27T00:00:00",
-    "companiesHouseNumber": "09032175",
-    "regionAndTerritory": "East of England"
+    "address": "3129 Kari Garden, Hayes Drive, HA3 2QY",
+    "openedDate": "2017-08-20T00:00:00",
+    "companiesHouseNumber": "07239921",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12511913,
+        "dateAcademyJoinedTrust": "2022-05-23T00:00:00",
+        "establishmentName": "St. James\u0027s C of E Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "511",
+        "schoolCapacity": "1067",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12519800,
+        "dateAcademyJoinedTrust": "2019-03-22T00:00:00",
+        "establishmentName": "Beacon Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "634",
+        "schoolCapacity": "626",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12519201,
+        "dateAcademyJoinedTrust": "2023-03-20T00:00:00",
+        "establishmentName": "St. James\u0027s Church of England Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1245",
+        "schoolCapacity": "2397",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12516584,
+        "dateAcademyJoinedTrust": "2020-08-16T00:00:00",
+        "establishmentName": "St. John\u0027s CE School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "384",
+        "schoolCapacity": "681",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1265",
     "name": "POTENTIAL LEARNING TRUST",
-    "groupId": "TR8109",
-    "ukprn": "10003508",
+    "groupId": "TR6137",
+    "ukprn": "10083354",
     "type": "Multi-academy trust",
-    "address": "834 Nelle Road, Sipes Roads, ER23 9LM",
-    "openedDate": "2019-05-31T00:00:00",
-    "companiesHouseNumber": "06152538",
-    "regionAndTerritory": ""
+    "address": "3196 Margarette Inlet, Arely Pike, Cormiermouth, OE0 8EY",
+    "openedDate": "2016-06-04T00:00:00",
+    "companiesHouseNumber": "04129867",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 12655339,
+        "dateAcademyJoinedTrust": "2016-07-14T00:00:00",
+        "establishmentName": "St. John\u0027s Church of England Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "130",
+        "schoolCapacity": "150",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12658784,
+        "dateAcademyJoinedTrust": "2023-03-12T00:00:00",
+        "establishmentName": "Co-op School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1036",
+        "schoolCapacity": "2509",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1238",
     "name": "PROGRESSIVE EDUCATION TRUST",
-    "groupId": "TR7792",
-    "ukprn": "10097245",
+    "groupId": "TR9814",
+    "ukprn": "10003594",
     "type": "Multi-academy trust",
-    "address": "5828 Rutherford Flats, VW33 2XD",
-    "openedDate": "2014-12-07T00:00:00",
-    "companiesHouseNumber": "02471956",
-    "regionAndTerritory": "Yorkshire and the Humber"
+    "address": "2167 Arne Field, CT3 5XD",
+    "openedDate": "2015-07-28T00:00:00",
+    "companiesHouseNumber": "07248291",
+    "regionAndTerritory": "South West",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1256",
     "name": "PROSPECT MULTI-ACADEMY TRUST",
-    "groupId": "TR108",
-    "ukprn": "10062864",
+    "groupId": "TR154",
+    "ukprn": "10095816",
     "type": "Multi-academy trust",
-    "address": "172 Dickens Cliff, Alden Extensions, South Rick, LV72 6IG",
-    "openedDate": "2015-11-29T00:00:00",
-    "companiesHouseNumber": "03932465",
-    "regionAndTerritory": "North West"
+    "address": "91342 Will Pike, TG73 6HN",
+    "openedDate": "2014-02-26T00:00:00",
+    "companiesHouseNumber": "01749712",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 12564083,
+        "dateAcademyJoinedTrust": "2015-01-23T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 R.C. Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "94",
+        "schoolCapacity": "155",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12562351,
+        "dateAcademyJoinedTrust": "2020-12-27T00:00:00",
+        "establishmentName": "East Riding of Yorkshire Cofe Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1478",
+        "schoolCapacity": "2151",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12562497,
+        "dateAcademyJoinedTrust": "2019-12-27T00:00:00",
+        "establishmentName": "Queensbridge Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1858",
+        "schoolCapacity": "2148",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12565341,
+        "dateAcademyJoinedTrust": "2023-01-18T00:00:00",
+        "establishmentName": "St. Marys Cofe School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1199",
+        "schoolCapacity": "1234",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12566580,
+        "dateAcademyJoinedTrust": "2015-08-12T00:00:00",
+        "establishmentName": "Malcolm Walks R.C. Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1163",
+        "schoolCapacity": "1541",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12566421,
+        "dateAcademyJoinedTrust": "2016-02-27T00:00:00",
+        "establishmentName": "Glyn Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1104",
+        "schoolCapacity": "869",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12563060,
+        "dateAcademyJoinedTrust": "2017-08-06T00:00:00",
+        "establishmentName": "Longhill School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2231",
+        "schoolCapacity": "1905",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1272",
     "name": "PROSPERITY EDUCATION TRUST",
-    "groupId": "TR2060",
-    "ukprn": "10082880",
+    "groupId": "TR9977",
+    "ukprn": "10016694",
     "type": "Multi-academy trust",
-    "address": "71250 Alfredo Orchard, PD5 9PP",
-    "openedDate": "2017-05-05T00:00:00",
-    "companiesHouseNumber": "05658617",
-    "regionAndTerritory": "East of England"
+    "address": "97249 Littel Crest, ZJ1 9MM",
+    "openedDate": "2023-01-01T00:00:00",
+    "companiesHouseNumber": "04640442",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 12721408,
+        "dateAcademyJoinedTrust": "2023-05-10T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "643",
+        "schoolCapacity": "1128",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12728634,
+        "dateAcademyJoinedTrust": "2023-07-28T00:00:00",
+        "establishmentName": "Oasis Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "844",
+        "schoolCapacity": "1923",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12726827,
+        "dateAcademyJoinedTrust": "2023-07-24T00:00:00",
+        "establishmentName": "Northwood Catholic Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "455",
+        "schoolCapacity": "769",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1267",
     "name": "RISE EDUCATION TRUST",
-    "groupId": "TR4261",
-    "ukprn": "10004356",
+    "groupId": "TR7310",
+    "ukprn": "10028834",
     "type": "Multi-academy trust",
-    "address": "4988 Jayda Field, Toy Ford, NR4 6TG",
-    "openedDate": "2019-10-14T00:00:00",
-    "companiesHouseNumber": "06220933",
-    "regionAndTerritory": "South West"
+    "address": "29511 Toney Hills, Port Marilyne, KD8 9PH",
+    "openedDate": "2016-03-24T00:00:00",
+    "companiesHouseNumber": "04162595",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 12674690,
+        "dateAcademyJoinedTrust": "2022-10-06T00:00:00",
+        "establishmentName": "Greensward Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1136",
+        "schoolCapacity": "940",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12674023,
+        "dateAcademyJoinedTrust": "2018-03-25T00:00:00",
+        "establishmentName": "Malbank Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "117",
+        "schoolCapacity": "158",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12677253,
+        "dateAcademyJoinedTrust": "2019-08-24T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 CE Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "944",
+        "schoolCapacity": "740",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12671161,
+        "dateAcademyJoinedTrust": "2018-09-24T00:00:00",
+        "establishmentName": "St. Anne\u0027s CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2008",
+        "schoolCapacity": "1936",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12677344,
+        "dateAcademyJoinedTrust": "2019-12-04T00:00:00",
+        "establishmentName": "Halewood Church of England Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "791",
+        "schoolCapacity": "907",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12672908,
+        "dateAcademyJoinedTrust": "2021-06-06T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "611",
+        "schoolCapacity": "1342",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12676634,
+        "dateAcademyJoinedTrust": "2017-05-30T00:00:00",
+        "establishmentName": "St. Paul\u0027s Catholic Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "61",
+        "schoolCapacity": "103",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12675341,
+        "dateAcademyJoinedTrust": "2016-03-28T00:00:00",
+        "establishmentName": "Barr and Community Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2535",
+        "schoolCapacity": "2556",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1310",
     "name": "SHEFFIELD SOUTH EAST TRUST",
-    "groupId": "TR893",
-    "ukprn": "10078208",
+    "groupId": "TR4678",
+    "ukprn": "10000318",
     "type": "Multi-academy trust",
-    "address": "9841 Loma Parkway, Wilbert Valley, JU6 5NM",
-    "openedDate": "2017-04-07T00:00:00",
-    "companiesHouseNumber": "05398515",
-    "regionAndTerritory": "North West"
+    "address": "6437 Enola Mission, ZK6 2XF",
+    "openedDate": "2022-08-21T00:00:00",
+    "companiesHouseNumber": "01297206",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 13101182,
+        "dateAcademyJoinedTrust": "2023-09-25T00:00:00",
+        "establishmentName": "Momentum Community Catholic Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1185",
+        "schoolCapacity": "1475",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13109948,
+        "dateAcademyJoinedTrust": "2023-08-17T00:00:00",
+        "establishmentName": "Bradford School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "211",
+        "schoolCapacity": "280",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13108338,
+        "dateAcademyJoinedTrust": "2023-03-10T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "288",
+        "schoolCapacity": "224",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13105774,
+        "dateAcademyJoinedTrust": "2022-11-30T00:00:00",
+        "establishmentName": "St. James\u0027 Catholic School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2205",
+        "schoolCapacity": "2597",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13103298,
+        "dateAcademyJoinedTrust": "2023-11-02T00:00:00",
+        "establishmentName": "Malbank Cofe Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "953",
+        "schoolCapacity": "2190",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13103165,
+        "dateAcademyJoinedTrust": "2023-01-15T00:00:00",
+        "establishmentName": "Meridian School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2091",
+        "schoolCapacity": "2352",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13106530,
+        "dateAcademyJoinedTrust": "2023-07-07T00:00:00",
+        "establishmentName": "Co-op R.C. Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2534",
+        "schoolCapacity": "2305",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13105566,
+        "dateAcademyJoinedTrust": "2022-10-27T00:00:00",
+        "establishmentName": "St. Marys Cofe School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2237",
+        "schoolCapacity": "2692",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13107538,
+        "dateAcademyJoinedTrust": "2023-01-08T00:00:00",
+        "establishmentName": "Greensward Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "493",
+        "schoolCapacity": "397",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1283",
     "name": "ST MARY\u0027S ACADEMY TRUST",
-    "groupId": "TR3646",
-    "ukprn": "10077868",
+    "groupId": "TR8361",
+    "ukprn": "10004518",
     "type": "Single-academy trust",
-    "address": "36740 Mozelle Square, Matt Isle, South Teresaland, LU8 9DI",
-    "openedDate": "2021-06-28T00:00:00",
-    "companiesHouseNumber": "01189440",
-    "regionAndTerritory": "South East"
+    "address": "9118 Jamal Plains, Bernhard Curve, CA9 1JB",
+    "openedDate": "2017-10-20T00:00:00",
+    "companiesHouseNumber": "04406078",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 12838836,
+        "dateAcademyJoinedTrust": "2018-06-12T00:00:00",
+        "establishmentName": "St. Mary\u0027s Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "259",
+        "schoolCapacity": "479",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1284",
     "name": "ST MARY\u0027S ANGLICAN ACADEMY",
-    "groupId": "TR1904",
-    "ukprn": "10065549",
+    "groupId": "TR8419",
+    "ukprn": "10087147",
     "type": "Single-academy trust",
-    "address": "77600 Blaise Meadow, Hunterburgh, GM42 0KY",
-    "openedDate": "2014-02-19T00:00:00",
-    "companiesHouseNumber": "04503965",
-    "regionAndTerritory": "North East"
+    "address": "267 Kling Cove, Nader Fall, TJ37 1TF",
+    "openedDate": "2020-07-17T00:00:00",
+    "companiesHouseNumber": "07551722",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12846297,
+        "dateAcademyJoinedTrust": "2022-06-23T00:00:00",
+        "establishmentName": "St. Mary\u0027s Anglican Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "205",
+        "schoolCapacity": "296",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1285",
     "name": "ST MARY\u0027S CATHOLIC HIGH SCHOOL ACADEMY TRUST",
-    "groupId": "TR4391",
-    "ukprn": "10053804",
+    "groupId": "TR6712",
+    "ukprn": "10027832",
     "type": "Single-academy trust",
-    "address": "2010 Lakin Village, Wisoky Camp, VF58 0TU",
-    "openedDate": "2016-11-20T00:00:00",
-    "companiesHouseNumber": "03164989",
-    "regionAndTerritory": "South West"
+    "address": "4265 White Village, Lennie Causeway, IB7 3YK",
+    "openedDate": "2014-01-18T00:00:00",
+    "companiesHouseNumber": "06657758",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12852401,
+        "dateAcademyJoinedTrust": "2014-03-06T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic High School Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1710",
+        "schoolCapacity": "2118",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1286",
     "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL",
-    "groupId": "TR747",
-    "ukprn": "10065631",
+    "groupId": "TR1191",
+    "ukprn": "10087464",
     "type": "Single-academy trust",
-    "address": "7065 Bode Crest, Manley Unions, BQ5 2LJ",
-    "openedDate": "2022-04-13T00:00:00",
-    "companiesHouseNumber": "02583599",
-    "regionAndTerritory": "Yorkshire and the Humber"
+    "address": "541 Morar Prairie, Murrayton, GT4 4GY",
+    "openedDate": "2014-11-06T00:00:00",
+    "companiesHouseNumber": "04895945",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12869362,
+        "dateAcademyJoinedTrust": "2022-08-04T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "993",
+        "schoolCapacity": "1329",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1287",
     "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (ACADEMY TRUST), SWINDON",
-    "groupId": "TR9211",
-    "ukprn": "10071925",
+    "groupId": "TR9125",
+    "ukprn": "10088269",
     "type": "Single-academy trust",
-    "address": "4258 Rowan Pike, CP44 1PQ",
-    "openedDate": "2017-10-16T00:00:00",
-    "companiesHouseNumber": "05821489",
-    "regionAndTerritory": ""
+    "address": "06825 Conroy Meadow, Alenechester, DP12 0PC",
+    "openedDate": "2017-08-01T00:00:00",
+    "companiesHouseNumber": "06099137",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12875737,
+        "dateAcademyJoinedTrust": "2020-01-02T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1432",
+        "schoolCapacity": "1816",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1288",
     "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (HERRINGTHORPE), A CATHOLIC VOLUNTARY ACADEMY",
-    "groupId": "TR3904",
-    "ukprn": "10091329",
+    "groupId": "TR257",
+    "ukprn": "10008877",
     "type": "Single-academy trust",
-    "address": "94687 Ruecker Drive, Macifort, YP5 4GC",
-    "openedDate": "2020-07-06T00:00:00",
-    "companiesHouseNumber": "03434646",
-    "regionAndTerritory": "South West"
+    "address": "1543 Cummerata Plains, Haley Shore, North Natmouth, FQ4 5CE",
+    "openedDate": "2017-01-17T00:00:00",
+    "companiesHouseNumber": "02318542",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 12882973,
+        "dateAcademyJoinedTrust": "2018-09-04T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "345",
+        "schoolCapacity": "285",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1289",
     "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (MALTBY)",
-    "groupId": "TR8784",
-    "ukprn": "10028937",
+    "groupId": "TR2329",
+    "ukprn": "10069471",
     "type": "Single-academy trust",
-    "address": "828 Marielle Rest, Waters Flats, JN69 5UM",
-    "openedDate": "2021-11-18T00:00:00",
-    "companiesHouseNumber": "06224280",
-    "regionAndTerritory": "North West"
+    "address": "1178 Ernser Summit, Greenholt Isle, New Zoe, TG2 7NX",
+    "openedDate": "2022-11-26T00:00:00",
+    "companiesHouseNumber": "01190953",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12898601,
+        "dateAcademyJoinedTrust": "2023-09-29T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3667",
+        "schoolCapacity": "2961",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1290",
     "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL, CHURCHDOWN",
-    "groupId": "TR7769",
-    "ukprn": "10036478",
+    "groupId": "TR4107",
+    "ukprn": "10078123",
     "type": "Single-academy trust",
-    "address": "633 Skiles Island, YB06 4TL",
-    "openedDate": "2016-08-30T00:00:00",
-    "companiesHouseNumber": "08468944",
-    "regionAndTerritory": "South East"
+    "address": "25258 Schuster Flats, Paige Ridges, CT0 6GA",
+    "openedDate": "2020-05-05T00:00:00",
+    "companiesHouseNumber": "04743862",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12907774,
+        "dateAcademyJoinedTrust": "2021-03-26T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3686",
+        "schoolCapacity": "2933",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1291",
     "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOLS TRUST",
-    "groupId": "TR5748",
-    "ukprn": "10091049",
+    "groupId": "TR3651",
+    "ukprn": "10025372",
     "type": "Multi-academy trust",
-    "address": "930 Marjorie Harbor, Bauchfurt, AO8 5DW",
-    "openedDate": "2014-07-15T00:00:00",
-    "companiesHouseNumber": "05915255",
-    "regionAndTerritory": ""
+    "address": "0990 Leannon Spur, Wilfredo Ville, OX12 3JM",
+    "openedDate": "2019-04-20T00:00:00",
+    "companiesHouseNumber": "06062342",
+    "regionAndTerritory": "East Midlands",
+    "academies": [
+      {
+        "urn": 12918070,
+        "dateAcademyJoinedTrust": "2023-10-30T00:00:00",
+        "establishmentName": "St Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "479",
+        "schoolCapacity": "1054",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12919507,
+        "dateAcademyJoinedTrust": "2022-02-05T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "486",
+        "schoolCapacity": "579",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12915004,
+        "dateAcademyJoinedTrust": "2021-05-24T00:00:00",
+        "establishmentName": "St. Marys Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "333",
+        "schoolCapacity": "356",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12911255,
+        "dateAcademyJoinedTrust": "2021-05-09T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1215",
+        "schoolCapacity": "1428",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12917771,
+        "dateAcademyJoinedTrust": "2023-09-16T00:00:00",
+        "establishmentName": "St Marys Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1094",
+        "schoolCapacity": "880",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12918782,
+        "dateAcademyJoinedTrust": "2023-11-02T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "590",
+        "schoolCapacity": "785",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12917133,
+        "dateAcademyJoinedTrust": "2019-04-24T00:00:00",
+        "establishmentName": "St. Mary\u0027s RC Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "470",
+        "schoolCapacity": "455",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12914299,
+        "dateAcademyJoinedTrust": "2022-03-17T00:00:00",
+        "establishmentName": "St. Mary\u0027s Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "875",
+        "schoolCapacity": "1269",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12915300,
+        "dateAcademyJoinedTrust": "2022-12-23T00:00:00",
+        "establishmentName": "St. Mary\u0027s Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "864",
+        "schoolCapacity": "956",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1292",
     "name": "ST MARY\u0027S CE ACADEMY, CHESHUNT",
-    "groupId": "TR1430",
-    "ukprn": "10049762",
+    "groupId": "TR7939",
+    "ukprn": "10075859",
     "type": "Single-academy trust",
-    "address": "91264 Thomas Plains, Urban Spurs, Sanfordshire, AH0 9II",
-    "openedDate": "2019-08-28T00:00:00",
-    "companiesHouseNumber": "02584157",
-    "regionAndTerritory": "East of England"
+    "address": "3600 Abdiel Track, Carroll Burg, HE5 1UP",
+    "openedDate": "2019-07-24T00:00:00",
+    "companiesHouseNumber": "05624236",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 12926712,
+        "dateAcademyJoinedTrust": "2019-09-15T00:00:00",
+        "establishmentName": "St Mary\u0027s CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1322",
+        "schoolCapacity": "1734",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1293",
     "name": "ST MARY\u0027S CHURCH OF ENGLAND ACADEMY TRUST",
-    "groupId": "TR9423",
-    "ukprn": "10097767",
+    "groupId": "TR7955",
+    "ukprn": "10029281",
     "type": "Single-academy trust",
-    "address": "898 Schuster Mission, Lake Billie, MF09 8DL",
-    "openedDate": "2017-08-18T00:00:00",
-    "companiesHouseNumber": "05655575",
-    "regionAndTerritory": "South East"
+    "address": "539 Terrell Rapid, Carroll Mountain, FN88 7NZ",
+    "openedDate": "2014-06-23T00:00:00",
+    "companiesHouseNumber": "05942564",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12933459,
+        "dateAcademyJoinedTrust": "2020-12-26T00:00:00",
+        "establishmentName": "St Mary\u0027s Church of England Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "455",
+        "schoolCapacity": "767",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1294",
     "name": "ST MARY\u0027S CHURCH OF ENGLAND ACADEMY, STOTFOLD",
-    "groupId": "TR8441",
-    "ukprn": "10046156",
+    "groupId": "TR4379",
+    "ukprn": "10025204",
     "type": "Single-academy trust",
-    "address": "67845 Camryn Route, West Demetris, PO9 9KW",
-    "openedDate": "2021-10-31T00:00:00",
-    "companiesHouseNumber": "02084024",
-    "regionAndTerritory": "North West"
+    "address": "88397 Lilian Forges, Stephon Mission, IR07 0HY",
+    "openedDate": "2021-10-28T00:00:00",
+    "companiesHouseNumber": "05043255",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 12943235,
+        "dateAcademyJoinedTrust": "2022-10-17T00:00:00",
+        "establishmentName": "St Mary\u0027s Cofe Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "376",
+        "schoolCapacity": "842",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1295",
     "name": "ST MARY\u0027S CHURCH OF ENGLAND JUNIOR SCHOOL",
-    "groupId": "TR9943",
-    "ukprn": "10015651",
+    "groupId": "TR444",
+    "ukprn": "10046678",
     "type": "Single-academy trust",
-    "address": "4330 Elton Shores, IJ5 4XC",
-    "openedDate": "2021-11-15T00:00:00",
-    "companiesHouseNumber": "09173613",
-    "regionAndTerritory": "North East"
+    "address": "267 Harvey Junctions, Orpha Drives, SW8 7SE",
+    "openedDate": "2014-06-16T00:00:00",
+    "companiesHouseNumber": "07152941",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12958241,
+        "dateAcademyJoinedTrust": "2021-02-17T00:00:00",
+        "establishmentName": "St Mary\u0027s C.E. Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1393",
+        "schoolCapacity": "2442",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1296",
     "name": "ST MARY\u0027S CHURCH OF ENGLAND PRIMARY ACADEMY, DILWYN",
-    "groupId": "TR2757",
-    "ukprn": "10054354",
+    "groupId": "TR9434",
+    "ukprn": "10009203",
     "type": "Single-academy trust",
-    "address": "29635 Lehner Glens, Schoen Street, New Earnestland, XY65 5WS",
-    "openedDate": "2019-03-03T00:00:00",
-    "companiesHouseNumber": "07727951",
-    "regionAndTerritory": "South East"
+    "address": "505 Bridgette Stream, ZK3 9NS",
+    "openedDate": "2014-02-10T00:00:00",
+    "companiesHouseNumber": "05794160",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12969050,
+        "dateAcademyJoinedTrust": "2019-10-17T00:00:00",
+        "establishmentName": "St Mary\u0027s C/E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2516",
+        "schoolCapacity": "2651",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1297",
     "name": "ST MARY\u0027S CHURCH OF ENGLAND SCHOOL, NORWOOD GREEN",
-    "groupId": "TR7246",
-    "ukprn": "10033189",
+    "groupId": "TR6480",
+    "ukprn": "10055816",
     "type": "Single-academy trust",
-    "address": "47805 Lazaro Alley, Pearlie Lights, South Jessieton, QZ11 3PQ",
-    "openedDate": "2017-07-11T00:00:00",
-    "companiesHouseNumber": "04459007",
-    "regionAndTerritory": "London"
+    "address": "60770 O\u0027Hara Squares, PO8 2KQ",
+    "openedDate": "2017-06-24T00:00:00",
+    "companiesHouseNumber": "08974676",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12977645,
+        "dateAcademyJoinedTrust": "2021-07-30T00:00:00",
+        "establishmentName": "St Mary\u0027s C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "816",
+        "schoolCapacity": "1034",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1298",
     "name": "ST MARY\u0027S CHURCH OF ENGLAND VA PRIMARY ACADEMY",
-    "groupId": "TR7505",
-    "ukprn": "10065784",
+    "groupId": "TR1137",
+    "ukprn": "10070773",
     "type": "Single-academy trust",
-    "address": "18963 Jess Circles, Craig Mountain, ZJ60 9CJ",
-    "openedDate": "2023-10-17T00:00:00",
-    "companiesHouseNumber": "03109883",
-    "regionAndTerritory": ""
+    "address": "7907 Erich Mount, West Max, EQ2 9BQ",
+    "openedDate": "2016-10-21T00:00:00",
+    "companiesHouseNumber": "06868744",
+    "regionAndTerritory": "East Midlands",
+    "academies": [
+      {
+        "urn": 12985125,
+        "dateAcademyJoinedTrust": "2020-10-30T00:00:00",
+        "establishmentName": "St Mary\u0027s Church of England VA Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "543",
+        "schoolCapacity": "496",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1299",
     "name": "ST MARY\u0027S PRIMARY SCHOOL, A CATHOLIC VOLUNTARY ACADEMY",
-    "groupId": "TR3884",
-    "ukprn": "10022500",
+    "groupId": "TR1332",
+    "ukprn": "10095750",
     "type": "Single-academy trust",
-    "address": "9683 Luther Point, Harley Crossing, Evalynfurt, DU2 0AB",
-    "openedDate": "2019-12-06T00:00:00",
-    "companiesHouseNumber": "04460858",
-    "regionAndTerritory": "West Midlands"
+    "address": "37529 Walter Rue, Wilfrid Overpass, Schaeferbury, KZ7 2FC",
+    "openedDate": "2018-05-24T00:00:00",
+    "companiesHouseNumber": "02258285",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 12994614,
+        "dateAcademyJoinedTrust": "2020-12-30T00:00:00",
+        "establishmentName": "St Mary\u0027s Primary School, A Catholic Voluntary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "370",
+        "schoolCapacity": "408",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1262",
     "name": "SUCCESS MULTI-ACADEMY TRUST",
-    "groupId": "TR7683",
-    "ukprn": "10072268",
+    "groupId": "TR7520",
+    "ukprn": "10098419",
     "type": "Multi-academy trust",
-    "address": "7176 Marge Parkways, North Bethchester, DT9 4AY",
-    "openedDate": "2016-10-16T00:00:00",
-    "companiesHouseNumber": "09186752",
-    "regionAndTerritory": "North East"
+    "address": "44612 Britney Plaza, WB35 5DZ",
+    "openedDate": "2014-10-26T00:00:00",
+    "companiesHouseNumber": "05351455",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1300",
     "name": "THE DIOCESE OF CANTERBURY ACADEMIES TRUST",
-    "groupId": "TR9963",
-    "ukprn": "10002695",
+    "groupId": "TR7014",
+    "ukprn": "10088816",
     "type": "Multi-academy trust",
-    "address": "66616 Mariana Ferry, Pagac Rest, Port Kevon, YC73 7XW",
-    "openedDate": "2019-06-13T00:00:00",
-    "companiesHouseNumber": "01895143",
-    "regionAndTerritory": "East Midlands"
+    "address": "3141 Lubowitz Inlet, Johanna Locks, CK53 6TM",
+    "openedDate": "2018-07-10T00:00:00",
+    "companiesHouseNumber": "04301397",
+    "regionAndTerritory": "East Midlands",
+    "academies": [
+      {
+        "urn": 13007888,
+        "dateAcademyJoinedTrust": "2018-09-27T00:00:00",
+        "establishmentName": "St. Anne\u0027s Catholic School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1101",
+        "schoolCapacity": "2536",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13005152,
+        "dateAcademyJoinedTrust": "2021-07-07T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "360",
+        "schoolCapacity": "485",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13003215,
+        "dateAcademyJoinedTrust": "2020-08-08T00:00:00",
+        "establishmentName": "Co-op Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "261",
+        "schoolCapacity": "236",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13002015,
+        "dateAcademyJoinedTrust": "2019-02-05T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Catholic Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2162",
+        "schoolCapacity": "2489",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13003134,
+        "dateAcademyJoinedTrust": "2019-12-17T00:00:00",
+        "establishmentName": "Lampton R.C. Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1080",
+        "schoolCapacity": "879",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13006237,
+        "dateAcademyJoinedTrust": "2022-12-11T00:00:00",
+        "establishmentName": "Co-op Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "417",
+        "schoolCapacity": "622",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13002996,
+        "dateAcademyJoinedTrust": "2020-07-27T00:00:00",
+        "establishmentName": "St. Mary\u0027s Cofe Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "229",
+        "schoolCapacity": "257",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13004550,
+        "dateAcademyJoinedTrust": "2019-11-08T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1164",
+        "schoolCapacity": "2887",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13001253,
+        "dateAcademyJoinedTrust": "2019-09-11T00:00:00",
+        "establishmentName": "Mulberry School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "835",
+        "schoolCapacity": "662",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13005578,
+        "dateAcademyJoinedTrust": "2018-10-29T00:00:00",
+        "establishmentName": "Limehurst Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1438",
+        "schoolCapacity": "1307",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13002735,
+        "dateAcademyJoinedTrust": "2021-11-15T00:00:00",
+        "establishmentName": "Peacehaven Community Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2065",
+        "schoolCapacity": "1878",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1301",
     "name": "THE DIOCESE OF CHELMSFORD VINE SCHOOLS TRUST",
-    "groupId": "TR1481",
-    "ukprn": "10037344",
+    "groupId": "TR1276",
+    "ukprn": "10021190",
     "type": "Multi-academy trust",
-    "address": "243 Jed View, LQ81 4XO",
-    "openedDate": "2019-05-08T00:00:00",
-    "companiesHouseNumber": "09149912",
-    "regionAndTerritory": "North East"
+    "address": "447 Ken Branch, Keonview, VQ82 1PA",
+    "openedDate": "2014-10-29T00:00:00",
+    "companiesHouseNumber": "02816021",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 13016001,
+        "dateAcademyJoinedTrust": "2018-06-14T00:00:00",
+        "establishmentName": "Horizon C of E School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "271",
+        "schoolCapacity": "300",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1302",
     "name": "THE DIOCESE OF COVENTRY MULTI-ACADEMY TRUST",
-    "groupId": "TR3125",
-    "ukprn": "10081748",
+    "groupId": "TR9913",
+    "ukprn": "10047215",
     "type": "Multi-academy trust",
-    "address": "677 Casper Grove, Damaris Fall, Willside, WD7 0XV",
-    "openedDate": "2022-05-25T00:00:00",
-    "companiesHouseNumber": "05098138",
-    "regionAndTerritory": "North East"
+    "address": "4880 Jacey Mission, Port Daynestad, JV1 7OB",
+    "openedDate": "2019-07-17T00:00:00",
+    "companiesHouseNumber": "04111124",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 13029770,
+        "dateAcademyJoinedTrust": "2020-03-08T00:00:00",
+        "establishmentName": "St. John\u0027s CE Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1210",
+        "schoolCapacity": "2267",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13028473,
+        "dateAcademyJoinedTrust": "2021-02-21T00:00:00",
+        "establishmentName": "Mulberry C of E School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "626",
+        "schoolCapacity": "866",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13028237,
+        "dateAcademyJoinedTrust": "2022-10-16T00:00:00",
+        "establishmentName": "Meridian Cofe Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1191",
+        "schoolCapacity": "2264",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13025571,
+        "dateAcademyJoinedTrust": "2021-05-06T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 CE Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1564",
+        "schoolCapacity": "1638",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13027063,
+        "dateAcademyJoinedTrust": "2021-12-30T00:00:00",
+        "establishmentName": "George Abbey CE School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "446",
+        "schoolCapacity": "344",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13022728,
+        "dateAcademyJoinedTrust": "2020-06-10T00:00:00",
+        "establishmentName": "Malbank C of E Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "538",
+        "schoolCapacity": "894",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13026479,
+        "dateAcademyJoinedTrust": "2022-07-13T00:00:00",
+        "establishmentName": "Northwood Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1069",
+        "schoolCapacity": "1328",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13021500,
+        "dateAcademyJoinedTrust": "2020-08-25T00:00:00",
+        "establishmentName": "Longhill Catholic Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1665",
+        "schoolCapacity": "2191",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13028981,
+        "dateAcademyJoinedTrust": "2022-01-27T00:00:00",
+        "establishmentName": "Peacehaven Community R.C. Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2606",
+        "schoolCapacity": "2387",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1303",
     "name": "THE DIOCESE OF ELY MULTI-ACADEMY TRUST",
-    "groupId": "TR8059",
-    "ukprn": "10023481",
+    "groupId": "TR1105",
+    "ukprn": "10046920",
     "type": "Multi-academy trust",
-    "address": "997 Iliana Union, Welch Shores, East Cesarborough, OC78 2IP",
-    "openedDate": "2017-03-15T00:00:00",
-    "companiesHouseNumber": "03818997",
-    "regionAndTerritory": "South East"
+    "address": "2085 Tamara Causeway, DN3 7RV",
+    "openedDate": "2019-03-09T00:00:00",
+    "companiesHouseNumber": "02565594",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 13039458,
+        "dateAcademyJoinedTrust": "2020-11-03T00:00:00",
+        "establishmentName": "St. John\u0027s Cofe Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1007",
+        "schoolCapacity": "1121",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13038599,
+        "dateAcademyJoinedTrust": "2022-12-16T00:00:00",
+        "establishmentName": "Co-op School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "801",
+        "schoolCapacity": "1183",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13036340,
+        "dateAcademyJoinedTrust": "2023-07-07T00:00:00",
+        "establishmentName": "Oasis Cofe Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "344",
+        "schoolCapacity": "291",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13036263,
+        "dateAcademyJoinedTrust": "2020-04-15T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 R.C. Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1171",
+        "schoolCapacity": "2193",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13035221,
+        "dateAcademyJoinedTrust": "2021-12-08T00:00:00",
+        "establishmentName": "Momentum Community Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3152",
+        "schoolCapacity": "2467",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13035579,
+        "dateAcademyJoinedTrust": "2022-10-10T00:00:00",
+        "establishmentName": "Tommie Way Cofe School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "249",
+        "schoolCapacity": "210",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1304",
     "name": "THE DIOCESE OF GLOUCESTER ACADEMIES TRUST",
-    "groupId": "TR1097",
-    "ukprn": "10026208",
+    "groupId": "TR3451",
+    "ukprn": "10018906",
     "type": "Multi-academy trust",
-    "address": "152 Hayes Drive, Jamey Loop, Baileyburgh, GQ9 6RW",
-    "openedDate": "2022-03-31T00:00:00",
-    "companiesHouseNumber": "06281348",
-    "regionAndTerritory": "North East"
+    "address": "5172 Glen Meadow, Bashirianstad, FX9 2LW",
+    "openedDate": "2018-12-07T00:00:00",
+    "companiesHouseNumber": "06723136",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 13049272,
+        "dateAcademyJoinedTrust": "2020-03-23T00:00:00",
+        "establishmentName": "Greensward Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1223",
+        "schoolCapacity": "1792",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13049763,
+        "dateAcademyJoinedTrust": "2022-04-30T00:00:00",
+        "establishmentName": "Limehurst R.C. Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "532",
+        "schoolCapacity": "731",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13046141,
+        "dateAcademyJoinedTrust": "2019-10-24T00:00:00",
+        "establishmentName": "Co-op School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "311",
+        "schoolCapacity": "385",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13043135,
+        "dateAcademyJoinedTrust": "2019-12-25T00:00:00",
+        "establishmentName": "Limehurst Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1718",
+        "schoolCapacity": "1711",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13048930,
+        "dateAcademyJoinedTrust": "2022-08-26T00:00:00",
+        "establishmentName": "Queensbridge R.C. Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "590",
+        "schoolCapacity": "622",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13048808,
+        "dateAcademyJoinedTrust": "2020-07-04T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "807",
+        "schoolCapacity": "776",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13043087,
+        "dateAcademyJoinedTrust": "2022-11-24T00:00:00",
+        "establishmentName": "Longhill Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1025",
+        "schoolCapacity": "1091",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13044327,
+        "dateAcademyJoinedTrust": "2023-07-10T00:00:00",
+        "establishmentName": "Halewood School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2082",
+        "schoolCapacity": "1637",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13045315,
+        "dateAcademyJoinedTrust": "2019-08-08T00:00:00",
+        "establishmentName": "Malbank Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1850",
+        "schoolCapacity": "2331",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13044110,
+        "dateAcademyJoinedTrust": "2021-03-14T00:00:00",
+        "establishmentName": "Lampton Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2300",
+        "schoolCapacity": "2112",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1305",
     "name": "THE DIOCESE OF NORWICH EDUCATION AND ACADEMIES TRUST",
-    "groupId": "TR3636",
-    "ukprn": "10010147",
+    "groupId": "TR4912",
+    "ukprn": "10070170",
     "type": "Multi-academy trust",
-    "address": "7530 Hartmann Port, EJ16 6GZ",
-    "openedDate": "2020-08-25T00:00:00",
-    "companiesHouseNumber": "01254059",
-    "regionAndTerritory": "London"
+    "address": "979 Rosemary Drive, VM71 8AL",
+    "openedDate": "2022-10-03T00:00:00",
+    "companiesHouseNumber": "01662784",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 13053611,
+        "dateAcademyJoinedTrust": "2023-05-08T00:00:00",
+        "establishmentName": "St. Marys Catholic Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1706",
+        "schoolCapacity": "1396",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13057948,
+        "dateAcademyJoinedTrust": "2023-07-07T00:00:00",
+        "establishmentName": "Lampton School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "397",
+        "schoolCapacity": "400",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13051445,
+        "dateAcademyJoinedTrust": "2023-03-27T00:00:00",
+        "establishmentName": "Cole Circles R.C. Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "756",
+        "schoolCapacity": "1375",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13056385,
+        "dateAcademyJoinedTrust": "2023-09-13T00:00:00",
+        "establishmentName": "Beacon Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2159",
+        "schoolCapacity": "2599",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13058125,
+        "dateAcademyJoinedTrust": "2023-06-11T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1106",
+        "schoolCapacity": "2616",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13055673,
+        "dateAcademyJoinedTrust": "2022-12-15T00:00:00",
+        "establishmentName": "Meridian Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2908",
+        "schoolCapacity": "2422",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1306",
     "name": "THE DIOCESE OF NORWICH ST BENET\u0027S MULTI-ACADEMY TRUST",
-    "groupId": "TR3672",
-    "ukprn": "10048763",
+    "groupId": "TR804",
+    "ukprn": "10057326",
     "type": "Multi-academy trust",
-    "address": "0099 Abernathy Lodge, Cole Isle, Gaylordport, LI0 6SH",
-    "openedDate": "2014-03-02T00:00:00",
-    "companiesHouseNumber": "02884439",
-    "regionAndTerritory": "South West"
+    "address": "213 Bayer Road, JX05 8NW",
+    "openedDate": "2017-05-15T00:00:00",
+    "companiesHouseNumber": "07242754",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 13067881,
+        "dateAcademyJoinedTrust": "2019-07-01T00:00:00",
+        "establishmentName": "Limehurst Catholic Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1013",
+        "schoolCapacity": "1175",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1307",
     "name": "THE DIOCESE OF SHEFFIELD ACADEMIES TRUST",
-    "groupId": "TR1821",
-    "ukprn": "10042030",
+    "groupId": "TR1900",
+    "ukprn": "10053379",
     "type": "Multi-academy trust",
-    "address": "460 Faye Summit, Mikel Spring, LV9 6HC",
-    "openedDate": "2023-08-28T00:00:00",
-    "companiesHouseNumber": "08362374",
-    "regionAndTerritory": "West Midlands"
+    "address": "22000 Gerlach Road, Abbott Point, South Joshua, VZ19 4AY",
+    "openedDate": "2014-11-29T00:00:00",
+    "companiesHouseNumber": "06492053",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 13078979,
+        "dateAcademyJoinedTrust": "2017-02-25T00:00:00",
+        "establishmentName": "St. John\u0027s R.C. Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "232",
+        "schoolCapacity": "261",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13071326,
+        "dateAcademyJoinedTrust": "2020-04-06T00:00:00",
+        "establishmentName": "St. Joseph\u0027s CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "881",
+        "schoolCapacity": "1509",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13078269,
+        "dateAcademyJoinedTrust": "2022-05-15T00:00:00",
+        "establishmentName": "Limehurst Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "342",
+        "schoolCapacity": "819",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13074992,
+        "dateAcademyJoinedTrust": "2020-04-23T00:00:00",
+        "establishmentName": "Northwood CE Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "797",
+        "schoolCapacity": "1274",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13072877,
+        "dateAcademyJoinedTrust": "2018-03-03T00:00:00",
+        "establishmentName": "Sheffield Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1280",
+        "schoolCapacity": "1230",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13076520,
+        "dateAcademyJoinedTrust": "2020-07-14T00:00:00",
+        "establishmentName": "Barr and Community Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "642",
+        "schoolCapacity": "755",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13074151,
+        "dateAcademyJoinedTrust": "2022-08-21T00:00:00",
+        "establishmentName": "Northwood C of E Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1727",
+        "schoolCapacity": "1607",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13076723,
+        "dateAcademyJoinedTrust": "2020-09-11T00:00:00",
+        "establishmentName": "George Abbey School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "83",
+        "schoolCapacity": "100",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1308",
     "name": "THE DIOCESE OF WESTMINSTER ACADEMY TRUST",
-    "groupId": "TR8707",
-    "ukprn": "10067538",
+    "groupId": "TR8822",
+    "ukprn": "10000118",
     "type": "Multi-academy trust",
-    "address": "88707 Jakubowski Garden, Cassie Cove, Lake Elmirafort, OW20 5VE",
-    "openedDate": "2021-01-06T00:00:00",
-    "companiesHouseNumber": "06193174",
-    "regionAndTerritory": "London"
+    "address": "67733 Christiansen Camp, Abernathy Radial, ZN2 3VC",
+    "openedDate": "2023-07-12T00:00:00",
+    "companiesHouseNumber": "02302768",
+    "regionAndTerritory": "",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1309",
     "name": "THE DIOCESE OF WORCESTER MULTI ACADEMY TRUST",
-    "groupId": "TR1174",
-    "ukprn": "10064331",
+    "groupId": "TR9806",
+    "ukprn": "10014446",
     "type": "Multi-academy trust",
-    "address": "8130 Effertz Village, Kunze Drive, Juliannetown, UW9 2OX",
-    "openedDate": "2020-09-03T00:00:00",
-    "companiesHouseNumber": "08348193",
-    "regionAndTerritory": "South West"
+    "address": "94197 Megane Track, RU63 7RU",
+    "openedDate": "2017-01-30T00:00:00",
+    "companiesHouseNumber": "07673659",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 13091319,
+        "dateAcademyJoinedTrust": "2018-10-12T00:00:00",
+        "establishmentName": "Limehurst School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "492",
+        "schoolCapacity": "1118",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13095065,
+        "dateAcademyJoinedTrust": "2019-01-09T00:00:00",
+        "establishmentName": "Momentum Community Church of England Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1849",
+        "schoolCapacity": "2589",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13093349,
+        "dateAcademyJoinedTrust": "2019-03-07T00:00:00",
+        "establishmentName": "Beacon Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "314",
+        "schoolCapacity": "260",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1252",
     "name": "THRIVE MULTI-ACADEMY TRUST",
-    "groupId": "TR3596",
-    "ukprn": "10023922",
+    "groupId": "TR8646",
+    "ukprn": "10053542",
     "type": "Multi-academy trust",
-    "address": "5658 Arjun Pass, Reilly Loop, Port Eunaview, TG4 2AS",
-    "openedDate": "2020-01-01T00:00:00",
-    "companiesHouseNumber": "01290370",
-    "regionAndTerritory": "East of England"
+    "address": "48963 Aisha Stravenue, KH01 1ID",
+    "openedDate": "2016-08-02T00:00:00",
+    "companiesHouseNumber": "03818391",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12522860,
+        "dateAcademyJoinedTrust": "2019-03-01T00:00:00",
+        "establishmentName": "St. Joseph\u0027s CE Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "366",
+        "schoolCapacity": "559",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12529505,
+        "dateAcademyJoinedTrust": "2022-08-13T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "298",
+        "schoolCapacity": "320",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12523863,
+        "dateAcademyJoinedTrust": "2019-04-25T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 R.C. School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1343",
+        "schoolCapacity": "1068",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12521835,
+        "dateAcademyJoinedTrust": "2023-07-28T00:00:00",
+        "establishmentName": "Greensward Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1344",
+        "schoolCapacity": "1215",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12528989,
+        "dateAcademyJoinedTrust": "2019-01-12T00:00:00",
+        "establishmentName": "North East Lincolnshire School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "794",
+        "schoolCapacity": "667",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12527650,
+        "dateAcademyJoinedTrust": "2021-04-25T00:00:00",
+        "establishmentName": "Glyn R.C. Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2155",
+        "schoolCapacity": "2476",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12527212,
+        "dateAcademyJoinedTrust": "2023-05-02T00:00:00",
+        "establishmentName": "Hoeger Islands Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "344",
+        "schoolCapacity": "383",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12521680,
+        "dateAcademyJoinedTrust": "2022-08-09T00:00:00",
+        "establishmentName": "St. Marys Catholic School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1296",
+        "schoolCapacity": "2845",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12526589,
+        "dateAcademyJoinedTrust": "2017-05-02T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Catholic Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "428",
+        "schoolCapacity": "687",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12529846,
+        "dateAcademyJoinedTrust": "2023-09-03T00:00:00",
+        "establishmentName": "Lampton Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3452",
+        "schoolCapacity": "2746",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1276",
     "name": "TRANSCENDENCE EDUCATION TRUST",
-    "groupId": "TR9626",
-    "ukprn": "10031118",
+    "groupId": "TR37",
+    "ukprn": "10061397",
     "type": "Multi-academy trust",
-    "address": "241 Schoen Spurs, Zulauf Park, XJ0 4UG",
-    "openedDate": "2022-03-04T00:00:00",
-    "companiesHouseNumber": "01415506",
-    "regionAndTerritory": ""
+    "address": "22044 Devon Divide, Baumbach Parkways, JS53 7HG",
+    "openedDate": "2015-08-28T00:00:00",
+    "companiesHouseNumber": "09000164",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12762215,
+        "dateAcademyJoinedTrust": "2016-10-22T00:00:00",
+        "establishmentName": "Longhill CE Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2688",
+        "schoolCapacity": "2175",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12769406,
+        "dateAcademyJoinedTrust": "2017-06-04T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 R.C. Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "450",
+        "schoolCapacity": "977",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12764983,
+        "dateAcademyJoinedTrust": "2023-07-19T00:00:00",
+        "establishmentName": "St. Marys R.C. Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "971",
+        "schoolCapacity": "1061",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12766346,
+        "dateAcademyJoinedTrust": "2023-01-29T00:00:00",
+        "establishmentName": "St. Anne\u0027s Catholic Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "746",
+        "schoolCapacity": "649",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12768113,
+        "dateAcademyJoinedTrust": "2017-02-11T00:00:00",
+        "establishmentName": "Oasis School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1823",
+        "schoolCapacity": "2002",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12761128,
+        "dateAcademyJoinedTrust": "2022-08-03T00:00:00",
+        "establishmentName": "Lampton CE Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1779",
+        "schoolCapacity": "2543",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12769251,
+        "dateAcademyJoinedTrust": "2020-08-31T00:00:00",
+        "establishmentName": "Greensward Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "178",
+        "schoolCapacity": "191",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12762853,
+        "dateAcademyJoinedTrust": "2018-02-23T00:00:00",
+        "establishmentName": "Malbank Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "349",
+        "schoolCapacity": "362",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12767641,
+        "dateAcademyJoinedTrust": "2018-11-13T00:00:00",
+        "establishmentName": "Limehurst Church of England Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "983",
+        "schoolCapacity": "1891",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12761219,
+        "dateAcademyJoinedTrust": "2019-05-10T00:00:00",
+        "establishmentName": "St. James\u0027s CE Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "486",
+        "schoolCapacity": "468",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12765192,
+        "dateAcademyJoinedTrust": "2020-08-31T00:00:00",
+        "establishmentName": "Peacehaven Community Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "725",
+        "schoolCapacity": "568",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1269",
     "name": "UNITY LEARNING TRUST",
-    "groupId": "TR4181",
-    "ukprn": "10099676",
+    "groupId": "TR9119",
+    "ukprn": "10068189",
     "type": "Multi-academy trust",
-    "address": "6153 Carey Cape, Fritsch Lodge, Stantontown, JF09 4CY",
-    "openedDate": "2017-10-31T00:00:00",
-    "companiesHouseNumber": "01533530",
-    "regionAndTerritory": "South East"
+    "address": "8531 Braun Knolls, Libby Center, Lake Oda, VT64 9YR",
+    "openedDate": "2023-03-28T00:00:00",
+    "companiesHouseNumber": "02503797",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 12699099,
+        "dateAcademyJoinedTrust": "2023-10-05T00:00:00",
+        "establishmentName": "St. James\u0027s Church of England School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1305",
+        "schoolCapacity": "2937",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12697432,
+        "dateAcademyJoinedTrust": "2023-06-05T00:00:00",
+        "establishmentName": "Momentum Community Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1341",
+        "schoolCapacity": "2713",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12698380,
+        "dateAcademyJoinedTrust": "2023-06-21T00:00:00",
+        "establishmentName": "Limehurst Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "833",
+        "schoolCapacity": "727",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12697667,
+        "dateAcademyJoinedTrust": "2023-05-08T00:00:00",
+        "establishmentName": "St. Peter\u0027s Church of England Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2759",
+        "schoolCapacity": "2231",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12693362,
+        "dateAcademyJoinedTrust": "2023-05-29T00:00:00",
+        "establishmentName": "St. Marys R.C. Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1043",
+        "schoolCapacity": "1244",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12691189,
+        "dateAcademyJoinedTrust": "2023-10-04T00:00:00",
+        "establishmentName": "St. Anne\u0027s CE School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "473",
+        "schoolCapacity": "705",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1237",
     "name": "VANGUARD LEARNING TRUST",
-    "groupId": "TR8316",
-    "ukprn": "10000337",
+    "groupId": "TR2875",
+    "ukprn": "10091225",
     "type": "Multi-academy trust",
-    "address": "877 Hoppe Hollow, FR0 4GU",
-    "openedDate": "2019-07-28T00:00:00",
-    "companiesHouseNumber": "02988019",
-    "regionAndTerritory": "South East"
+    "address": "519 Brandyn Key, Xanderville, YV3 8EH",
+    "openedDate": "2023-11-03T00:00:00",
+    "companiesHouseNumber": "09994759",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12377102,
+        "dateAcademyJoinedTrust": "2023-11-05T00:00:00",
+        "establishmentName": "St. Paul\u0027s R.C. Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "645",
+        "schoolCapacity": "1262",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12375381,
+        "dateAcademyJoinedTrust": "2023-11-03T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2624",
+        "schoolCapacity": "2933",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12374797,
+        "dateAcademyJoinedTrust": "2023-11-05T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2551",
+        "schoolCapacity": "2119",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12373821,
+        "dateAcademyJoinedTrust": "2023-11-03T00:00:00",
+        "establishmentName": "Peacehaven Community Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "207",
+        "schoolCapacity": "293",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12379770,
+        "dateAcademyJoinedTrust": "2023-11-07T00:00:00",
+        "establishmentName": "Peacehaven Community School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1749",
+        "schoolCapacity": "2416",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12375237,
+        "dateAcademyJoinedTrust": "2023-11-05T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Church of England School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1575",
+        "schoolCapacity": "2724",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12379648,
+        "dateAcademyJoinedTrust": "2023-11-05T00:00:00",
+        "establishmentName": "George Abbey Church of England Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "638",
+        "schoolCapacity": "1276",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12376082,
+        "dateAcademyJoinedTrust": "2023-11-07T00:00:00",
+        "establishmentName": "Longhill School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "927",
+        "schoolCapacity": "1903",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12377317,
+        "dateAcademyJoinedTrust": "2023-11-03T00:00:00",
+        "establishmentName": "Harris Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3270",
+        "schoolCapacity": "2720",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12376287,
+        "dateAcademyJoinedTrust": "2023-11-08T00:00:00",
+        "establishmentName": "St. Anne\u0027s CE Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "208",
+        "schoolCapacity": "163",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1241",
     "name": "VISIONARY ACADEMY TRUST",
-    "groupId": "TR450",
-    "ukprn": "10063631",
+    "groupId": "TR4599",
+    "ukprn": "10047712",
     "type": "Multi-academy trust",
-    "address": "810 Viola Parkways, Gerardberg, QX2 0DC",
-    "openedDate": "2020-03-27T00:00:00",
-    "companiesHouseNumber": "03057358",
-    "regionAndTerritory": "South West"
+    "address": "57293 Barton Terrace, Huel Locks, IM84 7VE",
+    "openedDate": "2017-03-15T00:00:00",
+    "companiesHouseNumber": "03447860",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12417590,
+        "dateAcademyJoinedTrust": "2022-04-19T00:00:00",
+        "establishmentName": "Horizon Catholic School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1148",
+        "schoolCapacity": "2368",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12413125,
+        "dateAcademyJoinedTrust": "2018-10-14T00:00:00",
+        "establishmentName": "St. Marys CE Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2933",
+        "schoolCapacity": "2623",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12418411,
+        "dateAcademyJoinedTrust": "2019-11-28T00:00:00",
+        "establishmentName": "Horizon Catholic School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "232",
+        "schoolCapacity": "187",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1274",
     "name": "VITALITY ACADEMY TRUST",
-    "groupId": "TR2163",
-    "ukprn": "10050184",
+    "groupId": "TR3038",
+    "ukprn": "10031057",
     "type": "Multi-academy trust",
-    "address": "0158 Lockman Brooks, NF2 1TV",
-    "openedDate": "2016-04-18T00:00:00",
-    "companiesHouseNumber": "04275021",
-    "regionAndTerritory": "North East"
+    "address": "3900 Henri Cliff, Port Avery, XR06 0UK",
+    "openedDate": "2023-07-12T00:00:00",
+    "companiesHouseNumber": "03566292",
+    "regionAndTerritory": "East Midlands",
+    "academies": [
+      {
+        "urn": 12747391,
+        "dateAcademyJoinedTrust": "2023-10-05T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Catholic Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1488",
+        "schoolCapacity": "2188",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   },
   {
     "uid": "1312",
     "name": "WESTMINSTER ACADEMY TRUST",
-    "groupId": "TR295",
-    "ukprn": "10047351",
+    "groupId": "TR7981",
+    "ukprn": "10015879",
     "type": "Multi-academy trust",
-    "address": "84294 Dion Rest, Candida Hill, JZ6 6VD",
-    "openedDate": "2023-02-05T00:00:00",
-    "companiesHouseNumber": "07722040",
-    "regionAndTerritory": "North East"
+    "address": "24161 Janice Estates, Vandervort Curve, Millerland, LQ43 3QJ",
+    "openedDate": "2015-04-27T00:00:00",
+    "companiesHouseNumber": "01137899",
+    "regionAndTerritory": "South East",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": null
   }
 ]


### PR DESCRIPTION
This updates the test data generator to include datasets required for displaying academies pages. It also includes a refactor on the AcademiesDb faker - to reduce the number of objects instantiated for every trust record. 

Related to [User Story 146083](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/146083?McasTsid=26110&McasCtx=4): Build: Get all the data we need from Academies DB for MVP

## Changes

- Create fakers for Gias.Establishment and Gias.GroupLink database tables
- Update the generate method on the AcademyDb faker to allow for the creation of interdependant records (ie. GroupLink will be the join between an academy and a trust)
- Refactor creation of fakers, and move externally set parameters to the Generate methods.

## Pending changes
- Have not set Ofsted ratings on establishments for now, as this may be taken from a different table.

## Potential improvements

- Improve random number generation for Uids and Urns. Bogus' number generation is not guaranteed to be unique, so using a combination of a counter for Uids and joining this with a random number to create a urn. We could move this to a separate class which is responsible for returning a unique random number
- Allow insertion of larger sets of data. We are currently running 1 sql insert script, which was attempting to insert over 1000 sets of rows when creating multiple academies for a trust. Have reduced the max data set for academies for now, but we are likely to need to split this insert statement.

## Screenshots of UI changes

N/A

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
