### PR TITLE
Get contacts from Academies db

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/PersonFactory.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/PersonFactory.cs
@@ -11,6 +11,6 @@ public class PersonFactory : IPersonFactory
 {
     public Person CreateFrom(CdmSystemuser cdmSystemuser)
     {
-        throw new NotImplementedException();
+        return new Person(cdmSystemuser.Fullname!, cdmSystemuser.Internalemailaddress!);
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/PersonFactory.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/PersonFactory.cs
@@ -1,0 +1,16 @@
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Cdm;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
+
+public interface IPersonFactory
+{
+    Person CreateFrom(CdmSystemuser cdmSystemuser);
+}
+
+public class PersonFactory : IPersonFactory
+{
+    public Person CreateFrom(CdmSystemuser cdmSystemuser)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/TrustFactory.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/TrustFactory.cs
@@ -6,12 +6,14 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
 
 public interface ITrustFactory
 {
-    Trust CreateTrustFrom(GiasGroup giasGroup, MstrTrust? mstrTrust, Academy[] academies, Governor[] governors);
+    Trust CreateTrustFrom(GiasGroup giasGroup, MstrTrust? mstrTrust, Academy[] academies, Governor[] governors,
+        Person? trustRelationshipManager, Person? sfsoLead);
 }
 
 public class TrustFactory : ITrustFactory
 {
-    public Trust CreateTrustFrom(GiasGroup giasGroup, MstrTrust? mstrTrust, Academy[] academies, Governor[] governors)
+    public Trust CreateTrustFrom(GiasGroup giasGroup, MstrTrust? mstrTrust, Academy[] academies, Governor[] governors,
+        Person? trustRelationshipManager, Person? sfsoLead)
     {
         return new Trust(
             giasGroup.GroupUid!,
@@ -25,8 +27,8 @@ public class TrustFactory : ITrustFactory
             mstrTrust?.GORregion ?? string.Empty,
             academies,
             governors,
-            null,
-            null
+            trustRelationshipManager,
+            sfsoLead
         );
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
@@ -36,7 +36,7 @@ public class TrustProvider : ITrustProvider
         var academies = await GetAcademiesLinkedTo(uid);
         var governors = await GetGovernorsLinkedTo(uid);
 
-        return _trustFactory.CreateTrustFrom(giasGroup, mstrTrust, academies, governors);
+        return _trustFactory.CreateTrustFrom(giasGroup, mstrTrust, academies, governors, null, null);
     }
 
     private async Task<Governor[]> GetGovernorsLinkedTo(string uid)

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -161,6 +161,7 @@ internal static class Program
         builder.Services.AddScoped<ITrustFactory, TrustFactory>();
         builder.Services.AddScoped<IAcademyFactory, AcademyFactory>();
         builder.Services.AddScoped<IGovernorFactory, GovernorFactory>();
+        builder.Services.AddScoped<IPersonFactory, PersonFactory>();
         builder.Services.AddScoped<IAuthorizationHandler, HeaderRequirementHandler>();
         builder.Services.AddHttpContextAccessor();
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/JsonGenerator.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/JsonGenerator.cs
@@ -22,7 +22,7 @@ public static class JsonGenerator
 
                 return trustHelper
                     .CreateTrustFrom(g, fakeData.MstrTrusts.FirstOrDefault(t => t.GroupUid == g.GroupUid)!,
-                        academies, Array.Empty<Governor>());
+                        academies, Array.Empty<Governor>(), null, null);
             });
 
         File.WriteAllText(outputFilePath, JsonSerializer.Serialize(trusts, serializeOptions));

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/PersonFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/PersonFactoryTests.cs
@@ -1,0 +1,21 @@
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Cdm;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Factories;
+
+public class PersonFactoryTests
+{
+    [Fact]
+    public void CreateFrom_should_transform_cdmSystemuser_into_person()
+    {
+        var sut = new PersonFactory();
+
+        var cdmSystemuser = new CdmSystemuser
+            { Fullname = "Test person", Internalemailaddress = "test.person@education.gov.uk" };
+
+        var result = sut.CreateFrom(cdmSystemuser);
+
+        result.FullName.Should().Be("Test person");
+        result.Email.Should().Be("test.person@education.gov.uk");
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/TrustFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/TrustFactoryTests.cs
@@ -29,7 +29,8 @@ public class TrustFactoryTests
             GroupUid = "1234", GORregion = "North East"
         };
 
-        var result = _sut.CreateTrustFrom(_testGiasGroup, mstrTrust, Array.Empty<Academy>(), Array.Empty<Governor>());
+        var result = _sut.CreateTrustFrom(_testGiasGroup, mstrTrust, Array.Empty<Academy>(), Array.Empty<Governor>(),
+            null, null);
 
         result.Should().BeEquivalentTo(new Trust(
                 "1234",
@@ -52,7 +53,8 @@ public class TrustFactoryTests
     [Fact]
     public void CreateTrustFrom_should_transform_a_group_without_mstrTrust_into_a_trust()
     {
-        var result = _sut.CreateTrustFrom(_testGiasGroup, null, Array.Empty<Academy>(), Array.Empty<Governor>());
+        var result = _sut.CreateTrustFrom(_testGiasGroup, null, Array.Empty<Academy>(), Array.Empty<Governor>(), null,
+            null);
 
         result.Should().BeEquivalentTo(new Trust(
                 "1234",
@@ -77,7 +79,7 @@ public class TrustFactoryTests
     {
         var academies = new[] { DummyAcademyFactory.GetDummyAcademy(1234546) };
 
-        var result = _sut.CreateTrustFrom(_testGiasGroup, null, academies, Array.Empty<Governor>());
+        var result = _sut.CreateTrustFrom(_testGiasGroup, null, academies, Array.Empty<Governor>(), null, null);
 
         result.Academies.Should().Equal(academies);
     }
@@ -87,9 +89,31 @@ public class TrustFactoryTests
     {
         var governors = new[] { DummyGovernorFactory.GetDummyGovernor("1234546", "1234") };
 
-        var result = _sut.CreateTrustFrom(_testGiasGroup, null, Array.Empty<Academy>(), governors);
+        var result = _sut.CreateTrustFrom(_testGiasGroup, null, Array.Empty<Academy>(), governors, null, null);
 
         result.Governors.Should().Equal(governors);
+    }
+
+    [Fact]
+    public void CreateTrustFrom_should_set_trustRelationshipManager_from_parameters()
+    {
+        var trustRelationshipManager = new Person("trust relationship manager", "trm@education.gov.uk");
+
+        var result = _sut.CreateTrustFrom(_testGiasGroup, null, Array.Empty<Academy>(), Array.Empty<Governor>(),
+            trustRelationshipManager, null);
+
+        result.TrustRelationshipManager.Should().Be(trustRelationshipManager);
+    }
+
+    [Fact]
+    public void CreateTrustFrom_should_set_sfsoLead_from_parameters()
+    {
+        var sfsoLead = new Person("SFSO Lead", "sfsoLead@education.gov.uk");
+
+        var result = _sut.CreateTrustFrom(_testGiasGroup, null, Array.Empty<Academy>(), Array.Empty<Governor>(), null,
+            sfsoLead);
+
+        result.SfsoLead.Should().Be(sfsoLead);
     }
 
     [Theory]
@@ -97,7 +121,8 @@ public class TrustFactoryTests
     public void CreateTrustFromGroup_Should_Include_Empty_string_values_if_properties_have_no_value(
         GiasGroup giasGroup, MstrTrust mstrTrust, Trust expected)
     {
-        var result = _sut.CreateTrustFrom(giasGroup, mstrTrust, Array.Empty<Academy>(), Array.Empty<Governor>());
+        var result = _sut.CreateTrustFrom(giasGroup, mstrTrust, Array.Empty<Academy>(), Array.Empty<Governor>(), null,
+            null);
         result.Should().BeEquivalentTo(expected);
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Cdm;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +9,8 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
 {
     private readonly List<GiasGroupLink> _giasGroupLinks = new();
+    private readonly List<CdmSystemuser> _cdmSystemusers = new();
+    private readonly List<CdmAccount> _cdmAccounts = new();
     private List<GiasGroup>? _addedGiasGroups;
     private List<MstrTrust>? _addedMstrTrusts;
 
@@ -15,6 +18,10 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
     {
         Setup(academiesDbContext => academiesDbContext.GiasGroupLinks)
             .Returns(new MockDbSet<GiasGroupLink>(_giasGroupLinks).Object);
+        Setup(academiesDbContext => academiesDbContext.CdmSystemusers)
+            .Returns(new MockDbSet<CdmSystemuser>(_cdmSystemusers).Object);
+        Setup(academiesDbContext => academiesDbContext.CdmAccounts)
+            .Returns(new MockDbSet<CdmAccount>(_cdmAccounts).Object);
     }
 
     public MstrTrust CreateMstrTrust(string groupUid)
@@ -33,6 +40,21 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
             { GroupName = "trust 1", GroupUid = groupUid, GroupType = "Multi-academy trust", Ukprn = "my ukprn" };
         _addedGiasGroups?.Add(giasGroup);
         return giasGroup;
+    }
+
+    public CdmSystemuser CreateCdmSystemuser(string fullName, string email)
+    {
+        var cdmSystemuser = new CdmSystemuser
+            { Systemuserid = Guid.NewGuid(), Fullname = fullName, Internalemailaddress = email };
+        _cdmSystemusers.Add(cdmSystemuser);
+        return cdmSystemuser;
+    }
+
+    public CdmAccount CreateCdmAccount(string groupUid)
+    {
+        var cdmAccount = new CdmAccount { SipUid = groupUid };
+        _cdmAccounts.Add(cdmAccount);
+        return cdmAccount;
     }
 
     public List<GiasGroup> SetupMockDbContextGiasGroups(int numMatches)

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -8,6 +8,8 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
 {
     private readonly List<GiasGroupLink> _giasGroupLinks = new();
+    private List<GiasGroup>? _addedGiasGroups;
+    private List<MstrTrust>? _addedMstrTrusts;
 
     public MockAcademiesDbContext()
     {
@@ -15,25 +17,45 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
             .Returns(new MockDbSet<GiasGroupLink>(_giasGroupLinks).Object);
     }
 
+    public MstrTrust CreateMstrTrust(string groupUid)
+    {
+        var mstrTrust = new MstrTrust
+        {
+            GroupUid = groupUid, GORregion = "North East"
+        };
+        _addedMstrTrusts?.Add(mstrTrust);
+        return mstrTrust;
+    }
+
+    public GiasGroup CreateGiasGroup(string groupUid)
+    {
+        var giasGroup = new GiasGroup
+            { GroupName = "trust 1", GroupUid = groupUid, GroupType = "Multi-academy trust", Ukprn = "my ukprn" };
+        _addedGiasGroups?.Add(giasGroup);
+        return giasGroup;
+    }
+
     public List<GiasGroup> SetupMockDbContextGiasGroups(int numMatches)
     {
-        return SetupMockDbContext(numMatches,
+        _addedGiasGroups = SetupMockDbContext(numMatches,
             i => new GiasGroup
             {
                 GroupName = $"trust {i}", GroupUid = $"{i}", GroupId = $"TR0{i}", GroupType = "Multi-academy trust"
             },
             academiesDbContext => academiesDbContext.Groups);
+        return _addedGiasGroups;
     }
 
     public List<MstrTrust> SetupMockDbContextMstrTrust(int numMatches)
     {
-        return SetupMockDbContext(numMatches,
+        _addedMstrTrusts = SetupMockDbContext(numMatches,
             i => new MstrTrust
             {
                 GroupUid = $"{i}",
                 GORregion = "North East"
             },
             academiesDbContext => academiesDbContext.MstrTrusts);
+        return _addedMstrTrusts;
     }
 
     public List<GiasEstablishment> SetupMockDbContextGiasEstablishment(int numMatches)

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
@@ -18,6 +18,9 @@ public class TrustProviderTests
     private readonly Mock<IAcademyFactory> _mockAcademyFactory = new();
     private readonly Mock<IGovernorFactory> _mockGovernorFactory = new();
     private readonly MockAcademiesDbContext _mockAcademiesDbContext = new();
+    private readonly string _groupUidToGet = "1234";
+    private readonly GiasGroup _giasGroupInDb;
+    private readonly MstrTrust _mstrTrustInDb;
 
     public TrustProviderTests()
     {
@@ -26,25 +29,36 @@ public class TrustProviderTests
         _giasEstablishments = _mockAcademiesDbContext.SetupMockDbContextGiasEstablishment(15);
         _giasGovernances = _mockAcademiesDbContext.SetupMockDbContextGiasGovernance(20, "Some other trust");
         _mstrTrustGovernances = _mockAcademiesDbContext.SetupMockDbContextMstrTrustGovernance(20);
+        SetUpAcademiesLinkedToTrust(_giasEstablishments.Skip(10).Take(3),
+            _mockAcademiesDbContext.CreateGiasGroup("Some other trust"));
+        SetUpGovernorsLinkedToTrust(5, "Some other trust");
 
         _sut = new TrustProvider(_mockAcademiesDbContext.Object, _mockTrustFactory.Object, _mockAcademyFactory.Object,
             _mockGovernorFactory.Object);
+
+        _giasGroupInDb = _mockAcademiesDbContext.CreateGiasGroup(_groupUidToGet);
+        _mstrTrustInDb = _mockAcademiesDbContext.CreateMstrTrust(_groupUidToGet);
+
+        _mockTrustFactory
+            .Setup(t => t.CreateTrustFrom(It.IsAny<GiasGroup>(), It.IsAny<MstrTrust>(),
+                It.IsAny<Academy[]>(), It.IsAny<Governor[]>(),
+                It.IsAny<Person>(), It.IsAny<Person>()))
+            .Returns((GiasGroup g, MstrTrust _, Academy[] _, Governor[] _, Person _, Person _) =>
+                DummyTrustFactory.GetDummyTrust(g.GroupUid!));
     }
 
     [Fact]
     public async Task GetTrustsByUidAsync_should_return_a_trust_if_giasGroup_and_mstrTrust_found()
     {
-        var groupUid = "1234";
-        var giasGroup = CreateGiasGroup(groupUid);
-        var mstrTrust = CreateMstrTrust(groupUid);
-        var expectedTrust = DummyTrustFactory.GetDummyTrust(groupUid);
+        var expectedTrust = DummyTrustFactory.GetDummyTrust(_groupUidToGet);
 
         _mockTrustFactory
-            .Setup(t => t.CreateTrustFrom(giasGroup, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>(), null,
-                null))
+            .Setup(t => t.CreateTrustFrom(_giasGroupInDb, _mstrTrustInDb,
+                It.IsAny<Academy[]>(), It.IsAny<Governor[]>(),
+                It.IsAny<Person>(), It.IsAny<Person>()))
             .Returns(expectedTrust);
 
-        var result = await _sut.GetTrustByUidAsync(groupUid);
+        var result = await _sut.GetTrustByUidAsync(_groupUidToGet);
 
         result.Should().Be(expectedTrust);
     }
@@ -52,26 +66,27 @@ public class TrustProviderTests
     [Fact]
     public async Task GetTrustsByUidAsync_should_return_null_when_giasGroup_not_found()
     {
-        var groupUid = "987654321";
-        CreateMstrTrust(groupUid);
+        const string groupUidWithoutGiasGroup = "987654321";
+        _mockAcademiesDbContext.CreateMstrTrust(groupUidWithoutGiasGroup);
 
-        var result = await _sut.GetTrustByUidAsync(groupUid);
+        var result = await _sut.GetTrustByUidAsync(groupUidWithoutGiasGroup);
         result.Should().BeNull();
     }
 
     [Fact]
     public async Task GetTrustsByUidAsync_should_return_a_trust_if_mstrTrust_not_found()
     {
-        var groupUid = "987654321";
-        var giasGroup = CreateGiasGroup(groupUid);
-        var expectedTrust = DummyTrustFactory.GetDummyTrust(groupUid);
+        const string groupUidWithoutMstrTrust = "987654321";
+        var giasGroup = _mockAcademiesDbContext.CreateGiasGroup(groupUidWithoutMstrTrust);
+        var expectedTrust = DummyTrustFactory.GetDummyTrust(groupUidWithoutMstrTrust);
 
         _mockTrustFactory.Setup(t =>
-                t.CreateTrustFrom(giasGroup, It.IsAny<MstrTrust>(), It.IsAny<Academy[]>(), Array.Empty<Governor>(),
-                    null, null))
+                t.CreateTrustFrom(giasGroup, null,
+                    It.IsAny<Academy[]>(), It.IsAny<Governor[]>(),
+                    It.IsAny<Person>(), It.IsAny<Person>()))
             .Returns(expectedTrust);
 
-        var result = await _sut.GetTrustByUidAsync(groupUid);
+        var result = await _sut.GetTrustByUidAsync(groupUidWithoutMstrTrust);
 
         result.Should().Be(expectedTrust);
     }
@@ -79,29 +94,19 @@ public class TrustProviderTests
     [Fact]
     public async Task GetTrustsByUidAsync_should_return_null_if_both_giasGroup_and_mstrTrust_not_found()
     {
-        var result = await _sut.GetTrustByUidAsync("987654321");
+        var result = await _sut.GetTrustByUidAsync("this uid doesn't exist");
         result.Should().BeNull();
     }
 
     [Fact]
     public async Task GetTrustByUidAsync_should_only_give_academies_linked_to_trust_to_trustFactory()
     {
-        const string groupUid = "1234";
-        var giasGroup = CreateGiasGroup(groupUid);
-        var mstrTrust = CreateMstrTrust(groupUid);
+        var expectedAcademies = SetUpAcademiesLinkedToTrust(_giasEstablishments.Take(3), _giasGroupInDb);
 
-        var expectedAcademies = SetUpAcademiesLinkedToTrust(_giasEstablishments.Take(3), giasGroup);
-        SetUpAcademiesLinkedToTrust(_giasEstablishments.Skip(5).Take(3), CreateGiasGroup("Some other trust"));
-
-        _mockTrustFactory
-            .Setup(t => t.CreateTrustFrom(giasGroup, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>(), null,
-                null))
-            .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
-
-        await _sut.GetTrustByUidAsync(groupUid);
+        await _sut.GetTrustByUidAsync(_groupUidToGet);
 
         _mockTrustFactory.Verify(t =>
-            t.CreateTrustFrom(giasGroup, mstrTrust,
+            t.CreateTrustFrom(_giasGroupInDb, _mstrTrustInDb,
                 It.Is<Academy[]>(a => expectedAcademies.SequenceEqual(a)), Array.Empty<Governor>(), null, null)
         );
     }
@@ -110,37 +115,23 @@ public class TrustProviderTests
     public async Task
         GetTrustByUidAsync_should_give_empty_academies_array_to_trustFactory_when_no_academies_linked_to_trust()
     {
-        const string groupUid = "1234";
-        var giasGroup = CreateGiasGroup(groupUid);
-        var mstrTrust = CreateMstrTrust(groupUid);
-
-        SetUpAcademiesLinkedToTrust(_giasEstablishments.Skip(5).Take(3), CreateGiasGroup("Some other trust"));
-
-        _mockTrustFactory
-            .Setup(t => t.CreateTrustFrom(giasGroup, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>(), null,
-                null))
-            .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
-
-        await _sut.GetTrustByUidAsync(groupUid);
+        await _sut.GetTrustByUidAsync(_groupUidToGet);
 
         _mockTrustFactory.Verify(t =>
-            t.CreateTrustFrom(giasGroup, mstrTrust, It.Is<Academy[]>(a => !a.Any()), Array.Empty<Governor>(), null,
+            t.CreateTrustFrom(_giasGroupInDb, _mstrTrustInDb, It.Is<Academy[]>(a => !a.Any()), Array.Empty<Governor>(),
+                null,
                 null));
     }
 
     [Fact]
     public async Task GetTrustByUidAsync_should_only_give_governors_linked_to_trust_to_trustFactory()
     {
-        const string groupUid = "1234";
-        var giasGroup = CreateGiasGroup(groupUid);
-        var mstrTrust = CreateMstrTrust(groupUid);
+        var expectedGovernors = SetUpGovernorsLinkedToTrust(5, _groupUidToGet);
 
-        var expectedGovernors = SetUpGovernorsLinkedToTrust(5, groupUid);
-
-        await _sut.GetTrustByUidAsync(groupUid);
+        await _sut.GetTrustByUidAsync(_groupUidToGet);
 
         _mockTrustFactory.Verify(t =>
-            t.CreateTrustFrom(giasGroup, mstrTrust, Array.Empty<Academy>(),
+            t.CreateTrustFrom(_giasGroupInDb, _mstrTrustInDb, Array.Empty<Academy>(),
                 It.Is<Governor[]>(g => expectedGovernors.SequenceEqual(g)), null, null)
         );
     }
@@ -149,17 +140,11 @@ public class TrustProviderTests
     public async Task
         GetTrustByUidAsync_should_give_empty_governors_array_to_trustFactory_when_no_governors_linked_to_trust()
     {
-        const string groupUid = "1234";
-        var giasGroup = CreateGiasGroup(groupUid);
-
-        _mockTrustFactory
-            .Setup(t => t.CreateTrustFrom(giasGroup, null, Array.Empty<Academy>(), Array.Empty<Governor>(), null, null))
-            .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
-
-        await _sut.GetTrustByUidAsync(groupUid);
+        await _sut.GetTrustByUidAsync(_groupUidToGet);
 
         _mockTrustFactory.Verify(t =>
-            t.CreateTrustFrom(giasGroup, null, It.IsAny<Academy[]>(), It.Is<Governor[]>(g => !g.Any()), null, null));
+            t.CreateTrustFrom(_giasGroupInDb, _mstrTrustInDb, It.IsAny<Academy[]>(), It.Is<Governor[]>(g => !g.Any()),
+                null, null));
     }
 
     private List<Academy> SetUpAcademiesLinkedToTrust(IEnumerable<GiasEstablishment> giasEstablishmentsLinkedToTrust,
@@ -210,23 +195,5 @@ public class TrustProviderTests
         }
 
         return governorsLinkedToTrust;
-    }
-
-    private MstrTrust CreateMstrTrust(string groupUid)
-    {
-        var mstrTrust = new MstrTrust
-        {
-            GroupUid = groupUid, GORregion = "North East"
-        };
-        _mstrTrusts.Add(mstrTrust);
-        return mstrTrust;
-    }
-
-    private GiasGroup CreateGiasGroup(string groupUid)
-    {
-        var giasGroup = new GiasGroup
-            { GroupName = "trust 1", GroupUid = groupUid, GroupType = "Multi-academy trust", Ukprn = "my ukprn" };
-        _giasGroups.Add(giasGroup);
-        return giasGroup;
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
@@ -40,7 +40,8 @@ public class TrustProviderTests
         var expectedTrust = DummyTrustFactory.GetDummyTrust(groupUid);
 
         _mockTrustFactory
-            .Setup(t => t.CreateTrustFrom(giasGroup, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>()))
+            .Setup(t => t.CreateTrustFrom(giasGroup, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>(), null,
+                null))
             .Returns(expectedTrust);
 
         var result = await _sut.GetTrustByUidAsync(groupUid);
@@ -66,7 +67,8 @@ public class TrustProviderTests
         var expectedTrust = DummyTrustFactory.GetDummyTrust(groupUid);
 
         _mockTrustFactory.Setup(t =>
-                t.CreateTrustFrom(giasGroup, It.IsAny<MstrTrust>(), It.IsAny<Academy[]>(), Array.Empty<Governor>()))
+                t.CreateTrustFrom(giasGroup, It.IsAny<MstrTrust>(), It.IsAny<Academy[]>(), Array.Empty<Governor>(),
+                    null, null))
             .Returns(expectedTrust);
 
         var result = await _sut.GetTrustByUidAsync(groupUid);
@@ -92,14 +94,15 @@ public class TrustProviderTests
         SetUpAcademiesLinkedToTrust(_giasEstablishments.Skip(5).Take(3), CreateGiasGroup("Some other trust"));
 
         _mockTrustFactory
-            .Setup(t => t.CreateTrustFrom(giasGroup, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>()))
+            .Setup(t => t.CreateTrustFrom(giasGroup, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>(), null,
+                null))
             .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
 
         await _sut.GetTrustByUidAsync(groupUid);
 
         _mockTrustFactory.Verify(t =>
             t.CreateTrustFrom(giasGroup, mstrTrust,
-                It.Is<Academy[]>(a => expectedAcademies.SequenceEqual(a)), Array.Empty<Governor>())
+                It.Is<Academy[]>(a => expectedAcademies.SequenceEqual(a)), Array.Empty<Governor>(), null, null)
         );
     }
 
@@ -114,13 +117,15 @@ public class TrustProviderTests
         SetUpAcademiesLinkedToTrust(_giasEstablishments.Skip(5).Take(3), CreateGiasGroup("Some other trust"));
 
         _mockTrustFactory
-            .Setup(t => t.CreateTrustFrom(giasGroup, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>()))
+            .Setup(t => t.CreateTrustFrom(giasGroup, mstrTrust, It.IsAny<Academy[]>(), Array.Empty<Governor>(), null,
+                null))
             .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
 
         await _sut.GetTrustByUidAsync(groupUid);
 
         _mockTrustFactory.Verify(t =>
-            t.CreateTrustFrom(giasGroup, mstrTrust, It.Is<Academy[]>(a => !a.Any()), Array.Empty<Governor>()));
+            t.CreateTrustFrom(giasGroup, mstrTrust, It.Is<Academy[]>(a => !a.Any()), Array.Empty<Governor>(), null,
+                null));
     }
 
     [Fact]
@@ -136,7 +141,7 @@ public class TrustProviderTests
 
         _mockTrustFactory.Verify(t =>
             t.CreateTrustFrom(giasGroup, mstrTrust, Array.Empty<Academy>(),
-                It.Is<Governor[]>(g => expectedGovernors.SequenceEqual(g)))
+                It.Is<Governor[]>(g => expectedGovernors.SequenceEqual(g)), null, null)
         );
     }
 
@@ -148,13 +153,13 @@ public class TrustProviderTests
         var giasGroup = CreateGiasGroup(groupUid);
 
         _mockTrustFactory
-            .Setup(t => t.CreateTrustFrom(giasGroup, null, Array.Empty<Academy>(), Array.Empty<Governor>()))
+            .Setup(t => t.CreateTrustFrom(giasGroup, null, Array.Empty<Academy>(), Array.Empty<Governor>(), null, null))
             .Returns(DummyTrustFactory.GetDummyTrust(groupUid));
 
         await _sut.GetTrustByUidAsync(groupUid);
 
         _mockTrustFactory.Verify(t =>
-            t.CreateTrustFrom(giasGroup, null, It.IsAny<Academy[]>(), It.Is<Governor[]>(g => !g.Any())));
+            t.CreateTrustFrom(giasGroup, null, It.IsAny<Academy[]>(), It.Is<Governor[]>(g => !g.Any()), null, null));
     }
 
     private List<Academy> SetUpAcademiesLinkedToTrust(IEnumerable<GiasEstablishment> giasEstablishmentsLinkedToTrust,


### PR DESCRIPTION
Gets the Trust Relationship Manager and SFSO Lead information from the cdm tables in Academies db and adds them to the `Trust` model used by FIAT's front end.

The cdm schema is exported by TRAMS and give us access to the contacts information managed by TRAMS. We will need to find another way to manage contact information before TRAMS can be decommissioned.

[User Story 146083](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/146083): Build: Get all the data we need from Academies DB for MVP

## Changes

* Adds mechanism to retrieve SFSO Lead (called amsd lead in the db) and Trust Relationship Manager from TRAMS
* Refactors unwieldy `TrustProvider` tests

## Checklist

- [n/a] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [n/a] Update the ADR decision log if needed
