### PR TITLE
Fake contacts data

### DIFF
--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/AcademiesDbData.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/AcademiesDbData.cs
@@ -1,6 +1,9 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Cdm;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
+using Microsoft.EntityFrameworkCore;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker;
 
@@ -12,5 +15,48 @@ public class AcademiesDbData
     public List<GiasGovernance> GiasGovernances { get; } = new();
     public List<GiasGroupLink> GiasGroupLinks { get; } = new();
     public List<GiasGroup> GiasGroups { get; } = new();
+    public List<MisEstablishment> MisEstablishments { get; } = new();
     public List<MstrTrust> MstrTrusts { get; } = new();
+    public List<MstrTrustGovernance> MstrTrustGovernances { get; } = new();
+
+    public IAcademiesDbContext AsAcademiesDbContext()
+    {
+        return new AcademiesDbDataContext(GiasEstablishments, GiasGovernances, GiasGroupLinks, GiasGroups, MstrTrusts,
+            CdmAccounts, MisEstablishments, CdmSystemusers, MstrTrustGovernances);
+    }
+
+    private class AcademiesDbDataContext : IAcademiesDbContext
+    {
+        public DbSet<GiasEstablishment> GiasEstablishments { get; }
+        public DbSet<GiasGovernance> GiasGovernances { get; }
+        public DbSet<GiasGroupLink> GiasGroupLinks { get; }
+        public DbSet<GiasGroup> Groups { get; }
+        public DbSet<MstrTrust> MstrTrusts { get; }
+        public DbSet<CdmAccount> CdmAccounts { get; }
+        public DbSet<MisEstablishment> MisEstablishments { get; }
+        public DbSet<CdmSystemuser> CdmSystemusers { get; }
+        public DbSet<MstrTrustGovernance> MstrTrustGovernances { get; }
+
+        public AcademiesDbDataContext(
+            IEnumerable<GiasEstablishment> giasEstablishments,
+            IEnumerable<GiasGovernance> giasGovernances,
+            IEnumerable<GiasGroupLink> giasGroupLinks,
+            IEnumerable<GiasGroup> giasGroups,
+            IEnumerable<MstrTrust> mstrTrusts,
+            IEnumerable<CdmAccount> cdmAccounts,
+            IEnumerable<MisEstablishment> misEstablishments,
+            IEnumerable<CdmSystemuser> cdmSystemusers,
+            IEnumerable<MstrTrustGovernance> mstrTrustGovernances)
+        {
+            GiasEstablishments = new MockDbSet<GiasEstablishment>(giasEstablishments).Object;
+            GiasGovernances = new MockDbSet<GiasGovernance>(giasGovernances).Object;
+            GiasGroupLinks = new MockDbSet<GiasGroupLink>(giasGroupLinks).Object;
+            Groups = new MockDbSet<GiasGroup>(giasGroups).Object;
+            MstrTrusts = new MockDbSet<MstrTrust>(mstrTrusts).Object;
+            CdmAccounts = new MockDbSet<CdmAccount>(cdmAccounts).Object;
+            MisEstablishments = new MockDbSet<MisEstablishment>(misEstablishments).Object;
+            CdmSystemusers = new MockDbSet<CdmSystemuser>(cdmSystemusers).Object;
+            MstrTrustGovernances = new MockDbSet<MstrTrustGovernance>(mstrTrustGovernances).Object;
+        }
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/AcademiesDbData.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/AcademiesDbData.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Cdm;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
 
@@ -5,6 +6,8 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker;
 
 public class AcademiesDbData
 {
+    public List<CdmAccount> CdmAccounts { get; } = new();
+    public List<CdmSystemuser> CdmSystemusers { get; } = new();
     public List<GiasEstablishment> GiasEstablishments { get; } = new();
     public List<GiasGovernance> GiasGovernances { get; } = new();
     public List<GiasGroupLink> GiasGroupLinks { get; } = new();

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.csproj
@@ -20,6 +20,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj"/>
+        <ProjectReference Include="..\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
@@ -1,6 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Helpers;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
-using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Fakers;
 
@@ -33,14 +32,14 @@ public class AcademiesDbFaker
     {
         var academiesDbData = new AcademiesDbData();
 
-        var dfeContacts = _cdmSystemuserFaker.Generate(10);
-        academiesDbData.CdmSystemusers.AddRange(dfeContacts);
+        ConfigureDfeContacts(academiesDbData);
 
         foreach (var trustToGenerate in trustsToGenerate)
         {
-            var group = GenerateGroup(trustToGenerate);
+            var group = _giasGroupFaker.Generate(trustToGenerate, _counter++);
             academiesDbData.GiasGroups.Add(group);
-            academiesDbData.MstrTrusts.Add(GenerateMstrTrust(group.GroupUid));
+            academiesDbData.MstrTrusts.Add(_mstrTrustFaker.Generate(group.GroupUid!));
+            academiesDbData.CdmAccounts.Add(_cdmAccountFaker.Generate(group.GroupUid!));
 
             var academies = GenerateAcademies(trustToGenerate, group.GroupUid!).ToArray();
             academiesDbData.GiasEstablishments.AddRange(academies);
@@ -50,14 +49,12 @@ public class AcademiesDbFaker
         return academiesDbData;
     }
 
-    private GiasGroup GenerateGroup(TrustToGenerate trustToGenerate)
+    private void ConfigureDfeContacts(AcademiesDbData academiesDbData)
     {
-        return _giasGroupFaker.Generate(trustToGenerate, _counter++);
-    }
-
-    private MstrTrust GenerateMstrTrust(string? uid)
-    {
-        return _mstrTrustFaker.Generate(uid!);
+        var dfeContacts = _cdmSystemuserFaker.Generate(50);
+        academiesDbData.CdmSystemusers.AddRange(dfeContacts);
+        _cdmAccountFaker.SetSfsoLeads(dfeContacts.Take(25).Select(c => c.Systemuserid));
+        _cdmAccountFaker.SetTrustRelationshipManagers(dfeContacts.Skip(25).Select(c => c.Systemuserid));
     }
 
     private GiasGroupLink GenerateGroupLink(GiasEstablishment establishment, GiasGroup giasGroup)

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
@@ -14,6 +14,8 @@ public class AcademiesDbFaker
     private readonly GiasEstablishmentFaker _giasEstablishmentFaker;
     private readonly GiasGroupFaker _giasGroupFaker;
     private readonly MstrTrustFaker _mstrTrustFaker;
+    private readonly CdmAccountFaker _cdmAccountFaker = new();
+    private readonly CdmSystemuserFaker _cdmSystemuserFaker = new();
 
     public AcademiesDbFaker(string?[] regions, string?[] localAuthorities, string[] fakeSchoolNames)
     {

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
@@ -33,6 +33,9 @@ public class AcademiesDbFaker
     {
         var academiesDbData = new AcademiesDbData();
 
+        var dfeContacts = _cdmSystemuserFaker.Generate(10);
+        academiesDbData.CdmSystemusers.AddRange(dfeContacts);
+
         foreach (var trustToGenerate in trustsToGenerate)
         {
             var group = GenerateGroup(trustToGenerate);

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/CdmAccountFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/CdmAccountFaker.cs
@@ -1,5 +1,38 @@
+using Bogus;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Cdm;
+
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Fakers;
 
 public class CdmAccountFaker
 {
+    private readonly Faker<CdmAccount> _cdmAccountFaker = new();
+    private IEnumerable<Guid?>? _sfsoLeadIds;
+    private IEnumerable<Guid?>? _trustRelationshipManagerIds;
+
+    public CdmAccountFaker()
+    {
+        _cdmAccountFaker
+            .RuleFor(a => a.SipTrustrelationshipmanager, f => f.PickRandom(_trustRelationshipManagerIds))
+            .RuleFor(a => a.SipAmsdlead, f => f.PickRandom(_sfsoLeadIds));
+    }
+
+    public void SetSfsoLeads(IEnumerable<Guid?> systemUserIds)
+    {
+        _sfsoLeadIds = systemUserIds
+            .Append(null); // Sfso Lead can sometimes be unassigned
+    }
+
+    public void SetTrustRelationshipManagers(IEnumerable<Guid?> systemUserIds)
+    {
+        _trustRelationshipManagerIds = systemUserIds
+            .Append(null); // Trust relationship manager sometimes be unassigned
+    }
+
+    public CdmAccount Generate(string uid)
+    {
+        var result = _cdmAccountFaker.Generate();
+        result.SipUid = uid;
+
+        return result;
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/CdmAccountFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/CdmAccountFaker.cs
@@ -12,6 +12,7 @@ public class CdmAccountFaker
     public CdmAccountFaker()
     {
         _cdmAccountFaker
+            .RuleFor(a => a.Id, f => f.Random.Guid())
             .RuleFor(a => a.SipTrustrelationshipmanager, f => f.PickRandom(_trustRelationshipManagerIds))
             .RuleFor(a => a.SipAmsdlead, f => f.PickRandom(_sfsoLeadIds));
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/CdmAccountFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/CdmAccountFaker.cs
@@ -1,0 +1,5 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Fakers;
+
+public class CdmAccountFaker
+{
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/CdmSystemuserFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/CdmSystemuserFaker.cs
@@ -1,5 +1,22 @@
+using Bogus;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Cdm;
+
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Fakers;
 
 public class CdmSystemuserFaker
 {
+    private readonly Faker<CdmSystemuser> _cdmSystemuserFaker;
+
+    public CdmSystemuserFaker()
+    {
+        _cdmSystemuserFaker = new Faker<CdmSystemuser>()
+            .RuleFor(u => u.Systemuserid, f => f.Random.Guid())
+            .RuleFor(u => u.Fullname, f => f.Person.FullName)
+            .RuleFor(u => u.Internalemailaddress, f => $"{f.Person.FirstName}.{f.Person.LastName}@education.gov.uk");
+    }
+
+    public CdmSystemuser[] Generate(int numToGenerate)
+    {
+        return _cdmSystemuserFaker.Generate(numToGenerate).ToArray();
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/CdmSystemuserFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/CdmSystemuserFaker.cs
@@ -1,0 +1,5 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Fakers;
+
+public class CdmSystemuserFaker
+{
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/JsonGenerator.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/JsonGenerator.cs
@@ -10,20 +10,12 @@ public static class JsonGenerator
         var serializeOptions = new JsonSerializerOptions
             { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
-        var trustHelper = new TrustFactory();
-        var academyFactory = new AcademyFactory();
+        var trustProvider = new TrustProvider(fakeData.AsAcademiesDbContext(), new TrustFactory(), new AcademyFactory(),
+            new GovernorFactory(),
+            new PersonFactory());
         var trusts = fakeData.GiasGroups
             .OrderBy(g => g.GroupName)
-            .Select(g =>
-            {
-                var academies = fakeData.GiasGroupLinks.Where(gl => gl.GroupUid == g.GroupUid && gl.Urn != null)
-                    .Join(fakeData.GiasEstablishments, e => e.Urn, gl => gl.Urn.ToString(),
-                        (gl, e) => academyFactory.CreateAcademyFrom(gl, e)).ToArray();
-
-                return trustHelper
-                    .CreateTrustFrom(g, fakeData.MstrTrusts.FirstOrDefault(t => t.GroupUid == g.GroupUid)!,
-                        academies, Array.Empty<Governor>(), null, null);
-            });
+            .Select(g => trustProvider.GetTrustByUidAsync(g.GroupUid!).Result);
 
         File.WriteAllText(outputFilePath, JsonSerializer.Serialize(trusts, serializeOptions));
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/SqlScriptGenerator.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/SqlScriptGenerator.cs
@@ -73,17 +73,18 @@ public static class SqlScriptGenerator
     {
         if (value is null)
             return "NULL";
+
         if (propertyType == typeof(string))
         {
             return TransformIntoSqlSafeString(value.ToString());
         }
 
-        if (propertyType == typeof(int))
+        if (propertyType == typeof(int) || propertyType == typeof(Guid) || propertyType == typeof(Guid?))
         {
             return value.ToString()!;
         }
 
-        throw new Exception("unknown type");
+        throw new ApplicationException($"Can't get value as string for unknown type '{propertyType}'");
     }
 
     private static string TransformIntoSqlSafeString(string? unsantisedString)

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/SqlScriptGenerator.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/SqlScriptGenerator.cs
@@ -27,15 +27,17 @@ public static class SqlScriptGenerator
     private static void GenerateSqlInsertScript(AcademiesDbContext context, string outputFilePath,
         AcademiesDbData fakeData)
     {
-        var insertScript = string.Join("; ",
+        var insertScripts = new[]
+        {
             GenerateSqlInsertScriptSegmentFor(fakeData.GiasGroups, context),
             GenerateSqlInsertScriptSegmentFor(fakeData.MstrTrusts, context),
             GenerateSqlInsertScriptSegmentFor(fakeData.GiasGroupLinks, context),
             GenerateSqlInsertScriptSegmentFor(fakeData.GiasEstablishments, context),
             GenerateSqlInsertScriptSegmentFor(fakeData.CdmAccounts, context),
             GenerateSqlInsertScriptSegmentFor(fakeData.CdmSystemusers, context)
-        );
-        File.WriteAllText(outputFilePath, insertScript);
+        };
+
+        File.WriteAllLines(outputFilePath, insertScripts);
     }
 
     private static string GenerateSqlInsertScriptSegmentFor<T>(List<T> fakeObjects, AcademiesDbContext context)
@@ -45,7 +47,7 @@ public static class SqlScriptGenerator
         var tableName = $"[{entityType.GetSchema()}].[{entityType.GetTableName()}]";
         var valuesStrings = fakeObjects.Select(obj => $"({GetEntityValues(obj, objProperties)})");
         var insertString =
-            $"INSERT INTO {tableName} ({GetEntityProperties(objProperties, entityType)}) VALUES {string.Join(',', valuesStrings)}";
+            $"INSERT INTO {tableName} ({GetEntityProperties(objProperties, entityType)}) VALUES {string.Join(',', valuesStrings)};";
         return insertString;
     }
 
@@ -79,9 +81,14 @@ public static class SqlScriptGenerator
             return TransformIntoSqlSafeString(value.ToString());
         }
 
-        if (propertyType == typeof(int) || propertyType == typeof(Guid) || propertyType == typeof(Guid?))
+        if (propertyType == typeof(int))
         {
             return value.ToString()!;
+        }
+
+        if (propertyType == typeof(Guid) || propertyType == typeof(Guid?))
+        {
+            return $"'{value}'";
         }
 
         throw new ApplicationException($"Can't get value as string for unknown type '{propertyType}'");

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/SqlScriptGenerator.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/SqlScriptGenerator.cs
@@ -31,7 +31,9 @@ public static class SqlScriptGenerator
             GenerateSqlInsertScriptSegmentFor(fakeData.GiasGroups, context),
             GenerateSqlInsertScriptSegmentFor(fakeData.MstrTrusts, context),
             GenerateSqlInsertScriptSegmentFor(fakeData.GiasGroupLinks, context),
-            GenerateSqlInsertScriptSegmentFor(fakeData.GiasEstablishments, context)
+            GenerateSqlInsertScriptSegmentFor(fakeData.GiasEstablishments, context),
+            GenerateSqlInsertScriptSegmentFor(fakeData.CdmAccounts, context),
+            GenerateSqlInsertScriptSegmentFor(fakeData.CdmSystemusers, context)
         );
         File.WriteAllText(outputFilePath, insertScript);
     }

--- a/tests/playwright/fake-data/trusts.json
+++ b/tests/playwright/fake-data/trusts.json
@@ -9,107 +9,17 @@
     "openedDate": "2018-04-03T00:00:00",
     "companiesHouseNumber": "08955858",
     "regionAndTerritory": "South West",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "George Muller",
-      "email": "George.Muller@education.gov.uk"
-    },
-    "sfsoLead": null
-  },
-  {
-    "uid": "1250",
-    "name": "ACCLIVITY MULTI-ACADEMY TRUST",
-    "groupId": "TR4543",
-    "ukprn": "10011710",
-    "type": "Multi-academy trust",
-    "address": "622 Stanton Estate, McGlynn Run, IS9 0EP",
-    "openedDate": "2017-05-04T00:00:00",
-    "companiesHouseNumber": "06247134",
-    "regionAndTerritory": "South West",
     "academies": [
       {
-        "urn": 12503504,
-        "dateAcademyJoinedTrust": "2020-12-17T00:00:00",
-        "establishmentName": "St. Marys Church of England School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1878",
-        "schoolCapacity": "2037",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12509834,
-        "dateAcademyJoinedTrust": "2020-03-13T00:00:00",
-        "establishmentName": "Peacehaven Community School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1799",
-        "schoolCapacity": "2410",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12502401,
-        "dateAcademyJoinedTrust": "2019-12-02T00:00:00",
-        "establishmentName": "Peacehaven Community School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1710",
-        "schoolCapacity": "2118",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12509991,
-        "dateAcademyJoinedTrust": "2021-11-03T00:00:00",
-        "establishmentName": "St. Marys Cofe School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1576",
-        "schoolCapacity": "1815",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12503201,
-        "dateAcademyJoinedTrust": "2018-06-04T00:00:00",
-        "establishmentName": "Northwood Church of England Secondary School",
+        "urn": 12335173,
+        "dateAcademyJoinedTrust": "2019-12-21T00:00:00",
+        "establishmentName": "St. Paul\u0027s Church of England School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2296",
-        "schoolCapacity": "1942",
+        "numberOfPupils": "2193",
+        "schoolCapacity": "1966",
         "percentageFreeSchoolMeals": "1",
         "ageRange": {
           "minimum": 11,
@@ -119,1837 +29,34 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12502398,
-        "dateAcademyJoinedTrust": "2021-05-06T00:00:00",
-        "establishmentName": "St. Joseph\u0027s CE School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "436",
-        "schoolCapacity": "956",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12507390,
-        "dateAcademyJoinedTrust": "2022-02-04T00:00:00",
-        "establishmentName": "Lampton Catholic Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "129",
-        "schoolCapacity": "145",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12508751,
-        "dateAcademyJoinedTrust": "2019-05-22T00:00:00",
-        "establishmentName": "Beacon Church of England Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2041",
-        "schoolCapacity": "1627",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Phyllis Kling",
-      "email": "Phyllis.Kling@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Misty Anderson",
-      "email": "Misty.Anderson@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1270",
-    "name": "ADEPT ACADEMY TRUST",
-    "groupId": "TR6662",
-    "ukprn": "10010270",
-    "type": "Multi-academy trust",
-    "address": "19302 Rene Plaza, Murazik Road, Hankhaven, CD7 6DF",
-    "openedDate": "2018-10-03T00:00:00",
-    "companiesHouseNumber": "05412650",
-    "regionAndTerritory": "North East",
-    "academies": [
-      {
-        "urn": 12702350,
-        "dateAcademyJoinedTrust": "2022-12-29T00:00:00",
-        "establishmentName": "Peacehaven Community Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2304",
-        "schoolCapacity": "1935",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12707902,
-        "dateAcademyJoinedTrust": "2021-03-13T00:00:00",
-        "establishmentName": "Halewood Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1163",
-        "schoolCapacity": "1655",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Tommy Lubowitz",
-      "email": "Tommy.Lubowitz@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Shelly Mayert",
-      "email": "Shelly.Mayert@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1277",
-    "name": "ADVANTAGE ACADEMY TRUST",
-    "groupId": "TR4373",
-    "ukprn": "10068234",
-    "type": "Multi-academy trust",
-    "address": "095 Predovic Locks, Scot Lights, Spinkafurt, BW62 1MX",
-    "openedDate": "2016-11-21T00:00:00",
-    "companiesHouseNumber": "03722006",
-    "regionAndTerritory": "Yorkshire and the Humber",
-    "academies": [
-      {
-        "urn": 12779750,
-        "dateAcademyJoinedTrust": "2023-08-13T00:00:00",
-        "establishmentName": "Beacon C of E School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "493",
-        "schoolCapacity": "824",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12771898,
-        "dateAcademyJoinedTrust": "2019-11-11T00:00:00",
-        "establishmentName": "Harris Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "756",
-        "schoolCapacity": "1383",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12771833,
-        "dateAcademyJoinedTrust": "2023-11-05T00:00:00",
-        "establishmentName": "St. Anne\u0027s R.C. Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2367",
-        "schoolCapacity": "2456",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12774963,
-        "dateAcademyJoinedTrust": "2023-05-12T00:00:00",
-        "establishmentName": "Malbank School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1572",
-        "schoolCapacity": "2517",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12772998,
-        "dateAcademyJoinedTrust": "2022-05-12T00:00:00",
-        "establishmentName": "Longhill Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "622",
-        "schoolCapacity": "1237",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12772582,
-        "dateAcademyJoinedTrust": "2023-09-12T00:00:00",
-        "establishmentName": "Mulberry C of E School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2845",
-        "schoolCapacity": "2525",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12772935,
-        "dateAcademyJoinedTrust": "2017-09-27T00:00:00",
-        "establishmentName": "Longhill Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "634",
-        "schoolCapacity": "675",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12775344,
-        "dateAcademyJoinedTrust": "2022-03-19T00:00:00",
-        "establishmentName": "Oasis Church of England Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1446",
-        "schoolCapacity": "1758",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Lamar Kulas",
-      "email": "Lamar.Kulas@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Amanda McGlynn",
-      "email": "Amanda.McGlynn@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1244",
-    "name": "ASCENDANCY ACADEMY TRUST",
-    "groupId": "TR4176",
-    "ukprn": "10017161",
-    "type": "Multi-academy trust",
-    "address": "6160 Florida Land, LP5 9SY",
-    "openedDate": "2016-11-21T00:00:00",
-    "companiesHouseNumber": "04811784",
-    "regionAndTerritory": "East Midlands",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Rudy McClure",
-      "email": "Rudy.McClure@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Shelly Mayert",
-      "email": "Shelly.Mayert@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1263",
-    "name": "BRIDGE EDUCATION TRUST",
-    "groupId": "TR854",
-    "ukprn": "10088817",
-    "type": "Multi-academy trust",
-    "address": "4908 Nikolas Meadow, North Burdette, UX82 7BG",
-    "openedDate": "2023-08-30T00:00:00",
-    "companiesHouseNumber": "05221120",
-    "regionAndTerritory": "Yorkshire and the Humber",
-    "academies": [
-      {
-        "urn": 12632102,
-        "dateAcademyJoinedTrust": "2023-10-19T00:00:00",
-        "establishmentName": "North Lincolnshire School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2534",
-        "schoolCapacity": "2770",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12638580,
-        "dateAcademyJoinedTrust": "2023-09-14T00:00:00",
-        "establishmentName": "Halewood R.C. Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "853",
-        "schoolCapacity": "905",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12635082,
-        "dateAcademyJoinedTrust": "2023-10-14T00:00:00",
-        "establishmentName": "Barr and Community CE School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2995",
-        "schoolCapacity": "2466",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12637267,
-        "dateAcademyJoinedTrust": "2023-10-28T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "311",
-        "schoolCapacity": "358",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "George Muller",
-      "email": "George.Muller@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Rachel Volkman",
-      "email": "Rachel.Volkman@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1311",
-    "name": "CANTERBURY CROSS EDUCATION TRUST",
-    "groupId": "TR1073",
-    "ukprn": "10062959",
-    "type": "Multi-academy trust",
-    "address": "872 Irwin Trail, Hintz Wells, Hollisbury, QY35 2XF",
-    "openedDate": "2017-03-24T00:00:00",
-    "companiesHouseNumber": "05121558",
-    "regionAndTerritory": "North West",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Silvia Berge",
-      "email": "Silvia.Berge@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Jennie Greenholt",
-      "email": "Jennie.Greenholt@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1282",
-    "name": "CHALLENGER MULTI-ACADEMY TRUST",
-    "groupId": "TR6071",
-    "ukprn": "10025552",
-    "type": "Multi-academy trust",
-    "address": "52699 Bechtelar Station, Port Darrylbury, OX0 3LI",
-    "openedDate": "2017-09-26T00:00:00",
-    "companiesHouseNumber": "04336231",
-    "regionAndTerritory": "East of England",
-    "academies": [
-      {
-        "urn": 12823741,
-        "dateAcademyJoinedTrust": "2022-01-24T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Cofe Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "895",
-        "schoolCapacity": "1165",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12821547,
-        "dateAcademyJoinedTrust": "2022-05-01T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 Church of England School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1760",
-        "schoolCapacity": "2533",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12829379,
-        "dateAcademyJoinedTrust": "2019-05-27T00:00:00",
-        "establishmentName": "Greensward School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "516",
-        "schoolCapacity": "618",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12821383,
-        "dateAcademyJoinedTrust": "2018-11-04T00:00:00",
-        "establishmentName": "St. Peter\u0027s C of E Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "406",
-        "schoolCapacity": "496",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Annette Breitenberg",
-      "email": "Annette.Breitenberg@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Ginger Dietrich",
-      "email": "Ginger.Dietrich@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1254",
-    "name": "CHAMPION ACADEMY TRUST",
-    "groupId": "TR8234",
-    "ukprn": "10032817",
-    "type": "Multi-academy trust",
-    "address": "1552 McKenzie Grove, UT27 5XE",
-    "openedDate": "2014-05-19T00:00:00",
-    "companiesHouseNumber": "06951312",
-    "regionAndTerritory": "Yorkshire and the Humber",
-    "academies": [
-      {
-        "urn": 12546832,
-        "dateAcademyJoinedTrust": "2021-11-04T00:00:00",
-        "establishmentName": "Co-op Church of England School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "397",
-        "schoolCapacity": "375",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12545889,
-        "dateAcademyJoinedTrust": "2018-04-03T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1615",
-        "schoolCapacity": "1783",
-        "percentageFreeSchoolMeals": "26",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12547645,
-        "dateAcademyJoinedTrust": "2015-07-03T00:00:00",
-        "establishmentName": "Meridian C of E School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "816",
-        "schoolCapacity": "1034",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12541197,
-        "dateAcademyJoinedTrust": "2016-09-04T00:00:00",
-        "establishmentName": "St. John\u0027s Church of England School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "322",
-        "schoolCapacity": "698",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12541688,
-        "dateAcademyJoinedTrust": "2018-05-05T00:00:00",
-        "establishmentName": "Glyn C of E Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1481",
-        "schoolCapacity": "2317",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12542198,
-        "dateAcademyJoinedTrust": "2023-09-25T00:00:00",
-        "establishmentName": "St. Paul\u0027s R.C. School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2088",
-        "schoolCapacity": "2376",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Josh D\u0027Amore",
-      "email": "Josh.D\u0027Amore@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Jennie Greenholt",
-      "email": "Jennie.Greenholt@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1260",
-    "name": "CORNERSTONE MULTI-ACADEMY TRUST",
-    "groupId": "TR5972",
-    "ukprn": "10026310",
-    "type": "Multi-academy trust",
-    "address": "28924 Kulas Point, Easton Rapids, VonRuedenburgh, PI28 7LP",
-    "openedDate": "2018-12-15T00:00:00",
-    "companiesHouseNumber": "06661660",
-    "regionAndTerritory": "North East",
-    "academies": [
-      {
-        "urn": 12608953,
-        "dateAcademyJoinedTrust": "2022-06-09T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2017",
-        "schoolCapacity": "2053",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12605073,
-        "dateAcademyJoinedTrust": "2023-05-14T00:00:00",
-        "establishmentName": "St. Anne\u0027s CE School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1108",
-        "schoolCapacity": "1375",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12607038,
-        "dateAcademyJoinedTrust": "2019-10-15T00:00:00",
-        "establishmentName": "Peacehaven Community Church of England School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2308",
-        "schoolCapacity": "2531",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12608878,
-        "dateAcademyJoinedTrust": "2019-08-29T00:00:00",
-        "establishmentName": "Peacehaven Community Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "168",
-        "schoolCapacity": "136",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Roberto Grimes",
-      "email": "Roberto.Grimes@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Sharon Roob",
-      "email": "Sharon.Roob@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1264",
-    "name": "CRESCENDO ACADEMY TRUST",
-    "groupId": "TR7914",
-    "ukprn": "10002659",
-    "type": "Multi-academy trust",
-    "address": "47756 Hilton Radial, Blanda Ranch, Robertstad, WQ80 0PU",
-    "openedDate": "2016-02-22T00:00:00",
-    "companiesHouseNumber": "04051749",
-    "regionAndTerritory": "South East",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Byron Quigley",
-      "email": "Byron.Quigley@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Jaime Russel",
-      "email": "Jaime.Russel@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1243",
-    "name": "ECHELON EDUCATION TRUST",
-    "groupId": "TR4708",
-    "ukprn": "10076316",
-    "type": "Multi-academy trust",
-    "address": "2502 Bertha Manor, PP95 9CS",
-    "openedDate": "2017-07-11T00:00:00",
-    "companiesHouseNumber": "08431337",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 12436745,
-        "dateAcademyJoinedTrust": "2018-10-19T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s C of E School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1098",
-        "schoolCapacity": "2118",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12436550,
-        "dateAcademyJoinedTrust": "2020-08-17T00:00:00",
-        "establishmentName": "St. James\u0027 Catholic Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "961",
-        "schoolCapacity": "1540",
-        "percentageFreeSchoolMeals": "17",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12437949,
-        "dateAcademyJoinedTrust": "2022-08-25T00:00:00",
-        "establishmentName": "Glyn C of E School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1427",
-        "schoolCapacity": "2812",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12439572,
-        "dateAcademyJoinedTrust": "2022-01-10T00:00:00",
-        "establishmentName": "Lampton School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1140",
-        "schoolCapacity": "2161",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12433037,
-        "dateAcademyJoinedTrust": "2021-10-07T00:00:00",
-        "establishmentName": "Malbank R.C. Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2639",
-        "schoolCapacity": "2871",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12433005,
-        "dateAcademyJoinedTrust": "2018-07-09T00:00:00",
-        "establishmentName": "Meridian School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "137",
-        "schoolCapacity": "300",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12435529,
-        "dateAcademyJoinedTrust": "2018-09-02T00:00:00",
-        "establishmentName": "Glyn Catholic Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "711",
-        "schoolCapacity": "1688",
-        "percentageFreeSchoolMeals": "12",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Rudy McClure",
-      "email": "Rudy.McClure@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Natasha Borer",
-      "email": "Natasha.Borer@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1234",
-    "name": "EDIFY MULTI-ACADEMY TRUST",
-    "groupId": "TR1598",
-    "ukprn": "10083390",
-    "type": "Multi-academy trust",
-    "address": "87158 Luciano Plaza, QU09 4CD",
-    "openedDate": "2022-05-11T00:00:00",
-    "companiesHouseNumber": "01136548",
-    "regionAndTerritory": "Yorkshire and the Humber",
-    "academies": [
-      {
-        "urn": 12342361,
-        "dateAcademyJoinedTrust": "2022-05-24T00:00:00",
-        "establishmentName": "Northwood Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "177",
-        "schoolCapacity": "399",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12346989,
-        "dateAcademyJoinedTrust": "2023-04-19T00:00:00",
-        "establishmentName": "Momentum Community Cofe Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1549",
-        "schoolCapacity": "2484",
-        "percentageFreeSchoolMeals": "12",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12343284,
-        "dateAcademyJoinedTrust": "2022-12-24T00:00:00",
-        "establishmentName": "St. John\u0027s CE Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2146",
-        "schoolCapacity": "1876",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12349659,
-        "dateAcademyJoinedTrust": "2022-12-19T00:00:00",
-        "establishmentName": "St. James\u0027 Catholic Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "186",
-        "schoolCapacity": "186",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12342621,
-        "dateAcademyJoinedTrust": "2023-07-03T00:00:00",
-        "establishmentName": "Peacehaven Community Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2498",
-        "schoolCapacity": "1932",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Patty Streich",
-      "email": "Patty.Streich@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Oscar Goldner",
-      "email": "Oscar.Goldner@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1240",
-    "name": "ELEVATE SCHOOLS TRUST",
-    "groupId": "TR5254",
-    "ukprn": "10034194",
-    "type": "Multi-academy trust",
-    "address": "239 Russel Fall, IR7 1FH",
-    "openedDate": "2019-06-12T00:00:00",
-    "companiesHouseNumber": "08133437",
-    "regionAndTerritory": "North West",
-    "academies": [
-      {
-        "urn": 12401676,
-        "dateAcademyJoinedTrust": "2023-08-11T00:00:00",
-        "establishmentName": "Glyn Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "744",
-        "schoolCapacity": "1022",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12406128,
-        "dateAcademyJoinedTrust": "2020-01-06T00:00:00",
-        "establishmentName": "Harris Cofe Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1950",
-        "schoolCapacity": "2659",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Colin Kiehn",
-      "email": "Colin.Kiehn@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Amanda McGlynn",
-      "email": "Amanda.McGlynn@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1253",
-    "name": "ELEVATED SCHOOLS TRUST",
-    "groupId": "TR2708",
-    "ukprn": "10000252",
-    "type": "Multi-academy trust",
-    "address": "610 Karen Spring, Shad Manor, NG3 2JQ",
-    "openedDate": "2022-01-19T00:00:00",
-    "companiesHouseNumber": "05406689",
-    "regionAndTerritory": "North East",
-    "academies": [
-      {
-        "urn": 12531306,
-        "dateAcademyJoinedTrust": "2023-10-02T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Catholic Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1305",
-        "schoolCapacity": "1737",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12536728,
-        "dateAcademyJoinedTrust": "2022-03-20T00:00:00",
-        "establishmentName": "Harris School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1744",
-        "schoolCapacity": "1551",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12531395,
-        "dateAcademyJoinedTrust": "2023-07-15T00:00:00",
-        "establishmentName": "Malbank Cofe Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "710",
-        "schoolCapacity": "898",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12534448,
-        "dateAcademyJoinedTrust": "2023-01-24T00:00:00",
-        "establishmentName": "Glyn C of E School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1185",
-        "schoolCapacity": "1898",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12531669,
-        "dateAcademyJoinedTrust": "2022-03-06T00:00:00",
-        "establishmentName": "St. James\u0027 CE Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1665",
-        "schoolCapacity": "2858",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12537327,
-        "dateAcademyJoinedTrust": "2023-02-02T00:00:00",
-        "establishmentName": "Longhill Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2015",
-        "schoolCapacity": "2578",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12534388,
-        "dateAcademyJoinedTrust": "2022-08-02T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2181",
-        "schoolCapacity": "2396",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12537120,
-        "dateAcademyJoinedTrust": "2022-04-18T00:00:00",
-        "establishmentName": "St. James\u0027 R.C. Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2707",
-        "schoolCapacity": "2671",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Byron Quigley",
-      "email": "Byron.Quigley@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Sharon Roob",
-      "email": "Sharon.Roob@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1280",
-    "name": "EMPOWER ACADEMY TRUST",
-    "groupId": "TR8397",
-    "ukprn": "10057999",
-    "type": "Multi-academy trust",
-    "address": "323 Francis Route, Schimmelside, IQ01 8SI",
-    "openedDate": "2019-06-30T00:00:00",
-    "companiesHouseNumber": "07530518",
-    "regionAndTerritory": "",
-    "academies": [
-      {
-        "urn": 12806203,
-        "dateAcademyJoinedTrust": "2021-08-09T00:00:00",
-        "establishmentName": "Queensbridge Church of England Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1744",
-        "schoolCapacity": "1754",
-        "percentageFreeSchoolMeals": "19",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12802984,
-        "dateAcademyJoinedTrust": "2023-05-27T00:00:00",
-        "establishmentName": "Horizon Cofe School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2201",
-        "schoolCapacity": "2070",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12803096,
-        "dateAcademyJoinedTrust": "2021-01-01T00:00:00",
-        "establishmentName": "Northwood CE Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1103",
-        "schoolCapacity": "2722",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12802742,
-        "dateAcademyJoinedTrust": "2019-09-18T00:00:00",
-        "establishmentName": "St. Anne\u0027s Catholic School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3366",
-        "schoolCapacity": "2708",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12809754,
-        "dateAcademyJoinedTrust": "2023-04-09T00:00:00",
-        "establishmentName": "St. Catherine\u0027s CE Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1829",
-        "schoolCapacity": "2671",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12806650,
-        "dateAcademyJoinedTrust": "2019-11-22T00:00:00",
-        "establishmentName": "St. James\u0027 C of E Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3114",
-        "schoolCapacity": "2917",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12809814,
-        "dateAcademyJoinedTrust": "2020-12-29T00:00:00",
-        "establishmentName": "George Abbey R.C. Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "785",
-        "schoolCapacity": "1571",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12804492,
-        "dateAcademyJoinedTrust": "2021-02-06T00:00:00",
-        "establishmentName": "Queensbridge Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1870",
-        "schoolCapacity": "1508",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12802963,
-        "dateAcademyJoinedTrust": "2022-12-13T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "100",
-        "schoolCapacity": "204",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12806345,
-        "dateAcademyJoinedTrust": "2022-02-27T00:00:00",
-        "establishmentName": "Northwood Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1588",
-        "schoolCapacity": "1364",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12804451,
-        "dateAcademyJoinedTrust": "2020-12-04T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Church of England Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1693",
-        "schoolCapacity": "2336",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": {
-      "fullName": "Sharon Roob",
-      "email": "Sharon.Roob@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1242",
-    "name": "EMPOWERMENT MULTI-ACADEMY TRUST",
-    "groupId": "TR8648",
-    "ukprn": "10029135",
-    "type": "Multi-academy trust",
-    "address": "9590 Aufderhar Locks, GH16 5OX",
-    "openedDate": "2016-04-18T00:00:00",
-    "companiesHouseNumber": "07906189",
-    "regionAndTerritory": "West Midlands",
-    "academies": [
-      {
-        "urn": 12423408,
-        "dateAcademyJoinedTrust": "2019-09-04T00:00:00",
-        "establishmentName": "St. Joseph\u0027s R.C. Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2065",
-        "schoolCapacity": "1612",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12427049,
-        "dateAcademyJoinedTrust": "2020-05-08T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 R.C. School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "643",
-        "schoolCapacity": "497",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12424810,
-        "dateAcademyJoinedTrust": "2019-03-14T00:00:00",
-        "establishmentName": "St. Catherine\u0027s C of E School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "333",
-        "schoolCapacity": "511",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12421832,
-        "dateAcademyJoinedTrust": "2019-06-02T00:00:00",
-        "establishmentName": "Northwood Catholic School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2022",
-        "schoolCapacity": "2052",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12427264,
-        "dateAcademyJoinedTrust": "2020-10-08T00:00:00",
-        "establishmentName": "Meridian Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1358",
-        "schoolCapacity": "1548",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12427769,
-        "dateAcademyJoinedTrust": "2019-07-24T00:00:00",
-        "establishmentName": "St. Peter\u0027s CE Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1170",
-        "schoolCapacity": "1064",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12425659,
-        "dateAcademyJoinedTrust": "2019-08-20T00:00:00",
-        "establishmentName": "Limehurst C of E Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2274",
-        "schoolCapacity": "2161",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12429596,
-        "dateAcademyJoinedTrust": "2017-04-30T00:00:00",
-        "establishmentName": "Northwood Cofe Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "375",
-        "schoolCapacity": "348",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12422844,
-        "dateAcademyJoinedTrust": "2020-07-15T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Cofe Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "177",
-        "schoolCapacity": "417",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": {
-      "fullName": "Cecilia Crona",
-      "email": "Cecilia.Crona@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1247",
-    "name": "EPIC LEARNING TRUST",
-    "groupId": "TR719",
-    "ukprn": "10076124",
-    "type": "Multi-academy trust",
-    "address": "1271 Nasir Forges, East Mossieview, KZ52 6JH",
-    "openedDate": "2018-08-15T00:00:00",
-    "companiesHouseNumber": "03707429",
-    "regionAndTerritory": "North East",
-    "academies": [
-      {
-        "urn": 12479640,
-        "dateAcademyJoinedTrust": "2022-08-12T00:00:00",
-        "establishmentName": "Harris Cofe Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "648",
-        "schoolCapacity": "1197",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Jessica Legros",
-      "email": "Jessica.Legros@education.gov.uk"
-    },
-    "sfsoLead": null
-  },
-  {
-    "uid": "1268",
-    "name": "EXCEL MULTI-ACADEMY TRUST",
-    "groupId": "TR260",
-    "ukprn": "10090580",
-    "type": "Multi-academy trust",
-    "address": "378 Joey Gateway, Croninburgh, DQ1 1ME",
-    "openedDate": "2017-02-25T00:00:00",
-    "companiesHouseNumber": "09209642",
-    "regionAndTerritory": "",
-    "academies": [
-      {
-        "urn": 12686614,
-        "dateAcademyJoinedTrust": "2019-08-27T00:00:00",
-        "establishmentName": "Malbank School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1441",
-        "schoolCapacity": "1955",
-        "percentageFreeSchoolMeals": "26",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12682649,
-        "dateAcademyJoinedTrust": "2018-12-04T00:00:00",
+        "urn": 12334622,
+        "dateAcademyJoinedTrust": "2023-03-27T00:00:00",
         "establishmentName": "Limehurst School",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Sheffield",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2154",
-        "schoolCapacity": "1782",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12686785,
-        "dateAcademyJoinedTrust": "2023-03-31T00:00:00",
-        "establishmentName": "Lampton School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3458",
-        "schoolCapacity": "2813",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12684219,
-        "dateAcademyJoinedTrust": "2018-12-15T00:00:00",
-        "establishmentName": "Mulberry Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1054",
-        "schoolCapacity": "2050",
-        "percentageFreeSchoolMeals": "26",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12688111,
-        "dateAcademyJoinedTrust": "2021-12-07T00:00:00",
-        "establishmentName": "George Abbey R.C. Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1441",
-        "schoolCapacity": "1978",
-        "percentageFreeSchoolMeals": "13",
+        "numberOfPupils": "645",
+        "schoolCapacity": "538",
+        "percentageFreeSchoolMeals": "4",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Tommy Lubowitz",
-      "email": "Tommy.Lubowitz@education.gov.uk"
-    },
-    "sfsoLead": null
-  },
-  {
-    "uid": "1271",
-    "name": "EXCELLENCE MULTI-ACADEMY TRUST",
-    "groupId": "TR2484",
-    "ukprn": "10046935",
-    "type": "Multi-academy trust",
-    "address": "2821 Leatha Terrace, Wittingmouth, MS8 5UX",
-    "openedDate": "2015-11-28T00:00:00",
-    "companiesHouseNumber": "04090584",
-    "regionAndTerritory": "West Midlands",
-    "academies": [
-      {
-        "urn": 12713784,
-        "dateAcademyJoinedTrust": "2021-12-16T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Catholic Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "217",
-        "schoolCapacity": "433",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
       },
       {
-        "urn": 12719892,
-        "dateAcademyJoinedTrust": "2017-01-05T00:00:00",
-        "establishmentName": "St. James\u0027s C of E Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
+        "urn": 12336069,
+        "dateAcademyJoinedTrust": "2022-11-02T00:00:00",
+        "establishmentName": "Malbank CE School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1673",
-        "schoolCapacity": "1362",
-        "percentageFreeSchoolMeals": "25",
+        "numberOfPupils": "2438",
+        "schoolCapacity": "2030",
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -1958,74 +65,70 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12714386,
-        "dateAcademyJoinedTrust": "2021-12-06T00:00:00",
-        "establishmentName": "St. James\u0027 CE Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
+        "urn": 12332652,
+        "dateAcademyJoinedTrust": "2022-04-28T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s CE School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "778",
-        "schoolCapacity": "675",
-        "percentageFreeSchoolMeals": "3",
+        "numberOfPupils": "815",
+        "schoolCapacity": "836",
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
-          "minimum": 5,
+          "minimum": 4,
           "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12714325,
-        "dateAcademyJoinedTrust": "2017-01-07T00:00:00",
-        "establishmentName": "St. Paul\u0027s Cofe Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
+        "urn": 12336278,
+        "dateAcademyJoinedTrust": "2020-03-18T00:00:00",
+        "establishmentName": "George Abbey C of E Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1934",
-        "schoolCapacity": "2166",
-        "percentageFreeSchoolMeals": "28",
+        "numberOfPupils": "2027",
+        "schoolCapacity": "2354",
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
-          "minimum": 5,
+          "minimum": 4,
           "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Silvia Berge",
-      "email": "Silvia.Berge@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Jennie Greenholt",
-      "email": "Jennie.Greenholt@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1275",
-    "name": "FORWARD MULTI-ACADEMY TRUST",
-    "groupId": "TR8943",
-    "ukprn": "10006202",
-    "type": "Multi-academy trust",
-    "address": "0353 Herminio Mews, SP5 4GH",
-    "openedDate": "2019-06-29T00:00:00",
-    "companiesHouseNumber": "02879856",
-    "regionAndTerritory": "London",
-    "academies": [
+      },
       {
-        "urn": 12754649,
-        "dateAcademyJoinedTrust": "2023-10-01T00:00:00",
-        "establishmentName": "Rotherham Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
+        "urn": 12334629,
+        "dateAcademyJoinedTrust": "2021-02-16T00:00:00",
+        "establishmentName": "Greensward R.C. Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "885",
+        "schoolCapacity": "997",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12338114,
+        "dateAcademyJoinedTrust": "2022-06-02T00:00:00",
+        "establishmentName": "Peacehaven Community Church of England Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1182",
-        "schoolCapacity": "1326",
-        "percentageFreeSchoolMeals": "18",
+        "numberOfPupils": "1393",
+        "schoolCapacity": "1279",
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -2034,55 +137,15 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12758371,
-        "dateAcademyJoinedTrust": "2021-11-20T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Catholic School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "urn": 12339801,
+        "dateAcademyJoinedTrust": "2021-06-30T00:00:00",
+        "establishmentName": "Harris Church of England Academy",
+        "typeOfEstablishment": "Free school",
         "localAuthority": "Rotherham",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "724",
-        "schoolCapacity": "1011",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Lamar Ritchie",
-      "email": "Lamar.Ritchie@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Ginger Dietrich",
-      "email": "Ginger.Dietrich@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1279",
-    "name": "FUSION EDUCATION TRUST",
-    "groupId": "TR4112",
-    "ukprn": "10004281",
-    "type": "Multi-academy trust",
-    "address": "376 King Courts, Gladyceland, KG03 2EZ",
-    "openedDate": "2020-01-05T00:00:00",
-    "companiesHouseNumber": "05267664",
-    "regionAndTerritory": "",
-    "academies": [
-      {
-        "urn": 12796068,
-        "dateAcademyJoinedTrust": "2022-12-29T00:00:00",
-        "establishmentName": "St. John\u0027s Church of England Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "390",
-        "schoolCapacity": "310",
+        "numberOfPupils": "590",
+        "schoolCapacity": "903",
         "percentageFreeSchoolMeals": "2",
         "ageRange": {
           "minimum": 11,
@@ -2092,850 +155,18 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12797620,
-        "dateAcademyJoinedTrust": "2023-10-13T00:00:00",
-        "establishmentName": "St. Anne\u0027s R.C. Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "379",
-        "schoolCapacity": "329",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12797588,
-        "dateAcademyJoinedTrust": "2021-04-10T00:00:00",
-        "establishmentName": "Northwood Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "846",
-        "schoolCapacity": "1144",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12795219,
-        "dateAcademyJoinedTrust": "2022-12-23T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1412",
-        "schoolCapacity": "2918",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Lamar Kulas",
-      "email": "Lamar.Kulas@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Walter Boyle",
-      "email": "Walter.Boyle@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1259",
-    "name": "GALVANIZE ACADEMY TRUST",
-    "groupId": "TR3915",
-    "ukprn": "10000846",
-    "type": "Multi-academy trust",
-    "address": "83509 Wolf Club, Lake Tillman, TI14 5DU",
-    "openedDate": "2021-02-02T00:00:00",
-    "companiesHouseNumber": "05526712",
-    "regionAndTerritory": "South East",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Rudy McClure",
-      "email": "Rudy.McClure@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Oscar Goldner",
-      "email": "Oscar.Goldner@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1239",
-    "name": "HORIZON MULTI-ACADEMY TRUST",
-    "groupId": "TR6707",
-    "ukprn": "10016426",
-    "type": "Multi-academy trust",
-    "address": "230 Schumm Plains, Clarafort, YS12 6IL",
-    "openedDate": "2019-02-25T00:00:00",
-    "companiesHouseNumber": "08134153",
-    "regionAndTerritory": "South East",
-    "academies": [
-      {
-        "urn": 12396702,
-        "dateAcademyJoinedTrust": "2019-03-24T00:00:00",
-        "establishmentName": "Horizon R.C. School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "818",
-        "schoolCapacity": "1598",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12398955,
-        "dateAcademyJoinedTrust": "2022-06-29T00:00:00",
-        "establishmentName": "St. Marys Catholic Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1605",
-        "schoolCapacity": "1677",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12397375,
-        "dateAcademyJoinedTrust": "2020-11-08T00:00:00",
-        "establishmentName": "St. Peter\u0027s Catholic Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "274",
-        "schoolCapacity": "354",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12395118,
-        "dateAcademyJoinedTrust": "2020-11-20T00:00:00",
-        "establishmentName": "Lampton R.C. Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "324",
-        "schoolCapacity": "430",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12397845,
-        "dateAcademyJoinedTrust": "2023-01-20T00:00:00",
-        "establishmentName": "St. Joseph\u0027s C of E Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "841",
-        "schoolCapacity": "1419",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12394872,
-        "dateAcademyJoinedTrust": "2019-06-27T00:00:00",
-        "establishmentName": "St. Paul\u0027s R.C. Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3422",
-        "schoolCapacity": "2693",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12397155,
-        "dateAcademyJoinedTrust": "2020-03-07T00:00:00",
-        "establishmentName": "St. James\u0027 R.C. School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "406",
-        "schoolCapacity": "646",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12395062,
-        "dateAcademyJoinedTrust": "2019-04-08T00:00:00",
-        "establishmentName": "Oasis Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1261",
-        "schoolCapacity": "1541",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12399779,
-        "dateAcademyJoinedTrust": "2019-07-02T00:00:00",
-        "establishmentName": "Queensbridge Church of England School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1682",
-        "schoolCapacity": "1321",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": {
-      "fullName": "Bertha Stanton",
-      "email": "Bertha.Stanton@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1266",
-    "name": "HORIZONS MULTI-ACADEMY TRUST",
-    "groupId": "TR4459",
-    "ukprn": "10085808",
-    "type": "Multi-academy trust",
-    "address": "2472 Hamill Fort, Breana Meadow, XI8 5MA",
-    "openedDate": "2020-03-04T00:00:00",
-    "companiesHouseNumber": "07712633",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 12661028,
-        "dateAcademyJoinedTrust": "2022-01-02T00:00:00",
-        "establishmentName": "Limehurst Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1266",
-        "schoolCapacity": "1168",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12665122,
-        "dateAcademyJoinedTrust": "2022-02-15T00:00:00",
-        "establishmentName": "St. Paul\u0027s C of E School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1210",
-        "schoolCapacity": "1276",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12668378,
-        "dateAcademyJoinedTrust": "2023-01-10T00:00:00",
-        "establishmentName": "Co-op CE Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2439",
-        "schoolCapacity": "2950",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12669641,
-        "dateAcademyJoinedTrust": "2023-05-19T00:00:00",
-        "establishmentName": "Mulberry Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "470",
-        "schoolCapacity": "1030",
-        "percentageFreeSchoolMeals": "12",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12664639,
-        "dateAcademyJoinedTrust": "2021-07-18T00:00:00",
-        "establishmentName": "St. Catherine\u0027s R.C. Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "800",
-        "schoolCapacity": "1823",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": {
-      "fullName": "Oscar Goldner",
-      "email": "Oscar.Goldner@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1281",
-    "name": "ILLUMINATE LEARNING TRUST",
-    "groupId": "TR1016",
-    "ukprn": "10084756",
-    "type": "Multi-academy trust",
-    "address": "433 Dare Garden, Fritsch Center, Alyciastad, FW43 9HQ",
-    "openedDate": "2017-12-12T00:00:00",
-    "companiesHouseNumber": "08425811",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 12814955,
-        "dateAcademyJoinedTrust": "2019-02-18T00:00:00",
-        "establishmentName": "St. Peter\u0027s CE School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1608",
-        "schoolCapacity": "2838",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12818595,
-        "dateAcademyJoinedTrust": "2020-05-08T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2868",
-        "schoolCapacity": "2382",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "George Muller",
-      "email": "George.Muller@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Jan Wunsch",
-      "email": "Jan.Wunsch@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1278",
-    "name": "ILLUMINATE MULTI-ACADEMY TRUST",
-    "groupId": "TR5332",
-    "ukprn": "10005853",
-    "type": "Multi-academy trust",
-    "address": "6122 Adelbert Views, Leanne Mills, Lempifort, SN4 7EO",
-    "openedDate": "2021-08-22T00:00:00",
-    "companiesHouseNumber": "09025306",
-    "regionAndTerritory": "East Midlands",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Phyllis Kling",
-      "email": "Phyllis.Kling@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Erick Kassulke",
-      "email": "Erick.Kassulke@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1235",
-    "name": "INNOVATE ACADEMY TRUST",
-    "groupId": "TR2511",
-    "ukprn": "10069274",
-    "type": "Multi-academy trust",
-    "address": "7084 Gladys Glen, East Earlene, SL75 2AS",
-    "openedDate": "2015-09-06T00:00:00",
-    "companiesHouseNumber": "05330947",
-    "regionAndTerritory": "South West",
-    "academies": [
-      {
-        "urn": 12358257,
-        "dateAcademyJoinedTrust": "2017-06-01T00:00:00",
-        "establishmentName": "Barr and Community Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2313",
-        "schoolCapacity": "2894",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12357143,
-        "dateAcademyJoinedTrust": "2020-11-03T00:00:00",
-        "establishmentName": "Momentum Community R.C. Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1186",
-        "schoolCapacity": "1152",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12356009,
-        "dateAcademyJoinedTrust": "2017-04-02T00:00:00",
-        "establishmentName": "St. Peter\u0027s Church of England Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "481",
-        "schoolCapacity": "575",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12354516,
-        "dateAcademyJoinedTrust": "2017-12-09T00:00:00",
-        "establishmentName": "St. James\u0027s R.C. Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "556",
-        "schoolCapacity": "770",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12357853,
-        "dateAcademyJoinedTrust": "2020-09-26T00:00:00",
-        "establishmentName": "Harris R.C. Academy",
+        "urn": 12339422,
+        "dateAcademyJoinedTrust": "2020-09-30T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Catholic School",
         "typeOfEstablishment": "Free school",
         "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "366",
-        "schoolCapacity": "390",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12359304,
-        "dateAcademyJoinedTrust": "2020-10-29T00:00:00",
-        "establishmentName": "Malbank CE School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban major conurbation",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1687",
-        "schoolCapacity": "1649",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12353965,
-        "dateAcademyJoinedTrust": "2016-08-08T00:00:00",
-        "establishmentName": "Harris Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1058",
-        "schoolCapacity": "950",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12354997,
-        "dateAcademyJoinedTrust": "2022-10-22T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Church of England Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Leeds",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "161",
-        "schoolCapacity": "267",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Lamar Kulas",
-      "email": "Lamar.Kulas@education.gov.uk"
-    },
-    "sfsoLead": null
-  },
-  {
-    "uid": "1261",
-    "name": "INSPIRE MULTI-ACADEMY TRUST",
-    "groupId": "TR912",
-    "ukprn": "10026018",
-    "type": "Multi-academy trust",
-    "address": "645 Feeney Mount, RQ97 5JF",
-    "openedDate": "2016-07-25T00:00:00",
-    "companiesHouseNumber": "07931015",
-    "regionAndTerritory": "North West",
-    "academies": [
-      {
-        "urn": 12616537,
-        "dateAcademyJoinedTrust": "2016-09-11T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Cofe School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1157",
-        "schoolCapacity": "1491",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12618197,
-        "dateAcademyJoinedTrust": "2017-04-26T00:00:00",
-        "establishmentName": "St. Anne\u0027s R.C. Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1121",
-        "schoolCapacity": "1102",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12616069,
-        "dateAcademyJoinedTrust": "2021-05-13T00:00:00",
-        "establishmentName": "Queensbridge CE Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "880",
-        "schoolCapacity": "862",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12619654,
-        "dateAcademyJoinedTrust": "2022-01-27T00:00:00",
-        "establishmentName": "Glyn Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1420",
-        "schoolCapacity": "2559",
+        "numberOfPupils": "3446",
+        "schoolCapacity": "2991",
         "percentageFreeSchoolMeals": "28",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12615298,
-        "dateAcademyJoinedTrust": "2018-12-08T00:00:00",
-        "establishmentName": "Peacehaven Community Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "160",
-        "schoolCapacity": "205",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
           "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12613472,
-        "dateAcademyJoinedTrust": "2022-08-20T00:00:00",
-        "establishmentName": "St. Paul\u0027s CE Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1623",
-        "schoolCapacity": "2123",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": {
-      "fullName": "Vickie Gulgowski",
-      "email": "Vickie.Gulgowski@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1255",
-    "name": "INTREPID EDUCATION TRUST",
-    "groupId": "TR7559",
-    "ukprn": "10021534",
-    "type": "Multi-academy trust",
-    "address": "05153 Bernhard Knoll, Bailey Prairie, Eladioland, XI31 4CX",
-    "openedDate": "2018-05-06T00:00:00",
-    "companiesHouseNumber": "04203414",
-    "regionAndTerritory": "South East",
-    "academies": [
-      {
-        "urn": 12559053,
-        "dateAcademyJoinedTrust": "2020-11-19T00:00:00",
-        "establishmentName": "Harris C of E Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "291",
-        "schoolCapacity": "383",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12557888,
-        "dateAcademyJoinedTrust": "2019-07-05T00:00:00",
-        "establishmentName": "St. Anne\u0027s Catholic School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1101",
-        "schoolCapacity": "2536",
-        "percentageFreeSchoolMeals": "19",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Ramona O\u0027Keefe",
-      "email": "Ramona.O\u0027Keefe@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Oscar Goldner",
-      "email": "Oscar.Goldner@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1249",
-    "name": "LEGACY EDUCATION TRUST",
-    "groupId": "TR6758",
-    "ukprn": "10005981",
-    "type": "Multi-academy trust",
-    "address": "9323 Gilda Harbor, Lake Arlene, VB5 9EC",
-    "openedDate": "2015-10-01T00:00:00",
-    "companiesHouseNumber": "02056762",
-    "regionAndTerritory": "West Midlands",
-    "academies": [
-      {
-        "urn": 12497841,
-        "dateAcademyJoinedTrust": "2022-02-19T00:00:00",
-        "establishmentName": "Lampton CE Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "679",
-        "schoolCapacity": "1397",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12499300,
-        "dateAcademyJoinedTrust": "2021-11-24T00:00:00",
-        "establishmentName": "Horizon School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1251",
-        "schoolCapacity": "2415",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 5,
           "maximum": 11
         },
         "currentOfstedRating": null,
@@ -2948,144 +179,50 @@
       "email": "Lynn.Rodriguez@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Suzanne Conroy",
-      "email": "Suzanne.Conroy@education.gov.uk"
+      "fullName": "Vickie Gulgowski",
+      "email": "Vickie.Gulgowski@education.gov.uk"
     }
   },
   {
-    "uid": "1246",
-    "name": "MERIT ACADEMY TRUST",
-    "groupId": "TR4895",
-    "ukprn": "10066911",
+    "uid": "1250",
+    "name": "ACCLIVITY MULTI-ACADEMY TRUST",
+    "groupId": "TR4030",
+    "ukprn": "10032206",
     "type": "Multi-academy trust",
-    "address": "2392 Carley Corner, Niko Ports, AY38 1ZH",
-    "openedDate": "2022-09-10T00:00:00",
-    "companiesHouseNumber": "01621172",
+    "address": "447 Annabell Green, AQ87 7MK",
+    "openedDate": "2017-06-01T00:00:00",
+    "companiesHouseNumber": "01178202",
     "regionAndTerritory": "London",
     "academies": [
       {
-        "urn": 12461366,
-        "dateAcademyJoinedTrust": "2023-10-14T00:00:00",
-        "establishmentName": "Harris Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "urn": 12503009,
+        "dateAcademyJoinedTrust": "2019-01-08T00:00:00",
+        "establishmentName": "St. Marys C of E Primary Academy",
+        "typeOfEstablishment": "Academy converter",
         "localAuthority": "Leeds",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1721",
-        "schoolCapacity": "2237",
-        "percentageFreeSchoolMeals": "30",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1425",
+        "schoolCapacity": "1503",
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12469700,
-        "dateAcademyJoinedTrust": "2023-06-16T00:00:00",
-        "establishmentName": "St. James\u0027s CE School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Leeds",
+        "urn": 12504510,
+        "dateAcademyJoinedTrust": "2018-11-21T00:00:00",
+        "establishmentName": "Limehurst School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1166",
-        "schoolCapacity": "2106",
-        "percentageFreeSchoolMeals": "26",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12463519,
-        "dateAcademyJoinedTrust": "2023-03-29T00:00:00",
-        "establishmentName": "St. Mary\u0027s Church of England Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Leeds",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "755",
-        "schoolCapacity": "1019",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12465924,
-        "dateAcademyJoinedTrust": "2023-08-11T00:00:00",
-        "establishmentName": "Longhill School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2265",
-        "schoolCapacity": "2613",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12465595,
-        "dateAcademyJoinedTrust": "2022-11-22T00:00:00",
-        "establishmentName": "Harris C of E Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Leeds",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "283",
-        "schoolCapacity": "557",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Lamar Kulas",
-      "email": "Lamar.Kulas@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Erick Kassulke",
-      "email": "Erick.Kassulke@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1258",
-    "name": "MILESTONE MULTI-ACADEMY TRUST",
-    "groupId": "TR5227",
-    "ukprn": "10021710",
-    "type": "Multi-academy trust",
-    "address": "12402 Emmalee Circle, New Kaiafort, XG34 4HJ",
-    "openedDate": "2016-10-06T00:00:00",
-    "companiesHouseNumber": "04773486",
-    "regionAndTerritory": "West Midlands",
-    "academies": [
-      {
-        "urn": 12584731,
-        "dateAcademyJoinedTrust": "2016-10-31T00:00:00",
-        "establishmentName": "Harris Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3308",
-        "schoolCapacity": "2939",
-        "percentageFreeSchoolMeals": "10",
+        "numberOfPupils": "2303",
+        "schoolCapacity": "2081",
+        "percentageFreeSchoolMeals": "4",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -3094,34 +231,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12586696,
-        "dateAcademyJoinedTrust": "2022-11-06T00:00:00",
-        "establishmentName": "Stehr Glen Cofe School",
+        "urn": 12508246,
+        "dateAcademyJoinedTrust": "2023-03-23T00:00:00",
+        "establishmentName": "St. Marys C of E Secondary School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1420",
-        "schoolCapacity": "2482",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12584344,
-        "dateAcademyJoinedTrust": "2018-12-30T00:00:00",
-        "establishmentName": "St. James\u0027s Church of England Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
+        "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "722",
-        "schoolCapacity": "705",
-        "percentageFreeSchoolMeals": "8",
+        "numberOfPupils": "3721",
+        "schoolCapacity": "2991",
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3130,108 +249,18 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12589199,
-        "dateAcademyJoinedTrust": "2021-04-13T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Catholic Primary Academy",
+        "urn": 12504901,
+        "dateAcademyJoinedTrust": "2020-09-20T00:00:00",
+        "establishmentName": "Horizon R.C. School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "764",
-        "schoolCapacity": "874",
-        "percentageFreeSchoolMeals": "29",
+        "numberOfPupils": "355",
+        "schoolCapacity": "512",
+        "percentageFreeSchoolMeals": "21",
         "ageRange": {
           "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12588383,
-        "dateAcademyJoinedTrust": "2020-04-06T00:00:00",
-        "establishmentName": "Barr and Community School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "416",
-        "schoolCapacity": "607",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12583766,
-        "dateAcademyJoinedTrust": "2017-10-20T00:00:00",
-        "establishmentName": "Beacon Church of England Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3115",
-        "schoolCapacity": "2496",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12589716,
-        "dateAcademyJoinedTrust": "2017-08-26T00:00:00",
-        "establishmentName": "Peacehaven Community School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "502",
-        "schoolCapacity": "1206",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12585048,
-        "dateAcademyJoinedTrust": "2020-05-15T00:00:00",
-        "establishmentName": "Meridian Catholic School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2041",
-        "schoolCapacity": "1761",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12586694,
-        "dateAcademyJoinedTrust": "2017-01-20T00:00:00",
-        "establishmentName": "Oasis Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "923",
-        "schoolCapacity": "748",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 4,
           "maximum": 11
         },
         "currentOfstedRating": null,
@@ -3244,144 +273,50 @@
       "email": "Annette.Breitenberg@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Natasha Borer",
-      "email": "Natasha.Borer@education.gov.uk"
+      "fullName": "Bertha Stanton",
+      "email": "Bertha.Stanton@education.gov.uk"
     }
   },
   {
-    "uid": "1236",
-    "name": "MOMENTUM MULTI-ACADEMY TRUST",
-    "groupId": "TR9338",
-    "ukprn": "10029242",
+    "uid": "1270",
+    "name": "ADEPT ACADEMY TRUST",
+    "groupId": "TR1067",
+    "ukprn": "10030052",
     "type": "Multi-academy trust",
-    "address": "28469 Nienow Mountains, Zieme Drive, Quigleyburgh, XO11 3GP",
-    "openedDate": "2019-01-28T00:00:00",
-    "companiesHouseNumber": "05180186",
-    "regionAndTerritory": "East Midlands",
+    "address": "090 Miller Stream, Feil Haven, East Bartholomeshire, RY0 9NW",
+    "openedDate": "2016-11-18T00:00:00",
+    "companiesHouseNumber": "05166675",
+    "regionAndTerritory": "West Midlands",
     "academies": [
       {
-        "urn": 12361768,
-        "dateAcademyJoinedTrust": "2022-02-11T00:00:00",
-        "establishmentName": "St. James\u0027s Catholic Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1314",
-        "schoolCapacity": "1598",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12369768,
-        "dateAcademyJoinedTrust": "2020-09-15T00:00:00",
-        "establishmentName": "St. James\u0027s C of E School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Calderdale",
+        "urn": 12702877,
+        "dateAcademyJoinedTrust": "2019-10-01T00:00:00",
+        "establishmentName": "Lampton C of E Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2506",
-        "schoolCapacity": "2728",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12365221,
-        "dateAcademyJoinedTrust": "2019-06-24T00:00:00",
-        "establishmentName": "Harris Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3143",
-        "schoolCapacity": "2468",
+        "numberOfPupils": "2899",
+        "schoolCapacity": "2274",
         "percentageFreeSchoolMeals": "1",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12362190,
-        "dateAcademyJoinedTrust": "2023-09-01T00:00:00",
-        "establishmentName": "Longhill Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1833",
-        "schoolCapacity": "2354",
-        "percentageFreeSchoolMeals": "17",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12361019,
-        "dateAcademyJoinedTrust": "2020-03-11T00:00:00",
-        "establishmentName": "St. Anne\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "324",
-        "schoolCapacity": "610",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
           "minimum": 4,
           "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Lyle Baumbach",
-      "email": "Lyle.Baumbach@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Misty Anderson",
-      "email": "Misty.Anderson@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1257",
-    "name": "NEW HORIZONS TRUST",
-    "groupId": "TR5213",
-    "ukprn": "10027611",
-    "type": "Multi-academy trust",
-    "address": "80927 Vern Orchard, Mckenna Common, Roobchester, NK0 4KU",
-    "openedDate": "2016-10-19T00:00:00",
-    "companiesHouseNumber": "03042382",
-    "regionAndTerritory": "",
-    "academies": [
+      },
       {
-        "urn": 12572735,
-        "dateAcademyJoinedTrust": "2022-12-27T00:00:00",
-        "establishmentName": "Peacehaven Community Primary Academy",
+        "urn": 12705325,
+        "dateAcademyJoinedTrust": "2017-03-07T00:00:00",
+        "establishmentName": "St. Anne\u0027s Cofe Primary Academy",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2065",
-        "schoolCapacity": "1878",
-        "percentageFreeSchoolMeals": "22",
+        "numberOfPupils": "95",
+        "schoolCapacity": "194",
+        "percentageFreeSchoolMeals": "12",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -3390,15 +325,365 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12571367,
-        "dateAcademyJoinedTrust": "2017-05-24T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Cofe School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kingston upon Hull, City of",
+        "urn": 12705775,
+        "dateAcademyJoinedTrust": "2022-10-14T00:00:00",
+        "establishmentName": "Co-op Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1218",
+        "schoolCapacity": "2521",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12703183,
+        "dateAcademyJoinedTrust": "2019-05-15T00:00:00",
+        "establishmentName": "Harris Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2368",
+        "schoolCapacity": "2974",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12707226,
+        "dateAcademyJoinedTrust": "2022-02-07T00:00:00",
+        "establishmentName": "St. James\u0027s CE Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1010",
-        "schoolCapacity": "881",
+        "numberOfPupils": "592",
+        "schoolCapacity": "987",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12707062,
+        "dateAcademyJoinedTrust": "2021-04-08T00:00:00",
+        "establishmentName": "St. Mary\u0027s R.C. Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1224",
+        "schoolCapacity": "2193",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12707869,
+        "dateAcademyJoinedTrust": "2020-10-24T00:00:00",
+        "establishmentName": "Lampton R.C. School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "587",
+        "schoolCapacity": "566",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12706894,
+        "dateAcademyJoinedTrust": "2020-01-01T00:00:00",
+        "establishmentName": "George Abbey School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1908",
+        "schoolCapacity": "2287",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12708280,
+        "dateAcademyJoinedTrust": "2017-08-28T00:00:00",
+        "establishmentName": "Ward Spurs C of E School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1829",
+        "schoolCapacity": "2314",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12707291,
+        "dateAcademyJoinedTrust": "2017-05-08T00:00:00",
+        "establishmentName": "Mulberry School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "331",
+        "schoolCapacity": "810",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12707313,
+        "dateAcademyJoinedTrust": "2018-01-01T00:00:00",
+        "establishmentName": "Malbank Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "512",
+        "schoolCapacity": "579",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "George Muller",
+      "email": "George.Muller@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Natasha Borer",
+      "email": "Natasha.Borer@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1277",
+    "name": "ADVANTAGE ACADEMY TRUST",
+    "groupId": "TR8700",
+    "ukprn": "10047996",
+    "type": "Multi-academy trust",
+    "address": "93581 Odie Mall, O\u0027Keefe Springs, LY37 2DT",
+    "openedDate": "2021-11-26T00:00:00",
+    "companiesHouseNumber": "09278932",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12776563,
+        "dateAcademyJoinedTrust": "2022-07-12T00:00:00",
+        "establishmentName": "Momentum Community Catholic Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1801",
+        "schoolCapacity": "1664",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Cindy Bergstrom",
+      "email": "Cindy.Bergstrom@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Erick Kassulke",
+      "email": "Erick.Kassulke@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1244",
+    "name": "ASCENDANCY ACADEMY TRUST",
+    "groupId": "TR7196",
+    "ukprn": "10057660",
+    "type": "Multi-academy trust",
+    "address": "197 Daija Gardens, LB84 4CS",
+    "openedDate": "2014-08-21T00:00:00",
+    "companiesHouseNumber": "08719824",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12444570,
+        "dateAcademyJoinedTrust": "2022-03-04T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "496",
+        "schoolCapacity": "1054",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12448528,
+        "dateAcademyJoinedTrust": "2017-06-26T00:00:00",
+        "establishmentName": "Glyn Catholic Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1351",
+        "schoolCapacity": "1677",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12441949,
+        "dateAcademyJoinedTrust": "2021-08-03T00:00:00",
+        "establishmentName": "Glyn Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1928",
+        "schoolCapacity": "1601",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12446798,
+        "dateAcademyJoinedTrust": "2018-01-25T00:00:00",
+        "establishmentName": "St. Mary\u0027s C of E School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "520",
+        "schoolCapacity": "710",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12443820,
+        "dateAcademyJoinedTrust": "2023-04-18T00:00:00",
+        "establishmentName": "St. Peter\u0027s Church of England Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "182",
+        "schoolCapacity": "145",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12441817,
+        "dateAcademyJoinedTrust": "2020-09-15T00:00:00",
+        "establishmentName": "Beacon Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "257",
+        "schoolCapacity": "198",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12443030,
+        "dateAcademyJoinedTrust": "2018-12-25T00:00:00",
+        "establishmentName": "St. James\u0027s Church of England School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1274",
+        "schoolCapacity": "2117",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12449903,
+        "dateAcademyJoinedTrust": "2021-11-29T00:00:00",
+        "establishmentName": "St. Marys Church of England School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "254",
+        "schoolCapacity": "552",
         "percentageFreeSchoolMeals": "12",
         "ageRange": {
           "minimum": 4,
@@ -3408,88 +693,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12578124,
-        "dateAcademyJoinedTrust": "2023-10-29T00:00:00",
-        "establishmentName": "Co-op Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "928",
-        "schoolCapacity": "2234",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12573187,
-        "dateAcademyJoinedTrust": "2019-11-05T00:00:00",
-        "establishmentName": "Harris Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1559",
-        "schoolCapacity": "2719",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12576305,
-        "dateAcademyJoinedTrust": "2022-08-02T00:00:00",
-        "establishmentName": "Co-op Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2827",
-        "schoolCapacity": "2455",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12578392,
-        "dateAcademyJoinedTrust": "2022-08-05T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Catholic Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1214",
-        "schoolCapacity": "1416",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12578512,
-        "dateAcademyJoinedTrust": "2018-03-27T00:00:00",
-        "establishmentName": "Deion Square Secondary School",
+        "urn": 12445146,
+        "dateAcademyJoinedTrust": "2016-03-24T00:00:00",
+        "establishmentName": "St. James\u0027 Catholic Secondary Academy",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "240",
-        "schoolCapacity": "304",
-        "percentageFreeSchoolMeals": "11",
+        "numberOfPupils": "1551",
+        "schoolCapacity": "2675",
+        "percentageFreeSchoolMeals": "4",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -3498,73 +711,19 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12572338,
-        "dateAcademyJoinedTrust": "2020-01-02T00:00:00",
-        "establishmentName": "Horizon Catholic Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
+        "urn": 12448020,
+        "dateAcademyJoinedTrust": "2015-04-20T00:00:00",
+        "establishmentName": "Malbank Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1152",
-        "schoolCapacity": "2334",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12571384,
-        "dateAcademyJoinedTrust": "2019-10-21T00:00:00",
-        "establishmentName": "Oasis Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2710",
-        "schoolCapacity": "2519",
+        "numberOfPupils": "339",
+        "schoolCapacity": "539",
         "percentageFreeSchoolMeals": "14",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12572261,
-        "dateAcademyJoinedTrust": "2018-01-18T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Catholic Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "510",
-        "schoolCapacity": "549",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
           "minimum": 4,
           "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12575773,
-        "dateAcademyJoinedTrust": "2019-03-13T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1499",
-        "schoolCapacity": "2927",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
@@ -3576,479 +735,160 @@
       "email": "Phyllis.Kling@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Amanda McGlynn",
-      "email": "Amanda.McGlynn@education.gov.uk"
+      "fullName": "Walter Boyle",
+      "email": "Walter.Boyle@education.gov.uk"
     }
   },
   {
-    "uid": "1245",
-    "name": "NEXUS MULTI-ACADEMY TRUST",
-    "groupId": "TR3760",
-    "ukprn": "10040753",
+    "uid": "1263",
+    "name": "BRIDGE EDUCATION TRUST",
+    "groupId": "TR1535",
+    "ukprn": "10035740",
     "type": "Multi-academy trust",
-    "address": "426 Bernard Turnpike, Abdiel Streets, SO8 1XS",
-    "openedDate": "2018-11-27T00:00:00",
-    "companiesHouseNumber": "03050926",
-    "regionAndTerritory": "East of England",
+    "address": "6294 Kuhn Bridge, UP6 0HV",
+    "openedDate": "2014-08-18T00:00:00",
+    "companiesHouseNumber": "02502627",
+    "regionAndTerritory": "North East",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lamar Kulas",
+      "email": "Lamar.Kulas@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Vickie Gulgowski",
+      "email": "Vickie.Gulgowski@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1311",
+    "name": "CANTERBURY CROSS EDUCATION TRUST",
+    "groupId": "TR6705",
+    "ukprn": "10027258",
+    "type": "Multi-academy trust",
+    "address": "0193 Mohr Knolls, Lake Oran, DR5 7LL",
+    "openedDate": "2013-12-18T00:00:00",
+    "companiesHouseNumber": "02500374",
+    "regionAndTerritory": "London",
     "academies": [
       {
-        "urn": 12458126,
-        "dateAcademyJoinedTrust": "2023-01-19T00:00:00",
-        "establishmentName": "St. Peter\u0027s CE Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1938",
-        "schoolCapacity": "2502",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12455595,
-        "dateAcademyJoinedTrust": "2020-12-31T00:00:00",
-        "establishmentName": "St. Anne\u0027s Church of England Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "575",
-        "schoolCapacity": "674",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12454482,
-        "dateAcademyJoinedTrust": "2023-08-26T00:00:00",
-        "establishmentName": "Northwood Primary Academy",
+        "urn": 13118566,
+        "dateAcademyJoinedTrust": "2016-03-12T00:00:00",
+        "establishmentName": "Mulberry Secondary School",
         "typeOfEstablishment": "Academy converter",
         "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "793",
-        "schoolCapacity": "1251",
-        "percentageFreeSchoolMeals": "27",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "357",
+        "schoolCapacity": "413",
+        "percentageFreeSchoolMeals": "3",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12458502,
-        "dateAcademyJoinedTrust": "2023-09-24T00:00:00",
-        "establishmentName": "Greensward Cofe Primary School",
+        "urn": 13111209,
+        "dateAcademyJoinedTrust": "2023-06-07T00:00:00",
+        "establishmentName": "Malbank Cofe Academy",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2642",
-        "schoolCapacity": "2526",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "935",
+        "schoolCapacity": "1507",
         "percentageFreeSchoolMeals": "9",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12455771,
-        "dateAcademyJoinedTrust": "2022-02-03T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Cofe Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "293",
-        "schoolCapacity": "406",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Annette Breitenberg",
-      "email": "Annette.Breitenberg@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Jennie Greenholt",
-      "email": "Jennie.Greenholt@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1273",
-    "name": "PATHFINDER MULTI-ACADEMY TRUST",
-    "groupId": "TR4046",
-    "ukprn": "10099740",
-    "type": "Multi-academy trust",
-    "address": "1823 Herzog Row, West Destineeville, BI4 8ZX",
-    "openedDate": "2018-10-29T00:00:00",
-    "companiesHouseNumber": "04622209",
-    "regionAndTerritory": "North East",
-    "academies": [
-      {
-        "urn": 12739764,
-        "dateAcademyJoinedTrust": "2023-03-28T00:00:00",
-        "establishmentName": "St. Mary\u0027s Cofe Academy",
+        "urn": 13117309,
+        "dateAcademyJoinedTrust": "2023-09-04T00:00:00",
+        "establishmentName": "St. Marys Church of England Academy",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
+        "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1525",
-        "schoolCapacity": "1630",
-        "percentageFreeSchoolMeals": "17",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "406",
+        "schoolCapacity": "629",
+        "percentageFreeSchoolMeals": "20",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12734541,
-        "dateAcademyJoinedTrust": "2019-06-07T00:00:00",
-        "establishmentName": "St. Peter\u0027s CE Primary School",
+        "urn": 13113882,
+        "dateAcademyJoinedTrust": "2014-04-08T00:00:00",
+        "establishmentName": "Limehurst CE School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "242",
-        "schoolCapacity": "280",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "632",
+        "schoolCapacity": "758",
         "percentageFreeSchoolMeals": "18",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12732755,
-        "dateAcademyJoinedTrust": "2019-04-23T00:00:00",
-        "establishmentName": "Beacon School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "urn": 13116180,
+        "dateAcademyJoinedTrust": "2021-04-30T00:00:00",
+        "establishmentName": "Schinner Points School",
+        "typeOfEstablishment": "Free school",
         "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1394",
-        "schoolCapacity": "2867",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Mae Bradtke",
-      "email": "Mae.Bradtke@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Roman Torp",
-      "email": "Roman.Torp@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1248",
-    "name": "PEAK MULTI-ACADEMY TRUST",
-    "groupId": "TR1061",
-    "ukprn": "10017192",
-    "type": "Multi-academy trust",
-    "address": "58450 Brant Spring, Lake Johnside, VX4 0BX",
-    "openedDate": "2014-02-08T00:00:00",
-    "companiesHouseNumber": "02690120",
-    "regionAndTerritory": "West Midlands",
-    "academies": [
-      {
-        "urn": 12481029,
-        "dateAcademyJoinedTrust": "2014-10-11T00:00:00",
-        "establishmentName": "Harris School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1945",
-        "schoolCapacity": "2737",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12485306,
-        "dateAcademyJoinedTrust": "2017-07-21T00:00:00",
-        "establishmentName": "Longhill Cofe Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "822",
-        "schoolCapacity": "860",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12484507,
-        "dateAcademyJoinedTrust": "2022-04-30T00:00:00",
-        "establishmentName": "North East Lincolnshire Church of England Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "451",
-        "schoolCapacity": "759",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Mae Bradtke",
-      "email": "Mae.Bradtke@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Rachel Volkman",
-      "email": "Rachel.Volkman@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1251",
-    "name": "PINNACLE EDUCATION TRUST",
-    "groupId": "TR7534",
-    "ukprn": "10004968",
-    "type": "Multi-academy trust",
-    "address": "07500 Lisa Knolls, TF9 0XB",
-    "openedDate": "2022-08-17T00:00:00",
-    "companiesHouseNumber": "03231362",
-    "regionAndTerritory": "East of England",
-    "academies": [
-      {
-        "urn": 12519095,
-        "dateAcademyJoinedTrust": "2023-05-30T00:00:00",
-        "establishmentName": "St. Peter\u0027s CE School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1715",
-        "schoolCapacity": "2582",
-        "percentageFreeSchoolMeals": "12",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12517681,
-        "dateAcademyJoinedTrust": "2023-05-25T00:00:00",
-        "establishmentName": "Mulberry Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "148",
-        "schoolCapacity": "129",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12518957,
-        "dateAcademyJoinedTrust": "2023-01-23T00:00:00",
-        "establishmentName": "St. James\u0027s Church of England Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "645",
-        "schoolCapacity": "702",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12519823,
-        "dateAcademyJoinedTrust": "2022-12-01T00:00:00",
-        "establishmentName": "Barr and Community Catholic Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "392",
-        "schoolCapacity": "800",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12516496,
-        "dateAcademyJoinedTrust": "2023-02-08T00:00:00",
-        "establishmentName": "St. Mary\u0027s R.C. School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1285",
-        "schoolCapacity": "2861",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12515674,
-        "dateAcademyJoinedTrust": "2022-11-28T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1526",
-        "schoolCapacity": "2873",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12514169,
-        "dateAcademyJoinedTrust": "2023-09-08T00:00:00",
-        "establishmentName": "Horizon Church of England School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1677",
-        "schoolCapacity": "2239",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12515911,
-        "dateAcademyJoinedTrust": "2023-06-18T00:00:00",
-        "establishmentName": "St. Peter\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1696",
-        "schoolCapacity": "1518",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12511340,
-        "dateAcademyJoinedTrust": "2023-11-04T00:00:00",
-        "establishmentName": "St. Catherine\u0027s R.C. Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "716",
-        "schoolCapacity": "1553",
+        "numberOfPupils": "3257",
+        "schoolCapacity": "2816",
         "percentageFreeSchoolMeals": "4",
         "ageRange": {
           "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13112375,
+        "dateAcademyJoinedTrust": "2021-11-28T00:00:00",
+        "establishmentName": "St. John\u0027s Church of England School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3003",
+        "schoolCapacity": "2384",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
           "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Roberto Grimes",
-      "email": "Roberto.Grimes@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Roman Torp",
-      "email": "Roman.Torp@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1265",
-    "name": "POTENTIAL LEARNING TRUST",
-    "groupId": "TR6698",
-    "ukprn": "10035005",
-    "type": "Multi-academy trust",
-    "address": "9390 Kuvalis Ford, Reece Corners, North Bethelhaven, DD94 1YU",
-    "openedDate": "2020-08-04T00:00:00",
-    "companiesHouseNumber": "07382092",
-    "regionAndTerritory": "Yorkshire and the Humber",
-    "academies": [
+      },
       {
-        "urn": 12654494,
-        "dateAcademyJoinedTrust": "2023-06-26T00:00:00",
-        "establishmentName": "Mulberry Cofe Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban major conurbation",
+        "urn": 13112770,
+        "dateAcademyJoinedTrust": "2016-09-13T00:00:00",
+        "establishmentName": "Malbank School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2316",
-        "schoolCapacity": "2341",
+        "numberOfPupils": "2070",
+        "schoolCapacity": "2711",
         "percentageFreeSchoolMeals": "12",
         "ageRange": {
           "minimum": 11,
@@ -4058,16 +898,70 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12656485,
-        "dateAcademyJoinedTrust": "2023-01-14T00:00:00",
-        "establishmentName": "Malbank Primary School",
+        "urn": 13111170,
+        "dateAcademyJoinedTrust": "2014-04-18T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "481",
+        "schoolCapacity": "607",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13115720,
+        "dateAcademyJoinedTrust": "2019-01-07T00:00:00",
+        "establishmentName": "George Abbey Catholic Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1432",
+        "schoolCapacity": "1386",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13118407,
+        "dateAcademyJoinedTrust": "2020-02-13T00:00:00",
+        "establishmentName": "Limehurst Secondary Academy",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Kirklees",
         "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2046",
+        "schoolCapacity": "2192",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13114357,
+        "dateAcademyJoinedTrust": "2016-05-07T00:00:00",
+        "establishmentName": "Mulberry Church of England Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "262",
-        "schoolCapacity": "228",
-        "percentageFreeSchoolMeals": "13",
+        "numberOfPupils": "2762",
+        "schoolCapacity": "2478",
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -4078,108 +972,36 @@
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "Ramona O\u0027Keefe",
-      "email": "Ramona.O\u0027Keefe@education.gov.uk"
+      "fullName": "Lynda Ziemann",
+      "email": "Lynda.Ziemann@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Ramon Wehner",
-      "email": "Ramon.Wehner@education.gov.uk"
+      "fullName": "Walter Boyle",
+      "email": "Walter.Boyle@education.gov.uk"
     }
   },
   {
-    "uid": "1238",
-    "name": "PROGRESSIVE EDUCATION TRUST",
-    "groupId": "TR1606",
-    "ukprn": "10067697",
+    "uid": "1282",
+    "name": "CHALLENGER MULTI-ACADEMY TRUST",
+    "groupId": "TR8235",
+    "ukprn": "10055855",
     "type": "Multi-academy trust",
-    "address": "992 Marvin Path, Bahringer Stravenue, South Beaulah, EF17 7KZ",
-    "openedDate": "2023-07-03T00:00:00",
-    "companiesHouseNumber": "06823179",
-    "regionAndTerritory": "South East",
+    "address": "8735 Tillman Mews, West Birdiefort, QX64 1LI",
+    "openedDate": "2017-05-22T00:00:00",
+    "companiesHouseNumber": "08332709",
+    "regionAndTerritory": "East Midlands",
     "academies": [
       {
-        "urn": 12389411,
-        "dateAcademyJoinedTrust": "2023-10-19T00:00:00",
-        "establishmentName": "Momentum Community School",
+        "urn": 12821184,
+        "dateAcademyJoinedTrust": "2021-05-25T00:00:00",
+        "establishmentName": "St. Joseph\u0027s R.C. Primary School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "691",
-        "schoolCapacity": "880",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12389223,
-        "dateAcademyJoinedTrust": "2023-08-30T00:00:00",
-        "establishmentName": "St. John\u0027s Cofe School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1503",
-        "schoolCapacity": "1187",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12382939,
-        "dateAcademyJoinedTrust": "2023-10-23T00:00:00",
-        "establishmentName": "St. Joseph\u0027s R.C. Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2338",
-        "schoolCapacity": "2234",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12381624,
-        "dateAcademyJoinedTrust": "2023-07-10T00:00:00",
-        "establishmentName": "Limehurst Church of England Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "352",
-        "schoolCapacity": "354",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12388773,
-        "dateAcademyJoinedTrust": "2023-08-29T00:00:00",
-        "establishmentName": "St. John\u0027s Church of England Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1517",
-        "schoolCapacity": "2332",
-        "percentageFreeSchoolMeals": "6",
+        "numberOfPupils": "1355",
+        "schoolCapacity": "2725",
+        "percentageFreeSchoolMeals": "21",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -4188,52 +1010,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12388017,
-        "dateAcademyJoinedTrust": "2023-09-20T00:00:00",
-        "establishmentName": "Beacon C of E Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1068",
-        "schoolCapacity": "1956",
-        "percentageFreeSchoolMeals": "17",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12382336,
-        "dateAcademyJoinedTrust": "2023-11-07T00:00:00",
-        "establishmentName": "St. Paul\u0027s R.C. Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "608",
-        "schoolCapacity": "908",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12386903,
-        "dateAcademyJoinedTrust": "2023-10-16T00:00:00",
-        "establishmentName": "St. Anne\u0027s C of E Academy",
+        "urn": 12822695,
+        "dateAcademyJoinedTrust": "2021-06-21T00:00:00",
+        "establishmentName": "St. Paul\u0027s Church of England Secondary School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Lincolnshire",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1188",
-        "schoolCapacity": "1660",
-        "percentageFreeSchoolMeals": "22",
+        "numberOfPupils": "605",
+        "schoolCapacity": "472",
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -4242,34 +1028,88 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12387398,
-        "dateAcademyJoinedTrust": "2023-08-14T00:00:00",
-        "establishmentName": "Mulberry R.C. School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
+        "urn": 12822179,
+        "dateAcademyJoinedTrust": "2023-04-19T00:00:00",
+        "establishmentName": "St. James\u0027 R.C. School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1716",
-        "schoolCapacity": "1712",
-        "percentageFreeSchoolMeals": "16",
+        "numberOfPupils": "1223",
+        "schoolCapacity": "1177",
+        "percentageFreeSchoolMeals": "21",
         "ageRange": {
           "minimum": 11,
-          "maximum": 16
+          "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12382823,
-        "dateAcademyJoinedTrust": "2023-09-14T00:00:00",
-        "establishmentName": "Wilton Parks Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
+        "urn": 12826868,
+        "dateAcademyJoinedTrust": "2022-06-17T00:00:00",
+        "establishmentName": "Barr and Community School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "333",
-        "schoolCapacity": "393",
-        "percentageFreeSchoolMeals": "24",
+        "numberOfPupils": "669",
+        "schoolCapacity": "1551",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12826429,
+        "dateAcademyJoinedTrust": "2023-09-28T00:00:00",
+        "establishmentName": "Mulberry Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "952",
+        "schoolCapacity": "971",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12824728,
+        "dateAcademyJoinedTrust": "2022-11-02T00:00:00",
+        "establishmentName": "St. Paul\u0027s C of E Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2009",
+        "schoolCapacity": "2562",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12822440,
+        "dateAcademyJoinedTrust": "2018-07-18T00:00:00",
+        "establishmentName": "St. James\u0027 Cofe School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1336",
+        "schoolCapacity": "2295",
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -4280,8 +1120,8 @@
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "Rudy McClure",
-      "email": "Rudy.McClure@education.gov.uk"
+      "fullName": "Arturo Purdy",
+      "email": "Arturo.Purdy@education.gov.uk"
     },
     "sfsoLead": {
       "fullName": "Misty Anderson",
@@ -4289,26 +1129,98 @@
     }
   },
   {
-    "uid": "1256",
-    "name": "PROSPECT MULTI-ACADEMY TRUST",
-    "groupId": "TR4017",
-    "ukprn": "10059649",
+    "uid": "1254",
+    "name": "CHAMPION ACADEMY TRUST",
+    "groupId": "TR118",
+    "ukprn": "10090285",
     "type": "Multi-academy trust",
-    "address": "33307 Adelbert Parks, Rowe Coves, Markview, BD05 8KN",
-    "openedDate": "2023-05-27T00:00:00",
-    "companiesHouseNumber": "02035444",
-    "regionAndTerritory": "Yorkshire and the Humber",
+    "address": "63371 Cormier Parkways, TR3 7KZ",
+    "openedDate": "2019-02-18T00:00:00",
+    "companiesHouseNumber": "04507649",
+    "regionAndTerritory": "West Midlands",
     "academies": [
       {
-        "urn": 12564726,
-        "dateAcademyJoinedTrust": "2023-07-13T00:00:00",
-        "establishmentName": "St. Marys Cofe Academy",
+        "urn": 12541633,
+        "dateAcademyJoinedTrust": "2022-10-10T00:00:00",
+        "establishmentName": "Mulberry Cofe School",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1852",
-        "schoolCapacity": "1968",
+        "numberOfPupils": "506",
+        "schoolCapacity": "817",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12541937,
+        "dateAcademyJoinedTrust": "2019-03-16T00:00:00",
+        "establishmentName": "Beacon Church of England Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "901",
+        "schoolCapacity": "1656",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12547759,
+        "dateAcademyJoinedTrust": "2022-10-20T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Church of England Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "446",
+        "schoolCapacity": "699",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12546297,
+        "dateAcademyJoinedTrust": "2022-05-05T00:00:00",
+        "establishmentName": "Harris School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "882",
+        "schoolCapacity": "1002",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12542122,
+        "dateAcademyJoinedTrust": "2020-02-06T00:00:00",
+        "establishmentName": "Peacehaven Community R.C. Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "678",
+        "schoolCapacity": "1514",
         "percentageFreeSchoolMeals": "27",
         "ageRange": {
           "minimum": 11,
@@ -4318,34 +1230,56 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12562406,
-        "dateAcademyJoinedTrust": "2023-08-02T00:00:00",
-        "establishmentName": "Queensbridge Secondary School",
+        "urn": 12542831,
+        "dateAcademyJoinedTrust": "2022-04-13T00:00:00",
+        "establishmentName": "St. Peter\u0027s Cofe Primary School",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1867",
-        "schoolCapacity": "1542",
-        "percentageFreeSchoolMeals": "26",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "945",
+        "schoolCapacity": "1086",
+        "percentageFreeSchoolMeals": "7",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      },
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lindsey Von",
+      "email": "Lindsey.Von@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Erick Kassulke",
+      "email": "Erick.Kassulke@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1260",
+    "name": "CORNERSTONE MULTI-ACADEMY TRUST",
+    "groupId": "TR2728",
+    "ukprn": "10028163",
+    "type": "Multi-academy trust",
+    "address": "00727 Abbott Point, ZL0 9XP",
+    "openedDate": "2014-04-15T00:00:00",
+    "companiesHouseNumber": "05199199",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
       {
-        "urn": 12566783,
-        "dateAcademyJoinedTrust": "2023-11-04T00:00:00",
-        "establishmentName": "Limehurst Church of England School",
+        "urn": 12607822,
+        "dateAcademyJoinedTrust": "2022-02-02T00:00:00",
+        "establishmentName": "Oasis School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
+        "localAuthority": "Wakefield",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1557",
-        "schoolCapacity": "1263",
-        "percentageFreeSchoolMeals": "15",
+        "numberOfPupils": "446",
+        "schoolCapacity": "392",
+        "percentageFreeSchoolMeals": "9",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -4354,16 +1288,432 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12562989,
-        "dateAcademyJoinedTrust": "2023-10-23T00:00:00",
-        "establishmentName": "Malbank Secondary School",
+        "urn": 12601549,
+        "dateAcademyJoinedTrust": "2022-12-12T00:00:00",
+        "establishmentName": "St. Joseph\u0027s CE Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1770",
+        "schoolCapacity": "2690",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12606147,
+        "dateAcademyJoinedTrust": "2016-06-12T00:00:00",
+        "establishmentName": "Horizon School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2204",
+        "schoolCapacity": "2080",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12606426,
+        "dateAcademyJoinedTrust": "2019-01-25T00:00:00",
+        "establishmentName": "St. Anne\u0027s CE Primary Academy",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "116",
+        "schoolCapacity": "148",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Margie Skiles",
+      "email": "Margie.Skiles@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Ginger Dietrich",
+      "email": "Ginger.Dietrich@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1264",
+    "name": "CRESCENDO ACADEMY TRUST",
+    "groupId": "TR9058",
+    "ukprn": "10080555",
+    "type": "Multi-academy trust",
+    "address": "7805 Constance Street, Rhiannon Squares, West Itzel, DD41 6XD",
+    "openedDate": "2019-12-07T00:00:00",
+    "companiesHouseNumber": "09807852",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 12647648,
+        "dateAcademyJoinedTrust": "2022-05-14T00:00:00",
+        "establishmentName": "Harris Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2143",
+        "schoolCapacity": "2706",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12644623,
+        "dateAcademyJoinedTrust": "2021-07-25T00:00:00",
+        "establishmentName": "Northwood Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3133",
+        "schoolCapacity": "2772",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lynn Rodriguez",
+      "email": "Lynn.Rodriguez@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Erick Kassulke",
+      "email": "Erick.Kassulke@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1243",
+    "name": "ECHELON EDUCATION TRUST",
+    "groupId": "TR6005",
+    "ukprn": "10071047",
+    "type": "Multi-academy trust",
+    "address": "07987 Ratke Mills, Trinity Flat, JZ2 6SC",
+    "openedDate": "2014-02-18T00:00:00",
+    "companiesHouseNumber": "02918540",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 12436932,
+        "dateAcademyJoinedTrust": "2016-12-17T00:00:00",
+        "establishmentName": "Greensward Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "990",
+        "schoolCapacity": "1454",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12432627,
+        "dateAcademyJoinedTrust": "2018-11-22T00:00:00",
+        "establishmentName": "Lampton C of E Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1108",
+        "schoolCapacity": "1936",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12433878,
+        "dateAcademyJoinedTrust": "2022-02-08T00:00:00",
+        "establishmentName": "Mulberry Catholic Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1739",
+        "schoolCapacity": "1852",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12433290,
+        "dateAcademyJoinedTrust": "2017-04-08T00:00:00",
+        "establishmentName": "St. Mary\u0027s Church of England School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1850",
+        "schoolCapacity": "2254",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "George Muller",
+      "email": "George.Muller@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Shelly Mayert",
+      "email": "Shelly.Mayert@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1234",
+    "name": "EDIFY MULTI-ACADEMY TRUST",
+    "groupId": "TR6826",
+    "ukprn": "10031699",
+    "type": "Multi-academy trust",
+    "address": "1363 Ahmad Divide, Port Theresemouth, WE4 3JX",
+    "openedDate": "2022-05-22T00:00:00",
+    "companiesHouseNumber": "09137449",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12341902,
+        "dateAcademyJoinedTrust": "2022-06-21T00:00:00",
+        "establishmentName": "Mulberry Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "713",
+        "schoolCapacity": "648",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12346588,
+        "dateAcademyJoinedTrust": "2022-09-20T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Cofe Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1077",
-        "schoolCapacity": "898",
+        "numberOfPupils": "728",
+        "schoolCapacity": "1168",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12342480,
+        "dateAcademyJoinedTrust": "2023-06-19T00:00:00",
+        "establishmentName": "Longhill CE School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1293",
+        "schoolCapacity": "2093",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Amelia Mitchell",
+      "email": "Amelia.Mitchell@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jonathon Littel",
+      "email": "Jonathon.Littel@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1240",
+    "name": "ELEVATE SCHOOLS TRUST",
+    "groupId": "TR5181",
+    "ukprn": "10002602",
+    "type": "Multi-academy trust",
+    "address": "791 Douglas Manor, White Course, Murphystad, YY48 4FV",
+    "openedDate": "2022-05-14T00:00:00",
+    "companiesHouseNumber": "04269920",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12404698,
+        "dateAcademyJoinedTrust": "2022-08-19T00:00:00",
+        "establishmentName": "Northwood R.C. Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "519",
+        "schoolCapacity": "963",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12403163,
+        "dateAcademyJoinedTrust": "2023-01-14T00:00:00",
+        "establishmentName": "St. Mary\u0027s Cofe Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "137",
+        "schoolCapacity": "169",
         "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12406691,
+        "dateAcademyJoinedTrust": "2022-12-30T00:00:00",
+        "establishmentName": "Barr and Community Catholic Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2542",
+        "schoolCapacity": "2792",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lamar Ritchie",
+      "email": "Lamar.Ritchie@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Suzanne Conroy",
+      "email": "Suzanne.Conroy@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1253",
+    "name": "ELEVATED SCHOOLS TRUST",
+    "groupId": "TR8884",
+    "ukprn": "10051326",
+    "type": "Multi-academy trust",
+    "address": "350 Willms Alley, Kolby Glen, Trompport, UA9 2TF",
+    "openedDate": "2014-04-16T00:00:00",
+    "companiesHouseNumber": "06001936",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12539504,
+        "dateAcademyJoinedTrust": "2016-08-12T00:00:00",
+        "establishmentName": "St. Mary\u0027s R.C. School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1061",
+        "schoolCapacity": "1115",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12536139,
+        "dateAcademyJoinedTrust": "2015-12-13T00:00:00",
+        "establishmentName": "Limehurst Cofe School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "265",
+        "schoolCapacity": "413",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12538124,
+        "dateAcademyJoinedTrust": "2020-01-30T00:00:00",
+        "establishmentName": "Co-op Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "928",
+        "schoolCapacity": "2234",
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -4378,85 +1728,49 @@
       "email": "Silvia.Berge@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Suzanne Conroy",
-      "email": "Suzanne.Conroy@education.gov.uk"
+      "fullName": "Marion MacGyver",
+      "email": "Marion.MacGyver@education.gov.uk"
     }
   },
   {
-    "uid": "1272",
-    "name": "PROSPERITY EDUCATION TRUST",
-    "groupId": "TR9824",
-    "ukprn": "10056922",
+    "uid": "1280",
+    "name": "EMPOWER ACADEMY TRUST",
+    "groupId": "TR8884",
+    "ukprn": "10063161",
     "type": "Multi-academy trust",
-    "address": "1992 Cindy Plains, Kirlinmouth, VP21 9NX",
-    "openedDate": "2023-04-18T00:00:00",
-    "companiesHouseNumber": "05762920",
-    "regionAndTerritory": "London",
+    "address": "3474 Kristoffer Throughway, Ethyl Lodge, New Holly, QP4 2ZI",
+    "openedDate": "2017-08-19T00:00:00",
+    "companiesHouseNumber": "01146922",
+    "regionAndTerritory": "West Midlands",
     "academies": [
       {
-        "urn": 12728202,
-        "dateAcademyJoinedTrust": "2023-08-18T00:00:00",
-        "establishmentName": "Peacehaven Community Church of England Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1461",
-        "schoolCapacity": "2295",
-        "percentageFreeSchoolMeals": "17",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12726105,
-        "dateAcademyJoinedTrust": "2023-06-16T00:00:00",
-        "establishmentName": "North East Lincolnshire Catholic Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "956",
-        "schoolCapacity": "1274",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12721571,
-        "dateAcademyJoinedTrust": "2023-10-20T00:00:00",
-        "establishmentName": "St. John\u0027s C of E Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2240",
-        "schoolCapacity": "2464",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12729999,
-        "dateAcademyJoinedTrust": "2023-05-17T00:00:00",
-        "establishmentName": "Momentum Community Cofe School",
+        "urn": 12807306,
+        "dateAcademyJoinedTrust": "2018-04-10T00:00:00",
+        "establishmentName": "St. Marys CE Academy",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "659",
+        "schoolCapacity": "832",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12808110,
+        "dateAcademyJoinedTrust": "2021-12-04T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "216",
-        "schoolCapacity": "286",
+        "numberOfPupils": "54",
+        "schoolCapacity": "125",
         "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 11,
@@ -4466,535 +1780,19 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12722761,
-        "dateAcademyJoinedTrust": "2023-04-28T00:00:00",
-        "establishmentName": "St. John\u0027s R.C. Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2270",
-        "schoolCapacity": "2108",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12725537,
-        "dateAcademyJoinedTrust": "2023-08-09T00:00:00",
-        "establishmentName": "St. John\u0027s C of E Academy",
+        "urn": 12802719,
+        "dateAcademyJoinedTrust": "2023-09-03T00:00:00",
+        "establishmentName": "Mulberry Primary Academy",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1104",
-        "schoolCapacity": "2309",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12722028,
-        "dateAcademyJoinedTrust": "2023-08-27T00:00:00",
-        "establishmentName": "Northwood Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "691",
-        "schoolCapacity": "1616",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12722423,
-        "dateAcademyJoinedTrust": "2023-05-23T00:00:00",
-        "establishmentName": "Halewood Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "477",
-        "schoolCapacity": "382",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12721373,
-        "dateAcademyJoinedTrust": "2023-08-21T00:00:00",
-        "establishmentName": "St. Catherine\u0027s C of E School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2628",
-        "schoolCapacity": "2063",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Cindy Bergstrom",
-      "email": "Cindy.Bergstrom@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Oscar Goldner",
-      "email": "Oscar.Goldner@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1267",
-    "name": "RISE EDUCATION TRUST",
-    "groupId": "TR8608",
-    "ukprn": "10049899",
-    "type": "Multi-academy trust",
-    "address": "071 Colt Overpass, Kemmer Ramp, XA4 7CR",
-    "openedDate": "2022-10-14T00:00:00",
-    "companiesHouseNumber": "03264715",
-    "regionAndTerritory": "East of England",
-    "academies": [
-      {
-        "urn": 12678009,
-        "dateAcademyJoinedTrust": "2023-04-06T00:00:00",
-        "establishmentName": "Co-op Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2739",
-        "schoolCapacity": "2479",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12673436,
-        "dateAcademyJoinedTrust": "2023-06-13T00:00:00",
-        "establishmentName": "Glyn Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3039",
-        "schoolCapacity": "2588",
+        "numberOfPupils": "701",
+        "schoolCapacity": "1656",
         "percentageFreeSchoolMeals": "27",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12674603,
-        "dateAcademyJoinedTrust": "2022-12-28T00:00:00",
-        "establishmentName": "Halewood C of E School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "705",
-        "schoolCapacity": "1143",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12675928,
-        "dateAcademyJoinedTrust": "2023-07-01T00:00:00",
-        "establishmentName": "Peacehaven Community R.C. School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3532",
-        "schoolCapacity": "2805",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12679865,
-        "dateAcademyJoinedTrust": "2023-04-17T00:00:00",
-        "establishmentName": "Beacon Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "433",
-        "schoolCapacity": "1013",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12678712,
-        "dateAcademyJoinedTrust": "2022-12-27T00:00:00",
-        "establishmentName": "George Abbey C of E Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2112",
-        "schoolCapacity": "2573",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12671155,
-        "dateAcademyJoinedTrust": "2023-06-22T00:00:00",
-        "establishmentName": "Beacon School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "877",
-        "schoolCapacity": "1439",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12675032,
-        "dateAcademyJoinedTrust": "2023-01-09T00:00:00",
-        "establishmentName": "Meridian C of E Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1954",
-        "schoolCapacity": "2649",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12673743,
-        "dateAcademyJoinedTrust": "2023-07-27T00:00:00",
-        "establishmentName": "Halewood Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1500",
-        "schoolCapacity": "1985",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Lindsey Von",
-      "email": "Lindsey.Von@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Ramon Wehner",
-      "email": "Ramon.Wehner@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1310",
-    "name": "SHEFFIELD SOUTH EAST TRUST",
-    "groupId": "TR7466",
-    "ukprn": "10052979",
-    "type": "Multi-academy trust",
-    "address": "475 Hoppe Ridge, NY6 5HY",
-    "openedDate": "2018-08-17T00:00:00",
-    "companiesHouseNumber": "01576727",
-    "regionAndTerritory": "North West",
-    "academies": [
-      {
-        "urn": 13108410,
-        "dateAcademyJoinedTrust": "2023-08-21T00:00:00",
-        "establishmentName": "Halewood Church of England Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3739",
-        "schoolCapacity": "2960",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13106934,
-        "dateAcademyJoinedTrust": "2023-10-26T00:00:00",
-        "establishmentName": "Meridian Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "518",
-        "schoolCapacity": "951",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13109407,
-        "dateAcademyJoinedTrust": "2023-09-19T00:00:00",
-        "establishmentName": "George Abbey Catholic School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3202",
-        "schoolCapacity": "2772",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13109970,
-        "dateAcademyJoinedTrust": "2023-10-31T00:00:00",
-        "establishmentName": "Beacon Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1611",
-        "schoolCapacity": "1837",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13103645,
-        "dateAcademyJoinedTrust": "2020-08-12T00:00:00",
-        "establishmentName": "Halewood Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2995",
-        "schoolCapacity": "2488",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13106978,
-        "dateAcademyJoinedTrust": "2022-01-12T00:00:00",
-        "establishmentName": "Northwood C of E School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3693",
-        "schoolCapacity": "2932",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13104827,
-        "dateAcademyJoinedTrust": "2023-09-12T00:00:00",
-        "establishmentName": "Greensward Cofe Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1763",
-        "schoolCapacity": "1965",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13107324,
-        "dateAcademyJoinedTrust": "2020-06-20T00:00:00",
-        "establishmentName": "St. Marys C of E School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "97",
-        "schoolCapacity": "137",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13105814,
-        "dateAcademyJoinedTrust": "2019-11-25T00:00:00",
-        "establishmentName": "Longhill Cofe Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "998",
-        "schoolCapacity": "2381",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13107663,
-        "dateAcademyJoinedTrust": "2020-06-16T00:00:00",
-        "establishmentName": "Horizon Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2053",
-        "schoolCapacity": "2662",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13109244,
-        "dateAcademyJoinedTrust": "2022-01-02T00:00:00",
-        "establishmentName": "Krajcik Ville CE Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2343",
-        "schoolCapacity": "2191",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Cindy Bergstrom",
-      "email": "Cindy.Bergstrom@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Erick Kassulke",
-      "email": "Erick.Kassulke@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1283",
-    "name": "ST MARY\u0027S ACADEMY TRUST",
-    "groupId": "TR9298",
-    "ukprn": "10043743",
-    "type": "Single-academy trust",
-    "address": "811 McDermott Springs, Dillan Prairie, KM5 4JB",
-    "openedDate": "2020-07-14T00:00:00",
-    "companiesHouseNumber": "09920255",
-    "regionAndTerritory": "South East",
-    "academies": [
-      {
-        "urn": 12833136,
-        "dateAcademyJoinedTrust": "2023-07-20T00:00:00",
-        "establishmentName": "St. Mary\u0027s Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1192",
-        "schoolCapacity": "1855",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
@@ -5006,72 +1804,68 @@
       "email": "Margie.Skiles@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Lillian Hand",
-      "email": "Lillian.Hand@education.gov.uk"
+      "fullName": "Amanda McGlynn",
+      "email": "Amanda.McGlynn@education.gov.uk"
     }
   },
   {
-    "uid": "1284",
-    "name": "ST MARY\u0027S ANGLICAN ACADEMY",
-    "groupId": "TR1761",
-    "ukprn": "10088941",
-    "type": "Single-academy trust",
-    "address": "84695 Sanford Fords, Rachelle Plaza, KT3 0JE",
-    "openedDate": "2015-08-26T00:00:00",
-    "companiesHouseNumber": "06925231",
-    "regionAndTerritory": "North East",
+    "uid": "1242",
+    "name": "EMPOWERMENT MULTI-ACADEMY TRUST",
+    "groupId": "TR3771",
+    "ukprn": "10027052",
+    "type": "Multi-academy trust",
+    "address": "31241 King Mountains, Harmon Pike, North Kelley, MG50 2FC",
+    "openedDate": "2019-01-22T00:00:00",
+    "companiesHouseNumber": "07083996",
+    "regionAndTerritory": "East Midlands",
     "academies": [
       {
-        "urn": 12846302,
-        "dateAcademyJoinedTrust": "2020-01-07T00:00:00",
-        "establishmentName": "St. Mary\u0027s Anglican Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "816",
-        "schoolCapacity": "1012",
-        "percentageFreeSchoolMeals": "26",
+        "urn": 12423675,
+        "dateAcademyJoinedTrust": "2023-08-17T00:00:00",
+        "establishmentName": "Malbank Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "297",
+        "schoolCapacity": "243",
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Lynda Ziemann",
-      "email": "Lynda.Ziemann@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Jennie Greenholt",
-      "email": "Jennie.Greenholt@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1285",
-    "name": "ST MARY\u0027S CATHOLIC HIGH SCHOOL ACADEMY TRUST",
-    "groupId": "TR8827",
-    "ukprn": "10051273",
-    "type": "Single-academy trust",
-    "address": "4544 Dianna Spurs, South Bradenside, JY2 2WU",
-    "openedDate": "2017-10-28T00:00:00",
-    "companiesHouseNumber": "07344251",
-    "regionAndTerritory": "Yorkshire and the Humber",
-    "academies": [
+      },
       {
-        "urn": 12855826,
-        "dateAcademyJoinedTrust": "2020-06-08T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic High School Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban city and town",
+        "urn": 12428522,
+        "dateAcademyJoinedTrust": "2019-10-22T00:00:00",
+        "establishmentName": "Longhill Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "734",
-        "schoolCapacity": "970",
-        "percentageFreeSchoolMeals": "4",
+        "numberOfPupils": "740",
+        "schoolCapacity": "822",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12422867,
+        "dateAcademyJoinedTrust": "2020-06-01T00:00:00",
+        "establishmentName": "St. James\u0027 C of E School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "369",
+        "schoolCapacity": "446",
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5082,38 +1876,239 @@
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "George Muller",
-      "email": "George.Muller@education.gov.uk"
+      "fullName": "Lana Mueller",
+      "email": "Lana.Mueller@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Jan Wunsch",
-      "email": "Jan.Wunsch@education.gov.uk"
+      "fullName": "Roman Torp",
+      "email": "Roman.Torp@education.gov.uk"
     }
   },
   {
-    "uid": "1286",
-    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL",
-    "groupId": "TR5683",
-    "ukprn": "10039180",
-    "type": "Single-academy trust",
-    "address": "839 Dangelo Drive, NW68 6HZ",
-    "openedDate": "2016-04-06T00:00:00",
-    "companiesHouseNumber": "08364397",
-    "regionAndTerritory": "South West",
+    "uid": "1247",
+    "name": "EPIC LEARNING TRUST",
+    "groupId": "TR6051",
+    "ukprn": "10037146",
+    "type": "Multi-academy trust",
+    "address": "7649 Schumm Motorway, Christiansen Dam, SG67 7LD",
+    "openedDate": "2013-11-30T00:00:00",
+    "companiesHouseNumber": "06726931",
+    "regionAndTerritory": "East of England",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Phyllis Kling",
+      "email": "Phyllis.Kling@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Lillian Hand",
+      "email": "Lillian.Hand@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1268",
+    "name": "EXCEL MULTI-ACADEMY TRUST",
+    "groupId": "TR2841",
+    "ukprn": "10037625",
+    "type": "Multi-academy trust",
+    "address": "6118 George Mews, Mossie Fall, Margarettefort, ON7 5XK",
+    "openedDate": "2013-11-25T00:00:00",
+    "companiesHouseNumber": "03129048",
+    "regionAndTerritory": "South East",
     "academies": [
       {
-        "urn": 12862901,
-        "dateAcademyJoinedTrust": "2017-12-12T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "urn": 12688773,
+        "dateAcademyJoinedTrust": "2015-08-01T00:00:00",
+        "establishmentName": "Queensbridge Catholic Primary School",
         "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2015",
+        "schoolCapacity": "1759",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12683980,
+        "dateAcademyJoinedTrust": "2021-12-05T00:00:00",
+        "establishmentName": "St. James\u0027 CE Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3013",
+        "schoolCapacity": "2421",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12684121,
+        "dateAcademyJoinedTrust": "2016-01-25T00:00:00",
+        "establishmentName": "Limehurst R.C. School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1249",
+        "schoolCapacity": "1372",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12682587,
+        "dateAcademyJoinedTrust": "2016-12-19T00:00:00",
+        "establishmentName": "St. Marys Church of England Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "246",
+        "schoolCapacity": "538",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12681546,
+        "dateAcademyJoinedTrust": "2021-02-14T00:00:00",
+        "establishmentName": "Harris Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1864",
+        "schoolCapacity": "1434",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12683713,
+        "dateAcademyJoinedTrust": "2017-06-20T00:00:00",
+        "establishmentName": "Mulberry Catholic Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "702",
+        "schoolCapacity": "1418",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12681671,
+        "dateAcademyJoinedTrust": "2021-03-11T00:00:00",
+        "establishmentName": "Longhill School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1848",
+        "schoolCapacity": "2165",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12681568,
+        "dateAcademyJoinedTrust": "2020-11-09T00:00:00",
+        "establishmentName": "Momentum Community Catholic Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1129",
+        "schoolCapacity": "2246",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12687785,
+        "dateAcademyJoinedTrust": "2021-03-08T00:00:00",
+        "establishmentName": "St. Peter\u0027s CE Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "519",
+        "schoolCapacity": "558",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12688146,
+        "dateAcademyJoinedTrust": "2019-10-06T00:00:00",
+        "establishmentName": "Greensward Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "99",
+        "schoolCapacity": "220",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12687899,
+        "dateAcademyJoinedTrust": "2023-10-03T00:00:00",
+        "establishmentName": "St. Paul\u0027s Catholic Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
         "localAuthority": "Kingston upon Hull, City of",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "981",
-        "schoolCapacity": "1188",
-        "percentageFreeSchoolMeals": "8",
+        "numberOfPupils": "1212",
+        "schoolCapacity": "1831",
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
-          "minimum": 5,
+          "minimum": 4,
           "maximum": 11
         },
         "currentOfstedRating": null,
@@ -5122,33 +2117,90 @@
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "Lynda Ziemann",
-      "email": "Lynda.Ziemann@education.gov.uk"
+      "fullName": "Lindsey Von",
+      "email": "Lindsey.Von@education.gov.uk"
     },
-    "sfsoLead": null
+    "sfsoLead": {
+      "fullName": "Lillian Hand",
+      "email": "Lillian.Hand@education.gov.uk"
+    }
   },
   {
-    "uid": "1287",
-    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (ACADEMY TRUST), SWINDON",
-    "groupId": "TR5711",
-    "ukprn": "10014809",
-    "type": "Single-academy trust",
-    "address": "335 Cremin Garden, Lake Keshawn, MF07 7EO",
-    "openedDate": "2017-06-25T00:00:00",
-    "companiesHouseNumber": "07687903",
-    "regionAndTerritory": "North East",
+    "uid": "1271",
+    "name": "EXCELLENCE MULTI-ACADEMY TRUST",
+    "groupId": "TR9278",
+    "ukprn": "10082969",
+    "type": "Multi-academy trust",
+    "address": "313 Johnston Forge, Esta Falls, Hoppeview, GR5 6CI",
+    "openedDate": "2018-03-23T00:00:00",
+    "companiesHouseNumber": "09762729",
+    "regionAndTerritory": "London",
     "academies": [
       {
-        "urn": 12875107,
-        "dateAcademyJoinedTrust": "2021-10-19T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Free school",
+        "urn": 12713367,
+        "dateAcademyJoinedTrust": "2020-09-05T00:00:00",
+        "establishmentName": "Barr and Community R.C. School",
+        "typeOfEstablishment": "Academy converter",
         "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1066",
+        "schoolCapacity": "1007",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12717059,
+        "dateAcademyJoinedTrust": "2022-04-17T00:00:00",
+        "establishmentName": "Meridian Catholic Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1818",
+        "schoolCapacity": "1459",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12718096,
+        "dateAcademyJoinedTrust": "2019-04-26T00:00:00",
+        "establishmentName": "St. Catherine\u0027s CE Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2049",
+        "schoolCapacity": "2945",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12719133,
+        "dateAcademyJoinedTrust": "2023-09-09T00:00:00",
+        "establishmentName": "St. Peter\u0027s Church of England Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1317",
-        "schoolCapacity": "1409",
-        "percentageFreeSchoolMeals": "6",
+        "numberOfPupils": "2916",
+        "schoolCapacity": "2616",
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -5163,75 +2215,215 @@
       "email": "Lana.Mueller@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Jaime Russel",
-      "email": "Jaime.Russel@education.gov.uk"
+      "fullName": "Harriet Wuckert",
+      "email": "Harriet.Wuckert@education.gov.uk"
     }
   },
   {
-    "uid": "1288",
-    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (HERRINGTHORPE), A CATHOLIC VOLUNTARY ACADEMY",
-    "groupId": "TR2036",
-    "ukprn": "10090211",
-    "type": "Single-academy trust",
-    "address": "545 Gilberto Gateway, Roob Locks, VB11 3HL",
-    "openedDate": "2021-04-14T00:00:00",
-    "companiesHouseNumber": "07081663",
-    "regionAndTerritory": "London",
+    "uid": "1275",
+    "name": "FORWARD MULTI-ACADEMY TRUST",
+    "groupId": "TR1744",
+    "ukprn": "10024275",
+    "type": "Multi-academy trust",
+    "address": "296 Kuphal Path, PV6 8BD",
+    "openedDate": "2022-05-20T00:00:00",
+    "companiesHouseNumber": "04135770",
+    "regionAndTerritory": "East of England",
     "academies": [
       {
-        "urn": 12888619,
-        "dateAcademyJoinedTrust": "2022-06-08T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban city and town",
+        "urn": 12754798,
+        "dateAcademyJoinedTrust": "2022-07-25T00:00:00",
+        "establishmentName": "St. Anne\u0027s R.C. Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "471",
-        "schoolCapacity": "543",
-        "percentageFreeSchoolMeals": "19",
+        "numberOfPupils": "636",
+        "schoolCapacity": "1107",
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Josh D\u0027Amore",
-      "email": "Josh.D\u0027Amore@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Vickie Gulgowski",
-      "email": "Vickie.Gulgowski@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1289",
-    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (MALTBY)",
-    "groupId": "TR6939",
-    "ukprn": "10077717",
-    "type": "Single-academy trust",
-    "address": "94369 Clementina Neck, Kellen Key, LM7 2OD",
-    "openedDate": "2015-08-29T00:00:00",
-    "companiesHouseNumber": "05868816",
-    "regionAndTerritory": "North East",
-    "academies": [
+      },
       {
-        "urn": 12896976,
-        "dateAcademyJoinedTrust": "2021-12-05T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
+        "urn": 12751167,
+        "dateAcademyJoinedTrust": "2023-02-11T00:00:00",
+        "establishmentName": "Halewood R.C. Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "614",
+        "schoolCapacity": "684",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12757513,
+        "dateAcademyJoinedTrust": "2022-08-04T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "167",
+        "schoolCapacity": "132",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12752771,
+        "dateAcademyJoinedTrust": "2022-06-11T00:00:00",
+        "establishmentName": "Longhill C of E Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "273",
-        "schoolCapacity": "666",
-        "percentageFreeSchoolMeals": "1",
+        "numberOfPupils": "2010",
+        "schoolCapacity": "1875",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12753794,
+        "dateAcademyJoinedTrust": "2023-03-12T00:00:00",
+        "establishmentName": "St. Marys R.C. School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "787",
+        "schoolCapacity": "1936",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12757116,
+        "dateAcademyJoinedTrust": "2023-07-06T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Church of England Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "836",
+        "schoolCapacity": "1218",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12753643,
+        "dateAcademyJoinedTrust": "2022-09-23T00:00:00",
+        "establishmentName": "St. John\u0027s Catholic Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1485",
+        "schoolCapacity": "2524",
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12753125,
+        "dateAcademyJoinedTrust": "2023-09-11T00:00:00",
+        "establishmentName": "George Abbey Cofe School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "550",
+        "schoolCapacity": "690",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12756843,
+        "dateAcademyJoinedTrust": "2022-05-24T00:00:00",
+        "establishmentName": "Harris Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "845",
+        "schoolCapacity": "1235",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12758940,
+        "dateAcademyJoinedTrust": "2023-01-18T00:00:00",
+        "establishmentName": "Harris Church of England Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "377",
+        "schoolCapacity": "487",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12752547,
+        "dateAcademyJoinedTrust": "2023-03-17T00:00:00",
+        "establishmentName": "St. James\u0027s CE Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2462",
+        "schoolCapacity": "2122",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
@@ -5243,108 +2435,50 @@
       "email": "Ramona.O\u0027Keefe@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Shelly Mayert",
-      "email": "Shelly.Mayert@education.gov.uk"
+      "fullName": "Vickie Gulgowski",
+      "email": "Vickie.Gulgowski@education.gov.uk"
     }
   },
   {
-    "uid": "1290",
-    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL, CHURCHDOWN",
-    "groupId": "TR8704",
-    "ukprn": "10052640",
-    "type": "Single-academy trust",
-    "address": "09823 Donnelly Lane, Gerlachfort, RB76 7LI",
-    "openedDate": "2021-12-08T00:00:00",
-    "companiesHouseNumber": "05937225",
+    "uid": "1279",
+    "name": "FUSION EDUCATION TRUST",
+    "groupId": "TR177",
+    "ukprn": "10000778",
+    "type": "Multi-academy trust",
+    "address": "34037 Korbin Parkways, Bernadinetown, ZC68 0SG",
+    "openedDate": "2020-09-16T00:00:00",
+    "companiesHouseNumber": "03782381",
     "regionAndTerritory": "North East",
     "academies": [
       {
-        "urn": 12907076,
-        "dateAcademyJoinedTrust": "2022-02-22T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1545",
-        "schoolCapacity": "1948",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Lynn Rodriguez",
-      "email": "Lynn.Rodriguez@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Jonathon Littel",
-      "email": "Jonathon.Littel@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1291",
-    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOLS TRUST",
-    "groupId": "TR4642",
-    "ukprn": "10035186",
-    "type": "Multi-academy trust",
-    "address": "3979 Lizzie Glens, South Lacy, FO47 5TB",
-    "openedDate": "2017-11-01T00:00:00",
-    "companiesHouseNumber": "03073796",
-    "regionAndTerritory": "Yorkshire and the Humber",
-    "academies": [
-      {
-        "urn": 12914972,
-        "dateAcademyJoinedTrust": "2019-08-16T00:00:00",
-        "establishmentName": "St Mary\u0027s Catholic Primary School",
+        "urn": 12797624,
+        "dateAcademyJoinedTrust": "2021-04-28T00:00:00",
+        "establishmentName": "St. Anne\u0027s R.C. Secondary School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2495",
-        "schoolCapacity": "2470",
-        "percentageFreeSchoolMeals": "13",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "770",
+        "schoolCapacity": "1069",
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12912758,
-        "dateAcademyJoinedTrust": "2023-06-28T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "urn": 12795347,
+        "dateAcademyJoinedTrust": "2021-02-26T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2121",
-        "schoolCapacity": "1983",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12914521,
-        "dateAcademyJoinedTrust": "2020-04-23T00:00:00",
-        "establishmentName": "St. Marys Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "207",
-        "schoolCapacity": "223",
-        "percentageFreeSchoolMeals": "26",
+        "numberOfPupils": "1463",
+        "schoolCapacity": "1856",
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -5353,146 +2487,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12919148,
-        "dateAcademyJoinedTrust": "2023-11-08T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1190",
-        "schoolCapacity": "2659",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12912202,
-        "dateAcademyJoinedTrust": "2017-12-17T00:00:00",
-        "establishmentName": "St Marys Catholic Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2098",
-        "schoolCapacity": "1828",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12912203,
-        "dateAcademyJoinedTrust": "2023-06-02T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1265",
-        "schoolCapacity": "2280",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12915141,
-        "dateAcademyJoinedTrust": "2022-08-23T00:00:00",
-        "establishmentName": "St. Mary\u0027s RC Primary School",
+        "urn": 12799522,
+        "dateAcademyJoinedTrust": "2023-06-04T00:00:00",
+        "establishmentName": "East Riding of Yorkshire Catholic School",
         "typeOfEstablishment": "Free school",
         "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1310",
-        "schoolCapacity": "2688",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12912854,
-        "dateAcademyJoinedTrust": "2022-04-01T00:00:00",
-        "establishmentName": "St. Mary\u0027s Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1481",
-        "schoolCapacity": "2896",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12911372,
-        "dateAcademyJoinedTrust": "2018-11-13T00:00:00",
-        "establishmentName": "St. Mary\u0027s Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1093",
-        "schoolCapacity": "2687",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Lynda Ziemann",
-      "email": "Lynda.Ziemann@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Walter Boyle",
-      "email": "Walter.Boyle@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1292",
-    "name": "ST MARY\u0027S CE ACADEMY, CHESHUNT",
-    "groupId": "TR2362",
-    "ukprn": "10084627",
-    "type": "Single-academy trust",
-    "address": "23502 Fadel Dale, Hansen Parks, Hermanhaven, SP4 2HX",
-    "openedDate": "2014-04-28T00:00:00",
-    "companiesHouseNumber": "07202060",
-    "regionAndTerritory": "",
-    "academies": [
-      {
-        "urn": 12923496,
-        "dateAcademyJoinedTrust": "2017-03-04T00:00:00",
-        "establishmentName": "St Mary\u0027s CE Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3103",
-        "schoolCapacity": "2937",
-        "percentageFreeSchoolMeals": "30",
+        "numberOfPupils": "577",
+        "schoolCapacity": "491",
+        "percentageFreeSchoolMeals": "25",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5507,32 +2511,786 @@
       "email": "Lyle.Baumbach@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Jan Wunsch",
-      "email": "Jan.Wunsch@education.gov.uk"
+      "fullName": "Suzanne Conroy",
+      "email": "Suzanne.Conroy@education.gov.uk"
     }
   },
   {
-    "uid": "1293",
-    "name": "ST MARY\u0027S CHURCH OF ENGLAND ACADEMY TRUST",
-    "groupId": "TR388",
-    "ukprn": "10097113",
-    "type": "Single-academy trust",
-    "address": "4450 Hansen Locks, New Felicity, YN9 8VT",
-    "openedDate": "2021-07-07T00:00:00",
-    "companiesHouseNumber": "05465093",
+    "uid": "1259",
+    "name": "GALVANIZE ACADEMY TRUST",
+    "groupId": "TR1821",
+    "ukprn": "10008048",
+    "type": "Multi-academy trust",
+    "address": "9213 Bayer Road, JX05 8NW",
+    "openedDate": "2017-05-15T00:00:00",
+    "companiesHouseNumber": "07242754",
+    "regionAndTerritory": "London",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Byron Quigley",
+      "email": "Byron.Quigley@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Sharon Roob",
+      "email": "Sharon.Roob@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1239",
+    "name": "HORIZON MULTI-ACADEMY TRUST",
+    "groupId": "TR9054",
+    "ukprn": "10017817",
+    "type": "Multi-academy trust",
+    "address": "633 Leonor River, Hacketthaven, UH01 9RL",
+    "openedDate": "2022-11-09T00:00:00",
+    "companiesHouseNumber": "04848875",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12394077,
+        "dateAcademyJoinedTrust": "2022-11-14T00:00:00",
+        "establishmentName": "Bradford C of E Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3344",
+        "schoolCapacity": "2740",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12394034,
+        "dateAcademyJoinedTrust": "2022-11-16T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Catholic Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "486",
+        "schoolCapacity": "756",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12395003,
+        "dateAcademyJoinedTrust": "2023-04-11T00:00:00",
+        "establishmentName": "St. Paul\u0027s Church of England Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1372",
+        "schoolCapacity": "2304",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12399927,
+        "dateAcademyJoinedTrust": "2023-01-18T00:00:00",
+        "establishmentName": "St. James\u0027s Church of England Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "789",
+        "schoolCapacity": "1096",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12392162,
+        "dateAcademyJoinedTrust": "2023-02-09T00:00:00",
+        "establishmentName": "Northwood Cofe School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "583",
+        "schoolCapacity": "706",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12399319,
+        "dateAcademyJoinedTrust": "2023-06-28T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "864",
+        "schoolCapacity": "2144",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Phyllis Kling",
+      "email": "Phyllis.Kling@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Cecilia Crona",
+      "email": "Cecilia.Crona@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1266",
+    "name": "HORIZONS MULTI-ACADEMY TRUST",
+    "groupId": "TR6813",
+    "ukprn": "10099249",
+    "type": "Multi-academy trust",
+    "address": "14934 Durgan Unions, RF72 0WQ",
+    "openedDate": "2021-09-22T00:00:00",
+    "companiesHouseNumber": "07855059",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12664230,
+        "dateAcademyJoinedTrust": "2022-02-19T00:00:00",
+        "establishmentName": "St. Paul\u0027s Church of England Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1488",
+        "schoolCapacity": "2879",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12667259,
+        "dateAcademyJoinedTrust": "2023-08-24T00:00:00",
+        "establishmentName": "St. Mary\u0027s C of E Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1554",
+        "schoolCapacity": "2099",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12663897,
+        "dateAcademyJoinedTrust": "2022-04-06T00:00:00",
+        "establishmentName": "Greensward Cofe Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "301",
+        "schoolCapacity": "706",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Amelia Mitchell",
+      "email": "Amelia.Mitchell@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Natasha Borer",
+      "email": "Natasha.Borer@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1281",
+    "name": "ILLUMINATE LEARNING TRUST",
+    "groupId": "TR1661",
+    "ukprn": "10041210",
+    "type": "Multi-academy trust",
+    "address": "26983 Amanda Station, TK1 0AP",
+    "openedDate": "2015-09-30T00:00:00",
+    "companiesHouseNumber": "04886875",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12812994,
+        "dateAcademyJoinedTrust": "2017-04-22T00:00:00",
+        "establishmentName": "Glyn Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "748",
+        "schoolCapacity": "699",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12813891,
+        "dateAcademyJoinedTrust": "2021-10-24T00:00:00",
+        "establishmentName": "Queensbridge Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1679",
+        "schoolCapacity": "2686",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12815924,
+        "dateAcademyJoinedTrust": "2019-06-28T00:00:00",
+        "establishmentName": "St. James\u0027s C of E Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "303",
+        "schoolCapacity": "413",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12815202,
+        "dateAcademyJoinedTrust": "2018-01-03T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Cofe Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1137",
+        "schoolCapacity": "944",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12815243,
+        "dateAcademyJoinedTrust": "2023-04-09T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Church of England School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2138",
+        "schoolCapacity": "2184",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12818862,
+        "dateAcademyJoinedTrust": "2018-10-06T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Cofe Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1446",
+        "schoolCapacity": "2015",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lyle Baumbach",
+      "email": "Lyle.Baumbach@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jonathon Littel",
+      "email": "Jonathon.Littel@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1278",
+    "name": "ILLUMINATE MULTI-ACADEMY TRUST",
+    "groupId": "TR4558",
+    "ukprn": "10097725",
+    "type": "Multi-academy trust",
+    "address": "134 Henri Passage, IW84 6ES",
+    "openedDate": "2015-12-11T00:00:00",
+    "companiesHouseNumber": "08589927",
+    "regionAndTerritory": "East Midlands",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Amelia Mitchell",
+      "email": "Amelia.Mitchell@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Harriet Wuckert",
+      "email": "Harriet.Wuckert@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1235",
+    "name": "INNOVATE ACADEMY TRUST",
+    "groupId": "TR7577",
+    "ukprn": "10090042",
+    "type": "Multi-academy trust",
+    "address": "881 Edwina Mountains, Coy Point, New Lola, YH22 8LR",
+    "openedDate": "2014-02-25T00:00:00",
+    "companiesHouseNumber": "06699180",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12359931,
+        "dateAcademyJoinedTrust": "2019-05-08T00:00:00",
+        "establishmentName": "Glyn School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1269",
+        "schoolCapacity": "1537",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12355763,
+        "dateAcademyJoinedTrust": "2023-05-11T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "342",
+        "schoolCapacity": "648",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12358310,
+        "dateAcademyJoinedTrust": "2016-05-22T00:00:00",
+        "establishmentName": "Rotherham Catholic Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "124",
+        "schoolCapacity": "225",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Josh D\u0027Amore",
+      "email": "Josh.D\u0027Amore@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Roman Torp",
+      "email": "Roman.Torp@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1261",
+    "name": "INSPIRE MULTI-ACADEMY TRUST",
+    "groupId": "TR5574",
+    "ukprn": "10005465",
+    "type": "Multi-academy trust",
+    "address": "32364 Predovic Inlet, XU2 7ZS",
+    "openedDate": "2021-09-05T00:00:00",
+    "companiesHouseNumber": "06760312",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12618940,
+        "dateAcademyJoinedTrust": "2022-03-23T00:00:00",
+        "establishmentName": "Lampton C of E Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2580",
+        "schoolCapacity": "2358",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12614321,
+        "dateAcademyJoinedTrust": "2022-04-21T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Church of England School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "954",
+        "schoolCapacity": "1559",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12612300,
+        "dateAcademyJoinedTrust": "2022-05-09T00:00:00",
+        "establishmentName": "Malbank C of E School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "499",
+        "schoolCapacity": "400",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12617016,
+        "dateAcademyJoinedTrust": "2022-09-11T00:00:00",
+        "establishmentName": "St. James\u0027 Cofe Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1482",
+        "schoolCapacity": "1999",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12616485,
+        "dateAcademyJoinedTrust": "2021-09-07T00:00:00",
+        "establishmentName": "Malbank Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "262",
+        "schoolCapacity": "228",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12618978,
+        "dateAcademyJoinedTrust": "2022-08-04T00:00:00",
+        "establishmentName": "St. Anne\u0027s Church of England Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "654",
+        "schoolCapacity": "1113",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12613349,
+        "dateAcademyJoinedTrust": "2023-03-04T00:00:00",
+        "establishmentName": "Beacon Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "314",
+        "schoolCapacity": "260",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lyle Baumbach",
+      "email": "Lyle.Baumbach@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Bertha Stanton",
+      "email": "Bertha.Stanton@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1255",
+    "name": "INTREPID EDUCATION TRUST",
+    "groupId": "TR5354",
+    "ukprn": "10083291",
+    "type": "Multi-academy trust",
+    "address": "68234 Eladio Inlet, Schadenfort, HU4 7KF",
+    "openedDate": "2014-01-25T00:00:00",
+    "companiesHouseNumber": "08275668",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12552343,
+        "dateAcademyJoinedTrust": "2017-01-27T00:00:00",
+        "establishmentName": "Limehurst Church of England Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1030",
+        "schoolCapacity": "1751",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12559199,
+        "dateAcademyJoinedTrust": "2014-12-20T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Catholic Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "764",
+        "schoolCapacity": "874",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12558383,
+        "dateAcademyJoinedTrust": "2014-09-05T00:00:00",
+        "establishmentName": "Barr and Community School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "416",
+        "schoolCapacity": "607",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Byron Quigley",
+      "email": "Byron.Quigley@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Erick Kassulke",
+      "email": "Erick.Kassulke@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1249",
+    "name": "LEGACY EDUCATION TRUST",
+    "groupId": "TR4681",
+    "ukprn": "10075274",
+    "type": "Multi-academy trust",
+    "address": "2999 Catalina Fork, Deondre Light, UA99 1UQ",
+    "openedDate": "2016-09-27T00:00:00",
+    "companiesHouseNumber": "06678834",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12499507,
+        "dateAcademyJoinedTrust": "2021-04-10T00:00:00",
+        "establishmentName": "Barr and Community Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "486",
+        "schoolCapacity": "579",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12491340,
+        "dateAcademyJoinedTrust": "2022-07-25T00:00:00",
+        "establishmentName": "St. Catherine\u0027s R.C. Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "716",
+        "schoolCapacity": "1553",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12496740,
+        "dateAcademyJoinedTrust": "2018-10-23T00:00:00",
+        "establishmentName": "St. Joseph\u0027s C of E School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "748",
+        "schoolCapacity": "1231",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Amelia Mitchell",
+      "email": "Amelia.Mitchell@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Misty Anderson",
+      "email": "Misty.Anderson@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1246",
+    "name": "MERIT ACADEMY TRUST",
+    "groupId": "TR6036",
+    "ukprn": "10087600",
+    "type": "Multi-academy trust",
+    "address": "1342 Marlon Shore, North Darrion, BJ8 6BK",
+    "openedDate": "2014-10-16T00:00:00",
+    "companiesHouseNumber": "04016752",
     "regionAndTerritory": "East of England",
     "academies": [
       {
-        "urn": 12933210,
-        "dateAcademyJoinedTrust": "2021-09-02T00:00:00",
-        "establishmentName": "St Mary\u0027s Church of England Academy",
+        "urn": 12465180,
+        "dateAcademyJoinedTrust": "2015-03-17T00:00:00",
+        "establishmentName": "St. Peter\u0027s Church of England School",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Rural town and fringe",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1314",
-        "schoolCapacity": "2150",
-        "percentageFreeSchoolMeals": "7",
+        "numberOfPupils": "329",
+        "schoolCapacity": "532",
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -5543,39 +3301,111 @@
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "Cindy Bergstrom",
-      "email": "Cindy.Bergstrom@education.gov.uk"
+      "fullName": "Mae Bradtke",
+      "email": "Mae.Bradtke@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Suzanne Conroy",
-      "email": "Suzanne.Conroy@education.gov.uk"
+      "fullName": "Lillian Hand",
+      "email": "Lillian.Hand@education.gov.uk"
     }
   },
   {
-    "uid": "1294",
-    "name": "ST MARY\u0027S CHURCH OF ENGLAND ACADEMY, STOTFOLD",
-    "groupId": "TR771",
-    "ukprn": "10088352",
-    "type": "Single-academy trust",
-    "address": "0133 Reilly Streets, QS9 7ZR",
-    "openedDate": "2018-02-28T00:00:00",
-    "companiesHouseNumber": "01438959",
+    "uid": "1258",
+    "name": "MILESTONE MULTI-ACADEMY TRUST",
+    "groupId": "TR2133",
+    "ukprn": "10075536",
+    "type": "Multi-academy trust",
+    "address": "89144 Schumm Vista, LY57 8MS",
+    "openedDate": "2022-03-13T00:00:00",
+    "companiesHouseNumber": "08835194",
     "regionAndTerritory": "London",
     "academies": [
       {
-        "urn": 12947863,
-        "dateAcademyJoinedTrust": "2022-11-13T00:00:00",
-        "establishmentName": "St Mary\u0027s Cofe Academy",
+        "urn": 12587948,
+        "dateAcademyJoinedTrust": "2023-02-03T00:00:00",
+        "establishmentName": "Lampton School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "397",
+        "schoolCapacity": "400",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12581445,
+        "dateAcademyJoinedTrust": "2023-05-04T00:00:00",
+        "establishmentName": "Cole Circles R.C. Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "373",
-        "schoolCapacity": "317",
-        "percentageFreeSchoolMeals": "9",
+        "numberOfPupils": "756",
+        "schoolCapacity": "1375",
+        "percentageFreeSchoolMeals": "15",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12586385,
+        "dateAcademyJoinedTrust": "2022-12-02T00:00:00",
+        "establishmentName": "Beacon Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2159",
+        "schoolCapacity": "2599",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12588125,
+        "dateAcademyJoinedTrust": "2023-08-15T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1106",
+        "schoolCapacity": "2616",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12585673,
+        "dateAcademyJoinedTrust": "2023-03-27T00:00:00",
+        "establishmentName": "Meridian Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2908",
+        "schoolCapacity": "2422",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
@@ -5587,32 +3417,1161 @@
       "email": "Tommy.Lubowitz@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Ginger Dietrich",
-      "email": "Ginger.Dietrich@education.gov.uk"
+      "fullName": "Ramon Wehner",
+      "email": "Ramon.Wehner@education.gov.uk"
     }
   },
   {
-    "uid": "1295",
-    "name": "ST MARY\u0027S CHURCH OF ENGLAND JUNIOR SCHOOL",
-    "groupId": "TR1570",
-    "ukprn": "10015235",
-    "type": "Single-academy trust",
-    "address": "064 Giovanni Radial, Heller Coves, West Kraig, NU1 3KL",
-    "openedDate": "2016-03-01T00:00:00",
-    "companiesHouseNumber": "08392292",
-    "regionAndTerritory": "South East",
+    "uid": "1236",
+    "name": "MOMENTUM MULTI-ACADEMY TRUST",
+    "groupId": "TR2123",
+    "ukprn": "10047090",
+    "type": "Multi-academy trust",
+    "address": "83774 Lang Mountain, Thaliachester, TI1 1IA",
+    "openedDate": "2020-03-08T00:00:00",
+    "companiesHouseNumber": "05480418",
+    "regionAndTerritory": "North East",
     "academies": [
       {
-        "urn": 12959099,
-        "dateAcademyJoinedTrust": "2022-04-20T00:00:00",
-        "establishmentName": "St Mary\u0027s C.E. Academy",
+        "urn": 12363105,
+        "dateAcademyJoinedTrust": "2022-10-29T00:00:00",
+        "establishmentName": "Mulberry R.C. Secondary Academy",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1764",
+        "schoolCapacity": "2650",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12361289,
+        "dateAcademyJoinedTrust": "2021-04-29T00:00:00",
+        "establishmentName": "Greensward Church of England Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2390",
-        "schoolCapacity": "2966",
+        "numberOfPupils": "1448",
+        "schoolCapacity": "1417",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12364783,
+        "dateAcademyJoinedTrust": "2021-06-17T00:00:00",
+        "establishmentName": "St. Catherine\u0027s CE School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1014",
+        "schoolCapacity": "2295",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12364786,
+        "dateAcademyJoinedTrust": "2021-04-04T00:00:00",
+        "establishmentName": "Beacon R.C. Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2559",
+        "schoolCapacity": "2323",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12367986,
+        "dateAcademyJoinedTrust": "2023-08-10T00:00:00",
+        "establishmentName": "Peacehaven Community Cofe School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "675",
+        "schoolCapacity": "1042",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12361254,
+        "dateAcademyJoinedTrust": "2022-07-07T00:00:00",
+        "establishmentName": "Mulberry R.C. School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2265",
+        "schoolCapacity": "2319",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12366257,
+        "dateAcademyJoinedTrust": "2021-07-13T00:00:00",
+        "establishmentName": "Mulberry R.C. Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "168",
+        "schoolCapacity": "377",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12369223,
+        "dateAcademyJoinedTrust": "2021-03-07T00:00:00",
+        "establishmentName": "Lampton C of E Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "147",
+        "schoolCapacity": "132",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Amelia Mitchell",
+      "email": "Amelia.Mitchell@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Rachel Volkman",
+      "email": "Rachel.Volkman@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1257",
+    "name": "NEW HORIZONS TRUST",
+    "groupId": "TR8913",
+    "ukprn": "10035466",
+    "type": "Multi-academy trust",
+    "address": "925 Hegmann Expressway, South Glen, QU8 9AP",
+    "openedDate": "2021-03-23T00:00:00",
+    "companiesHouseNumber": "01269091",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 12574904,
+        "dateAcademyJoinedTrust": "2022-10-28T00:00:00",
+        "establishmentName": "St. James\u0027s CE School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2019",
+        "schoolCapacity": "1939",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12571130,
+        "dateAcademyJoinedTrust": "2022-10-24T00:00:00",
+        "establishmentName": "Northwood CE Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1527",
+        "schoolCapacity": "2574",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12574957,
+        "dateAcademyJoinedTrust": "2022-09-15T00:00:00",
+        "establishmentName": "Harris School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1542",
+        "schoolCapacity": "2465",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12578542,
+        "dateAcademyJoinedTrust": "2021-07-07T00:00:00",
+        "establishmentName": "St. James\u0027 Catholic Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2540",
+        "schoolCapacity": "2049",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12576799,
+        "dateAcademyJoinedTrust": "2023-09-30T00:00:00",
+        "establishmentName": "St. Anne\u0027s Cofe Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1817",
+        "schoolCapacity": "2851",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12572296,
+        "dateAcademyJoinedTrust": "2021-07-12T00:00:00",
+        "establishmentName": "Mulberry Catholic Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1535",
+        "schoolCapacity": "1966",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12575923,
+        "dateAcademyJoinedTrust": "2021-11-30T00:00:00",
+        "establishmentName": "Harris Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3077",
+        "schoolCapacity": "2873",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12577644,
+        "dateAcademyJoinedTrust": "2023-01-14T00:00:00",
+        "establishmentName": "Northwood Church of England Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1934",
+        "schoolCapacity": "2949",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12572371,
+        "dateAcademyJoinedTrust": "2021-09-10T00:00:00",
+        "establishmentName": "Northwood Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "947",
+        "schoolCapacity": "1664",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Josh D\u0027Amore",
+      "email": "Josh.D\u0027Amore@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Misty Anderson",
+      "email": "Misty.Anderson@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1245",
+    "name": "NEXUS MULTI-ACADEMY TRUST",
+    "groupId": "TR7612",
+    "ukprn": "10035423",
+    "type": "Multi-academy trust",
+    "address": "27137 Mona Passage, Ward Falls, ZP2 6JH",
+    "openedDate": "2018-08-15T00:00:00",
+    "companiesHouseNumber": "03707429",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12452595,
+        "dateAcademyJoinedTrust": "2022-02-09T00:00:00",
+        "establishmentName": "St. Joseph\u0027s C of E Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "304",
+        "schoolCapacity": "343",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12457405,
+        "dateAcademyJoinedTrust": "2019-11-13T00:00:00",
+        "establishmentName": "St. John\u0027s R.C. School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1443",
+        "schoolCapacity": "2815",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12459010,
+        "dateAcademyJoinedTrust": "2019-10-05T00:00:00",
+        "establishmentName": "Barr and Community Catholic Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2017",
+        "schoolCapacity": "2924",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12455774,
+        "dateAcademyJoinedTrust": "2021-09-27T00:00:00",
+        "establishmentName": "Halewood Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1821",
+        "schoolCapacity": "2192",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "George Muller",
+      "email": "George.Muller@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Tony Hintz",
+      "email": "Tony.Hintz@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1273",
+    "name": "PATHFINDER MULTI-ACADEMY TRUST",
+    "groupId": "TR2511",
+    "ukprn": "10005926",
+    "type": "Multi-academy trust",
+    "address": "50615 Ruby Land, Reneeton, SV1 0EL",
+    "openedDate": "2020-04-29T00:00:00",
+    "companiesHouseNumber": "08761916",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12738590,
+        "dateAcademyJoinedTrust": "2022-10-28T00:00:00",
+        "establishmentName": "Halewood C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1659",
+        "schoolCapacity": "1372",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12731470,
+        "dateAcademyJoinedTrust": "2020-10-22T00:00:00",
+        "establishmentName": "Co-op School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "917",
+        "schoolCapacity": "813",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12734898,
+        "dateAcademyJoinedTrust": "2021-12-20T00:00:00",
+        "establishmentName": "Queensbridge Cofe Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "994",
+        "schoolCapacity": "891",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12734306,
+        "dateAcademyJoinedTrust": "2023-01-03T00:00:00",
+        "establishmentName": "St. John\u0027s Church of England Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "505",
+        "schoolCapacity": "539",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12732813,
+        "dateAcademyJoinedTrust": "2022-09-05T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Catholic School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1168",
+        "schoolCapacity": "1861",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12736191,
+        "dateAcademyJoinedTrust": "2021-01-23T00:00:00",
+        "establishmentName": "George Abbey Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "193",
+        "schoolCapacity": "295",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Annette Breitenberg",
+      "email": "Annette.Breitenberg@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Brent Fahey",
+      "email": "Brent.Fahey@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1248",
+    "name": "PEAK MULTI-ACADEMY TRUST",
+    "groupId": "TR3240",
+    "ukprn": "10063986",
+    "type": "Multi-academy trust",
+    "address": "956 Kieran Lodge, DT0 7ZB",
+    "openedDate": "2020-06-10T00:00:00",
+    "companiesHouseNumber": "01661008",
+    "regionAndTerritory": "East Midlands",
+    "academies": [
+      {
+        "urn": 12486356,
+        "dateAcademyJoinedTrust": "2021-04-07T00:00:00",
+        "establishmentName": "Limehurst Cofe Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1864",
+        "schoolCapacity": "1878",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12484806,
+        "dateAcademyJoinedTrust": "2020-10-13T00:00:00",
+        "establishmentName": "Lampton School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2126",
+        "schoolCapacity": "2712",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12484815,
+        "dateAcademyJoinedTrust": "2023-01-17T00:00:00",
+        "establishmentName": "St. James\u0027 Catholic School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3168",
+        "schoolCapacity": "2594",
         "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12485514,
+        "dateAcademyJoinedTrust": "2020-09-05T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Cofe Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "819",
+        "schoolCapacity": "1927",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12486645,
+        "dateAcademyJoinedTrust": "2022-10-06T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Catholic Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1259",
+        "schoolCapacity": "2598",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12484473,
+        "dateAcademyJoinedTrust": "2021-04-07T00:00:00",
+        "establishmentName": "Meridian C of E Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "593",
+        "schoolCapacity": "659",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12487690,
+        "dateAcademyJoinedTrust": "2020-06-14T00:00:00",
+        "establishmentName": "St. Joseph\u0027s CE Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "708",
+        "schoolCapacity": "735",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12482973,
+        "dateAcademyJoinedTrust": "2021-08-21T00:00:00",
+        "establishmentName": "Greensward Cofe Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "345",
+        "schoolCapacity": "285",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12482993,
+        "dateAcademyJoinedTrust": "2021-11-02T00:00:00",
+        "establishmentName": "Mulberry Cofe Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "657",
+        "schoolCapacity": "1195",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12481857,
+        "dateAcademyJoinedTrust": "2022-07-18T00:00:00",
+        "establishmentName": "Queensbridge R.C. Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3413",
+        "schoolCapacity": "2942",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12482867,
+        "dateAcademyJoinedTrust": "2021-01-21T00:00:00",
+        "establishmentName": "Beacon Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2335",
+        "schoolCapacity": "2541",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Margie Skiles",
+      "email": "Margie.Skiles@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Shelly Mayert",
+      "email": "Shelly.Mayert@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1251",
+    "name": "PINNACLE EDUCATION TRUST",
+    "groupId": "TR1882",
+    "ukprn": "10056750",
+    "type": "Multi-academy trust",
+    "address": "4793 Blanda Squares, Dorothea Village, South Nettie, FI2 8CS",
+    "openedDate": "2021-04-18T00:00:00",
+    "companiesHouseNumber": "01564158",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12518817,
+        "dateAcademyJoinedTrust": "2022-12-17T00:00:00",
+        "establishmentName": "Malbank School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "746",
+        "schoolCapacity": "599",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12518266,
+        "dateAcademyJoinedTrust": "2023-02-06T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Church of England School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2539",
+        "schoolCapacity": "2443",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12512369,
+        "dateAcademyJoinedTrust": "2022-12-15T00:00:00",
+        "establishmentName": "Halewood Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2156",
+        "schoolCapacity": "2317",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12518006,
+        "dateAcademyJoinedTrust": "2023-04-02T00:00:00",
+        "establishmentName": "Peacehaven Community Church of England Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1888",
+        "schoolCapacity": "1567",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12513983,
+        "dateAcademyJoinedTrust": "2021-12-22T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "958",
+        "schoolCapacity": "2183",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12516252,
+        "dateAcademyJoinedTrust": "2021-07-30T00:00:00",
+        "establishmentName": "Nienow Tunnel R.C. Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2007",
+        "schoolCapacity": "1730",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12519485,
+        "dateAcademyJoinedTrust": "2022-02-15T00:00:00",
+        "establishmentName": "Northwood Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "387",
+        "schoolCapacity": "852",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12513933,
+        "dateAcademyJoinedTrust": "2022-06-20T00:00:00",
+        "establishmentName": "St. Paul\u0027s Catholic Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "382",
+        "schoolCapacity": "295",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Annette Breitenberg",
+      "email": "Annette.Breitenberg@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Rachel Volkman",
+      "email": "Rachel.Volkman@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1265",
+    "name": "POTENTIAL LEARNING TRUST",
+    "groupId": "TR3765",
+    "ukprn": "10067222",
+    "type": "Multi-academy trust",
+    "address": "87076 Pacocha Ford, East Luzborough, YS7 4CV",
+    "openedDate": "2015-06-16T00:00:00",
+    "companiesHouseNumber": "07500897",
+    "regionAndTerritory": "North West",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Jessica Legros",
+      "email": "Jessica.Legros@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Natasha Borer",
+      "email": "Natasha.Borer@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1238",
+    "name": "PROGRESSIVE EDUCATION TRUST",
+    "groupId": "TR8438",
+    "ukprn": "10045192",
+    "type": "Multi-academy trust",
+    "address": "046 Schumm Highway, QG54 6NE",
+    "openedDate": "2015-07-13T00:00:00",
+    "companiesHouseNumber": "05450116",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12382120,
+        "dateAcademyJoinedTrust": "2017-02-04T00:00:00",
+        "establishmentName": "Momentum Community School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1827",
+        "schoolCapacity": "2521",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12385894,
+        "dateAcademyJoinedTrust": "2017-08-24T00:00:00",
+        "establishmentName": "St. John\u0027s C of E School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "735",
+        "schoolCapacity": "858",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12381791,
+        "dateAcademyJoinedTrust": "2015-07-21T00:00:00",
+        "establishmentName": "Co-op CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "496",
+        "schoolCapacity": "741",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12384529,
+        "dateAcademyJoinedTrust": "2016-09-12T00:00:00",
+        "establishmentName": "Greensward School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1305",
+        "schoolCapacity": "2073",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12385092,
+        "dateAcademyJoinedTrust": "2017-04-29T00:00:00",
+        "establishmentName": "St. Mary\u0027s CE School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "417",
+        "schoolCapacity": "704",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12389045,
+        "dateAcademyJoinedTrust": "2023-07-17T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2224",
+        "schoolCapacity": "2240",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lyle Baumbach",
+      "email": "Lyle.Baumbach@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Vickie Gulgowski",
+      "email": "Vickie.Gulgowski@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1256",
+    "name": "PROSPECT MULTI-ACADEMY TRUST",
+    "groupId": "TR1770",
+    "ukprn": "10082593",
+    "type": "Multi-academy trust",
+    "address": "887 Laurine Isle, JA55 2RB",
+    "openedDate": "2015-03-01T00:00:00",
+    "companiesHouseNumber": "06517674",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12569335,
+        "dateAcademyJoinedTrust": "2019-08-30T00:00:00",
+        "establishmentName": "St. Mary\u0027s R.C. Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1226",
+        "schoolCapacity": "1859",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12562319,
+        "dateAcademyJoinedTrust": "2017-02-16T00:00:00",
+        "establishmentName": "Queensbridge School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "503",
+        "schoolCapacity": "1235",
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -5623,36 +4582,426 @@
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "Lynn Rodriguez",
-      "email": "Lynn.Rodriguez@education.gov.uk"
+      "fullName": "Josh D\u0027Amore",
+      "email": "Josh.D\u0027Amore@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Amanda McGlynn",
-      "email": "Amanda.McGlynn@education.gov.uk"
+      "fullName": "Jaime Russel",
+      "email": "Jaime.Russel@education.gov.uk"
     }
   },
   {
-    "uid": "1296",
-    "name": "ST MARY\u0027S CHURCH OF ENGLAND PRIMARY ACADEMY, DILWYN",
-    "groupId": "TR997",
-    "ukprn": "10038823",
-    "type": "Single-academy trust",
-    "address": "6414 Yost Hollow, East Peyton, QE24 1GN",
-    "openedDate": "2015-10-13T00:00:00",
-    "companiesHouseNumber": "07975646",
-    "regionAndTerritory": "South East",
+    "uid": "1272",
+    "name": "PROSPERITY EDUCATION TRUST",
+    "groupId": "TR4140",
+    "ukprn": "10000653",
+    "type": "Multi-academy trust",
+    "address": "956 Zieme Parkway, Hoppeside, SZ8 2CQ",
+    "openedDate": "2016-12-15T00:00:00",
+    "companiesHouseNumber": "07144270",
+    "regionAndTerritory": "East Midlands",
     "academies": [
       {
-        "urn": 12962141,
-        "dateAcademyJoinedTrust": "2017-05-02T00:00:00",
-        "establishmentName": "St Mary\u0027s C/E Academy",
+        "urn": 12723670,
+        "dateAcademyJoinedTrust": "2022-10-20T00:00:00",
+        "establishmentName": "St. Paul\u0027s C of E Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "312",
+        "schoolCapacity": "544",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12723194,
+        "dateAcademyJoinedTrust": "2022-02-08T00:00:00",
+        "establishmentName": "St. Peter\u0027s R.C. Secondary School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Barnsley",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1090",
-        "schoolCapacity": "857",
-        "percentageFreeSchoolMeals": "11",
+        "numberOfPupils": "3474",
+        "schoolCapacity": "2724",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12723392,
+        "dateAcademyJoinedTrust": "2019-12-05T00:00:00",
+        "establishmentName": "Barr and Community C of E Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1799",
+        "schoolCapacity": "1864",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12727496,
+        "dateAcademyJoinedTrust": "2019-01-23T00:00:00",
+        "establishmentName": "Peacehaven Community Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3510",
+        "schoolCapacity": "2941",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12723719,
+        "dateAcademyJoinedTrust": "2019-04-05T00:00:00",
+        "establishmentName": "St. James\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "764",
+        "schoolCapacity": "1019",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12729461,
+        "dateAcademyJoinedTrust": "2023-03-24T00:00:00",
+        "establishmentName": "Halewood Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1410",
+        "schoolCapacity": "2364",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12726034,
+        "dateAcademyJoinedTrust": "2018-03-03T00:00:00",
+        "establishmentName": "Greensward Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2344",
+        "schoolCapacity": "2508",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12727931,
+        "dateAcademyJoinedTrust": "2018-11-08T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Cofe Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2087",
+        "schoolCapacity": "2801",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12723499,
+        "dateAcademyJoinedTrust": "2022-12-18T00:00:00",
+        "establishmentName": "Barr and Community C of E School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "809",
+        "schoolCapacity": "967",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lana Mueller",
+      "email": "Lana.Mueller@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Ramon Wehner",
+      "email": "Ramon.Wehner@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1267",
+    "name": "RISE EDUCATION TRUST",
+    "groupId": "TR5014",
+    "ukprn": "10091060",
+    "type": "Multi-academy trust",
+    "address": "9918 Hodkiewicz Park, Lebsack Alley, RC2 1ZJ",
+    "openedDate": "2023-08-01T00:00:00",
+    "companiesHouseNumber": "02918371",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 12674864,
+        "dateAcademyJoinedTrust": "2023-11-05T00:00:00",
+        "establishmentName": "Oasis C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "321",
+        "schoolCapacity": "535",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12676444,
+        "dateAcademyJoinedTrust": "2023-10-18T00:00:00",
+        "establishmentName": "Mulberry Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "565",
+        "schoolCapacity": "732",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12673763,
+        "dateAcademyJoinedTrust": "2023-08-24T00:00:00",
+        "establishmentName": "St. James\u0027 Cofe Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "929",
+        "schoolCapacity": "1489",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12673996,
+        "dateAcademyJoinedTrust": "2023-10-14T00:00:00",
+        "establishmentName": "Harris Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3131",
+        "schoolCapacity": "2915",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12674601,
+        "dateAcademyJoinedTrust": "2023-08-31T00:00:00",
+        "establishmentName": "Beacon Church of England Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "739",
+        "schoolCapacity": "1665",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12676440,
+        "dateAcademyJoinedTrust": "2023-10-24T00:00:00",
+        "establishmentName": "George Abbey School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1915",
+        "schoolCapacity": "1813",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Cindy Bergstrom",
+      "email": "Cindy.Bergstrom@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Shelly Mayert",
+      "email": "Shelly.Mayert@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1310",
+    "name": "SHEFFIELD SOUTH EAST TRUST",
+    "groupId": "TR8979",
+    "ukprn": "10029501",
+    "type": "Multi-academy trust",
+    "address": "84036 Kenya Throughway, Stark Street, HC2 8CH",
+    "openedDate": "2014-04-15T00:00:00",
+    "companiesHouseNumber": "05994616",
+    "regionAndTerritory": "East Midlands",
+    "academies": [
+      {
+        "urn": 13101225,
+        "dateAcademyJoinedTrust": "2017-06-24T00:00:00",
+        "establishmentName": "Oasis Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "489",
+        "schoolCapacity": "433",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13104241,
+        "dateAcademyJoinedTrust": "2018-12-25T00:00:00",
+        "establishmentName": "Co-op CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "166",
+        "schoolCapacity": "195",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13104907,
+        "dateAcademyJoinedTrust": "2020-12-25T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s C of E Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "183",
+        "schoolCapacity": "163",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Roberto Grimes",
+      "email": "Roberto.Grimes@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Sharon Roob",
+      "email": "Sharon.Roob@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1283",
+    "name": "ST MARY\u0027S ACADEMY TRUST",
+    "groupId": "TR1762",
+    "ukprn": "10062927",
+    "type": "Single-academy trust",
+    "address": "526 Mariah Meadows, Rueckerport, NW14 3VS",
+    "openedDate": "2016-06-16T00:00:00",
+    "companiesHouseNumber": "07547557",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 12833094,
+        "dateAcademyJoinedTrust": "2023-03-20T00:00:00",
+        "establishmentName": "St. Mary\u0027s Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1529",
+        "schoolCapacity": "2276",
+        "percentageFreeSchoolMeals": "3",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5667,34 +5016,194 @@
       "email": "Amelia.Mitchell@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Bertha Stanton",
-      "email": "Bertha.Stanton@education.gov.uk"
+      "fullName": "Lillian Hand",
+      "email": "Lillian.Hand@education.gov.uk"
     }
   },
   {
-    "uid": "1297",
-    "name": "ST MARY\u0027S CHURCH OF ENGLAND SCHOOL, NORWOOD GREEN",
-    "groupId": "TR33",
-    "ukprn": "10076934",
+    "uid": "1284",
+    "name": "ST MARY\u0027S ANGLICAN ACADEMY",
+    "groupId": "TR5061",
+    "ukprn": "10050424",
     "type": "Single-academy trust",
-    "address": "7673 Nitzsche Terrace, Lake Cortney, FX34 2ER",
-    "openedDate": "2021-04-06T00:00:00",
-    "companiesHouseNumber": "01301373",
-    "regionAndTerritory": "South East",
+    "address": "40243 Okuneva Mission, Burdette Lane, GS07 3XJ",
+    "openedDate": "2023-07-01T00:00:00",
+    "companiesHouseNumber": "07043349",
+    "regionAndTerritory": "Yorkshire and the Humber",
     "academies": [
       {
-        "urn": 12973686,
-        "dateAcademyJoinedTrust": "2022-11-12T00:00:00",
-        "establishmentName": "St Mary\u0027s C of E Academy",
+        "urn": 12846115,
+        "dateAcademyJoinedTrust": "2023-10-02T00:00:00",
+        "establishmentName": "St. Mary\u0027s Anglican Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "480",
+        "schoolCapacity": "996",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Arturo Purdy",
+      "email": "Arturo.Purdy@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Rachel Volkman",
+      "email": "Rachel.Volkman@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1285",
+    "name": "ST MARY\u0027S CATHOLIC HIGH SCHOOL ACADEMY TRUST",
+    "groupId": "TR6939",
+    "ukprn": "10088163",
+    "type": "Single-academy trust",
+    "address": "9646 Emmy Club, Mraz Crest, FV66 6ZU",
+    "openedDate": "2022-08-02T00:00:00",
+    "companiesHouseNumber": "01557826",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 12855506,
+        "dateAcademyJoinedTrust": "2023-09-26T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic High School Academy",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3440",
+        "schoolCapacity": "2653",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lamar Ritchie",
+      "email": "Lamar.Ritchie@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Rachel Volkman",
+      "email": "Rachel.Volkman@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1286",
+    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL",
+    "groupId": "TR3650",
+    "ukprn": "10062442",
+    "type": "Single-academy trust",
+    "address": "63777 Bartoletti Vista, Weber Shore, Lake Kamryn, GT2 3FC",
+    "openedDate": "2015-07-19T00:00:00",
+    "companiesHouseNumber": "06928290",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 12862465,
+        "dateAcademyJoinedTrust": "2018-12-27T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1008",
-        "schoolCapacity": "2081",
-        "percentageFreeSchoolMeals": "27",
+        "numberOfPupils": "1962",
+        "schoolCapacity": "2024",
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
-          "minimum": 4,
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Colin Kiehn",
+      "email": "Colin.Kiehn@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Vickie Gulgowski",
+      "email": "Vickie.Gulgowski@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1287",
+    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (ACADEMY TRUST), SWINDON",
+    "groupId": "TR2916",
+    "ukprn": "10088921",
+    "type": "Single-academy trust",
+    "address": "22730 Annetta Mission, Kyler Trace, Kingville, NL44 0LP",
+    "openedDate": "2015-07-17T00:00:00",
+    "companiesHouseNumber": "08456394",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12871080,
+        "dateAcademyJoinedTrust": "2016-09-30T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1277",
+        "schoolCapacity": "1342",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Byron Quigley",
+      "email": "Byron.Quigley@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jennie Greenholt",
+      "email": "Jennie.Greenholt@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1288",
+    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (HERRINGTHORPE), A CATHOLIC VOLUNTARY ACADEMY",
+    "groupId": "TR4800",
+    "ukprn": "10019875",
+    "type": "Single-academy trust",
+    "address": "03174 Mariah Trail, HR85 1XY",
+    "openedDate": "2018-04-30T00:00:00",
+    "companiesHouseNumber": "05762372",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 12884828,
+        "dateAcademyJoinedTrust": "2023-06-15T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "871",
+        "schoolCapacity": "1338",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 5,
           "maximum": 11
         },
         "currentOfstedRating": null,
@@ -5707,32 +5216,72 @@
       "email": "Lamar.Kulas@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Jennie Greenholt",
-      "email": "Jennie.Greenholt@education.gov.uk"
+      "fullName": "Marion MacGyver",
+      "email": "Marion.MacGyver@education.gov.uk"
     }
   },
   {
-    "uid": "1298",
-    "name": "ST MARY\u0027S CHURCH OF ENGLAND VA PRIMARY ACADEMY",
-    "groupId": "TR6921",
-    "ukprn": "10091961",
+    "uid": "1289",
+    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (MALTBY)",
+    "groupId": "TR7937",
+    "ukprn": "10015319",
     "type": "Single-academy trust",
-    "address": "57276 Mathias Groves, EJ43 4PX",
-    "openedDate": "2014-10-15T00:00:00",
-    "companiesHouseNumber": "05656636",
+    "address": "3313 Swift Mill, Alex Hills, TG62 5NU",
+    "openedDate": "2014-06-21T00:00:00",
+    "companiesHouseNumber": "01112889",
     "regionAndTerritory": "Yorkshire and the Humber",
     "academies": [
       {
-        "urn": 12989794,
-        "dateAcademyJoinedTrust": "2021-12-17T00:00:00",
-        "establishmentName": "St Mary\u0027s Church of England VA Primary Academy",
+        "urn": 12898683,
+        "dateAcademyJoinedTrust": "2022-09-07T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1306",
-        "schoolCapacity": "1342",
+        "numberOfPupils": "1347",
+        "schoolCapacity": "1662",
         "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Silvia Berge",
+      "email": "Silvia.Berge@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Lillian Hand",
+      "email": "Lillian.Hand@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1290",
+    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL, CHURCHDOWN",
+    "groupId": "TR3117",
+    "ukprn": "10045476",
+    "type": "Single-academy trust",
+    "address": "044 Shea Place, Nitzsche Radial, FQ4 6PF",
+    "openedDate": "2019-11-18T00:00:00",
+    "companiesHouseNumber": "02482151",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12907110,
+        "dateAcademyJoinedTrust": "2022-04-30T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1403",
+        "schoolCapacity": "1408",
+        "percentageFreeSchoolMeals": "26",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -5747,126 +5296,32 @@
       "email": "Margie.Skiles@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Jonathon Littel",
-      "email": "Jonathon.Littel@education.gov.uk"
+      "fullName": "Jaime Russel",
+      "email": "Jaime.Russel@education.gov.uk"
     }
   },
   {
-    "uid": "1299",
-    "name": "ST MARY\u0027S PRIMARY SCHOOL, A CATHOLIC VOLUNTARY ACADEMY",
-    "groupId": "TR8415",
-    "ukprn": "10072860",
-    "type": "Single-academy trust",
-    "address": "02347 Jalyn Estates, East Enidhaven, GH0 0AE",
-    "openedDate": "2019-11-17T00:00:00",
-    "companiesHouseNumber": "05420361",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 12996150,
-        "dateAcademyJoinedTrust": "2022-01-31T00:00:00",
-        "establishmentName": "St Mary\u0027s Primary School, A Catholic Voluntary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "891",
-        "schoolCapacity": "1790",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Arturo Purdy",
-      "email": "Arturo.Purdy@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Natasha Borer",
-      "email": "Natasha.Borer@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1262",
-    "name": "SUCCESS MULTI-ACADEMY TRUST",
-    "groupId": "TR7798",
-    "ukprn": "10053812",
+    "uid": "1291",
+    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOLS TRUST",
+    "groupId": "TR3353",
+    "ukprn": "10040182",
     "type": "Multi-academy trust",
-    "address": "8841 Sheldon Parks, Idell Drive, Josephineland, FV30 9PO",
-    "openedDate": "2017-09-16T00:00:00",
-    "companiesHouseNumber": "03387253",
-    "regionAndTerritory": "Yorkshire and the Humber",
+    "address": "670 Considine Ridges, Beatty Glen, Lesterchester, EC6 4DK",
+    "openedDate": "2016-07-13T00:00:00",
+    "companiesHouseNumber": "03081261",
+    "regionAndTerritory": "East Midlands",
     "academies": [
       {
-        "urn": 12624375,
-        "dateAcademyJoinedTrust": "2020-09-23T00:00:00",
-        "establishmentName": "Lampton Church of England Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1079",
-        "schoolCapacity": "970",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12627895,
-        "dateAcademyJoinedTrust": "2018-01-18T00:00:00",
-        "establishmentName": "Co-op School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
+        "urn": 12915924,
+        "dateAcademyJoinedTrust": "2018-06-10T00:00:00",
+        "establishmentName": "St Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1589",
-        "schoolCapacity": "1606",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12628408,
-        "dateAcademyJoinedTrust": "2021-01-19T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1703",
-        "schoolCapacity": "1669",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12625556,
-        "dateAcademyJoinedTrust": "2021-08-16T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "909",
-        "schoolCapacity": "1402",
-        "percentageFreeSchoolMeals": "26",
+        "numberOfPupils": "1747",
+        "schoolCapacity": "1733",
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -5875,51 +5330,141 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12625808,
-        "dateAcademyJoinedTrust": "2019-07-29T00:00:00",
-        "establishmentName": "Barr and Community School",
+        "urn": 12919179,
+        "dateAcademyJoinedTrust": "2016-08-30T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Leeds",
+        "localAuthority": "Doncaster",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2023",
-        "schoolCapacity": "1981",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12627869,
-        "dateAcademyJoinedTrust": "2022-03-14T00:00:00",
-        "establishmentName": "Barr and Community Catholic Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "397",
-        "schoolCapacity": "407",
+        "numberOfPupils": "904",
+        "schoolCapacity": "1496",
         "percentageFreeSchoolMeals": "9",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12621272,
-        "dateAcademyJoinedTrust": "2020-10-23T00:00:00",
-        "establishmentName": "Halewood Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
+        "urn": 12917535,
+        "dateAcademyJoinedTrust": "2023-10-02T00:00:00",
+        "establishmentName": "St. Marys Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "884",
-        "schoolCapacity": "849",
+        "numberOfPupils": "940",
+        "schoolCapacity": "2167",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12916774,
+        "dateAcademyJoinedTrust": "2023-07-22T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2183",
+        "schoolCapacity": "2879",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12915357,
+        "dateAcademyJoinedTrust": "2019-10-21T00:00:00",
+        "establishmentName": "St Marys Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3053",
+        "schoolCapacity": "2848",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12914937,
+        "dateAcademyJoinedTrust": "2020-03-14T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1242",
+        "schoolCapacity": "1211",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12919071,
+        "dateAcademyJoinedTrust": "2019-05-22T00:00:00",
+        "establishmentName": "St. Mary\u0027s RC Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3227",
+        "schoolCapacity": "2825",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12919568,
+        "dateAcademyJoinedTrust": "2023-06-17T00:00:00",
+        "establishmentName": "St. Mary\u0027s Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2483",
+        "schoolCapacity": "2852",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12912765,
+        "dateAcademyJoinedTrust": "2023-01-25T00:00:00",
+        "establishmentName": "St. Mary\u0027s Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3767",
+        "schoolCapacity": "2975",
         "percentageFreeSchoolMeals": "25",
         "ageRange": {
           "minimum": 5,
@@ -5927,30 +5472,12 @@
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      },
-      {
-        "urn": 12629874,
-        "dateAcademyJoinedTrust": "2018-05-28T00:00:00",
-        "establishmentName": "St. Mary\u0027s C of E School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "162",
-        "schoolCapacity": "130",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
       }
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "Rudy McClure",
-      "email": "Rudy.McClure@education.gov.uk"
+      "fullName": "Phyllis Kling",
+      "email": "Phyllis.Kling@education.gov.uk"
     },
     "sfsoLead": {
       "fullName": "Vickie Gulgowski",
@@ -5958,45 +5485,27 @@
     }
   },
   {
-    "uid": "1300",
-    "name": "THE DIOCESE OF CANTERBURY ACADEMIES TRUST",
-    "groupId": "TR9778",
-    "ukprn": "10009892",
-    "type": "Multi-academy trust",
-    "address": "8072 Elisha Plains, Kole Lights, East Candicetown, DK9 7YG",
-    "openedDate": "2015-09-28T00:00:00",
-    "companiesHouseNumber": "06944068",
-    "regionAndTerritory": "North East",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "George Muller",
-      "email": "George.Muller@education.gov.uk"
-    },
-    "sfsoLead": null
-  },
-  {
-    "uid": "1301",
-    "name": "THE DIOCESE OF CHELMSFORD VINE SCHOOLS TRUST",
-    "groupId": "TR9187",
-    "ukprn": "10035221",
-    "type": "Multi-academy trust",
-    "address": "3770 Rosina Fords, Collier Fall, LO19 9UX",
-    "openedDate": "2017-11-09T00:00:00",
-    "companiesHouseNumber": "07232979",
-    "regionAndTerritory": "London",
+    "uid": "1292",
+    "name": "ST MARY\u0027S CE ACADEMY, CHESHUNT",
+    "groupId": "TR5146",
+    "ukprn": "10000580",
+    "type": "Single-academy trust",
+    "address": "08865 Hettinger Green, XF9 0IZ",
+    "openedDate": "2014-08-23T00:00:00",
+    "companiesHouseNumber": "08565724",
+    "regionAndTerritory": "North West",
     "academies": [
       {
-        "urn": 13018755,
-        "dateAcademyJoinedTrust": "2021-10-10T00:00:00",
-        "establishmentName": "Lampton Church of England Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
+        "urn": 12924303,
+        "dateAcademyJoinedTrust": "2022-03-24T00:00:00",
+        "establishmentName": "St Mary\u0027s CE Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "936",
-        "schoolCapacity": "1919",
-        "percentageFreeSchoolMeals": "29",
+        "numberOfPupils": "1974",
+        "schoolCapacity": "2970",
+        "percentageFreeSchoolMeals": "3",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -6007,35 +5516,35 @@
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "Lynn Rodriguez",
-      "email": "Lynn.Rodriguez@education.gov.uk"
+      "fullName": "Lyle Baumbach",
+      "email": "Lyle.Baumbach@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Ginger Dietrich",
-      "email": "Ginger.Dietrich@education.gov.uk"
+      "fullName": "Marion MacGyver",
+      "email": "Marion.MacGyver@education.gov.uk"
     }
   },
   {
-    "uid": "1302",
-    "name": "THE DIOCESE OF COVENTRY MULTI-ACADEMY TRUST",
-    "groupId": "TR3048",
-    "ukprn": "10047401",
-    "type": "Multi-academy trust",
-    "address": "445 Dach Hill, LG93 6AK",
-    "openedDate": "2014-01-29T00:00:00",
-    "companiesHouseNumber": "06796598",
-    "regionAndTerritory": "East of England",
+    "uid": "1293",
+    "name": "ST MARY\u0027S CHURCH OF ENGLAND ACADEMY TRUST",
+    "groupId": "TR8931",
+    "ukprn": "10082054",
+    "type": "Single-academy trust",
+    "address": "69058 Graham Route, YQ72 6RL",
+    "openedDate": "2013-12-28T00:00:00",
+    "companiesHouseNumber": "04885101",
+    "regionAndTerritory": "",
     "academies": [
       {
-        "urn": 13027003,
-        "dateAcademyJoinedTrust": "2022-02-25T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Cofe School",
+        "urn": 12934049,
+        "dateAcademyJoinedTrust": "2016-05-07T00:00:00",
+        "establishmentName": "St Mary\u0027s Church of England Academy",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Barnsley",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1001",
-        "schoolCapacity": "1326",
+        "numberOfPupils": "1657",
+        "schoolCapacity": "2608",
         "percentageFreeSchoolMeals": "2",
         "ageRange": {
           "minimum": 11,
@@ -6043,97 +5552,43 @@
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      },
-      {
-        "urn": 13025689,
-        "dateAcademyJoinedTrust": "2019-04-28T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2622",
-        "schoolCapacity": "2058",
-        "percentageFreeSchoolMeals": "26",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13029767,
-        "dateAcademyJoinedTrust": "2014-04-30T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Church of England Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1708",
-        "schoolCapacity": "2952",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
       }
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "Tommy Lubowitz",
-      "email": "Tommy.Lubowitz@education.gov.uk"
+      "fullName": "Margie Skiles",
+      "email": "Margie.Skiles@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Rachel Volkman",
-      "email": "Rachel.Volkman@education.gov.uk"
+      "fullName": "Walter Boyle",
+      "email": "Walter.Boyle@education.gov.uk"
     }
   },
   {
-    "uid": "1303",
-    "name": "THE DIOCESE OF ELY MULTI-ACADEMY TRUST",
-    "groupId": "TR8935",
-    "ukprn": "10030162",
-    "type": "Multi-academy trust",
-    "address": "947 Huel Village, XI00 8DK",
-    "openedDate": "2016-09-30T00:00:00",
-    "companiesHouseNumber": "07146483",
+    "uid": "1294",
+    "name": "ST MARY\u0027S CHURCH OF ENGLAND ACADEMY, STOTFOLD",
+    "groupId": "TR5838",
+    "ukprn": "10053494",
+    "type": "Single-academy trust",
+    "address": "1970 Kozey Plaza, Felton Port, GF84 8SL",
+    "openedDate": "2020-02-08T00:00:00",
+    "companiesHouseNumber": "07221159",
     "regionAndTerritory": "Yorkshire and the Humber",
     "academies": [
       {
-        "urn": 13031429,
-        "dateAcademyJoinedTrust": "2022-01-14T00:00:00",
-        "establishmentName": "Rico Pines School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1503",
-        "schoolCapacity": "1334",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13039123,
-        "dateAcademyJoinedTrust": "2018-05-12T00:00:00",
-        "establishmentName": "St. James\u0027s Church of England Primary School",
+        "urn": 12946623,
+        "dateAcademyJoinedTrust": "2021-01-06T00:00:00",
+        "establishmentName": "St Mary\u0027s Cofe Academy",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "421",
-        "schoolCapacity": "833",
-        "percentageFreeSchoolMeals": "26",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2218",
+        "schoolCapacity": "2988",
+        "percentageFreeSchoolMeals": "20",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
@@ -6141,182 +5596,155 @@
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "Roberto Grimes",
-      "email": "Roberto.Grimes@education.gov.uk"
+      "fullName": "Silvia Berge",
+      "email": "Silvia.Berge@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Jonathon Littel",
-      "email": "Jonathon.Littel@education.gov.uk"
+      "fullName": "Roman Torp",
+      "email": "Roman.Torp@education.gov.uk"
     }
   },
   {
-    "uid": "1304",
-    "name": "THE DIOCESE OF GLOUCESTER ACADEMIES TRUST",
-    "groupId": "TR1945",
-    "ukprn": "10023025",
-    "type": "Multi-academy trust",
-    "address": "14577 Emmy Squares, Wyman Tunnel, Ricomouth, YY15 7OG",
-    "openedDate": "2023-05-18T00:00:00",
-    "companiesHouseNumber": "02368147",
-    "regionAndTerritory": "",
+    "uid": "1295",
+    "name": "ST MARY\u0027S CHURCH OF ENGLAND JUNIOR SCHOOL",
+    "groupId": "TR3506",
+    "ukprn": "10064608",
+    "type": "Single-academy trust",
+    "address": "67872 Irwin Trail, Hintz Wells, Hollisbury, QY35 2XF",
+    "openedDate": "2017-03-24T00:00:00",
+    "companiesHouseNumber": "05121558",
+    "regionAndTerritory": "North West",
     "academies": [
       {
-        "urn": 13043204,
-        "dateAcademyJoinedTrust": "2023-09-14T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban city and town",
+        "urn": 12955650,
+        "dateAcademyJoinedTrust": "2017-07-31T00:00:00",
+        "establishmentName": "St Mary\u0027s C.E. Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "310",
-        "schoolCapacity": "644",
-        "percentageFreeSchoolMeals": "15",
+        "numberOfPupils": "956",
+        "schoolCapacity": "1061",
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      },
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Josh D\u0027Amore",
+      "email": "Josh.D\u0027Amore@education.gov.uk"
+    },
+    "sfsoLead": null
+  },
+  {
+    "uid": "1296",
+    "name": "ST MARY\u0027S CHURCH OF ENGLAND PRIMARY ACADEMY, DILWYN",
+    "groupId": "TR7489",
+    "ukprn": "10057154",
+    "type": "Single-academy trust",
+    "address": "0386 Armand Glens, Maximillianburgh, FA0 5WJ",
+    "openedDate": "2014-05-09T00:00:00",
+    "companiesHouseNumber": "08707061",
+    "regionAndTerritory": "South West",
+    "academies": [
       {
-        "urn": 13048936,
-        "dateAcademyJoinedTrust": "2023-07-21T00:00:00",
-        "establishmentName": "Limehurst R.C. Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Leeds",
+        "urn": 12961216,
+        "dateAcademyJoinedTrust": "2014-09-29T00:00:00",
+        "establishmentName": "St Mary\u0027s C/E Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2682",
+        "schoolCapacity": "2086",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Byron Quigley",
+      "email": "Byron.Quigley@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Lillian Hand",
+      "email": "Lillian.Hand@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1297",
+    "name": "ST MARY\u0027S CHURCH OF ENGLAND SCHOOL, NORWOOD GREEN",
+    "groupId": "TR6085",
+    "ukprn": "10057231",
+    "type": "Single-academy trust",
+    "address": "58935 Johnston Bypass, Watersburgh, ZE07 7JY",
+    "openedDate": "2022-03-17T00:00:00",
+    "companiesHouseNumber": "05135830",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12972390,
+        "dateAcademyJoinedTrust": "2023-10-25T00:00:00",
+        "establishmentName": "St Mary\u0027s C of E Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1159",
+        "schoolCapacity": "1363",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Amelia Mitchell",
+      "email": "Amelia.Mitchell@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Suzanne Conroy",
+      "email": "Suzanne.Conroy@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1298",
+    "name": "ST MARY\u0027S CHURCH OF ENGLAND VA PRIMARY ACADEMY",
+    "groupId": "TR1624",
+    "ukprn": "10014212",
+    "type": "Single-academy trust",
+    "address": "647 Bahringer Squares, OM2 7NT",
+    "openedDate": "2017-04-09T00:00:00",
+    "companiesHouseNumber": "02747433",
+    "regionAndTerritory": "East Midlands",
+    "academies": [
+      {
+        "urn": 12983816,
+        "dateAcademyJoinedTrust": "2018-06-22T00:00:00",
+        "establishmentName": "St Mary\u0027s Church of England VA Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "387",
-        "schoolCapacity": "865",
-        "percentageFreeSchoolMeals": "15",
+        "numberOfPupils": "109",
+        "schoolCapacity": "108",
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13042234,
-        "dateAcademyJoinedTrust": "2023-09-19T00:00:00",
-        "establishmentName": "Greensward School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1450",
-        "schoolCapacity": "1222",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13046144,
-        "dateAcademyJoinedTrust": "2023-09-14T00:00:00",
-        "establishmentName": "Beacon Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "504",
-        "schoolCapacity": "599",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13048068,
-        "dateAcademyJoinedTrust": "2023-11-06T00:00:00",
-        "establishmentName": "Co-op R.C. Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2247",
-        "schoolCapacity": "2659",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13049030,
-        "dateAcademyJoinedTrust": "2023-10-13T00:00:00",
-        "establishmentName": "Leeds Catholic School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1010",
-        "schoolCapacity": "1421",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13047366,
-        "dateAcademyJoinedTrust": "2023-07-23T00:00:00",
-        "establishmentName": "Oasis School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1229",
-        "schoolCapacity": "2620",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13047568,
-        "dateAcademyJoinedTrust": "2023-06-30T00:00:00",
-        "establishmentName": "Co-op Catholic Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1438",
-        "schoolCapacity": "2064",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13046351,
-        "dateAcademyJoinedTrust": "2023-06-21T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Church of England Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "693",
-        "schoolCapacity": "1645",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 4,
           "maximum": 11
         },
         "currentOfstedRating": null,
@@ -6329,88 +5757,34 @@
       "email": "Lindsey.Von@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Sharon Roob",
-      "email": "Sharon.Roob@education.gov.uk"
+      "fullName": "Cecilia Crona",
+      "email": "Cecilia.Crona@education.gov.uk"
     }
   },
   {
-    "uid": "1305",
-    "name": "THE DIOCESE OF NORWICH EDUCATION AND ACADEMIES TRUST",
-    "groupId": "TR9558",
-    "ukprn": "10074724",
-    "type": "Multi-academy trust",
-    "address": "66718 Barton Mews, New Joana, PD9 9HQ",
-    "openedDate": "2021-07-05T00:00:00",
-    "companiesHouseNumber": "05354525",
+    "uid": "1299",
+    "name": "ST MARY\u0027S PRIMARY SCHOOL, A CATHOLIC VOLUNTARY ACADEMY",
+    "groupId": "TR9475",
+    "ukprn": "10023135",
+    "type": "Single-academy trust",
+    "address": "464 Miller Harbor, Schaden Mount, CE50 7QE",
+    "openedDate": "2023-07-01T00:00:00",
+    "companiesHouseNumber": "07063460",
     "regionAndTerritory": "Yorkshire and the Humber",
     "academies": [
       {
-        "urn": 13058724,
-        "dateAcademyJoinedTrust": "2022-07-18T00:00:00",
-        "establishmentName": "Oasis CE Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1152",
-        "schoolCapacity": "1338",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13056349,
-        "dateAcademyJoinedTrust": "2022-10-25T00:00:00",
-        "establishmentName": "Mulberry Cofe Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "402",
-        "schoolCapacity": "989",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13058058,
-        "dateAcademyJoinedTrust": "2022-05-10T00:00:00",
-        "establishmentName": "Longhill R.C. Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "590",
-        "schoolCapacity": "611",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13058180,
-        "dateAcademyJoinedTrust": "2022-04-02T00:00:00",
-        "establishmentName": "Meridian Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
+        "urn": 12992955,
+        "dateAcademyJoinedTrust": "2023-08-07T00:00:00",
+        "establishmentName": "St Mary\u0027s Primary School, A Catholic Voluntary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1467",
-        "schoolCapacity": "1700",
-        "percentageFreeSchoolMeals": "27",
+        "numberOfPupils": "1382",
+        "schoolCapacity": "1428",
+        "percentageFreeSchoolMeals": "26",
         "ageRange": {
-          "minimum": 4,
+          "minimum": 5,
           "maximum": 11
         },
         "currentOfstedRating": null,
@@ -6423,328 +5797,32 @@
       "email": "Arturo.Purdy@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Amanda McGlynn",
-      "email": "Amanda.McGlynn@education.gov.uk"
+      "fullName": "Jennie Greenholt",
+      "email": "Jennie.Greenholt@education.gov.uk"
     }
   },
   {
-    "uid": "1306",
-    "name": "THE DIOCESE OF NORWICH ST BENET\u0027S MULTI-ACADEMY TRUST",
-    "groupId": "TR415",
-    "ukprn": "10041812",
+    "uid": "1262",
+    "name": "SUCCESS MULTI-ACADEMY TRUST",
+    "groupId": "TR4015",
+    "ukprn": "10036827",
     "type": "Multi-academy trust",
-    "address": "86034 Johnpaul Ferry, Crist Square, Brownchester, ZA7 3CU",
-    "openedDate": "2018-09-20T00:00:00",
-    "companiesHouseNumber": "09230599",
-    "regionAndTerritory": "North West",
-    "academies": [
-      {
-        "urn": 13064417,
-        "dateAcademyJoinedTrust": "2019-05-16T00:00:00",
-        "establishmentName": "Harris Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "819",
-        "schoolCapacity": "1545",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13067653,
-        "dateAcademyJoinedTrust": "2018-12-25T00:00:00",
-        "establishmentName": "Queensbridge CE Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "203",
-        "schoolCapacity": "203",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13063912,
-        "dateAcademyJoinedTrust": "2019-07-07T00:00:00",
-        "establishmentName": "St. Paul\u0027s Cofe Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "690",
-        "schoolCapacity": "650",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13065004,
-        "dateAcademyJoinedTrust": "2022-05-02T00:00:00",
-        "establishmentName": "Malbank C of E Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2209",
-        "schoolCapacity": "2790",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13067069,
-        "dateAcademyJoinedTrust": "2022-04-03T00:00:00",
-        "establishmentName": "Malbank Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1660",
-        "schoolCapacity": "1855",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Ramona O\u0027Keefe",
-      "email": "Ramona.O\u0027Keefe@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Marion MacGyver",
-      "email": "Marion.MacGyver@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1307",
-    "name": "THE DIOCESE OF SHEFFIELD ACADEMIES TRUST",
-    "groupId": "TR9542",
-    "ukprn": "10088823",
-    "type": "Multi-academy trust",
-    "address": "5557 Beatty Dam, NP12 8ZG",
-    "openedDate": "2014-07-14T00:00:00",
-    "companiesHouseNumber": "09884347",
-    "regionAndTerritory": "South West",
-    "academies": [
-      {
-        "urn": 13077599,
-        "dateAcademyJoinedTrust": "2021-11-15T00:00:00",
-        "establishmentName": "Harris Church of England Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3283",
-        "schoolCapacity": "2898",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13074559,
-        "dateAcademyJoinedTrust": "2014-07-19T00:00:00",
-        "establishmentName": "Malbank Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1722",
-        "schoolCapacity": "1999",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13078571,
-        "dateAcademyJoinedTrust": "2022-06-20T00:00:00",
-        "establishmentName": "St. Paul\u0027s C of E Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2723",
-        "schoolCapacity": "2442",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13076691,
-        "dateAcademyJoinedTrust": "2021-03-30T00:00:00",
-        "establishmentName": "St. Mary\u0027s Cofe Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1134",
-        "schoolCapacity": "945",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13076280,
-        "dateAcademyJoinedTrust": "2017-02-21T00:00:00",
-        "establishmentName": "Glyn CE Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "770",
-        "schoolCapacity": "1397",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13071578,
-        "dateAcademyJoinedTrust": "2020-10-28T00:00:00",
-        "establishmentName": "Greensward Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1876",
-        "schoolCapacity": "2514",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13071694,
-        "dateAcademyJoinedTrust": "2022-06-10T00:00:00",
-        "establishmentName": "George Abbey Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "320",
-        "schoolCapacity": "539",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13075320,
-        "dateAcademyJoinedTrust": "2020-01-07T00:00:00",
-        "establishmentName": "Horizon Church of England School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "679",
-        "schoolCapacity": "1232",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Lindsey Von",
-      "email": "Lindsey.Von@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Vickie Gulgowski",
-      "email": "Vickie.Gulgowski@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1308",
-    "name": "THE DIOCESE OF WESTMINSTER ACADEMY TRUST",
-    "groupId": "TR1115",
-    "ukprn": "10088919",
-    "type": "Multi-academy trust",
-    "address": "555 Jordane View, Jakob Green, Port Reilly, MI6 6EB",
-    "openedDate": "2015-09-26T00:00:00",
-    "companiesHouseNumber": "03491410",
+    "address": "135 Carley Point, Erdman Lights, PH8 2DA",
+    "openedDate": "2022-03-21T00:00:00",
+    "companiesHouseNumber": "07644450",
     "regionAndTerritory": "Yorkshire and the Humber",
     "academies": [
       {
-        "urn": 13084843,
-        "dateAcademyJoinedTrust": "2016-03-13T00:00:00",
-        "establishmentName": "Co-op School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3109",
-        "schoolCapacity": "2790",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13081267,
-        "dateAcademyJoinedTrust": "2023-04-16T00:00:00",
-        "establishmentName": "Malbank Catholic Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
+        "urn": 12623887,
+        "dateAcademyJoinedTrust": "2022-03-31T00:00:00",
+        "establishmentName": "St. Paul\u0027s CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2012",
-        "schoolCapacity": "1586",
-        "percentageFreeSchoolMeals": "13",
+        "numberOfPupils": "1407",
+        "schoolCapacity": "2422",
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -6753,109 +5831,105 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13081013,
-        "dateAcademyJoinedTrust": "2016-06-08T00:00:00",
-        "establishmentName": "St. John\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
+        "urn": 12626345,
+        "dateAcademyJoinedTrust": "2023-06-06T00:00:00",
+        "establishmentName": "Harris Catholic Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "84",
-        "schoolCapacity": "104",
-        "percentageFreeSchoolMeals": "14",
+        "numberOfPupils": "231",
+        "schoolCapacity": "393",
+        "percentageFreeSchoolMeals": "12",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Jessica Legros",
-      "email": "Jessica.Legros@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Ginger Dietrich",
-      "email": "Ginger.Dietrich@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1309",
-    "name": "THE DIOCESE OF WORCESTER MULTI ACADEMY TRUST",
-    "groupId": "TR1542",
-    "ukprn": "10032472",
-    "type": "Multi-academy trust",
-    "address": "485 Dibbert Mountains, South Mireya, LA8 6WQ",
-    "openedDate": "2017-03-01T00:00:00",
-    "companiesHouseNumber": "02211996",
-    "regionAndTerritory": "North East",
-    "academies": [
+      },
       {
-        "urn": 13096524,
-        "dateAcademyJoinedTrust": "2017-09-08T00:00:00",
-        "establishmentName": "George Abbey Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kingston upon Hull, City of",
+        "urn": 12628747,
+        "dateAcademyJoinedTrust": "2022-11-12T00:00:00",
+        "establishmentName": "Longhill R.C. Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "127",
-        "schoolCapacity": "272",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1223",
+        "schoolCapacity": "2168",
         "percentageFreeSchoolMeals": "9",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 13098513,
-        "dateAcademyJoinedTrust": "2022-03-17T00:00:00",
-        "establishmentName": "Harris Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1359",
-        "schoolCapacity": "1691",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13095058,
-        "dateAcademyJoinedTrust": "2020-05-27T00:00:00",
-        "establishmentName": "North Yorkshire C of E School",
-        "typeOfEstablishment": "Free school",
+        "urn": 12621352,
+        "dateAcademyJoinedTrust": "2023-06-25T00:00:00",
+        "establishmentName": "Malbank CE Academy",
+        "typeOfEstablishment": "Academy sponsor led",
         "localAuthority": "North Yorkshire",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1325",
-        "schoolCapacity": "1888",
-        "percentageFreeSchoolMeals": "13",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1194",
+        "schoolCapacity": "2390",
+        "percentageFreeSchoolMeals": "21",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 13095301,
-        "dateAcademyJoinedTrust": "2017-04-22T00:00:00",
-        "establishmentName": "Co-op Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
+        "urn": 12625891,
+        "dateAcademyJoinedTrust": "2022-12-22T00:00:00",
+        "establishmentName": "Lampton School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
         "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3119",
+        "schoolCapacity": "2655",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12627991,
+        "dateAcademyJoinedTrust": "2022-08-07T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "367",
-        "schoolCapacity": "748",
+        "numberOfPupils": "1249",
+        "schoolCapacity": "2691",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12629043,
+        "dateAcademyJoinedTrust": "2022-05-03T00:00:00",
+        "establishmentName": "Meridian Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3629",
+        "schoolCapacity": "2918",
         "percentageFreeSchoolMeals": "5",
         "ageRange": {
           "minimum": 5,
@@ -6865,55 +5939,55 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13094373,
-        "dateAcademyJoinedTrust": "2018-09-27T00:00:00",
-        "establishmentName": "George Abbey Catholic Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2834",
-        "schoolCapacity": "2603",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13093233,
-        "dateAcademyJoinedTrust": "2019-04-11T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Catholic School",
+        "urn": 12621924,
+        "dateAcademyJoinedTrust": "2022-06-15T00:00:00",
+        "establishmentName": "Co-op School",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "809",
-        "schoolCapacity": "1339",
-        "percentageFreeSchoolMeals": "17",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13093504,
-        "dateAcademyJoinedTrust": "2023-07-03T00:00:00",
-        "establishmentName": "St. Anne\u0027s C of E Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1654",
-        "schoolCapacity": "2118",
-        "percentageFreeSchoolMeals": "22",
+        "numberOfPupils": "3519",
+        "schoolCapacity": "2869",
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12629865,
+        "dateAcademyJoinedTrust": "2023-03-29T00:00:00",
+        "establishmentName": "Beacon Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "433",
+        "schoolCapacity": "1013",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12628712,
+        "dateAcademyJoinedTrust": "2023-03-14T00:00:00",
+        "establishmentName": "George Abbey C of E Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2112",
+        "schoolCapacity": "2573",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
@@ -6921,77 +5995,53 @@
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "Patty Streich",
-      "email": "Patty.Streich@education.gov.uk"
+      "fullName": "Byron Quigley",
+      "email": "Byron.Quigley@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Vickie Gulgowski",
-      "email": "Vickie.Gulgowski@education.gov.uk"
+      "fullName": "Shelly Mayert",
+      "email": "Shelly.Mayert@education.gov.uk"
     }
   },
   {
-    "uid": "1252",
-    "name": "THRIVE MULTI-ACADEMY TRUST",
-    "groupId": "TR1125",
-    "ukprn": "10042404",
+    "uid": "1300",
+    "name": "THE DIOCESE OF CANTERBURY ACADEMIES TRUST",
+    "groupId": "TR2472",
+    "ukprn": "10063869",
     "type": "Multi-academy trust",
-    "address": "78136 Greenfelder Knoll, Sarah Loaf, Boehmton, FN96 4LZ",
-    "openedDate": "2013-11-22T00:00:00",
-    "companiesHouseNumber": "01124592",
-    "regionAndTerritory": "North East",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Annette Breitenberg",
-      "email": "Annette.Breitenberg@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Natasha Borer",
-      "email": "Natasha.Borer@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1276",
-    "name": "TRANSCENDENCE EDUCATION TRUST",
-    "groupId": "TR3060",
-    "ukprn": "10092879",
-    "type": "Multi-academy trust",
-    "address": "72516 Cummings Groves, Russ Locks, XB7 5VN",
-    "openedDate": "2021-07-02T00:00:00",
-    "companiesHouseNumber": "03974334",
-    "regionAndTerritory": "West Midlands",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": {
-      "fullName": "Jessica Legros",
-      "email": "Jessica.Legros@education.gov.uk"
-    },
-    "sfsoLead": {
-      "fullName": "Cecilia Crona",
-      "email": "Cecilia.Crona@education.gov.uk"
-    }
-  },
-  {
-    "uid": "1269",
-    "name": "UNITY LEARNING TRUST",
-    "groupId": "TR9978",
-    "ukprn": "10051627",
-    "type": "Multi-academy trust",
-    "address": "4612 Barbara Park, Considine Squares, EL9 3KQ",
-    "openedDate": "2021-10-07T00:00:00",
-    "companiesHouseNumber": "09231053",
-    "regionAndTerritory": "South West",
+    "address": "860 Miguel Way, AI27 2QS",
+    "openedDate": "2015-07-18T00:00:00",
+    "companiesHouseNumber": "05998614",
+    "regionAndTerritory": "East Midlands",
     "academies": [
       {
-        "urn": 12696922,
-        "dateAcademyJoinedTrust": "2022-09-30T00:00:00",
-        "establishmentName": "Oasis Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
+        "urn": 13007263,
+        "dateAcademyJoinedTrust": "2021-12-04T00:00:00",
+        "establishmentName": "Erdman Plain Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "202",
-        "schoolCapacity": "170",
+        "numberOfPupils": "3471",
+        "schoolCapacity": "2883",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13004094,
+        "dateAcademyJoinedTrust": "2019-05-27T00:00:00",
+        "establishmentName": "Greensward Church of England Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3273",
+        "schoolCapacity": "2532",
         "percentageFreeSchoolMeals": "19",
         "ageRange": {
           "minimum": 4,
@@ -7001,52 +6051,34 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12697394,
-        "dateAcademyJoinedTrust": "2023-07-11T00:00:00",
-        "establishmentName": "Oasis Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "309",
-        "schoolCapacity": "584",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12693777,
-        "dateAcademyJoinedTrust": "2023-02-02T00:00:00",
-        "establishmentName": "Longhill Church of England Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "urn": 13002558,
+        "dateAcademyJoinedTrust": "2020-12-24T00:00:00",
+        "establishmentName": "Kirklees School",
+        "typeOfEstablishment": "Free school",
         "localAuthority": "Kirklees",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1014",
-        "schoolCapacity": "803",
-        "percentageFreeSchoolMeals": "4",
+        "numberOfPupils": "582",
+        "schoolCapacity": "903",
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 11,
-          "maximum": 18
+          "maximum": 16
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12697259,
-        "dateAcademyJoinedTrust": "2023-03-20T00:00:00",
-        "establishmentName": "St. Mary\u0027s C of E Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
+        "urn": 13002398,
+        "dateAcademyJoinedTrust": "2023-09-27T00:00:00",
+        "establishmentName": "Barr and Community C of E Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1554",
-        "schoolCapacity": "2099",
-        "percentageFreeSchoolMeals": "16",
+        "numberOfPupils": "1072",
+        "schoolCapacity": "2335",
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -7055,16 +6087,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12693897,
-        "dateAcademyJoinedTrust": "2023-01-01T00:00:00",
-        "establishmentName": "Greensward Cofe Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "urn": 13006896,
+        "dateAcademyJoinedTrust": "2015-08-09T00:00:00",
+        "establishmentName": "Lampton Church of England Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
         "localAuthority": "Kirklees",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "301",
-        "schoolCapacity": "706",
-        "percentageFreeSchoolMeals": "23",
+        "numberOfPupils": "612",
+        "schoolCapacity": "1331",
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -7073,19 +6105,91 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12692745,
-        "dateAcademyJoinedTrust": "2022-08-06T00:00:00",
-        "establishmentName": "Beacon Academy",
+        "urn": 13003710,
+        "dateAcademyJoinedTrust": "2016-03-01T00:00:00",
+        "establishmentName": "St. Peter\u0027s C of E School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "862",
+        "schoolCapacity": "1734",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13006147,
+        "dateAcademyJoinedTrust": "2016-04-27T00:00:00",
+        "establishmentName": "Malbank School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2624",
-        "schoolCapacity": "2741",
-        "percentageFreeSchoolMeals": "30",
+        "numberOfPupils": "3063",
+        "schoolCapacity": "2896",
+        "percentageFreeSchoolMeals": "7",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13002228,
+        "dateAcademyJoinedTrust": "2023-05-10T00:00:00",
+        "establishmentName": "St. Mary\u0027s R.C. School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1086",
+        "schoolCapacity": "2164",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13009325,
+        "dateAcademyJoinedTrust": "2020-05-24T00:00:00",
+        "establishmentName": "Limehurst Cofe Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "250",
+        "schoolCapacity": "548",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13005877,
+        "dateAcademyJoinedTrust": "2020-05-19T00:00:00",
+        "establishmentName": "Horizon Church of England Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2594",
+        "schoolCapacity": "2891",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
@@ -7097,32 +6201,32 @@
       "email": "Lamar.Kulas@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Jan Wunsch",
-      "email": "Jan.Wunsch@education.gov.uk"
+      "fullName": "Vickie Gulgowski",
+      "email": "Vickie.Gulgowski@education.gov.uk"
     }
   },
   {
-    "uid": "1237",
-    "name": "VANGUARD LEARNING TRUST",
-    "groupId": "TR3116",
-    "ukprn": "10039020",
+    "uid": "1301",
+    "name": "THE DIOCESE OF CHELMSFORD VINE SCHOOLS TRUST",
+    "groupId": "TR8591",
+    "ukprn": "10045983",
     "type": "Multi-academy trust",
-    "address": "66585 Addison Trail, KJ27 3WE",
-    "openedDate": "2016-08-10T00:00:00",
-    "companiesHouseNumber": "02294370",
-    "regionAndTerritory": "London",
+    "address": "12913 Abernathy Plaza, Schmidt Locks, DC8 5LA",
+    "openedDate": "2020-10-04T00:00:00",
+    "companiesHouseNumber": "09381281",
+    "regionAndTerritory": "North West",
     "academies": [
       {
-        "urn": 12375557,
-        "dateAcademyJoinedTrust": "2018-07-31T00:00:00",
-        "establishmentName": "Oasis Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Rural village in a sparse setting",
+        "urn": 13018233,
+        "dateAcademyJoinedTrust": "2021-05-03T00:00:00",
+        "establishmentName": "St. Paul\u0027s C of E Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "107",
-        "schoolCapacity": "128",
-        "percentageFreeSchoolMeals": "24",
+        "numberOfPupils": "1559",
+        "schoolCapacity": "1413",
+        "percentageFreeSchoolMeals": "20",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -7131,106 +6235,70 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12378586,
-        "dateAcademyJoinedTrust": "2020-05-24T00:00:00",
-        "establishmentName": "George Abbey Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1298",
-        "schoolCapacity": "1145",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12377852,
-        "dateAcademyJoinedTrust": "2020-01-12T00:00:00",
-        "establishmentName": "Co-op Cofe Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "306",
-        "schoolCapacity": "245",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12375718,
-        "dateAcademyJoinedTrust": "2022-11-07T00:00:00",
-        "establishmentName": "Northwood C of E Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "892",
-        "schoolCapacity": "1324",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12371430,
-        "dateAcademyJoinedTrust": "2018-09-15T00:00:00",
-        "establishmentName": "York Church of England Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1476",
-        "schoolCapacity": "1219",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12373181,
-        "dateAcademyJoinedTrust": "2021-09-28T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1322",
-        "schoolCapacity": "1084",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12371293,
-        "dateAcademyJoinedTrust": "2021-03-09T00:00:00",
-        "establishmentName": "Momentum Community Cofe Academy",
+        "urn": 13016255,
+        "dateAcademyJoinedTrust": "2021-12-08T00:00:00",
+        "establishmentName": "St. Mary\u0027s Cofe School",
         "typeOfEstablishment": "Free school",
         "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "389",
+        "schoolCapacity": "401",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13012938,
+        "dateAcademyJoinedTrust": "2021-12-27T00:00:00",
+        "establishmentName": "Oasis R.C. School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1510",
+        "schoolCapacity": "2939",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13018604,
+        "dateAcademyJoinedTrust": "2022-06-03T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1896",
+        "schoolCapacity": "2581",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13015588,
+        "dateAcademyJoinedTrust": "2023-02-17T00:00:00",
+        "establishmentName": "Meridian Catholic Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "983",
-        "schoolCapacity": "1874",
-        "percentageFreeSchoolMeals": "22",
+        "numberOfPupils": "1926",
+        "schoolCapacity": "2353",
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -7241,36 +6309,90 @@
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "Arturo Purdy",
-      "email": "Arturo.Purdy@education.gov.uk"
+      "fullName": "Annette Breitenberg",
+      "email": "Annette.Breitenberg@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Oscar Goldner",
-      "email": "Oscar.Goldner@education.gov.uk"
+      "fullName": "Suzanne Conroy",
+      "email": "Suzanne.Conroy@education.gov.uk"
     }
   },
   {
-    "uid": "1241",
-    "name": "VISIONARY ACADEMY TRUST",
-    "groupId": "TR6235",
-    "ukprn": "10003639",
+    "uid": "1302",
+    "name": "THE DIOCESE OF COVENTRY MULTI-ACADEMY TRUST",
+    "groupId": "TR3600",
+    "ukprn": "10068723",
     "type": "Multi-academy trust",
-    "address": "24616 Darrin Springs, Efren Shoal, Port Candidoside, AC37 5FX",
-    "openedDate": "2015-11-22T00:00:00",
-    "companiesHouseNumber": "03676412",
-    "regionAndTerritory": "Yorkshire and the Humber",
+    "address": "651 Schultz Dale, Botsfordbury, TN3 7AL",
+    "openedDate": "2022-10-08T00:00:00",
+    "companiesHouseNumber": "08627346",
+    "regionAndTerritory": "East Midlands",
     "academies": [
       {
-        "urn": 12413280,
-        "dateAcademyJoinedTrust": "2018-06-18T00:00:00",
-        "establishmentName": "Oasis Primary School",
+        "urn": 13021591,
+        "dateAcademyJoinedTrust": "2023-07-19T00:00:00",
+        "establishmentName": "Beacon Cofe School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "122",
+        "schoolCapacity": "150",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13027249,
+        "dateAcademyJoinedTrust": "2023-04-06T00:00:00",
+        "establishmentName": "Rotherham School",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
+        "localAuthority": "Rotherham",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2454",
-        "schoolCapacity": "2310",
-        "percentageFreeSchoolMeals": "28",
+        "numberOfPupils": "1578",
+        "schoolCapacity": "1291",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13028367,
+        "dateAcademyJoinedTrust": "2023-10-30T00:00:00",
+        "establishmentName": "St. Joseph\u0027s R.C. Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "209",
+        "schoolCapacity": "325",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13028546,
+        "dateAcademyJoinedTrust": "2023-01-02T00:00:00",
+        "establishmentName": "Beacon Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2474",
+        "schoolCapacity": "2906",
+        "percentageFreeSchoolMeals": "20",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -7279,19 +6401,1066 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12416656,
-        "dateAcademyJoinedTrust": "2017-04-10T00:00:00",
-        "establishmentName": "St. Paul\u0027s CE School",
+        "urn": 13026970,
+        "dateAcademyJoinedTrust": "2022-11-27T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s CE Primary School",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "705",
+        "schoolCapacity": "1316",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13026606,
+        "dateAcademyJoinedTrust": "2023-08-19T00:00:00",
+        "establishmentName": "Kristian Terrace Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3588",
-        "schoolCapacity": "2847",
-        "percentageFreeSchoolMeals": "15",
+        "numberOfPupils": "897",
+        "schoolCapacity": "1154",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Phyllis Kling",
+      "email": "Phyllis.Kling@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Brent Fahey",
+      "email": "Brent.Fahey@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1303",
+    "name": "THE DIOCESE OF ELY MULTI-ACADEMY TRUST",
+    "groupId": "TR6875",
+    "ukprn": "10081876",
+    "type": "Multi-academy trust",
+    "address": "9687 Boyer Spurs, North Elinoremouth, IO1 4VC",
+    "openedDate": "2014-03-30T00:00:00",
+    "companiesHouseNumber": "03747724",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 13032393,
+        "dateAcademyJoinedTrust": "2020-11-18T00:00:00",
+        "establishmentName": "Greensward Church of England Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "717",
+        "schoolCapacity": "1416",
+        "percentageFreeSchoolMeals": "20",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13033722,
+        "dateAcademyJoinedTrust": "2019-03-05T00:00:00",
+        "establishmentName": "Harris R.C. Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2980",
+        "schoolCapacity": "2735",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13038052,
+        "dateAcademyJoinedTrust": "2017-07-06T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "807",
+        "schoolCapacity": "1187",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13035114,
+        "dateAcademyJoinedTrust": "2023-05-02T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 R.C. School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "359",
+        "schoolCapacity": "578",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13034881,
+        "dateAcademyJoinedTrust": "2021-12-29T00:00:00",
+        "establishmentName": "St. Marys CE Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1295",
+        "schoolCapacity": "1049",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13038413,
+        "dateAcademyJoinedTrust": "2022-06-29T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3137",
+        "schoolCapacity": "2958",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13035795,
+        "dateAcademyJoinedTrust": "2019-02-23T00:00:00",
+        "establishmentName": "Lampton Catholic Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1026",
+        "schoolCapacity": "1504",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13033072,
+        "dateAcademyJoinedTrust": "2019-11-09T00:00:00",
+        "establishmentName": "Horizon Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "204",
+        "schoolCapacity": "232",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Colin Kiehn",
+      "email": "Colin.Kiehn@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jaime Russel",
+      "email": "Jaime.Russel@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1304",
+    "name": "THE DIOCESE OF GLOUCESTER ACADEMIES TRUST",
+    "groupId": "TR2610",
+    "ukprn": "10092167",
+    "type": "Multi-academy trust",
+    "address": "59269 Abby Lake, Bergstrom Keys, NB4 3MG",
+    "openedDate": "2019-01-21T00:00:00",
+    "companiesHouseNumber": "01194078",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 13047229,
+        "dateAcademyJoinedTrust": "2022-08-11T00:00:00",
+        "establishmentName": "Halewood Catholic Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "535",
+        "schoolCapacity": "665",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13043564,
+        "dateAcademyJoinedTrust": "2022-10-13T00:00:00",
+        "establishmentName": "Barr and Community Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "329",
+        "schoolCapacity": "712",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Jessica Legros",
+      "email": "Jessica.Legros@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jan Wunsch",
+      "email": "Jan.Wunsch@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1305",
+    "name": "THE DIOCESE OF NORWICH EDUCATION AND ACADEMIES TRUST",
+    "groupId": "TR1623",
+    "ukprn": "10066494",
+    "type": "Multi-academy trust",
+    "address": "9641 Queenie Summit, Janie Canyon, SM17 1UO",
+    "openedDate": "2017-04-01T00:00:00",
+    "companiesHouseNumber": "07527021",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 13052617,
+        "dateAcademyJoinedTrust": "2017-05-31T00:00:00",
+        "establishmentName": "George Abbey Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "402",
+        "schoolCapacity": "958",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lamar Ritchie",
+      "email": "Lamar.Ritchie@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jennie Greenholt",
+      "email": "Jennie.Greenholt@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1306",
+    "name": "THE DIOCESE OF NORWICH ST BENET\u0027S MULTI-ACADEMY TRUST",
+    "groupId": "TR2880",
+    "ukprn": "10018227",
+    "type": "Multi-academy trust",
+    "address": "069 Evans Mills, JY4 4WA",
+    "openedDate": "2019-10-08T00:00:00",
+    "companiesHouseNumber": "03195216",
+    "regionAndTerritory": "North West",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Jessica Legros",
+      "email": "Jessica.Legros@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Erick Kassulke",
+      "email": "Erick.Kassulke@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1307",
+    "name": "THE DIOCESE OF SHEFFIELD ACADEMIES TRUST",
+    "groupId": "TR8065",
+    "ukprn": "10079977",
+    "type": "Multi-academy trust",
+    "address": "58366 Greta Estates, August Stream, WA9 7RS",
+    "openedDate": "2021-12-13T00:00:00",
+    "companiesHouseNumber": "05506224",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 13077901,
+        "dateAcademyJoinedTrust": "2023-05-10T00:00:00",
+        "establishmentName": "Glyn C of E Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1649",
+        "schoolCapacity": "2378",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13076918,
+        "dateAcademyJoinedTrust": "2023-05-02T00:00:00",
+        "establishmentName": "Darius Locks C of E Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2362",
+        "schoolCapacity": "2764",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13077598,
+        "dateAcademyJoinedTrust": "2023-10-16T00:00:00",
+        "establishmentName": "Malbank Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "130",
+        "schoolCapacity": "116",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Roberto Grimes",
+      "email": "Roberto.Grimes@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Misty Anderson",
+      "email": "Misty.Anderson@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1308",
+    "name": "THE DIOCESE OF WESTMINSTER ACADEMY TRUST",
+    "groupId": "TR7180",
+    "ukprn": "10085004",
+    "type": "Multi-academy trust",
+    "address": "051 Botsford Key, HQ11 8XO",
+    "openedDate": "2016-07-07T00:00:00",
+    "companiesHouseNumber": "01589721",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 13085153,
+        "dateAcademyJoinedTrust": "2018-08-27T00:00:00",
+        "establishmentName": "Co-op Catholic Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "168",
+        "schoolCapacity": "134",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Annette Breitenberg",
+      "email": "Annette.Breitenberg@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jan Wunsch",
+      "email": "Jan.Wunsch@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1309",
+    "name": "THE DIOCESE OF WORCESTER MULTI ACADEMY TRUST",
+    "groupId": "TR660",
+    "ukprn": "10087864",
+    "type": "Multi-academy trust",
+    "address": "1330 Benjamin Green, Ebert Well, Port Clark, IA95 4ZY",
+    "openedDate": "2016-02-23T00:00:00",
+    "companiesHouseNumber": "07221271",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 13096534,
+        "dateAcademyJoinedTrust": "2019-04-18T00:00:00",
+        "establishmentName": "Lampton Cofe Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "360",
+        "schoolCapacity": "616",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lamar Ritchie",
+      "email": "Lamar.Ritchie@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Tony Hintz",
+      "email": "Tony.Hintz@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1252",
+    "name": "THRIVE MULTI-ACADEMY TRUST",
+    "groupId": "TR6602",
+    "ukprn": "10093739",
+    "type": "Multi-academy trust",
+    "address": "1766 Collier Ville, ZO0 8UK",
+    "openedDate": "2022-09-01T00:00:00",
+    "companiesHouseNumber": "03258956",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 12528993,
+        "dateAcademyJoinedTrust": "2023-04-24T00:00:00",
+        "establishmentName": "Glyn Church of England Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "732",
+        "schoolCapacity": "1489",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12527258,
+        "dateAcademyJoinedTrust": "2022-11-23T00:00:00",
+        "establishmentName": "Northwood Church of England Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1095",
+        "schoolCapacity": "1624",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12521890,
+        "dateAcademyJoinedTrust": "2023-08-23T00:00:00",
+        "establishmentName": "Leeds R.C. Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1496",
+        "schoolCapacity": "1871",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12526368,
+        "dateAcademyJoinedTrust": "2022-12-05T00:00:00",
+        "establishmentName": "Mulberry Cofe Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "496",
+        "schoolCapacity": "1151",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12521423,
+        "dateAcademyJoinedTrust": "2023-03-03T00:00:00",
+        "establishmentName": "Oasis Catholic Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "307",
+        "schoolCapacity": "346",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12525685,
+        "dateAcademyJoinedTrust": "2023-04-25T00:00:00",
+        "establishmentName": "St. Anne\u0027s R.C. Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1666",
+        "schoolCapacity": "2236",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12529287,
+        "dateAcademyJoinedTrust": "2022-09-04T00:00:00",
+        "establishmentName": "Lampton Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "782",
+        "schoolCapacity": "909",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12522620,
+        "dateAcademyJoinedTrust": "2022-12-29T00:00:00",
+        "establishmentName": "Longhill Church of England School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "405",
+        "schoolCapacity": "964",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Byron Quigley",
+      "email": "Byron.Quigley@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jan Wunsch",
+      "email": "Jan.Wunsch@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1276",
+    "name": "TRANSCENDENCE EDUCATION TRUST",
+    "groupId": "TR2972",
+    "ukprn": "10093910",
+    "type": "Multi-academy trust",
+    "address": "9097 D\u0027Amore Fords, Denesik Falls, EN3 5AO",
+    "openedDate": "2019-08-09T00:00:00",
+    "companiesHouseNumber": "08857213",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 12768065,
+        "dateAcademyJoinedTrust": "2021-01-05T00:00:00",
+        "establishmentName": "Glyn Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "896",
+        "schoolCapacity": "1177",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12765469,
+        "dateAcademyJoinedTrust": "2023-04-07T00:00:00",
+        "establishmentName": "St. James\u0027s CE Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "735",
+        "schoolCapacity": "588",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12767632,
+        "dateAcademyJoinedTrust": "2022-03-04T00:00:00",
+        "establishmentName": "St. Marys Cofe Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1002",
+        "schoolCapacity": "812",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12764339,
+        "dateAcademyJoinedTrust": "2023-10-16T00:00:00",
+        "establishmentName": "Harris Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1436",
+        "schoolCapacity": "1197",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12764386,
+        "dateAcademyJoinedTrust": "2022-12-15T00:00:00",
+        "establishmentName": "Queensbridge Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2860",
+        "schoolCapacity": "2207",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12767863,
+        "dateAcademyJoinedTrust": "2021-10-30T00:00:00",
+        "establishmentName": "St. Paul\u0027s C of E Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "373",
+        "schoolCapacity": "317",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12762160,
+        "dateAcademyJoinedTrust": "2020-11-11T00:00:00",
+        "establishmentName": "Momentum Community School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "567",
+        "schoolCapacity": "1115",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12764565,
+        "dateAcademyJoinedTrust": "2019-10-08T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1095",
+        "schoolCapacity": "1136",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12765056,
+        "dateAcademyJoinedTrust": "2020-02-21T00:00:00",
+        "establishmentName": "Greensward School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1182",
+        "schoolCapacity": "2414",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12767367,
+        "dateAcademyJoinedTrust": "2020-02-22T00:00:00",
+        "establishmentName": "Greensward Cofe Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1021",
+        "schoolCapacity": "914",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "George Muller",
+      "email": "George.Muller@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Misty Anderson",
+      "email": "Misty.Anderson@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1269",
+    "name": "UNITY LEARNING TRUST",
+    "groupId": "TR1869",
+    "ukprn": "10040041",
+    "type": "Multi-academy trust",
+    "address": "13003 Sabryna Way, HZ7 3BN",
+    "openedDate": "2017-11-27T00:00:00",
+    "companiesHouseNumber": "05932756",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 12692755,
+        "dateAcademyJoinedTrust": "2021-01-21T00:00:00",
+        "establishmentName": "Beacon School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1394",
+        "schoolCapacity": "2867",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12698895,
+        "dateAcademyJoinedTrust": "2018-08-31T00:00:00",
+        "establishmentName": "Oasis Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2348",
+        "schoolCapacity": "2004",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12692991,
+        "dateAcademyJoinedTrust": "2021-07-29T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Cofe Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "737",
+        "schoolCapacity": "1564",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12695616,
+        "dateAcademyJoinedTrust": "2023-03-24T00:00:00",
+        "establishmentName": "Horizon Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "289",
+        "schoolCapacity": "526",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12699752,
+        "dateAcademyJoinedTrust": "2018-11-26T00:00:00",
+        "establishmentName": "Leeds Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "327",
+        "schoolCapacity": "342",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12698014,
+        "dateAcademyJoinedTrust": "2019-10-03T00:00:00",
+        "establishmentName": "Mulberry Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "697",
+        "schoolCapacity": "717",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12699330,
+        "dateAcademyJoinedTrust": "2019-11-06T00:00:00",
+        "establishmentName": "Barr and Community Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "427",
+        "schoolCapacity": "414",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12695446,
+        "dateAcademyJoinedTrust": "2022-12-30T00:00:00",
+        "establishmentName": "Lampton Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1478",
+        "schoolCapacity": "2164",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12694928,
+        "dateAcademyJoinedTrust": "2020-08-15T00:00:00",
+        "establishmentName": "Northwood Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2282",
+        "schoolCapacity": "2785",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12699920,
+        "dateAcademyJoinedTrust": "2020-06-22T00:00:00",
+        "establishmentName": "St. Marys R.C. Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2639",
+        "schoolCapacity": "2861",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12692663,
+        "dateAcademyJoinedTrust": "2023-04-26T00:00:00",
+        "establishmentName": "Momentum Community Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "796",
+        "schoolCapacity": "896",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
@@ -7303,32 +7472,32 @@
       "email": "Mae.Bradtke@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Jonathon Littel",
-      "email": "Jonathon.Littel@education.gov.uk"
+      "fullName": "Ramon Wehner",
+      "email": "Ramon.Wehner@education.gov.uk"
     }
   },
   {
-    "uid": "1274",
-    "name": "VITALITY ACADEMY TRUST",
-    "groupId": "TR1215",
-    "ukprn": "10065648",
+    "uid": "1237",
+    "name": "VANGUARD LEARNING TRUST",
+    "groupId": "TR5228",
+    "ukprn": "10047223",
     "type": "Multi-academy trust",
-    "address": "241 Carolanne Station, VH4 6AD",
-    "openedDate": "2021-11-21T00:00:00",
-    "companiesHouseNumber": "03237671",
-    "regionAndTerritory": "South East",
+    "address": "276 Mariane Rapid, Kylerport, IK41 4YE",
+    "openedDate": "2021-07-30T00:00:00",
+    "companiesHouseNumber": "02793731",
+    "regionAndTerritory": "East Midlands",
     "academies": [
       {
-        "urn": 12742324,
-        "dateAcademyJoinedTrust": "2022-02-06T00:00:00",
-        "establishmentName": "St. Peter\u0027s R.C. Secondary School",
+        "urn": 12373431,
+        "dateAcademyJoinedTrust": "2022-04-07T00:00:00",
+        "establishmentName": "Beacon Secondary School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1699",
-        "schoolCapacity": "1573",
-        "percentageFreeSchoolMeals": "16",
+        "numberOfPupils": "1890",
+        "schoolCapacity": "2433",
+        "percentageFreeSchoolMeals": "1",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -7337,16 +7506,52 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12741752,
-        "dateAcademyJoinedTrust": "2023-04-09T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Secondary School",
+        "urn": 12376853,
+        "dateAcademyJoinedTrust": "2021-09-23T00:00:00",
+        "establishmentName": "Mulberry Academy",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban major conurbation",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1890",
+        "schoolCapacity": "2900",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12371553,
+        "dateAcademyJoinedTrust": "2023-10-26T00:00:00",
+        "establishmentName": "St. John\u0027s Catholic Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2220",
+        "schoolCapacity": "2179",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12377448,
+        "dateAcademyJoinedTrust": "2022-11-14T00:00:00",
+        "establishmentName": "St. Catherine\u0027s C of E Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1031",
-        "schoolCapacity": "922",
-        "percentageFreeSchoolMeals": "20",
+        "numberOfPupils": "228",
+        "schoolCapacity": "280",
+        "percentageFreeSchoolMeals": "26",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -7355,19 +7560,91 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12742916,
-        "dateAcademyJoinedTrust": "2023-09-14T00:00:00",
-        "establishmentName": "Glyn School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Doncaster",
+        "urn": 12377125,
+        "dateAcademyJoinedTrust": "2023-11-08T00:00:00",
+        "establishmentName": "Momentum Community Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2280",
-        "schoolCapacity": "2754",
-        "percentageFreeSchoolMeals": "3",
+        "numberOfPupils": "259",
+        "schoolCapacity": "493",
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
           "minimum": 11,
-          "maximum": 18
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12376048,
+        "dateAcademyJoinedTrust": "2023-05-01T00:00:00",
+        "establishmentName": "Lampton Cofe Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "996",
+        "schoolCapacity": "965",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12375081,
+        "dateAcademyJoinedTrust": "2023-01-06T00:00:00",
+        "establishmentName": "Halewood Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1195",
+        "schoolCapacity": "2717",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12373783,
+        "dateAcademyJoinedTrust": "2022-11-12T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Catholic Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2971",
+        "schoolCapacity": "2478",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12379356,
+        "dateAcademyJoinedTrust": "2022-07-21T00:00:00",
+        "establishmentName": "Co-op Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1175",
+        "schoolCapacity": "955",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
@@ -7375,75 +7652,75 @@
     ],
     "governors": [],
     "trustRelationshipManager": {
-      "fullName": "Lana Mueller",
-      "email": "Lana.Mueller@education.gov.uk"
+      "fullName": "Cindy Bergstrom",
+      "email": "Cindy.Bergstrom@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Shelly Mayert",
-      "email": "Shelly.Mayert@education.gov.uk"
+      "fullName": "Walter Boyle",
+      "email": "Walter.Boyle@education.gov.uk"
     }
   },
   {
-    "uid": "1312",
-    "name": "WESTMINSTER ACADEMY TRUST",
-    "groupId": "TR5276",
-    "ukprn": "10014123",
+    "uid": "1241",
+    "name": "VISIONARY ACADEMY TRUST",
+    "groupId": "TR7076",
+    "ukprn": "10053905",
     "type": "Multi-academy trust",
-    "address": "028 Letitia Forks, QK35 4WR",
-    "openedDate": "2023-04-27T00:00:00",
-    "companiesHouseNumber": "07765983",
+    "address": "1223 Shyann Path, Nettie Stravenue, RQ24 9JE",
+    "openedDate": "2016-02-08T00:00:00",
+    "companiesHouseNumber": "04350151",
     "regionAndTerritory": "North West",
     "academies": [
       {
-        "urn": 13121724,
-        "dateAcademyJoinedTrust": "2023-08-30T00:00:00",
-        "establishmentName": "St. James\u0027 Church of England Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1779",
-        "schoolCapacity": "1678",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13124258,
-        "dateAcademyJoinedTrust": "2023-07-06T00:00:00",
-        "establishmentName": "Oasis Cofe Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2729",
-        "schoolCapacity": "2142",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13124469,
-        "dateAcademyJoinedTrust": "2023-05-05T00:00:00",
-        "establishmentName": "Halewood Church of England Academy",
+        "urn": 12417999,
+        "dateAcademyJoinedTrust": "2016-12-13T00:00:00",
+        "establishmentName": "Halewood Church of England Primary Academy",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural village in a sparse setting",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1358",
+        "schoolCapacity": "1255",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12416338,
+        "dateAcademyJoinedTrust": "2016-04-25T00:00:00",
+        "establishmentName": "Rotherham Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "721",
-        "schoolCapacity": "557",
-        "percentageFreeSchoolMeals": "27",
+        "numberOfPupils": "1426",
+        "schoolCapacity": "1457",
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12417776,
+        "dateAcademyJoinedTrust": "2022-03-22T00:00:00",
+        "establishmentName": "St. Marys Cofe School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1418",
+        "schoolCapacity": "2889",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
@@ -7455,8 +7732,412 @@
       "email": "Arturo.Purdy@education.gov.uk"
     },
     "sfsoLead": {
-      "fullName": "Jonathon Littel",
-      "email": "Jonathon.Littel@education.gov.uk"
+      "fullName": "Shelly Mayert",
+      "email": "Shelly.Mayert@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1274",
+    "name": "VITALITY ACADEMY TRUST",
+    "groupId": "TR1144",
+    "ukprn": "10015102",
+    "type": "Multi-academy trust",
+    "address": "68547 Goldner Estate, GR4 7GW",
+    "openedDate": "2016-09-05T00:00:00",
+    "companiesHouseNumber": "05286853",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12741716,
+        "dateAcademyJoinedTrust": "2017-07-31T00:00:00",
+        "establishmentName": "Limehurst Church of England Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2641",
+        "schoolCapacity": "2837",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12747645,
+        "dateAcademyJoinedTrust": "2019-07-10T00:00:00",
+        "establishmentName": "Meridian Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "485",
+        "schoolCapacity": "1143",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12746302,
+        "dateAcademyJoinedTrust": "2019-11-28T00:00:00",
+        "establishmentName": "Halewood Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "816",
+        "schoolCapacity": "1012",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12744908,
+        "dateAcademyJoinedTrust": "2018-05-12T00:00:00",
+        "establishmentName": "Queensbridge Church of England Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1266",
+        "schoolCapacity": "2342",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12743214,
+        "dateAcademyJoinedTrust": "2019-12-15T00:00:00",
+        "establishmentName": "St. Joseph\u0027s R.C. School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2401",
+        "schoolCapacity": "2135",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12742451,
+        "dateAcademyJoinedTrust": "2021-12-09T00:00:00",
+        "establishmentName": "Barr and Community Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2216",
+        "schoolCapacity": "2343",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12749302,
+        "dateAcademyJoinedTrust": "2022-07-29T00:00:00",
+        "establishmentName": "Malbank School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2663",
+        "schoolCapacity": "2288",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12747833,
+        "dateAcademyJoinedTrust": "2023-10-11T00:00:00",
+        "establishmentName": "Crawford Ferry School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3334",
+        "schoolCapacity": "2906",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12743160,
+        "dateAcademyJoinedTrust": "2019-12-02T00:00:00",
+        "establishmentName": "St. Catherine\u0027s C of E Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "578",
+        "schoolCapacity": "529",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12744645,
+        "dateAcademyJoinedTrust": "2020-12-10T00:00:00",
+        "establishmentName": "Harris Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1354",
+        "schoolCapacity": "1620",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Josh D\u0027Amore",
+      "email": "Josh.D\u0027Amore@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jan Wunsch",
+      "email": "Jan.Wunsch@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1312",
+    "name": "WESTMINSTER ACADEMY TRUST",
+    "groupId": "TR3944",
+    "ukprn": "10011621",
+    "type": "Multi-academy trust",
+    "address": "876 Garland Shoal, Port Maci, HR97 4PB",
+    "openedDate": "2014-04-21T00:00:00",
+    "companiesHouseNumber": "07408684",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 13122364,
+        "dateAcademyJoinedTrust": "2021-06-08T00:00:00",
+        "establishmentName": "Nickolas Spurs Church of England Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1837",
+        "schoolCapacity": "2886",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13128718,
+        "dateAcademyJoinedTrust": "2019-01-19T00:00:00",
+        "establishmentName": "St. Mary\u0027s R.C. Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "941",
+        "schoolCapacity": "853",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13127962,
+        "dateAcademyJoinedTrust": "2017-07-15T00:00:00",
+        "establishmentName": "St. Anne\u0027s C of E School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "235",
+        "schoolCapacity": "399",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13127224,
+        "dateAcademyJoinedTrust": "2015-07-04T00:00:00",
+        "establishmentName": "Co-op Catholic Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1868",
+        "schoolCapacity": "2664",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13128761,
+        "dateAcademyJoinedTrust": "2014-10-14T00:00:00",
+        "establishmentName": "St. Marys C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1380",
+        "schoolCapacity": "2705",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13128450,
+        "dateAcademyJoinedTrust": "2021-05-26T00:00:00",
+        "establishmentName": "Horizon C of E Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "281",
+        "schoolCapacity": "457",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13122488,
+        "dateAcademyJoinedTrust": "2021-02-19T00:00:00",
+        "establishmentName": "Queensbridge Cofe School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1283",
+        "schoolCapacity": "1151",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13125641,
+        "dateAcademyJoinedTrust": "2022-10-12T00:00:00",
+        "establishmentName": "Oasis R.C. Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2747",
+        "schoolCapacity": "2859",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13126148,
+        "dateAcademyJoinedTrust": "2019-09-07T00:00:00",
+        "establishmentName": "Co-op CE School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1279",
+        "schoolCapacity": "1449",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13123028,
+        "dateAcademyJoinedTrust": "2020-07-07T00:00:00",
+        "establishmentName": "Lampton CE School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "418",
+        "schoolCapacity": "721",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Colin Kiehn",
+      "email": "Colin.Kiehn@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Ginger Dietrich",
+      "email": "Ginger.Dietrich@education.gov.uk"
     }
   }
 ]

--- a/tests/playwright/fake-data/trusts.json
+++ b/tests/playwright/fake-data/trusts.json
@@ -2,378 +2,42 @@
   {
     "uid": "1233",
     "name": "ABBEY LANE ACADEMIES TRUST",
-    "groupId": "TR2879",
-    "ukprn": "10034481",
+    "groupId": "TR5597",
+    "ukprn": "10054450",
     "type": "Multi-academy trust",
-    "address": "99627 Mathilde Way, YN0 5GP",
-    "openedDate": "2019-03-02T00:00:00",
-    "companiesHouseNumber": "02851944",
-    "regionAndTerritory": "South East",
-    "academies": [
-      {
-        "urn": 12335187,
-        "dateAcademyJoinedTrust": "2022-10-07T00:00:00",
-        "establishmentName": "Halewood Church of England Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "245",
-        "schoolCapacity": "198",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12335729,
-        "dateAcademyJoinedTrust": "2022-10-23T00:00:00",
-        "establishmentName": "St. Marys CE Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1329",
-        "schoolCapacity": "1219",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12339637,
-        "dateAcademyJoinedTrust": "2021-12-31T00:00:00",
-        "establishmentName": "St. Anne\u0027s Church of England Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1091",
-        "schoolCapacity": "1644",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12334923,
-        "dateAcademyJoinedTrust": "2020-12-19T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1400",
-        "schoolCapacity": "1825",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12331100,
-        "dateAcademyJoinedTrust": "2020-10-10T00:00:00",
-        "establishmentName": "St. Paul\u0027s C of E Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1629",
-        "schoolCapacity": "1993",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
+    "address": "210 Beatty Locks, North Kaydenborough, YH69 1GF",
+    "openedDate": "2018-04-03T00:00:00",
+    "companiesHouseNumber": "08955858",
+    "regionAndTerritory": "South West",
+    "academies": [],
     "governors": [],
-    "trustRelationshipManager": null,
+    "trustRelationshipManager": {
+      "fullName": "George Muller",
+      "email": "George.Muller@education.gov.uk"
+    },
     "sfsoLead": null
   },
   {
     "uid": "1250",
     "name": "ACCLIVITY MULTI-ACADEMY TRUST",
-    "groupId": "TR9610",
-    "ukprn": "10061152",
+    "groupId": "TR4543",
+    "ukprn": "10011710",
     "type": "Multi-academy trust",
-    "address": "0401 Juliet Bypass, ZC3 0FK",
-    "openedDate": "2021-08-09T00:00:00",
-    "companiesHouseNumber": "04628262",
+    "address": "622 Stanton Estate, McGlynn Run, IS9 0EP",
+    "openedDate": "2017-05-04T00:00:00",
+    "companiesHouseNumber": "06247134",
     "regionAndTerritory": "South West",
     "academies": [
       {
-        "urn": 12506693,
-        "dateAcademyJoinedTrust": "2021-09-20T00:00:00",
-        "establishmentName": "Northwood Church of England Secondary School",
+        "urn": 12503504,
+        "dateAcademyJoinedTrust": "2020-12-17T00:00:00",
+        "establishmentName": "St. Marys Church of England School",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1271",
-        "schoolCapacity": "1393",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12504398,
-        "dateAcademyJoinedTrust": "2023-02-03T00:00:00",
-        "establishmentName": "St. James\u0027s Catholic Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1996",
-        "schoolCapacity": "2119",
-        "percentageFreeSchoolMeals": "19",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12505001,
-        "dateAcademyJoinedTrust": "2022-11-15T00:00:00",
-        "establishmentName": "Peacehaven Community Church of England Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3152",
-        "schoolCapacity": "2554",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12503692,
-        "dateAcademyJoinedTrust": "2021-10-18T00:00:00",
-        "establishmentName": "Longhill R.C. School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "York",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1880",
-        "schoolCapacity": "1513",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12508690,
-        "dateAcademyJoinedTrust": "2023-03-11T00:00:00",
-        "establishmentName": "Meridian School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1357",
-        "schoolCapacity": "1684",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12504408,
-        "dateAcademyJoinedTrust": "2023-08-16T00:00:00",
-        "establishmentName": "Oasis R.C. School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3532",
-        "schoolCapacity": "2799",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12508253,
-        "dateAcademyJoinedTrust": "2022-03-01T00:00:00",
-        "establishmentName": "Mulberry Cofe Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2960",
-        "schoolCapacity": "2747",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1270",
-    "name": "ADEPT ACADEMY TRUST",
-    "groupId": "TR7224",
-    "ukprn": "10025385",
-    "type": "Multi-academy trust",
-    "address": "5368 Torphy Junction, Kirstin Circles, NP06 9NL",
-    "openedDate": "2022-08-29T00:00:00",
-    "companiesHouseNumber": "07564297",
-    "regionAndTerritory": "East of England",
-    "academies": [
-      {
-        "urn": 12701578,
-        "dateAcademyJoinedTrust": "2023-10-29T00:00:00",
-        "establishmentName": "Northwood Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1333",
-        "schoolCapacity": "2978",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12706647,
-        "dateAcademyJoinedTrust": "2023-09-23T00:00:00",
-        "establishmentName": "St. Peter\u0027s CE Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "847",
-        "schoolCapacity": "828",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1277",
-    "name": "ADVANTAGE ACADEMY TRUST",
-    "groupId": "TR7031",
-    "ukprn": "10040879",
-    "type": "Multi-academy trust",
-    "address": "4573 Hyatt Squares, Haag Cape, Padbergview, ZV1 5CD",
-    "openedDate": "2014-07-16T00:00:00",
-    "companiesHouseNumber": "01652826",
-    "regionAndTerritory": "",
-    "academies": [
-      {
-        "urn": 12774263,
-        "dateAcademyJoinedTrust": "2023-05-12T00:00:00",
-        "establishmentName": "Barr and Community Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "311",
-        "schoolCapacity": "736",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12772526,
-        "dateAcademyJoinedTrust": "2023-06-11T00:00:00",
-        "establishmentName": "Meridian Cofe Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1665",
-        "schoolCapacity": "1495",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12776359,
-        "dateAcademyJoinedTrust": "2018-12-31T00:00:00",
-        "establishmentName": "Beacon Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1115",
-        "schoolCapacity": "1854",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12779418,
-        "dateAcademyJoinedTrust": "2022-09-13T00:00:00",
-        "establishmentName": "Beacon CE Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "140",
-        "schoolCapacity": "231",
+        "numberOfPupils": "1878",
+        "schoolCapacity": "2037",
         "percentageFreeSchoolMeals": "18",
         "ageRange": {
           "minimum": 11,
@@ -383,2620 +47,15 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12775897,
-        "dateAcademyJoinedTrust": "2018-07-08T00:00:00",
-        "establishmentName": "St. James\u0027s CE School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
+        "urn": 12509834,
+        "dateAcademyJoinedTrust": "2020-03-13T00:00:00",
+        "establishmentName": "Peacehaven Community School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "241",
-        "schoolCapacity": "265",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12774945,
-        "dateAcademyJoinedTrust": "2016-07-26T00:00:00",
-        "establishmentName": "Barr and Community Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1008",
-        "schoolCapacity": "942",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12777573,
-        "dateAcademyJoinedTrust": "2022-05-06T00:00:00",
-        "establishmentName": "St. James\u0027 Cofe Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1592",
+        "numberOfPupils": "1799",
         "schoolCapacity": "2410",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12777858,
-        "dateAcademyJoinedTrust": "2015-12-04T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "704",
-        "schoolCapacity": "1086",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1244",
-    "name": "ASCENDANCY ACADEMY TRUST",
-    "groupId": "TR3227",
-    "ukprn": "10072217",
-    "type": "Multi-academy trust",
-    "address": "650 Bosco Brooks, IA5 3PU",
-    "openedDate": "2015-07-30T00:00:00",
-    "companiesHouseNumber": "09147744",
-    "regionAndTerritory": "East of England",
-    "academies": [
-      {
-        "urn": 12446470,
-        "dateAcademyJoinedTrust": "2018-07-06T00:00:00",
-        "establishmentName": "Queensbridge School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1675",
-        "schoolCapacity": "1782",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12445152,
-        "dateAcademyJoinedTrust": "2016-01-27T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2422",
-        "schoolCapacity": "2344",
-        "percentageFreeSchoolMeals": "26",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12441781,
-        "dateAcademyJoinedTrust": "2019-03-30T00:00:00",
-        "establishmentName": "Halewood Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "380",
-        "schoolCapacity": "883",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1263",
-    "name": "BRIDGE EDUCATION TRUST",
-    "groupId": "TR3928",
-    "ukprn": "10073429",
-    "type": "Multi-academy trust",
-    "address": "067 Khalid Causeway, New Jaedenshire, SP69 3RG",
-    "openedDate": "2016-04-24T00:00:00",
-    "companiesHouseNumber": "05019966",
-    "regionAndTerritory": "South East",
-    "academies": [
-      {
-        "urn": 12638706,
-        "dateAcademyJoinedTrust": "2022-02-01T00:00:00",
-        "establishmentName": "Beacon Cofe Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "654",
-        "schoolCapacity": "514",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12632536,
-        "dateAcademyJoinedTrust": "2023-06-01T00:00:00",
-        "establishmentName": "St. James\u0027 C of E Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2263",
-        "schoolCapacity": "2436",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12631776,
-        "dateAcademyJoinedTrust": "2019-02-19T00:00:00",
-        "establishmentName": "St. Joseph\u0027s R.C. Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "682",
-        "schoolCapacity": "609",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12631756,
-        "dateAcademyJoinedTrust": "2020-08-31T00:00:00",
-        "establishmentName": "Barr and Community Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "340",
-        "schoolCapacity": "573",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12635380,
-        "dateAcademyJoinedTrust": "2019-11-10T00:00:00",
-        "establishmentName": "Mulberry Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "651",
-        "schoolCapacity": "863",
-        "percentageFreeSchoolMeals": "12",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12634277,
-        "dateAcademyJoinedTrust": "2019-11-02T00:00:00",
-        "establishmentName": "Harris Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1101",
-        "schoolCapacity": "1070",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12638962,
-        "dateAcademyJoinedTrust": "2016-05-24T00:00:00",
-        "establishmentName": "Harris Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Leeds",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3405",
-        "schoolCapacity": "2797",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12632041,
-        "dateAcademyJoinedTrust": "2022-11-23T00:00:00",
-        "establishmentName": "Kuphal Path C of E Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "868",
-        "schoolCapacity": "723",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12637012,
-        "dateAcademyJoinedTrust": "2016-07-19T00:00:00",
-        "establishmentName": "Limehurst Cofe Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "265",
-        "schoolCapacity": "246",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12634984,
-        "dateAcademyJoinedTrust": "2021-12-16T00:00:00",
-        "establishmentName": "Mulberry Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2597",
-        "schoolCapacity": "2005",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12632657,
-        "dateAcademyJoinedTrust": "2018-01-22T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Church of England Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "527",
-        "schoolCapacity": "1150",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1311",
-    "name": "CANTERBURY CROSS EDUCATION TRUST",
-    "groupId": "TR299",
-    "ukprn": "10078878",
-    "type": "Multi-academy trust",
-    "address": "385 Reyes Prairie, Jones Terrace, Marvinhaven, ZP83 4BT",
-    "openedDate": "2022-04-19T00:00:00",
-    "companiesHouseNumber": "05443627",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 13117944,
-        "dateAcademyJoinedTrust": "2022-08-13T00:00:00",
-        "establishmentName": "St. Catherine\u0027s R.C. Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "501",
-        "schoolCapacity": "521",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13111130,
-        "dateAcademyJoinedTrust": "2023-08-08T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2171",
-        "schoolCapacity": "2027",
-        "percentageFreeSchoolMeals": "17",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13119303,
-        "dateAcademyJoinedTrust": "2022-10-31T00:00:00",
-        "establishmentName": "St. John\u0027s Cofe Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "652",
-        "schoolCapacity": "620",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13112739,
-        "dateAcademyJoinedTrust": "2023-08-03T00:00:00",
-        "establishmentName": "Northwood Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1178",
-        "schoolCapacity": "1962",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1282",
-    "name": "CHALLENGER MULTI-ACADEMY TRUST",
-    "groupId": "TR9097",
-    "ukprn": "10046583",
-    "type": "Multi-academy trust",
-    "address": "09914 Lockman Knolls, Wiza Haven, BO0 6DN",
-    "openedDate": "2015-06-28T00:00:00",
-    "companiesHouseNumber": "09498309",
-    "regionAndTerritory": "West Midlands",
-    "academies": [
-      {
-        "urn": 12823359,
-        "dateAcademyJoinedTrust": "2016-02-26T00:00:00",
-        "establishmentName": "Lampton Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1446",
-        "schoolCapacity": "1534",
-        "percentageFreeSchoolMeals": "26",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12824807,
-        "dateAcademyJoinedTrust": "2017-12-25T00:00:00",
-        "establishmentName": "St. James\u0027s Church of England Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1651",
-        "schoolCapacity": "2284",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12828590,
-        "dateAcademyJoinedTrust": "2017-08-03T00:00:00",
-        "establishmentName": "Oasis Catholic School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1897",
-        "schoolCapacity": "2729",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1254",
-    "name": "CHAMPION ACADEMY TRUST",
-    "groupId": "TR5615",
-    "ukprn": "10098893",
-    "type": "Multi-academy trust",
-    "address": "0991 Houston Pine, LD2 0FC",
-    "openedDate": "2016-03-08T00:00:00",
-    "companiesHouseNumber": "04962165",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 12547934,
-        "dateAcademyJoinedTrust": "2017-02-04T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Church of England Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2275",
-        "schoolCapacity": "2888",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12549532,
-        "dateAcademyJoinedTrust": "2017-04-15T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1225",
-        "schoolCapacity": "1705",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12545894,
-        "dateAcademyJoinedTrust": "2019-02-10T00:00:00",
-        "establishmentName": "Longhill Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "608",
-        "schoolCapacity": "677",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12547264,
-        "dateAcademyJoinedTrust": "2017-06-26T00:00:00",
-        "establishmentName": "Mulberry School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "792",
-        "schoolCapacity": "1511",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12543408,
-        "dateAcademyJoinedTrust": "2023-02-21T00:00:00",
-        "establishmentName": "Co-op Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1600",
-        "schoolCapacity": "1235",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12546472,
-        "dateAcademyJoinedTrust": "2018-02-25T00:00:00",
-        "establishmentName": "George Abbey R.C. School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1261",
-        "schoolCapacity": "2897",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12545857,
-        "dateAcademyJoinedTrust": "2017-12-07T00:00:00",
-        "establishmentName": "Meridian School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2800",
-        "schoolCapacity": "2754",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1260",
-    "name": "CORNERSTONE MULTI-ACADEMY TRUST",
-    "groupId": "TR7616",
-    "ukprn": "10062669",
-    "type": "Multi-academy trust",
-    "address": "1914 Hansen Unions, Schamberger Park, Lake Brennan, KN9 9WI",
-    "openedDate": "2016-07-22T00:00:00",
-    "companiesHouseNumber": "06570508",
-    "regionAndTerritory": "East Midlands",
-    "academies": [
-      {
-        "urn": 12607012,
-        "dateAcademyJoinedTrust": "2018-01-25T00:00:00",
-        "establishmentName": "Northwood Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3088",
-        "schoolCapacity": "2594",
-        "percentageFreeSchoolMeals": "26",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12602116,
-        "dateAcademyJoinedTrust": "2019-05-09T00:00:00",
-        "establishmentName": "Harris Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1720",
-        "schoolCapacity": "1971",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12606191,
-        "dateAcademyJoinedTrust": "2017-10-15T00:00:00",
-        "establishmentName": "Queensbridge Church of England Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "845",
-        "schoolCapacity": "2071",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12607972,
-        "dateAcademyJoinedTrust": "2020-03-24T00:00:00",
-        "establishmentName": "Longhill Catholic Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1366",
-        "schoolCapacity": "1253",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1264",
-    "name": "CRESCENDO ACADEMY TRUST",
-    "groupId": "TR3189",
-    "ukprn": "10013508",
-    "type": "Multi-academy trust",
-    "address": "996 Amaya Extension, Celestino Trail, WS4 1FZ",
-    "openedDate": "2018-03-31T00:00:00",
-    "companiesHouseNumber": "08770407",
-    "regionAndTerritory": "South East",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1243",
-    "name": "ECHELON EDUCATION TRUST",
-    "groupId": "TR4877",
-    "ukprn": "10065588",
-    "type": "Multi-academy trust",
-    "address": "44348 Nienow Key, Linnie Greens, GY26 6PM",
-    "openedDate": "2022-04-29T00:00:00",
-    "companiesHouseNumber": "07954541",
-    "regionAndTerritory": "North East",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1234",
-    "name": "EDIFY MULTI-ACADEMY TRUST",
-    "groupId": "TR9131",
-    "ukprn": "10068736",
-    "type": "Multi-academy trust",
-    "address": "5702 Farrell Ferry, Abbott Lodge, KN82 8YU",
-    "openedDate": "2021-08-02T00:00:00",
-    "companiesHouseNumber": "05593282",
-    "regionAndTerritory": "North West",
-    "academies": [
-      {
-        "urn": 12345999,
-        "dateAcademyJoinedTrust": "2023-11-07T00:00:00",
-        "establishmentName": "Beacon School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "935",
-        "schoolCapacity": "1249",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1240",
-    "name": "ELEVATE SCHOOLS TRUST",
-    "groupId": "TR5063",
-    "ukprn": "10037274",
-    "type": "Multi-academy trust",
-    "address": "4788 Kessler Tunnel, North Brycehaven, DK81 2JP",
-    "openedDate": "2020-05-20T00:00:00",
-    "companiesHouseNumber": "03426988",
-    "regionAndTerritory": "East Midlands",
-    "academies": [
-      {
-        "urn": 12405527,
-        "dateAcademyJoinedTrust": "2021-09-01T00:00:00",
-        "establishmentName": "Oasis Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1342",
-        "schoolCapacity": "1290",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12405286,
-        "dateAcademyJoinedTrust": "2021-06-05T00:00:00",
-        "establishmentName": "Meridian C of E Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "882",
-        "schoolCapacity": "1489",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12407280,
-        "dateAcademyJoinedTrust": "2021-04-28T00:00:00",
-        "establishmentName": "Harris C of E School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "928",
-        "schoolCapacity": "2183",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12407418,
-        "dateAcademyJoinedTrust": "2021-07-28T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Cofe Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "170",
-        "schoolCapacity": "170",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12402612,
-        "dateAcademyJoinedTrust": "2022-09-09T00:00:00",
-        "establishmentName": "Barr and Community Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2028",
-        "schoolCapacity": "1874",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12405487,
-        "dateAcademyJoinedTrust": "2023-10-02T00:00:00",
-        "establishmentName": "Northwood Church of England Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1547",
-        "schoolCapacity": "2022",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12404795,
-        "dateAcademyJoinedTrust": "2022-03-04T00:00:00",
-        "establishmentName": "Williamson Throughway Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "605",
-        "schoolCapacity": "1471",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12409161,
-        "dateAcademyJoinedTrust": "2023-09-08T00:00:00",
-        "establishmentName": "St. James\u0027 CE Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2106",
-        "schoolCapacity": "2559",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12409660,
-        "dateAcademyJoinedTrust": "2021-08-24T00:00:00",
-        "establishmentName": "Glyn Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "198",
-        "schoolCapacity": "180",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1253",
-    "name": "ELEVATED SCHOOLS TRUST",
-    "groupId": "TR5247",
-    "ukprn": "10039717",
-    "type": "Multi-academy trust",
-    "address": "23563 Claudine Mall, Murray Radial, Asiaside, ZN2 6UT",
-    "openedDate": "2017-04-10T00:00:00",
-    "companiesHouseNumber": "08730124",
-    "regionAndTerritory": "East of England",
-    "academies": [
-      {
-        "urn": 12539436,
-        "dateAcademyJoinedTrust": "2021-11-16T00:00:00",
-        "establishmentName": "Oasis Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3295",
-        "schoolCapacity": "2657",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1280",
-    "name": "EMPOWER ACADEMY TRUST",
-    "groupId": "TR2014",
-    "ukprn": "10049042",
-    "type": "Multi-academy trust",
-    "address": "761 Hayley Drive, TZ8 1IX",
-    "openedDate": "2020-05-18T00:00:00",
-    "companiesHouseNumber": "04993633",
-    "regionAndTerritory": "North East",
-    "academies": [
-      {
-        "urn": 12804753,
-        "dateAcademyJoinedTrust": "2022-09-14T00:00:00",
-        "establishmentName": "Mulberry Cofe School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2028",
-        "schoolCapacity": "1764",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12809048,
-        "dateAcademyJoinedTrust": "2022-04-29T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "738",
-        "schoolCapacity": "1048",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12805453,
-        "dateAcademyJoinedTrust": "2021-02-09T00:00:00",
-        "establishmentName": "Northwood Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2980",
-        "schoolCapacity": "2569",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12804746,
-        "dateAcademyJoinedTrust": "2021-08-29T00:00:00",
-        "establishmentName": "Halewood C of E Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3247",
-        "schoolCapacity": "2774",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12801303,
-        "dateAcademyJoinedTrust": "2023-09-01T00:00:00",
-        "establishmentName": "Horizon R.C. Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "817",
-        "schoolCapacity": "1294",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12802443,
-        "dateAcademyJoinedTrust": "2021-04-18T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Church of England Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2323",
-        "schoolCapacity": "2383",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12803597,
-        "dateAcademyJoinedTrust": "2021-10-01T00:00:00",
-        "establishmentName": "Malbank School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "622",
-        "schoolCapacity": "1540",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12803253,
-        "dateAcademyJoinedTrust": "2020-12-02T00:00:00",
-        "establishmentName": "George Abbey Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "295",
-        "schoolCapacity": "445",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1242",
-    "name": "EMPOWERMENT MULTI-ACADEMY TRUST",
-    "groupId": "TR5753",
-    "ukprn": "10071479",
-    "type": "Multi-academy trust",
-    "address": "447 Abner Parkways, Jerald Loop, Hammesmouth, QH8 5GI",
-    "openedDate": "2014-02-02T00:00:00",
-    "companiesHouseNumber": "02095640",
-    "regionAndTerritory": "North East",
-    "academies": [
-      {
-        "urn": 12425871,
-        "dateAcademyJoinedTrust": "2022-05-29T00:00:00",
-        "establishmentName": "St. Marys CE School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "272",
-        "schoolCapacity": "245",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12421849,
-        "dateAcademyJoinedTrust": "2016-11-16T00:00:00",
-        "establishmentName": "St. Peter\u0027s C of E Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2650",
-        "schoolCapacity": "2813",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1247",
-    "name": "EPIC LEARNING TRUST",
-    "groupId": "TR2215",
-    "ukprn": "10006697",
-    "type": "Multi-academy trust",
-    "address": "05597 Bauch Lock, AT76 2BR",
-    "openedDate": "2020-04-19T00:00:00",
-    "companiesHouseNumber": "07394657",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 12471486,
-        "dateAcademyJoinedTrust": "2023-07-29T00:00:00",
-        "establishmentName": "Harris CE Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2033",
-        "schoolCapacity": "2801",
-        "percentageFreeSchoolMeals": "17",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1268",
-    "name": "EXCEL MULTI-ACADEMY TRUST",
-    "groupId": "TR2703",
-    "ukprn": "10012927",
-    "type": "Multi-academy trust",
-    "address": "64708 Eileen Lake, Bashirian Prairie, PE8 5XV",
-    "openedDate": "2020-10-16T00:00:00",
-    "companiesHouseNumber": "03420836",
-    "regionAndTerritory": "South East",
-    "academies": [
-      {
-        "urn": 12687775,
-        "dateAcademyJoinedTrust": "2023-01-08T00:00:00",
-        "establishmentName": "St. Catherine\u0027s C of E Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "786",
-        "schoolCapacity": "928",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12688357,
-        "dateAcademyJoinedTrust": "2023-06-09T00:00:00",
-        "establishmentName": "Northwood School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "646",
-        "schoolCapacity": "1297",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1271",
-    "name": "EXCELLENCE MULTI-ACADEMY TRUST",
-    "groupId": "TR2945",
-    "ukprn": "10027704",
-    "type": "Multi-academy trust",
-    "address": "09747 Fahey Bypass, JS85 1OZ",
-    "openedDate": "2019-06-02T00:00:00",
-    "companiesHouseNumber": "02786907",
-    "regionAndTerritory": "South East",
-    "academies": [
-      {
-        "urn": 12716208,
-        "dateAcademyJoinedTrust": "2023-01-13T00:00:00",
-        "establishmentName": "St. Paul\u0027s Cofe Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "813",
-        "schoolCapacity": "1545",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12712258,
-        "dateAcademyJoinedTrust": "2021-06-07T00:00:00",
-        "establishmentName": "Queensbridge R.C. Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1227",
-        "schoolCapacity": "1477",
-        "percentageFreeSchoolMeals": "26",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12714898,
-        "dateAcademyJoinedTrust": "2022-05-18T00:00:00",
-        "establishmentName": "Harris Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1264",
-        "schoolCapacity": "1605",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12719172,
-        "dateAcademyJoinedTrust": "2023-09-21T00:00:00",
-        "establishmentName": "Northwood Catholic Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1845",
-        "schoolCapacity": "2875",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12717677,
-        "dateAcademyJoinedTrust": "2022-03-17T00:00:00",
-        "establishmentName": "Northwood School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1951",
-        "schoolCapacity": "2035",
-        "percentageFreeSchoolMeals": "17",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12719177,
-        "dateAcademyJoinedTrust": "2022-03-31T00:00:00",
-        "establishmentName": "St. Anne\u0027s CE Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1743",
-        "schoolCapacity": "2128",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12711985,
-        "dateAcademyJoinedTrust": "2021-10-21T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1414",
-        "schoolCapacity": "2858",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12711963,
-        "dateAcademyJoinedTrust": "2022-12-25T00:00:00",
-        "establishmentName": "Peacehaven Community Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "693",
-        "schoolCapacity": "716",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1275",
-    "name": "FORWARD MULTI-ACADEMY TRUST",
-    "groupId": "TR6319",
-    "ukprn": "10016066",
-    "type": "Multi-academy trust",
-    "address": "699 Mark Parkway, West Jammie, YE2 1US",
-    "openedDate": "2019-10-06T00:00:00",
-    "companiesHouseNumber": "09832691",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 12757687,
-        "dateAcademyJoinedTrust": "2020-12-25T00:00:00",
-        "establishmentName": "Meridian Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2275",
-        "schoolCapacity": "2811",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12759598,
-        "dateAcademyJoinedTrust": "2022-08-21T00:00:00",
-        "establishmentName": "St. Mary\u0027s R.C. School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1356",
-        "schoolCapacity": "2750",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12753388,
-        "dateAcademyJoinedTrust": "2023-10-11T00:00:00",
-        "establishmentName": "Oasis Church of England School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "656",
-        "schoolCapacity": "725",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12757451,
-        "dateAcademyJoinedTrust": "2022-03-24T00:00:00",
-        "establishmentName": "St. James\u0027 C of E Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "974",
-        "schoolCapacity": "992",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12751560,
-        "dateAcademyJoinedTrust": "2019-11-28T00:00:00",
-        "establishmentName": "St. James\u0027 C of E Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1283",
-        "schoolCapacity": "2605",
-        "percentageFreeSchoolMeals": "12",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12752221,
-        "dateAcademyJoinedTrust": "2020-05-15T00:00:00",
-        "establishmentName": "St. John\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "977",
-        "schoolCapacity": "2361",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1279",
-    "name": "FUSION EDUCATION TRUST",
-    "groupId": "TR5365",
-    "ukprn": "10038409",
-    "type": "Multi-academy trust",
-    "address": "5441 Kovacek Skyway, Darion Parkways, East Bertha, UL85 3CV",
-    "openedDate": "2017-10-18T00:00:00",
-    "companiesHouseNumber": "06516649",
-    "regionAndTerritory": "North East",
-    "academies": [
-      {
-        "urn": 12798413,
-        "dateAcademyJoinedTrust": "2020-07-26T00:00:00",
-        "establishmentName": "Malbank Church of England School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "230",
-        "schoolCapacity": "446",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12795435,
-        "dateAcademyJoinedTrust": "2020-08-16T00:00:00",
-        "establishmentName": "Greensward Catholic Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1044",
-        "schoolCapacity": "2416",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12794928,
-        "dateAcademyJoinedTrust": "2019-09-09T00:00:00",
-        "establishmentName": "St. Joseph\u0027s CE Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1709",
-        "schoolCapacity": "1704",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12795915,
-        "dateAcademyJoinedTrust": "2021-08-07T00:00:00",
-        "establishmentName": "Meridian Church of England Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1197",
-        "schoolCapacity": "2833",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12797739,
-        "dateAcademyJoinedTrust": "2017-11-29T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 CE School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1069",
-        "schoolCapacity": "858",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12797326,
-        "dateAcademyJoinedTrust": "2021-06-27T00:00:00",
-        "establishmentName": "St. John\u0027s Church of England Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1061",
-        "schoolCapacity": "1377",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12793752,
-        "dateAcademyJoinedTrust": "2019-08-31T00:00:00",
-        "establishmentName": "St. Mary\u0027s CE Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "668",
-        "schoolCapacity": "1018",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1259",
-    "name": "GALVANIZE ACADEMY TRUST",
-    "groupId": "TR4008",
-    "ukprn": "10018644",
-    "type": "Multi-academy trust",
-    "address": "330 Wyatt Pike, Kihn Roads, TZ4 4IO",
-    "openedDate": "2017-08-07T00:00:00",
-    "companiesHouseNumber": "07856980",
-    "regionAndTerritory": "South East",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1239",
-    "name": "HORIZON MULTI-ACADEMY TRUST",
-    "groupId": "TR9910",
-    "ukprn": "10030338",
-    "type": "Multi-academy trust",
-    "address": "90149 Ozella Plains, FQ45 0IY",
-    "openedDate": "2015-09-19T00:00:00",
-    "companiesHouseNumber": "06896749",
-    "regionAndTerritory": "South West",
-    "academies": [
-      {
-        "urn": 12399338,
-        "dateAcademyJoinedTrust": "2020-08-21T00:00:00",
-        "establishmentName": "St. John\u0027s CE Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2111",
-        "schoolCapacity": "1923",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12393349,
-        "dateAcademyJoinedTrust": "2016-01-14T00:00:00",
-        "establishmentName": "St. Anne\u0027s C of E Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2083",
-        "schoolCapacity": "2567",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12398882,
-        "dateAcademyJoinedTrust": "2016-03-25T00:00:00",
-        "establishmentName": "Glyn R.C. Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "736",
-        "schoolCapacity": "846",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1266",
-    "name": "HORIZONS MULTI-ACADEMY TRUST",
-    "groupId": "TR5949",
-    "ukprn": "10044044",
-    "type": "Multi-academy trust",
-    "address": "410 Farrell Tunnel, Aufderhar Run, Hellerfort, RB3 4IS",
-    "openedDate": "2018-08-23T00:00:00",
-    "companiesHouseNumber": "08155384",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 12661517,
-        "dateAcademyJoinedTrust": "2018-11-01T00:00:00",
-        "establishmentName": "St. John\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1675",
-        "schoolCapacity": "2173",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1281",
-    "name": "ILLUMINATE LEARNING TRUST",
-    "groupId": "TR960",
-    "ukprn": "10002923",
-    "type": "Multi-academy trust",
-    "address": "614 Sasha Route, Armstrong Villages, Dachshire, BA1 8CM",
-    "openedDate": "2018-12-03T00:00:00",
-    "companiesHouseNumber": "01462188",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 12814254,
-        "dateAcademyJoinedTrust": "2023-02-10T00:00:00",
-        "establishmentName": "York Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1105",
-        "schoolCapacity": "1833",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12812933,
-        "dateAcademyJoinedTrust": "2022-06-07T00:00:00",
-        "establishmentName": "Co-op CE School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1474",
-        "schoolCapacity": "1142",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12812442,
-        "dateAcademyJoinedTrust": "2019-10-06T00:00:00",
-        "establishmentName": "Peacehaven Community Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1478",
-        "schoolCapacity": "1436",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12816461,
-        "dateAcademyJoinedTrust": "2022-09-25T00:00:00",
-        "establishmentName": "St. Paul\u0027s Church of England Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1866",
-        "schoolCapacity": "2362",
-        "percentageFreeSchoolMeals": "12",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12819105,
-        "dateAcademyJoinedTrust": "2021-06-09T00:00:00",
-        "establishmentName": "Northwood Church of England School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1676",
-        "schoolCapacity": "2471",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12812820,
-        "dateAcademyJoinedTrust": "2023-07-16T00:00:00",
-        "establishmentName": "St. Anne\u0027s C of E Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1410",
-        "schoolCapacity": "2256",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12814687,
-        "dateAcademyJoinedTrust": "2019-07-16T00:00:00",
-        "establishmentName": "York Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1473",
-        "schoolCapacity": "2005",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12811785,
-        "dateAcademyJoinedTrust": "2019-01-28T00:00:00",
-        "establishmentName": "Beacon Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1119",
-        "schoolCapacity": "1512",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12814730,
-        "dateAcademyJoinedTrust": "2022-11-28T00:00:00",
-        "establishmentName": "St. Peter\u0027s Church of England School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "284",
-        "schoolCapacity": "598",
-        "percentageFreeSchoolMeals": "17",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1278",
-    "name": "ILLUMINATE MULTI-ACADEMY TRUST",
-    "groupId": "TR3561",
-    "ukprn": "10088976",
-    "type": "Multi-academy trust",
-    "address": "23182 Vandervort Pass, Boyle Vista, FZ24 5UG",
-    "openedDate": "2020-11-17T00:00:00",
-    "companiesHouseNumber": "02473158",
-    "regionAndTerritory": "North East",
-    "academies": [
-      {
-        "urn": 12785053,
-        "dateAcademyJoinedTrust": "2021-09-07T00:00:00",
-        "establishmentName": "Halewood School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1446",
-        "schoolCapacity": "2347",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12781095,
-        "dateAcademyJoinedTrust": "2021-04-26T00:00:00",
-        "establishmentName": "St. Joseph\u0027s R.C. Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1168",
-        "schoolCapacity": "1205",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12784083,
-        "dateAcademyJoinedTrust": "2021-10-19T00:00:00",
-        "establishmentName": "Co-op Cofe Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3433",
-        "schoolCapacity": "2755",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12788991,
-        "dateAcademyJoinedTrust": "2021-04-07T00:00:00",
-        "establishmentName": "Longhill Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1843",
-        "schoolCapacity": "2472",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12784455,
-        "dateAcademyJoinedTrust": "2021-09-01T00:00:00",
-        "establishmentName": "St. Peter\u0027s CE School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1956",
-        "schoolCapacity": "1694",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12782844,
-        "dateAcademyJoinedTrust": "2022-03-18T00:00:00",
-        "establishmentName": "Homenick Isle C of E School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1577",
-        "schoolCapacity": "2291",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12784585,
-        "dateAcademyJoinedTrust": "2021-05-15T00:00:00",
-        "establishmentName": "Meridian School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2759",
-        "schoolCapacity": "2992",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12782666,
-        "dateAcademyJoinedTrust": "2022-12-11T00:00:00",
-        "establishmentName": "Glyn C of E Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1272",
-        "schoolCapacity": "2085",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12789653,
-        "dateAcademyJoinedTrust": "2022-03-18T00:00:00",
-        "establishmentName": "St. James\u0027s Church of England Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "347",
-        "schoolCapacity": "591",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1235",
-    "name": "INNOVATE ACADEMY TRUST",
-    "groupId": "TR6318",
-    "ukprn": "10098055",
-    "type": "Multi-academy trust",
-    "address": "047 Altenwerth Streets, Hoppe Lakes, East Erik, OK9 5AG",
-    "openedDate": "2014-08-03T00:00:00",
-    "companiesHouseNumber": "02327386",
-    "regionAndTerritory": "South West",
-    "academies": [
-      {
-        "urn": 12358070,
-        "dateAcademyJoinedTrust": "2017-11-15T00:00:00",
-        "establishmentName": "Queensbridge C of E Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1547",
-        "schoolCapacity": "3000",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12356726,
-        "dateAcademyJoinedTrust": "2022-03-08T00:00:00",
-        "establishmentName": "Peacehaven Community Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "163",
-        "schoolCapacity": "362",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12352450,
-        "dateAcademyJoinedTrust": "2022-08-21T00:00:00",
-        "establishmentName": "George Abbey CE Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "60",
-        "schoolCapacity": "116",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1261",
-    "name": "INSPIRE MULTI-ACADEMY TRUST",
-    "groupId": "TR2798",
-    "ukprn": "10011503",
-    "type": "Multi-academy trust",
-    "address": "5251 Hoppe Mountains, Wittington, TY78 2TZ",
-    "openedDate": "2019-01-14T00:00:00",
-    "companiesHouseNumber": "06687377",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 12618215,
-        "dateAcademyJoinedTrust": "2020-04-26T00:00:00",
-        "establishmentName": "Longhill Church of England Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1351",
-        "schoolCapacity": "2667",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12619566,
-        "dateAcademyJoinedTrust": "2022-10-06T00:00:00",
-        "establishmentName": "Greensward Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1583",
-        "schoolCapacity": "1771",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12611577,
-        "dateAcademyJoinedTrust": "2021-07-27T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Catholic Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "392",
-        "schoolCapacity": "668",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12617292,
-        "dateAcademyJoinedTrust": "2022-09-06T00:00:00",
-        "establishmentName": "Horizon Catholic Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "596",
-        "schoolCapacity": "1262",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12615510,
-        "dateAcademyJoinedTrust": "2022-12-27T00:00:00",
-        "establishmentName": "Co-op School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1212",
-        "schoolCapacity": "1219",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1255",
-    "name": "INTREPID EDUCATION TRUST",
-    "groupId": "TR773",
-    "ukprn": "10016959",
-    "type": "Multi-academy trust",
-    "address": "80097 Gusikowski Plains, UP6 8SV",
-    "openedDate": "2023-10-19T00:00:00",
-    "companiesHouseNumber": "03998808",
-    "regionAndTerritory": "Yorkshire and the Humber",
-    "academies": [
-      {
-        "urn": 12552918,
-        "dateAcademyJoinedTrust": "2023-11-06T00:00:00",
-        "establishmentName": "Northwood Cofe School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2026",
-        "schoolCapacity": "1953",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12554931,
-        "dateAcademyJoinedTrust": "2023-10-26T00:00:00",
-        "establishmentName": "York CE Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "York",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1271",
-        "schoolCapacity": "1515",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1249",
-    "name": "LEGACY EDUCATION TRUST",
-    "groupId": "TR2511",
-    "ukprn": "10035238",
-    "type": "Multi-academy trust",
-    "address": "6599 Sandy Fall, West Emely, IT9 2KW",
-    "openedDate": "2017-01-07T00:00:00",
-    "companiesHouseNumber": "09698699",
-    "regionAndTerritory": "South East",
-    "academies": [
-      {
-        "urn": 12499083,
-        "dateAcademyJoinedTrust": "2021-07-07T00:00:00",
-        "establishmentName": "Harris School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "799",
-        "schoolCapacity": "899",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12498261,
-        "dateAcademyJoinedTrust": "2017-07-30T00:00:00",
-        "establishmentName": "Limehurst Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1302",
-        "schoolCapacity": "1993",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12495218,
-        "dateAcademyJoinedTrust": "2018-01-06T00:00:00",
-        "establishmentName": "Lampton Cofe School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "449",
-        "schoolCapacity": "585",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12491220,
-        "dateAcademyJoinedTrust": "2022-07-08T00:00:00",
-        "establishmentName": "Lampton School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1408",
-        "schoolCapacity": "1300",
-        "percentageFreeSchoolMeals": "19",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1246",
-    "name": "MERIT ACADEMY TRUST",
-    "groupId": "TR9956",
-    "ukprn": "10008714",
-    "type": "Multi-academy trust",
-    "address": "22984 Cronin Junctions, Batzbury, BD74 5WA",
-    "openedDate": "2018-01-18T00:00:00",
-    "companiesHouseNumber": "08056460",
-    "regionAndTerritory": "West Midlands",
-    "academies": [
-      {
-        "urn": 12468336,
-        "dateAcademyJoinedTrust": "2020-04-24T00:00:00",
-        "establishmentName": "St. James\u0027s CE Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "966",
-        "schoolCapacity": "2206",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12462126,
-        "dateAcademyJoinedTrust": "2023-07-01T00:00:00",
-        "establishmentName": "Harris Catholic Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1197",
-        "schoolCapacity": "1017",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12463750,
-        "dateAcademyJoinedTrust": "2023-09-10T00:00:00",
-        "establishmentName": "St. James\u0027 C of E Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1598",
-        "schoolCapacity": "2735",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12464847,
-        "dateAcademyJoinedTrust": "2020-04-08T00:00:00",
-        "establishmentName": "Beacon Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1076",
-        "schoolCapacity": "1615",
         "percentageFreeSchoolMeals": "29",
         "ageRange": {
           "minimum": 5,
@@ -3006,1670 +65,11 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12467448,
-        "dateAcademyJoinedTrust": "2020-08-06T00:00:00",
-        "establishmentName": "Glyn Secondary School",
+        "urn": 12502401,
+        "dateAcademyJoinedTrust": "2019-12-02T00:00:00",
+        "establishmentName": "Peacehaven Community School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2475",
-        "schoolCapacity": "2227",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12464836,
-        "dateAcademyJoinedTrust": "2021-03-04T00:00:00",
-        "establishmentName": "Meridian School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "322",
-        "schoolCapacity": "473",
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12461090,
-        "dateAcademyJoinedTrust": "2020-05-23T00:00:00",
-        "establishmentName": "Halewood CE Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "531",
-        "schoolCapacity": "451",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1258",
-    "name": "MILESTONE MULTI-ACADEMY TRUST",
-    "groupId": "TR8965",
-    "ukprn": "10077712",
-    "type": "Multi-academy trust",
-    "address": "5553 Hermina Islands, McClure Mountain, OL98 3GR",
-    "openedDate": "2020-04-01T00:00:00",
-    "companiesHouseNumber": "08342395",
-    "regionAndTerritory": "",
-    "academies": [
-      {
-        "urn": 12589884,
-        "dateAcademyJoinedTrust": "2020-09-23T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Church of England School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2272",
-        "schoolCapacity": "2720",
-        "percentageFreeSchoolMeals": "19",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12587486,
-        "dateAcademyJoinedTrust": "2022-02-01T00:00:00",
-        "establishmentName": "St. Paul\u0027s Catholic Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2612",
-        "schoolCapacity": "2744",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12581589,
-        "dateAcademyJoinedTrust": "2021-09-18T00:00:00",
-        "establishmentName": "Limehurst Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "708",
-        "schoolCapacity": "1039",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1236",
-    "name": "MOMENTUM MULTI-ACADEMY TRUST",
-    "groupId": "TR3336",
-    "ukprn": "10009801",
-    "type": "Multi-academy trust",
-    "address": "597 Spencer Land, Deondre Drive, BN54 9BA",
-    "openedDate": "2018-06-08T00:00:00",
-    "companiesHouseNumber": "03401075",
-    "regionAndTerritory": "East Midlands",
-    "academies": [
-      {
-        "urn": 12368890,
-        "dateAcademyJoinedTrust": "2019-09-28T00:00:00",
-        "establishmentName": "Horizon Catholic Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "777",
-        "schoolCapacity": "1222",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12361532,
-        "dateAcademyJoinedTrust": "2018-08-27T00:00:00",
-        "establishmentName": "Jean Courts Cofe Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1409",
-        "schoolCapacity": "2585",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12368454,
-        "dateAcademyJoinedTrust": "2022-09-09T00:00:00",
-        "establishmentName": "St. James\u0027 CE Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1146",
-        "schoolCapacity": "1042",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12362830,
-        "dateAcademyJoinedTrust": "2023-04-16T00:00:00",
-        "establishmentName": "St. James\u0027 Cofe Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "137",
-        "schoolCapacity": "328",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1257",
-    "name": "NEW HORIZONS TRUST",
-    "groupId": "TR8430",
-    "ukprn": "10014617",
-    "type": "Multi-academy trust",
-    "address": "40264 Pedro Shores, Kaycee Road, Nathanielmouth, RG86 4WJ",
-    "openedDate": "2020-02-07T00:00:00",
-    "companiesHouseNumber": "09304462",
-    "regionAndTerritory": "East Midlands",
-    "academies": [
-      {
-        "urn": 12572319,
-        "dateAcademyJoinedTrust": "2023-04-04T00:00:00",
-        "establishmentName": "Glyn Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2765",
-        "schoolCapacity": "2969",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12578702,
-        "dateAcademyJoinedTrust": "2022-11-05T00:00:00",
-        "establishmentName": "St. Anne\u0027s Catholic Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1989",
-        "schoolCapacity": "2111",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12572649,
-        "dateAcademyJoinedTrust": "2020-05-11T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "274",
-        "schoolCapacity": "398",
-        "percentageFreeSchoolMeals": "17",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12577148,
-        "dateAcademyJoinedTrust": "2022-09-04T00:00:00",
-        "establishmentName": "Mulberry Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "134",
-        "schoolCapacity": "190",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12574038,
-        "dateAcademyJoinedTrust": "2023-09-13T00:00:00",
-        "establishmentName": "St. James\u0027 C of E Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1744",
-        "schoolCapacity": "1698",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12573458,
-        "dateAcademyJoinedTrust": "2020-07-28T00:00:00",
-        "establishmentName": "Oasis Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1881",
-        "schoolCapacity": "1934",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12579064,
-        "dateAcademyJoinedTrust": "2021-08-17T00:00:00",
-        "establishmentName": "Greensward Church of England Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2180",
-        "schoolCapacity": "2162",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12574257,
-        "dateAcademyJoinedTrust": "2020-10-26T00:00:00",
-        "establishmentName": "Horizon Catholic Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "95",
-        "schoolCapacity": "151",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12573564,
-        "dateAcademyJoinedTrust": "2022-06-10T00:00:00",
-        "establishmentName": "St. Paul\u0027s Catholic Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1003",
-        "schoolCapacity": "1070",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12574007,
-        "dateAcademyJoinedTrust": "2021-12-05T00:00:00",
-        "establishmentName": "St. Paul\u0027s Church of England Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3284",
-        "schoolCapacity": "2759",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12577951,
-        "dateAcademyJoinedTrust": "2020-04-01T00:00:00",
-        "establishmentName": "Johnpaul Loop C of E Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "969",
-        "schoolCapacity": "899",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1245",
-    "name": "NEXUS MULTI-ACADEMY TRUST",
-    "groupId": "TR8923",
-    "ukprn": "10040502",
-    "type": "Multi-academy trust",
-    "address": "5925 Deondre Expressway, Schroeder Shores, Lake Norbertton, LD1 7TO",
-    "openedDate": "2020-05-04T00:00:00",
-    "companiesHouseNumber": "02431960",
-    "regionAndTerritory": "",
-    "academies": [
-      {
-        "urn": 12456520,
-        "dateAcademyJoinedTrust": "2022-01-20T00:00:00",
-        "establishmentName": "Co-op C of E Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2587",
-        "schoolCapacity": "2425",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12459995,
-        "dateAcademyJoinedTrust": "2023-01-15T00:00:00",
-        "establishmentName": "Greensward Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "884",
-        "schoolCapacity": "791",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12458091,
-        "dateAcademyJoinedTrust": "2023-04-19T00:00:00",
-        "establishmentName": "Harris Cofe Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1411",
-        "schoolCapacity": "1571",
-        "percentageFreeSchoolMeals": "23",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12454926,
-        "dateAcademyJoinedTrust": "2021-01-05T00:00:00",
-        "establishmentName": "Northwood Catholic School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1821",
-        "schoolCapacity": "2469",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12454249,
-        "dateAcademyJoinedTrust": "2023-04-03T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Cofe Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1104",
-        "schoolCapacity": "1378",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12455326,
-        "dateAcademyJoinedTrust": "2021-11-19T00:00:00",
-        "establishmentName": "Co-op School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1348",
-        "schoolCapacity": "1058",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1273",
-    "name": "PATHFINDER MULTI-ACADEMY TRUST",
-    "groupId": "TR5338",
-    "ukprn": "10092069",
-    "type": "Multi-academy trust",
-    "address": "037 Charity Crossroad, Abel Islands, Destineefurt, HQ3 0YG",
-    "openedDate": "2020-09-26T00:00:00",
-    "companiesHouseNumber": "04572847",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 12734214,
-        "dateAcademyJoinedTrust": "2022-06-05T00:00:00",
-        "establishmentName": "Halewood CE Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "685",
-        "schoolCapacity": "778",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12738693,
-        "dateAcademyJoinedTrust": "2021-07-16T00:00:00",
-        "establishmentName": "Meridian Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "132",
-        "schoolCapacity": "193",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12735040,
-        "dateAcademyJoinedTrust": "2023-01-16T00:00:00",
-        "establishmentName": "St. Peter\u0027s CE Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1278",
-        "schoolCapacity": "1642",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12733596,
-        "dateAcademyJoinedTrust": "2021-12-09T00:00:00",
-        "establishmentName": "Horizon School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "363",
-        "schoolCapacity": "466",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12734228,
-        "dateAcademyJoinedTrust": "2023-07-19T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Cofe Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3103",
-        "schoolCapacity": "2424",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12737692,
-        "dateAcademyJoinedTrust": "2022-08-01T00:00:00",
-        "establishmentName": "Northwood School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1404",
-        "schoolCapacity": "2106",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1248",
-    "name": "PEAK MULTI-ACADEMY TRUST",
-    "groupId": "TR7192",
-    "ukprn": "10036830",
-    "type": "Multi-academy trust",
-    "address": "2584 Medhurst Brooks, Jacobson Trail, CP44 1PQ",
-    "openedDate": "2017-10-16T00:00:00",
-    "companiesHouseNumber": "05821489",
-    "regionAndTerritory": "South East",
-    "academies": [
-      {
-        "urn": 12487416,
-        "dateAcademyJoinedTrust": "2021-02-04T00:00:00",
-        "establishmentName": "St. Paul\u0027s CE Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "309",
-        "schoolCapacity": "297",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12485316,
-        "dateAcademyJoinedTrust": "2018-01-28T00:00:00",
-        "establishmentName": "Glyn Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1024",
-        "schoolCapacity": "860",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12483047,
-        "dateAcademyJoinedTrust": "2018-09-17T00:00:00",
-        "establishmentName": "Harris Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "509",
-        "schoolCapacity": "481",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12487992,
-        "dateAcademyJoinedTrust": "2022-03-14T00:00:00",
-        "establishmentName": "Horizon School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "829",
-        "schoolCapacity": "1212",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12487226,
-        "dateAcademyJoinedTrust": "2018-08-31T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "309",
-        "schoolCapacity": "326",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12481380,
-        "dateAcademyJoinedTrust": "2018-07-12T00:00:00",
-        "establishmentName": "St. John\u0027s CE Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1682",
-        "schoolCapacity": "2538",
-        "percentageFreeSchoolMeals": "17",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12486374,
-        "dateAcademyJoinedTrust": "2023-03-03T00:00:00",
-        "establishmentName": "Longhill Church of England Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "882",
-        "schoolCapacity": "1669",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12489533,
-        "dateAcademyJoinedTrust": "2021-11-18T00:00:00",
-        "establishmentName": "North Yorkshire CE Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3033",
-        "schoolCapacity": "2351",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12489799,
-        "dateAcademyJoinedTrust": "2020-05-08T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s C of E Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3020",
-        "schoolCapacity": "2497",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12485198,
-        "dateAcademyJoinedTrust": "2020-04-09T00:00:00",
-        "establishmentName": "St. James\u0027 Catholic Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1326",
-        "schoolCapacity": "2482",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1251",
-    "name": "PINNACLE EDUCATION TRUST",
-    "groupId": "TR3298",
-    "ukprn": "10057900",
-    "type": "Multi-academy trust",
-    "address": "3129 Kari Garden, Hayes Drive, HA3 2QY",
-    "openedDate": "2017-08-20T00:00:00",
-    "companiesHouseNumber": "07239921",
-    "regionAndTerritory": "Yorkshire and the Humber",
-    "academies": [
-      {
-        "urn": 12511913,
-        "dateAcademyJoinedTrust": "2022-05-23T00:00:00",
-        "establishmentName": "St. James\u0027s C of E Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "511",
-        "schoolCapacity": "1067",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12519800,
-        "dateAcademyJoinedTrust": "2019-03-22T00:00:00",
-        "establishmentName": "Beacon Catholic Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "634",
-        "schoolCapacity": "626",
-        "percentageFreeSchoolMeals": "19",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12519201,
-        "dateAcademyJoinedTrust": "2023-03-20T00:00:00",
-        "establishmentName": "St. James\u0027s Church of England Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1245",
-        "schoolCapacity": "2397",
-        "percentageFreeSchoolMeals": "12",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12516584,
-        "dateAcademyJoinedTrust": "2020-08-16T00:00:00",
-        "establishmentName": "St. John\u0027s CE School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "384",
-        "schoolCapacity": "681",
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1265",
-    "name": "POTENTIAL LEARNING TRUST",
-    "groupId": "TR6137",
-    "ukprn": "10083354",
-    "type": "Multi-academy trust",
-    "address": "3196 Margarette Inlet, Arely Pike, Cormiermouth, OE0 8EY",
-    "openedDate": "2016-06-04T00:00:00",
-    "companiesHouseNumber": "04129867",
-    "regionAndTerritory": "",
-    "academies": [
-      {
-        "urn": 12655339,
-        "dateAcademyJoinedTrust": "2016-07-14T00:00:00",
-        "establishmentName": "St. John\u0027s Church of England Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "130",
-        "schoolCapacity": "150",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12658784,
-        "dateAcademyJoinedTrust": "2023-03-12T00:00:00",
-        "establishmentName": "Co-op School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1036",
-        "schoolCapacity": "2509",
-        "percentageFreeSchoolMeals": "26",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1238",
-    "name": "PROGRESSIVE EDUCATION TRUST",
-    "groupId": "TR9814",
-    "ukprn": "10003594",
-    "type": "Multi-academy trust",
-    "address": "2167 Arne Field, CT3 5XD",
-    "openedDate": "2015-07-28T00:00:00",
-    "companiesHouseNumber": "07248291",
-    "regionAndTerritory": "South West",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1256",
-    "name": "PROSPECT MULTI-ACADEMY TRUST",
-    "groupId": "TR154",
-    "ukprn": "10095816",
-    "type": "Multi-academy trust",
-    "address": "91342 Will Pike, TG73 6HN",
-    "openedDate": "2014-02-26T00:00:00",
-    "companiesHouseNumber": "01749712",
-    "regionAndTerritory": "East of England",
-    "academies": [
-      {
-        "urn": 12564083,
-        "dateAcademyJoinedTrust": "2015-01-23T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 R.C. Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "94",
-        "schoolCapacity": "155",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12562351,
-        "dateAcademyJoinedTrust": "2020-12-27T00:00:00",
-        "establishmentName": "East Riding of Yorkshire Cofe Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1478",
-        "schoolCapacity": "2151",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12562497,
-        "dateAcademyJoinedTrust": "2019-12-27T00:00:00",
-        "establishmentName": "Queensbridge Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1858",
-        "schoolCapacity": "2148",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12565341,
-        "dateAcademyJoinedTrust": "2023-01-18T00:00:00",
-        "establishmentName": "St. Marys Cofe School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1199",
-        "schoolCapacity": "1234",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12566580,
-        "dateAcademyJoinedTrust": "2015-08-12T00:00:00",
-        "establishmentName": "Malcolm Walks R.C. Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1163",
-        "schoolCapacity": "1541",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12566421,
-        "dateAcademyJoinedTrust": "2016-02-27T00:00:00",
-        "establishmentName": "Glyn Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1104",
-        "schoolCapacity": "869",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12563060,
-        "dateAcademyJoinedTrust": "2017-08-06T00:00:00",
-        "establishmentName": "Longhill School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2231",
-        "schoolCapacity": "1905",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1272",
-    "name": "PROSPERITY EDUCATION TRUST",
-    "groupId": "TR9977",
-    "ukprn": "10016694",
-    "type": "Multi-academy trust",
-    "address": "97249 Littel Crest, ZJ1 9MM",
-    "openedDate": "2023-01-01T00:00:00",
-    "companiesHouseNumber": "04640442",
-    "regionAndTerritory": "",
-    "academies": [
-      {
-        "urn": 12721408,
-        "dateAcademyJoinedTrust": "2023-05-10T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "643",
-        "schoolCapacity": "1128",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12728634,
-        "dateAcademyJoinedTrust": "2023-07-28T00:00:00",
-        "establishmentName": "Oasis Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "844",
-        "schoolCapacity": "1923",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12726827,
-        "dateAcademyJoinedTrust": "2023-07-24T00:00:00",
-        "establishmentName": "Northwood Catholic Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "455",
-        "schoolCapacity": "769",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1267",
-    "name": "RISE EDUCATION TRUST",
-    "groupId": "TR7310",
-    "ukprn": "10028834",
-    "type": "Multi-academy trust",
-    "address": "29511 Toney Hills, Port Marilyne, KD8 9PH",
-    "openedDate": "2016-03-24T00:00:00",
-    "companiesHouseNumber": "04162595",
-    "regionAndTerritory": "East of England",
-    "academies": [
-      {
-        "urn": 12674690,
-        "dateAcademyJoinedTrust": "2022-10-06T00:00:00",
-        "establishmentName": "Greensward Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1136",
-        "schoolCapacity": "940",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12674023,
-        "dateAcademyJoinedTrust": "2018-03-25T00:00:00",
-        "establishmentName": "Malbank Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "117",
-        "schoolCapacity": "158",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12677253,
-        "dateAcademyJoinedTrust": "2019-08-24T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 CE Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "944",
-        "schoolCapacity": "740",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12671161,
-        "dateAcademyJoinedTrust": "2018-09-24T00:00:00",
-        "establishmentName": "St. Anne\u0027s CE Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2008",
-        "schoolCapacity": "1936",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12677344,
-        "dateAcademyJoinedTrust": "2019-12-04T00:00:00",
-        "establishmentName": "Halewood Church of England Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "791",
-        "schoolCapacity": "907",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12672908,
-        "dateAcademyJoinedTrust": "2021-06-06T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "611",
-        "schoolCapacity": "1342",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12676634,
-        "dateAcademyJoinedTrust": "2017-05-30T00:00:00",
-        "establishmentName": "St. Paul\u0027s Catholic Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "61",
-        "schoolCapacity": "103",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12675341,
-        "dateAcademyJoinedTrust": "2016-03-28T00:00:00",
-        "establishmentName": "Barr and Community Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2535",
-        "schoolCapacity": "2556",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1310",
-    "name": "SHEFFIELD SOUTH EAST TRUST",
-    "groupId": "TR4678",
-    "ukprn": "10000318",
-    "type": "Multi-academy trust",
-    "address": "6437 Enola Mission, ZK6 2XF",
-    "openedDate": "2022-08-21T00:00:00",
-    "companiesHouseNumber": "01297206",
-    "regionAndTerritory": "",
-    "academies": [
-      {
-        "urn": 13101182,
-        "dateAcademyJoinedTrust": "2023-09-25T00:00:00",
-        "establishmentName": "Momentum Community Catholic Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1185",
-        "schoolCapacity": "1475",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13109948,
-        "dateAcademyJoinedTrust": "2023-08-17T00:00:00",
-        "establishmentName": "Bradford School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "211",
-        "schoolCapacity": "280",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13108338,
-        "dateAcademyJoinedTrust": "2023-03-10T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "288",
-        "schoolCapacity": "224",
-        "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13105774,
-        "dateAcademyJoinedTrust": "2022-11-30T00:00:00",
-        "establishmentName": "St. James\u0027 Catholic School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2205",
-        "schoolCapacity": "2597",
-        "percentageFreeSchoolMeals": "29",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13103298,
-        "dateAcademyJoinedTrust": "2023-11-02T00:00:00",
-        "establishmentName": "Malbank Cofe Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Rotherham",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "953",
-        "schoolCapacity": "2190",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13103165,
-        "dateAcademyJoinedTrust": "2023-01-15T00:00:00",
-        "establishmentName": "Meridian School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2091",
-        "schoolCapacity": "2352",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13106530,
-        "dateAcademyJoinedTrust": "2023-07-07T00:00:00",
-        "establishmentName": "Co-op R.C. Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2534",
-        "schoolCapacity": "2305",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13105566,
-        "dateAcademyJoinedTrust": "2022-10-27T00:00:00",
-        "establishmentName": "St. Marys Cofe School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2237",
-        "schoolCapacity": "2692",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13107538,
-        "dateAcademyJoinedTrust": "2023-01-08T00:00:00",
-        "establishmentName": "Greensward Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "493",
-        "schoolCapacity": "397",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1283",
-    "name": "ST MARY\u0027S ACADEMY TRUST",
-    "groupId": "TR8361",
-    "ukprn": "10004518",
-    "type": "Single-academy trust",
-    "address": "9118 Jamal Plains, Bernhard Curve, CA9 1JB",
-    "openedDate": "2017-10-20T00:00:00",
-    "companiesHouseNumber": "04406078",
-    "regionAndTerritory": "West Midlands",
-    "academies": [
-      {
-        "urn": 12838836,
-        "dateAcademyJoinedTrust": "2018-06-12T00:00:00",
-        "establishmentName": "St. Mary\u0027s Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "259",
-        "schoolCapacity": "479",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1284",
-    "name": "ST MARY\u0027S ANGLICAN ACADEMY",
-    "groupId": "TR8419",
-    "ukprn": "10087147",
-    "type": "Single-academy trust",
-    "address": "267 Kling Cove, Nader Fall, TJ37 1TF",
-    "openedDate": "2020-07-17T00:00:00",
-    "companiesHouseNumber": "07551722",
-    "regionAndTerritory": "South West",
-    "academies": [
-      {
-        "urn": 12846297,
-        "dateAcademyJoinedTrust": "2022-06-23T00:00:00",
-        "establishmentName": "St. Mary\u0027s Anglican Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "205",
-        "schoolCapacity": "296",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1285",
-    "name": "ST MARY\u0027S CATHOLIC HIGH SCHOOL ACADEMY TRUST",
-    "groupId": "TR6712",
-    "ukprn": "10027832",
-    "type": "Single-academy trust",
-    "address": "4265 White Village, Lennie Causeway, IB7 3YK",
-    "openedDate": "2014-01-18T00:00:00",
-    "companiesHouseNumber": "06657758",
-    "regionAndTerritory": "South East",
-    "academies": [
-      {
-        "urn": 12852401,
-        "dateAcademyJoinedTrust": "2014-03-06T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic High School Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Calderdale",
+        "localAuthority": "North Lincolnshire",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": "1710",
@@ -4681,329 +81,89 @@
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1286",
-    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL",
-    "groupId": "TR1191",
-    "ukprn": "10087464",
-    "type": "Single-academy trust",
-    "address": "541 Morar Prairie, Murrayton, GT4 4GY",
-    "openedDate": "2014-11-06T00:00:00",
-    "companiesHouseNumber": "04895945",
-    "regionAndTerritory": "North East",
-    "academies": [
+      },
       {
-        "urn": 12869362,
-        "dateAcademyJoinedTrust": "2022-08-04T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "993",
-        "schoolCapacity": "1329",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1287",
-    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (ACADEMY TRUST), SWINDON",
-    "groupId": "TR9125",
-    "ukprn": "10088269",
-    "type": "Single-academy trust",
-    "address": "06825 Conroy Meadow, Alenechester, DP12 0PC",
-    "openedDate": "2017-08-01T00:00:00",
-    "companiesHouseNumber": "06099137",
-    "regionAndTerritory": "North East",
-    "academies": [
-      {
-        "urn": 12875737,
-        "dateAcademyJoinedTrust": "2020-01-02T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1432",
-        "schoolCapacity": "1816",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1288",
-    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (HERRINGTHORPE), A CATHOLIC VOLUNTARY ACADEMY",
-    "groupId": "TR257",
-    "ukprn": "10008877",
-    "type": "Single-academy trust",
-    "address": "1543 Cummerata Plains, Haley Shore, North Natmouth, FQ4 5CE",
-    "openedDate": "2017-01-17T00:00:00",
-    "companiesHouseNumber": "02318542",
-    "regionAndTerritory": "West Midlands",
-    "academies": [
-      {
-        "urn": 12882973,
-        "dateAcademyJoinedTrust": "2018-09-04T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "345",
-        "schoolCapacity": "285",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1289",
-    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (MALTBY)",
-    "groupId": "TR2329",
-    "ukprn": "10069471",
-    "type": "Single-academy trust",
-    "address": "1178 Ernser Summit, Greenholt Isle, New Zoe, TG2 7NX",
-    "openedDate": "2022-11-26T00:00:00",
-    "companiesHouseNumber": "01190953",
-    "regionAndTerritory": "Yorkshire and the Humber",
-    "academies": [
-      {
-        "urn": 12898601,
-        "dateAcademyJoinedTrust": "2023-09-29T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Free school",
+        "urn": 12509991,
+        "dateAcademyJoinedTrust": "2021-11-03T00:00:00",
+        "establishmentName": "St. Marys Cofe School",
+        "typeOfEstablishment": "Academy converter",
         "localAuthority": "York",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3667",
-        "schoolCapacity": "2961",
-        "percentageFreeSchoolMeals": "28",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1576",
+        "schoolCapacity": "1815",
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1290",
-    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL, CHURCHDOWN",
-    "groupId": "TR4107",
-    "ukprn": "10078123",
-    "type": "Single-academy trust",
-    "address": "25258 Schuster Flats, Paige Ridges, CT0 6GA",
-    "openedDate": "2020-05-05T00:00:00",
-    "companiesHouseNumber": "04743862",
-    "regionAndTerritory": "North East",
-    "academies": [
+      },
       {
-        "urn": 12907774,
-        "dateAcademyJoinedTrust": "2021-03-26T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "3686",
-        "schoolCapacity": "2933",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1291",
-    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOLS TRUST",
-    "groupId": "TR3651",
-    "ukprn": "10025372",
-    "type": "Multi-academy trust",
-    "address": "0990 Leannon Spur, Wilfredo Ville, OX12 3JM",
-    "openedDate": "2019-04-20T00:00:00",
-    "companiesHouseNumber": "06062342",
-    "regionAndTerritory": "East Midlands",
-    "academies": [
-      {
-        "urn": 12918070,
-        "dateAcademyJoinedTrust": "2023-10-30T00:00:00",
-        "establishmentName": "St Mary\u0027s Catholic Primary School",
+        "urn": 12503201,
+        "dateAcademyJoinedTrust": "2018-06-04T00:00:00",
+        "establishmentName": "Northwood Church of England Secondary School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "479",
-        "schoolCapacity": "1054",
-        "percentageFreeSchoolMeals": "23",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2296",
+        "schoolCapacity": "1942",
+        "percentageFreeSchoolMeals": "1",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12919507,
-        "dateAcademyJoinedTrust": "2022-02-05T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "urn": 12502398,
+        "dateAcademyJoinedTrust": "2021-05-06T00:00:00",
+        "establishmentName": "St. Joseph\u0027s CE School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
+        "localAuthority": "North Lincolnshire",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "486",
-        "schoolCapacity": "579",
-        "percentageFreeSchoolMeals": "24",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "436",
+        "schoolCapacity": "956",
+        "percentageFreeSchoolMeals": "20",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12915004,
-        "dateAcademyJoinedTrust": "2021-05-24T00:00:00",
-        "establishmentName": "St. Marys Catholic Primary School",
+        "urn": 12507390,
+        "dateAcademyJoinedTrust": "2022-02-04T00:00:00",
+        "establishmentName": "Lampton Catholic Academy",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "333",
-        "schoolCapacity": "356",
-        "percentageFreeSchoolMeals": "11",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "129",
+        "schoolCapacity": "145",
+        "percentageFreeSchoolMeals": "4",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 12911255,
-        "dateAcademyJoinedTrust": "2021-05-09T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
+        "urn": 12508751,
+        "dateAcademyJoinedTrust": "2019-05-22T00:00:00",
+        "establishmentName": "Beacon Church of England Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1215",
-        "schoolCapacity": "1428",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12917771,
-        "dateAcademyJoinedTrust": "2023-09-16T00:00:00",
-        "establishmentName": "St Marys Catholic Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1094",
-        "schoolCapacity": "880",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12918782,
-        "dateAcademyJoinedTrust": "2023-11-02T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "590",
-        "schoolCapacity": "785",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12917133,
-        "dateAcademyJoinedTrust": "2019-04-24T00:00:00",
-        "establishmentName": "St. Mary\u0027s RC Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "470",
-        "schoolCapacity": "455",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12914299,
-        "dateAcademyJoinedTrust": "2022-03-17T00:00:00",
-        "establishmentName": "St. Mary\u0027s Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "875",
-        "schoolCapacity": "1269",
+        "numberOfPupils": "2041",
+        "schoolCapacity": "1627",
         "percentageFreeSchoolMeals": "27",
         "ageRange": {
           "minimum": 4,
@@ -5011,120 +171,58 @@
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      },
-      {
-        "urn": 12915300,
-        "dateAcademyJoinedTrust": "2022-12-23T00:00:00",
-        "establishmentName": "St. Mary\u0027s Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "864",
-        "schoolCapacity": "956",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
       }
     ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "Phyllis Kling",
+      "email": "Phyllis.Kling@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Misty Anderson",
+      "email": "Misty.Anderson@education.gov.uk"
+    }
   },
   {
-    "uid": "1292",
-    "name": "ST MARY\u0027S CE ACADEMY, CHESHUNT",
-    "groupId": "TR7939",
-    "ukprn": "10075859",
-    "type": "Single-academy trust",
-    "address": "3600 Abdiel Track, Carroll Burg, HE5 1UP",
-    "openedDate": "2019-07-24T00:00:00",
-    "companiesHouseNumber": "05624236",
-    "regionAndTerritory": "East of England",
-    "academies": [
-      {
-        "urn": 12926712,
-        "dateAcademyJoinedTrust": "2019-09-15T00:00:00",
-        "establishmentName": "St Mary\u0027s CE Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1322",
-        "schoolCapacity": "1734",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1293",
-    "name": "ST MARY\u0027S CHURCH OF ENGLAND ACADEMY TRUST",
-    "groupId": "TR7955",
-    "ukprn": "10029281",
-    "type": "Single-academy trust",
-    "address": "539 Terrell Rapid, Carroll Mountain, FN88 7NZ",
-    "openedDate": "2014-06-23T00:00:00",
-    "companiesHouseNumber": "05942564",
+    "uid": "1270",
+    "name": "ADEPT ACADEMY TRUST",
+    "groupId": "TR6662",
+    "ukprn": "10010270",
+    "type": "Multi-academy trust",
+    "address": "19302 Rene Plaza, Murazik Road, Hankhaven, CD7 6DF",
+    "openedDate": "2018-10-03T00:00:00",
+    "companiesHouseNumber": "05412650",
     "regionAndTerritory": "North East",
     "academies": [
       {
-        "urn": 12933459,
-        "dateAcademyJoinedTrust": "2020-12-26T00:00:00",
-        "establishmentName": "St Mary\u0027s Church of England Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Calderdale",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "455",
-        "schoolCapacity": "767",
-        "percentageFreeSchoolMeals": "14",
+        "urn": 12702350,
+        "dateAcademyJoinedTrust": "2022-12-29T00:00:00",
+        "establishmentName": "Peacehaven Community Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2304",
+        "schoolCapacity": "1935",
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1294",
-    "name": "ST MARY\u0027S CHURCH OF ENGLAND ACADEMY, STOTFOLD",
-    "groupId": "TR4379",
-    "ukprn": "10025204",
-    "type": "Single-academy trust",
-    "address": "88397 Lilian Forges, Stephon Mission, IR07 0HY",
-    "openedDate": "2021-10-28T00:00:00",
-    "companiesHouseNumber": "05043255",
-    "regionAndTerritory": "North West",
-    "academies": [
+      },
       {
-        "urn": 12943235,
-        "dateAcademyJoinedTrust": "2022-10-17T00:00:00",
-        "establishmentName": "St Mary\u0027s Cofe Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban major conurbation",
+        "urn": 12707902,
+        "dateAcademyJoinedTrust": "2021-03-13T00:00:00",
+        "establishmentName": "Halewood Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "376",
-        "schoolCapacity": "842",
-        "percentageFreeSchoolMeals": "20",
+        "numberOfPupils": "1163",
+        "schoolCapacity": "1655",
+        "percentageFreeSchoolMeals": "21",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -5134,67 +232,280 @@
       }
     ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "Tommy Lubowitz",
+      "email": "Tommy.Lubowitz@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Shelly Mayert",
+      "email": "Shelly.Mayert@education.gov.uk"
+    }
   },
   {
-    "uid": "1295",
-    "name": "ST MARY\u0027S CHURCH OF ENGLAND JUNIOR SCHOOL",
-    "groupId": "TR444",
-    "ukprn": "10046678",
-    "type": "Single-academy trust",
-    "address": "267 Harvey Junctions, Orpha Drives, SW8 7SE",
-    "openedDate": "2014-06-16T00:00:00",
-    "companiesHouseNumber": "07152941",
-    "regionAndTerritory": "South East",
+    "uid": "1277",
+    "name": "ADVANTAGE ACADEMY TRUST",
+    "groupId": "TR4373",
+    "ukprn": "10068234",
+    "type": "Multi-academy trust",
+    "address": "095 Predovic Locks, Scot Lights, Spinkafurt, BW62 1MX",
+    "openedDate": "2016-11-21T00:00:00",
+    "companiesHouseNumber": "03722006",
+    "regionAndTerritory": "Yorkshire and the Humber",
     "academies": [
       {
-        "urn": 12958241,
-        "dateAcademyJoinedTrust": "2021-02-17T00:00:00",
-        "establishmentName": "St Mary\u0027s C.E. Academy",
+        "urn": 12779750,
+        "dateAcademyJoinedTrust": "2023-08-13T00:00:00",
+        "establishmentName": "Beacon C of E School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "493",
+        "schoolCapacity": "824",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12771898,
+        "dateAcademyJoinedTrust": "2019-11-11T00:00:00",
+        "establishmentName": "Harris Primary School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Urban city and town",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "756",
+        "schoolCapacity": "1383",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12771833,
+        "dateAcademyJoinedTrust": "2023-11-05T00:00:00",
+        "establishmentName": "St. Anne\u0027s R.C. Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1393",
-        "schoolCapacity": "2442",
-        "percentageFreeSchoolMeals": "29",
+        "numberOfPupils": "2367",
+        "schoolCapacity": "2456",
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
+      },
+      {
+        "urn": 12774963,
+        "dateAcademyJoinedTrust": "2023-05-12T00:00:00",
+        "establishmentName": "Malbank School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1572",
+        "schoolCapacity": "2517",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12772998,
+        "dateAcademyJoinedTrust": "2022-05-12T00:00:00",
+        "establishmentName": "Longhill Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "622",
+        "schoolCapacity": "1237",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12772582,
+        "dateAcademyJoinedTrust": "2023-09-12T00:00:00",
+        "establishmentName": "Mulberry C of E School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2845",
+        "schoolCapacity": "2525",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12772935,
+        "dateAcademyJoinedTrust": "2017-09-27T00:00:00",
+        "establishmentName": "Longhill Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "634",
+        "schoolCapacity": "675",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12775344,
+        "dateAcademyJoinedTrust": "2022-03-19T00:00:00",
+        "establishmentName": "Oasis Church of England Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1446",
+        "schoolCapacity": "1758",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
       }
     ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "Lamar Kulas",
+      "email": "Lamar.Kulas@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Amanda McGlynn",
+      "email": "Amanda.McGlynn@education.gov.uk"
+    }
   },
   {
-    "uid": "1296",
-    "name": "ST MARY\u0027S CHURCH OF ENGLAND PRIMARY ACADEMY, DILWYN",
-    "groupId": "TR9434",
-    "ukprn": "10009203",
-    "type": "Single-academy trust",
-    "address": "505 Bridgette Stream, ZK3 9NS",
-    "openedDate": "2014-02-10T00:00:00",
-    "companiesHouseNumber": "05794160",
-    "regionAndTerritory": "South West",
+    "uid": "1244",
+    "name": "ASCENDANCY ACADEMY TRUST",
+    "groupId": "TR4176",
+    "ukprn": "10017161",
+    "type": "Multi-academy trust",
+    "address": "6160 Florida Land, LP5 9SY",
+    "openedDate": "2016-11-21T00:00:00",
+    "companiesHouseNumber": "04811784",
+    "regionAndTerritory": "East Midlands",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Rudy McClure",
+      "email": "Rudy.McClure@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Shelly Mayert",
+      "email": "Shelly.Mayert@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1263",
+    "name": "BRIDGE EDUCATION TRUST",
+    "groupId": "TR854",
+    "ukprn": "10088817",
+    "type": "Multi-academy trust",
+    "address": "4908 Nikolas Meadow, North Burdette, UX82 7BG",
+    "openedDate": "2023-08-30T00:00:00",
+    "companiesHouseNumber": "05221120",
+    "regionAndTerritory": "Yorkshire and the Humber",
     "academies": [
       {
-        "urn": 12969050,
-        "dateAcademyJoinedTrust": "2019-10-17T00:00:00",
-        "establishmentName": "St Mary\u0027s C/E Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Rotherham",
+        "urn": 12632102,
+        "dateAcademyJoinedTrust": "2023-10-19T00:00:00",
+        "establishmentName": "North Lincolnshire School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2516",
-        "schoolCapacity": "2651",
-        "percentageFreeSchoolMeals": "27",
+        "numberOfPupils": "2534",
+        "schoolCapacity": "2770",
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12638580,
+        "dateAcademyJoinedTrust": "2023-09-14T00:00:00",
+        "establishmentName": "Halewood R.C. Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "853",
+        "schoolCapacity": "905",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12635082,
+        "dateAcademyJoinedTrust": "2023-10-14T00:00:00",
+        "establishmentName": "Barr and Community CE School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2995",
+        "schoolCapacity": "2466",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12637267,
+        "dateAcademyJoinedTrust": "2023-10-28T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "311",
+        "schoolCapacity": "358",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 5,
           "maximum": 11
         },
         "currentOfstedRating": null,
@@ -5202,26 +513,183 @@
       }
     ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "George Muller",
+      "email": "George.Muller@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Rachel Volkman",
+      "email": "Rachel.Volkman@education.gov.uk"
+    }
   },
   {
-    "uid": "1297",
-    "name": "ST MARY\u0027S CHURCH OF ENGLAND SCHOOL, NORWOOD GREEN",
-    "groupId": "TR6480",
-    "ukprn": "10055816",
-    "type": "Single-academy trust",
-    "address": "60770 O\u0027Hara Squares, PO8 2KQ",
-    "openedDate": "2017-06-24T00:00:00",
-    "companiesHouseNumber": "08974676",
-    "regionAndTerritory": "South West",
+    "uid": "1311",
+    "name": "CANTERBURY CROSS EDUCATION TRUST",
+    "groupId": "TR1073",
+    "ukprn": "10062959",
+    "type": "Multi-academy trust",
+    "address": "872 Irwin Trail, Hintz Wells, Hollisbury, QY35 2XF",
+    "openedDate": "2017-03-24T00:00:00",
+    "companiesHouseNumber": "05121558",
+    "regionAndTerritory": "North West",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Silvia Berge",
+      "email": "Silvia.Berge@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jennie Greenholt",
+      "email": "Jennie.Greenholt@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1282",
+    "name": "CHALLENGER MULTI-ACADEMY TRUST",
+    "groupId": "TR6071",
+    "ukprn": "10025552",
+    "type": "Multi-academy trust",
+    "address": "52699 Bechtelar Station, Port Darrylbury, OX0 3LI",
+    "openedDate": "2017-09-26T00:00:00",
+    "companiesHouseNumber": "04336231",
+    "regionAndTerritory": "East of England",
     "academies": [
       {
-        "urn": 12977645,
-        "dateAcademyJoinedTrust": "2021-07-30T00:00:00",
-        "establishmentName": "St Mary\u0027s C of E Academy",
+        "urn": 12823741,
+        "dateAcademyJoinedTrust": "2022-01-24T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Cofe Primary School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "895",
+        "schoolCapacity": "1165",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12821547,
+        "dateAcademyJoinedTrust": "2022-05-01T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Church of England School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1760",
+        "schoolCapacity": "2533",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12829379,
+        "dateAcademyJoinedTrust": "2019-05-27T00:00:00",
+        "establishmentName": "Greensward School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "516",
+        "schoolCapacity": "618",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12821383,
+        "dateAcademyJoinedTrust": "2018-11-04T00:00:00",
+        "establishmentName": "St. Peter\u0027s C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "406",
+        "schoolCapacity": "496",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Annette Breitenberg",
+      "email": "Annette.Breitenberg@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Ginger Dietrich",
+      "email": "Ginger.Dietrich@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1254",
+    "name": "CHAMPION ACADEMY TRUST",
+    "groupId": "TR8234",
+    "ukprn": "10032817",
+    "type": "Multi-academy trust",
+    "address": "1552 McKenzie Grove, UT27 5XE",
+    "openedDate": "2014-05-19T00:00:00",
+    "companiesHouseNumber": "06951312",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12546832,
+        "dateAcademyJoinedTrust": "2021-11-04T00:00:00",
+        "establishmentName": "Co-op Church of England School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "397",
+        "schoolCapacity": "375",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12545889,
+        "dateAcademyJoinedTrust": "2018-04-03T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1615",
+        "schoolCapacity": "1783",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12547645,
+        "dateAcademyJoinedTrust": "2015-07-03T00:00:00",
+        "establishmentName": "Meridian C of E School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
         "numberOfPupils": "816",
@@ -5233,34 +701,429 @@
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
+      },
+      {
+        "urn": 12541197,
+        "dateAcademyJoinedTrust": "2016-09-04T00:00:00",
+        "establishmentName": "St. John\u0027s Church of England School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "322",
+        "schoolCapacity": "698",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12541688,
+        "dateAcademyJoinedTrust": "2018-05-05T00:00:00",
+        "establishmentName": "Glyn C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1481",
+        "schoolCapacity": "2317",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12542198,
+        "dateAcademyJoinedTrust": "2023-09-25T00:00:00",
+        "establishmentName": "St. Paul\u0027s R.C. School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2088",
+        "schoolCapacity": "2376",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
       }
     ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "Josh D\u0027Amore",
+      "email": "Josh.D\u0027Amore@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jennie Greenholt",
+      "email": "Jennie.Greenholt@education.gov.uk"
+    }
   },
   {
-    "uid": "1298",
-    "name": "ST MARY\u0027S CHURCH OF ENGLAND VA PRIMARY ACADEMY",
-    "groupId": "TR1137",
-    "ukprn": "10070773",
-    "type": "Single-academy trust",
-    "address": "7907 Erich Mount, West Max, EQ2 9BQ",
-    "openedDate": "2016-10-21T00:00:00",
-    "companiesHouseNumber": "06868744",
-    "regionAndTerritory": "East Midlands",
+    "uid": "1260",
+    "name": "CORNERSTONE MULTI-ACADEMY TRUST",
+    "groupId": "TR5972",
+    "ukprn": "10026310",
+    "type": "Multi-academy trust",
+    "address": "28924 Kulas Point, Easton Rapids, VonRuedenburgh, PI28 7LP",
+    "openedDate": "2018-12-15T00:00:00",
+    "companiesHouseNumber": "06661660",
+    "regionAndTerritory": "North East",
     "academies": [
       {
-        "urn": 12985125,
-        "dateAcademyJoinedTrust": "2020-10-30T00:00:00",
-        "establishmentName": "St Mary\u0027s Church of England VA Primary Academy",
+        "urn": 12608953,
+        "dateAcademyJoinedTrust": "2022-06-09T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2017",
+        "schoolCapacity": "2053",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12605073,
+        "dateAcademyJoinedTrust": "2023-05-14T00:00:00",
+        "establishmentName": "St. Anne\u0027s CE School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1108",
+        "schoolCapacity": "1375",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12607038,
+        "dateAcademyJoinedTrust": "2019-10-15T00:00:00",
+        "establishmentName": "Peacehaven Community Church of England School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2308",
+        "schoolCapacity": "2531",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12608878,
+        "dateAcademyJoinedTrust": "2019-08-29T00:00:00",
+        "establishmentName": "Peacehaven Community Secondary School",
         "typeOfEstablishment": "Free school",
         "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "168",
+        "schoolCapacity": "136",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Roberto Grimes",
+      "email": "Roberto.Grimes@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Sharon Roob",
+      "email": "Sharon.Roob@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1264",
+    "name": "CRESCENDO ACADEMY TRUST",
+    "groupId": "TR7914",
+    "ukprn": "10002659",
+    "type": "Multi-academy trust",
+    "address": "47756 Hilton Radial, Blanda Ranch, Robertstad, WQ80 0PU",
+    "openedDate": "2016-02-22T00:00:00",
+    "companiesHouseNumber": "04051749",
+    "regionAndTerritory": "South East",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Byron Quigley",
+      "email": "Byron.Quigley@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jaime Russel",
+      "email": "Jaime.Russel@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1243",
+    "name": "ECHELON EDUCATION TRUST",
+    "groupId": "TR4708",
+    "ukprn": "10076316",
+    "type": "Multi-academy trust",
+    "address": "2502 Bertha Manor, PP95 9CS",
+    "openedDate": "2017-07-11T00:00:00",
+    "companiesHouseNumber": "08431337",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12436745,
+        "dateAcademyJoinedTrust": "2018-10-19T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s C of E School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1098",
+        "schoolCapacity": "2118",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12436550,
+        "dateAcademyJoinedTrust": "2020-08-17T00:00:00",
+        "establishmentName": "St. James\u0027 Catholic Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "961",
+        "schoolCapacity": "1540",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12437949,
+        "dateAcademyJoinedTrust": "2022-08-25T00:00:00",
+        "establishmentName": "Glyn C of E School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1427",
+        "schoolCapacity": "2812",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12439572,
+        "dateAcademyJoinedTrust": "2022-01-10T00:00:00",
+        "establishmentName": "Lampton School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1140",
+        "schoolCapacity": "2161",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12433037,
+        "dateAcademyJoinedTrust": "2021-10-07T00:00:00",
+        "establishmentName": "Malbank R.C. Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "543",
-        "schoolCapacity": "496",
-        "percentageFreeSchoolMeals": "19",
+        "numberOfPupils": "2639",
+        "schoolCapacity": "2871",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12433005,
+        "dateAcademyJoinedTrust": "2018-07-09T00:00:00",
+        "establishmentName": "Meridian School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "137",
+        "schoolCapacity": "300",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12435529,
+        "dateAcademyJoinedTrust": "2018-09-02T00:00:00",
+        "establishmentName": "Glyn Catholic Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "711",
+        "schoolCapacity": "1688",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Rudy McClure",
+      "email": "Rudy.McClure@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Natasha Borer",
+      "email": "Natasha.Borer@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1234",
+    "name": "EDIFY MULTI-ACADEMY TRUST",
+    "groupId": "TR1598",
+    "ukprn": "10083390",
+    "type": "Multi-academy trust",
+    "address": "87158 Luciano Plaza, QU09 4CD",
+    "openedDate": "2022-05-11T00:00:00",
+    "companiesHouseNumber": "01136548",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12342361,
+        "dateAcademyJoinedTrust": "2022-05-24T00:00:00",
+        "establishmentName": "Northwood Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "177",
+        "schoolCapacity": "399",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12346989,
+        "dateAcademyJoinedTrust": "2023-04-19T00:00:00",
+        "establishmentName": "Momentum Community Cofe Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1549",
+        "schoolCapacity": "2484",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12343284,
+        "dateAcademyJoinedTrust": "2022-12-24T00:00:00",
+        "establishmentName": "St. John\u0027s CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2146",
+        "schoolCapacity": "1876",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12349659,
+        "dateAcademyJoinedTrust": "2022-12-19T00:00:00",
+        "establishmentName": "St. James\u0027 Catholic Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "186",
+        "schoolCapacity": "186",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12342621,
+        "dateAcademyJoinedTrust": "2023-07-03T00:00:00",
+        "establishmentName": "Peacehaven Community Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2498",
+        "schoolCapacity": "1932",
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -5270,30 +1133,440 @@
       }
     ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "Patty Streich",
+      "email": "Patty.Streich@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Oscar Goldner",
+      "email": "Oscar.Goldner@education.gov.uk"
+    }
   },
   {
-    "uid": "1299",
-    "name": "ST MARY\u0027S PRIMARY SCHOOL, A CATHOLIC VOLUNTARY ACADEMY",
-    "groupId": "TR1332",
-    "ukprn": "10095750",
-    "type": "Single-academy trust",
-    "address": "37529 Walter Rue, Wilfrid Overpass, Schaeferbury, KZ7 2FC",
-    "openedDate": "2018-05-24T00:00:00",
-    "companiesHouseNumber": "02258285",
+    "uid": "1240",
+    "name": "ELEVATE SCHOOLS TRUST",
+    "groupId": "TR5254",
+    "ukprn": "10034194",
+    "type": "Multi-academy trust",
+    "address": "239 Russel Fall, IR7 1FH",
+    "openedDate": "2019-06-12T00:00:00",
+    "companiesHouseNumber": "08133437",
     "regionAndTerritory": "North West",
     "academies": [
       {
-        "urn": 12994614,
-        "dateAcademyJoinedTrust": "2020-12-30T00:00:00",
-        "establishmentName": "St Mary\u0027s Primary School, A Catholic Voluntary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
+        "urn": 12401676,
+        "dateAcademyJoinedTrust": "2023-08-11T00:00:00",
+        "establishmentName": "Glyn Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "744",
+        "schoolCapacity": "1022",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12406128,
+        "dateAcademyJoinedTrust": "2020-01-06T00:00:00",
+        "establishmentName": "Harris Cofe Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "370",
-        "schoolCapacity": "408",
+        "numberOfPupils": "1950",
+        "schoolCapacity": "2659",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Colin Kiehn",
+      "email": "Colin.Kiehn@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Amanda McGlynn",
+      "email": "Amanda.McGlynn@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1253",
+    "name": "ELEVATED SCHOOLS TRUST",
+    "groupId": "TR2708",
+    "ukprn": "10000252",
+    "type": "Multi-academy trust",
+    "address": "610 Karen Spring, Shad Manor, NG3 2JQ",
+    "openedDate": "2022-01-19T00:00:00",
+    "companiesHouseNumber": "05406689",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12531306,
+        "dateAcademyJoinedTrust": "2023-10-02T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Catholic Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1305",
+        "schoolCapacity": "1737",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12536728,
+        "dateAcademyJoinedTrust": "2022-03-20T00:00:00",
+        "establishmentName": "Harris School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1744",
+        "schoolCapacity": "1551",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12531395,
+        "dateAcademyJoinedTrust": "2023-07-15T00:00:00",
+        "establishmentName": "Malbank Cofe Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "710",
+        "schoolCapacity": "898",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12534448,
+        "dateAcademyJoinedTrust": "2023-01-24T00:00:00",
+        "establishmentName": "Glyn C of E School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1185",
+        "schoolCapacity": "1898",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12531669,
+        "dateAcademyJoinedTrust": "2022-03-06T00:00:00",
+        "establishmentName": "St. James\u0027 CE Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1665",
+        "schoolCapacity": "2858",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12537327,
+        "dateAcademyJoinedTrust": "2023-02-02T00:00:00",
+        "establishmentName": "Longhill Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2015",
+        "schoolCapacity": "2578",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12534388,
+        "dateAcademyJoinedTrust": "2022-08-02T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2181",
+        "schoolCapacity": "2396",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12537120,
+        "dateAcademyJoinedTrust": "2022-04-18T00:00:00",
+        "establishmentName": "St. James\u0027 R.C. Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2707",
+        "schoolCapacity": "2671",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Byron Quigley",
+      "email": "Byron.Quigley@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Sharon Roob",
+      "email": "Sharon.Roob@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1280",
+    "name": "EMPOWER ACADEMY TRUST",
+    "groupId": "TR8397",
+    "ukprn": "10057999",
+    "type": "Multi-academy trust",
+    "address": "323 Francis Route, Schimmelside, IQ01 8SI",
+    "openedDate": "2019-06-30T00:00:00",
+    "companiesHouseNumber": "07530518",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 12806203,
+        "dateAcademyJoinedTrust": "2021-08-09T00:00:00",
+        "establishmentName": "Queensbridge Church of England Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1744",
+        "schoolCapacity": "1754",
+        "percentageFreeSchoolMeals": "19",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12802984,
+        "dateAcademyJoinedTrust": "2023-05-27T00:00:00",
+        "establishmentName": "Horizon Cofe School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2201",
+        "schoolCapacity": "2070",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12803096,
+        "dateAcademyJoinedTrust": "2021-01-01T00:00:00",
+        "establishmentName": "Northwood CE Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1103",
+        "schoolCapacity": "2722",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12802742,
+        "dateAcademyJoinedTrust": "2019-09-18T00:00:00",
+        "establishmentName": "St. Anne\u0027s Catholic School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3366",
+        "schoolCapacity": "2708",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12809754,
+        "dateAcademyJoinedTrust": "2023-04-09T00:00:00",
+        "establishmentName": "St. Catherine\u0027s CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1829",
+        "schoolCapacity": "2671",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12806650,
+        "dateAcademyJoinedTrust": "2019-11-22T00:00:00",
+        "establishmentName": "St. James\u0027 C of E Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3114",
+        "schoolCapacity": "2917",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12809814,
+        "dateAcademyJoinedTrust": "2020-12-29T00:00:00",
+        "establishmentName": "George Abbey R.C. Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "785",
+        "schoolCapacity": "1571",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12804492,
+        "dateAcademyJoinedTrust": "2021-02-06T00:00:00",
+        "establishmentName": "Queensbridge Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1870",
+        "schoolCapacity": "1508",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12802963,
+        "dateAcademyJoinedTrust": "2022-12-13T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "100",
+        "schoolCapacity": "204",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12806345,
+        "dateAcademyJoinedTrust": "2022-02-27T00:00:00",
+        "establishmentName": "Northwood Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1588",
+        "schoolCapacity": "1364",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12804451,
+        "dateAcademyJoinedTrust": "2020-12-04T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Church of England Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1693",
+        "schoolCapacity": "2336",
         "percentageFreeSchoolMeals": "9",
         "ageRange": {
           "minimum": 4,
@@ -5305,40 +1578,1299 @@
     ],
     "governors": [],
     "trustRelationshipManager": null,
-    "sfsoLead": null
+    "sfsoLead": {
+      "fullName": "Sharon Roob",
+      "email": "Sharon.Roob@education.gov.uk"
+    }
   },
   {
-    "uid": "1262",
-    "name": "SUCCESS MULTI-ACADEMY TRUST",
-    "groupId": "TR7520",
-    "ukprn": "10098419",
+    "uid": "1242",
+    "name": "EMPOWERMENT MULTI-ACADEMY TRUST",
+    "groupId": "TR8648",
+    "ukprn": "10029135",
     "type": "Multi-academy trust",
-    "address": "44612 Britney Plaza, WB35 5DZ",
-    "openedDate": "2014-10-26T00:00:00",
-    "companiesHouseNumber": "05351455",
-    "regionAndTerritory": "Yorkshire and the Humber",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1300",
-    "name": "THE DIOCESE OF CANTERBURY ACADEMIES TRUST",
-    "groupId": "TR7014",
-    "ukprn": "10088816",
-    "type": "Multi-academy trust",
-    "address": "3141 Lubowitz Inlet, Johanna Locks, CK53 6TM",
-    "openedDate": "2018-07-10T00:00:00",
-    "companiesHouseNumber": "04301397",
-    "regionAndTerritory": "East Midlands",
+    "address": "9590 Aufderhar Locks, GH16 5OX",
+    "openedDate": "2016-04-18T00:00:00",
+    "companiesHouseNumber": "07906189",
+    "regionAndTerritory": "West Midlands",
     "academies": [
       {
-        "urn": 13007888,
-        "dateAcademyJoinedTrust": "2018-09-27T00:00:00",
+        "urn": 12423408,
+        "dateAcademyJoinedTrust": "2019-09-04T00:00:00",
+        "establishmentName": "St. Joseph\u0027s R.C. Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2065",
+        "schoolCapacity": "1612",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12427049,
+        "dateAcademyJoinedTrust": "2020-05-08T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 R.C. School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "643",
+        "schoolCapacity": "497",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12424810,
+        "dateAcademyJoinedTrust": "2019-03-14T00:00:00",
+        "establishmentName": "St. Catherine\u0027s C of E School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "333",
+        "schoolCapacity": "511",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12421832,
+        "dateAcademyJoinedTrust": "2019-06-02T00:00:00",
+        "establishmentName": "Northwood Catholic School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2022",
+        "schoolCapacity": "2052",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12427264,
+        "dateAcademyJoinedTrust": "2020-10-08T00:00:00",
+        "establishmentName": "Meridian Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1358",
+        "schoolCapacity": "1548",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12427769,
+        "dateAcademyJoinedTrust": "2019-07-24T00:00:00",
+        "establishmentName": "St. Peter\u0027s CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1170",
+        "schoolCapacity": "1064",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12425659,
+        "dateAcademyJoinedTrust": "2019-08-20T00:00:00",
+        "establishmentName": "Limehurst C of E Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2274",
+        "schoolCapacity": "2161",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12429596,
+        "dateAcademyJoinedTrust": "2017-04-30T00:00:00",
+        "establishmentName": "Northwood Cofe Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "375",
+        "schoolCapacity": "348",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12422844,
+        "dateAcademyJoinedTrust": "2020-07-15T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Cofe Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "177",
+        "schoolCapacity": "417",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": {
+      "fullName": "Cecilia Crona",
+      "email": "Cecilia.Crona@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1247",
+    "name": "EPIC LEARNING TRUST",
+    "groupId": "TR719",
+    "ukprn": "10076124",
+    "type": "Multi-academy trust",
+    "address": "1271 Nasir Forges, East Mossieview, KZ52 6JH",
+    "openedDate": "2018-08-15T00:00:00",
+    "companiesHouseNumber": "03707429",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12479640,
+        "dateAcademyJoinedTrust": "2022-08-12T00:00:00",
+        "establishmentName": "Harris Cofe Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "648",
+        "schoolCapacity": "1197",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Jessica Legros",
+      "email": "Jessica.Legros@education.gov.uk"
+    },
+    "sfsoLead": null
+  },
+  {
+    "uid": "1268",
+    "name": "EXCEL MULTI-ACADEMY TRUST",
+    "groupId": "TR260",
+    "ukprn": "10090580",
+    "type": "Multi-academy trust",
+    "address": "378 Joey Gateway, Croninburgh, DQ1 1ME",
+    "openedDate": "2017-02-25T00:00:00",
+    "companiesHouseNumber": "09209642",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 12686614,
+        "dateAcademyJoinedTrust": "2019-08-27T00:00:00",
+        "establishmentName": "Malbank School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1441",
+        "schoolCapacity": "1955",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12682649,
+        "dateAcademyJoinedTrust": "2018-12-04T00:00:00",
+        "establishmentName": "Limehurst School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2154",
+        "schoolCapacity": "1782",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12686785,
+        "dateAcademyJoinedTrust": "2023-03-31T00:00:00",
+        "establishmentName": "Lampton School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3458",
+        "schoolCapacity": "2813",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12684219,
+        "dateAcademyJoinedTrust": "2018-12-15T00:00:00",
+        "establishmentName": "Mulberry Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1054",
+        "schoolCapacity": "2050",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12688111,
+        "dateAcademyJoinedTrust": "2021-12-07T00:00:00",
+        "establishmentName": "George Abbey R.C. Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1441",
+        "schoolCapacity": "1978",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Tommy Lubowitz",
+      "email": "Tommy.Lubowitz@education.gov.uk"
+    },
+    "sfsoLead": null
+  },
+  {
+    "uid": "1271",
+    "name": "EXCELLENCE MULTI-ACADEMY TRUST",
+    "groupId": "TR2484",
+    "ukprn": "10046935",
+    "type": "Multi-academy trust",
+    "address": "2821 Leatha Terrace, Wittingmouth, MS8 5UX",
+    "openedDate": "2015-11-28T00:00:00",
+    "companiesHouseNumber": "04090584",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 12713784,
+        "dateAcademyJoinedTrust": "2021-12-16T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Catholic Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "217",
+        "schoolCapacity": "433",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12719892,
+        "dateAcademyJoinedTrust": "2017-01-05T00:00:00",
+        "establishmentName": "St. James\u0027s C of E Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1673",
+        "schoolCapacity": "1362",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12714386,
+        "dateAcademyJoinedTrust": "2021-12-06T00:00:00",
+        "establishmentName": "St. James\u0027 CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "778",
+        "schoolCapacity": "675",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12714325,
+        "dateAcademyJoinedTrust": "2017-01-07T00:00:00",
+        "establishmentName": "St. Paul\u0027s Cofe Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1934",
+        "schoolCapacity": "2166",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Silvia Berge",
+      "email": "Silvia.Berge@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jennie Greenholt",
+      "email": "Jennie.Greenholt@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1275",
+    "name": "FORWARD MULTI-ACADEMY TRUST",
+    "groupId": "TR8943",
+    "ukprn": "10006202",
+    "type": "Multi-academy trust",
+    "address": "0353 Herminio Mews, SP5 4GH",
+    "openedDate": "2019-06-29T00:00:00",
+    "companiesHouseNumber": "02879856",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12754649,
+        "dateAcademyJoinedTrust": "2023-10-01T00:00:00",
+        "establishmentName": "Rotherham Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1182",
+        "schoolCapacity": "1326",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12758371,
+        "dateAcademyJoinedTrust": "2021-11-20T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Catholic School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "724",
+        "schoolCapacity": "1011",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lamar Ritchie",
+      "email": "Lamar.Ritchie@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Ginger Dietrich",
+      "email": "Ginger.Dietrich@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1279",
+    "name": "FUSION EDUCATION TRUST",
+    "groupId": "TR4112",
+    "ukprn": "10004281",
+    "type": "Multi-academy trust",
+    "address": "376 King Courts, Gladyceland, KG03 2EZ",
+    "openedDate": "2020-01-05T00:00:00",
+    "companiesHouseNumber": "05267664",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 12796068,
+        "dateAcademyJoinedTrust": "2022-12-29T00:00:00",
+        "establishmentName": "St. John\u0027s Church of England Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "390",
+        "schoolCapacity": "310",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12797620,
+        "dateAcademyJoinedTrust": "2023-10-13T00:00:00",
+        "establishmentName": "St. Anne\u0027s R.C. Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "379",
+        "schoolCapacity": "329",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12797588,
+        "dateAcademyJoinedTrust": "2021-04-10T00:00:00",
+        "establishmentName": "Northwood Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "846",
+        "schoolCapacity": "1144",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12795219,
+        "dateAcademyJoinedTrust": "2022-12-23T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1412",
+        "schoolCapacity": "2918",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lamar Kulas",
+      "email": "Lamar.Kulas@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Walter Boyle",
+      "email": "Walter.Boyle@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1259",
+    "name": "GALVANIZE ACADEMY TRUST",
+    "groupId": "TR3915",
+    "ukprn": "10000846",
+    "type": "Multi-academy trust",
+    "address": "83509 Wolf Club, Lake Tillman, TI14 5DU",
+    "openedDate": "2021-02-02T00:00:00",
+    "companiesHouseNumber": "05526712",
+    "regionAndTerritory": "South East",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Rudy McClure",
+      "email": "Rudy.McClure@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Oscar Goldner",
+      "email": "Oscar.Goldner@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1239",
+    "name": "HORIZON MULTI-ACADEMY TRUST",
+    "groupId": "TR6707",
+    "ukprn": "10016426",
+    "type": "Multi-academy trust",
+    "address": "230 Schumm Plains, Clarafort, YS12 6IL",
+    "openedDate": "2019-02-25T00:00:00",
+    "companiesHouseNumber": "08134153",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12396702,
+        "dateAcademyJoinedTrust": "2019-03-24T00:00:00",
+        "establishmentName": "Horizon R.C. School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "818",
+        "schoolCapacity": "1598",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12398955,
+        "dateAcademyJoinedTrust": "2022-06-29T00:00:00",
+        "establishmentName": "St. Marys Catholic Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1605",
+        "schoolCapacity": "1677",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12397375,
+        "dateAcademyJoinedTrust": "2020-11-08T00:00:00",
+        "establishmentName": "St. Peter\u0027s Catholic Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "274",
+        "schoolCapacity": "354",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12395118,
+        "dateAcademyJoinedTrust": "2020-11-20T00:00:00",
+        "establishmentName": "Lampton R.C. Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "324",
+        "schoolCapacity": "430",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12397845,
+        "dateAcademyJoinedTrust": "2023-01-20T00:00:00",
+        "establishmentName": "St. Joseph\u0027s C of E Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "841",
+        "schoolCapacity": "1419",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12394872,
+        "dateAcademyJoinedTrust": "2019-06-27T00:00:00",
+        "establishmentName": "St. Paul\u0027s R.C. Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3422",
+        "schoolCapacity": "2693",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12397155,
+        "dateAcademyJoinedTrust": "2020-03-07T00:00:00",
+        "establishmentName": "St. James\u0027 R.C. School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "406",
+        "schoolCapacity": "646",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12395062,
+        "dateAcademyJoinedTrust": "2019-04-08T00:00:00",
+        "establishmentName": "Oasis Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1261",
+        "schoolCapacity": "1541",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12399779,
+        "dateAcademyJoinedTrust": "2019-07-02T00:00:00",
+        "establishmentName": "Queensbridge Church of England School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1682",
+        "schoolCapacity": "1321",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": {
+      "fullName": "Bertha Stanton",
+      "email": "Bertha.Stanton@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1266",
+    "name": "HORIZONS MULTI-ACADEMY TRUST",
+    "groupId": "TR4459",
+    "ukprn": "10085808",
+    "type": "Multi-academy trust",
+    "address": "2472 Hamill Fort, Breana Meadow, XI8 5MA",
+    "openedDate": "2020-03-04T00:00:00",
+    "companiesHouseNumber": "07712633",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12661028,
+        "dateAcademyJoinedTrust": "2022-01-02T00:00:00",
+        "establishmentName": "Limehurst Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1266",
+        "schoolCapacity": "1168",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12665122,
+        "dateAcademyJoinedTrust": "2022-02-15T00:00:00",
+        "establishmentName": "St. Paul\u0027s C of E School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1210",
+        "schoolCapacity": "1276",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12668378,
+        "dateAcademyJoinedTrust": "2023-01-10T00:00:00",
+        "establishmentName": "Co-op CE Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2439",
+        "schoolCapacity": "2950",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12669641,
+        "dateAcademyJoinedTrust": "2023-05-19T00:00:00",
+        "establishmentName": "Mulberry Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "470",
+        "schoolCapacity": "1030",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12664639,
+        "dateAcademyJoinedTrust": "2021-07-18T00:00:00",
+        "establishmentName": "St. Catherine\u0027s R.C. Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "800",
+        "schoolCapacity": "1823",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": {
+      "fullName": "Oscar Goldner",
+      "email": "Oscar.Goldner@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1281",
+    "name": "ILLUMINATE LEARNING TRUST",
+    "groupId": "TR1016",
+    "ukprn": "10084756",
+    "type": "Multi-academy trust",
+    "address": "433 Dare Garden, Fritsch Center, Alyciastad, FW43 9HQ",
+    "openedDate": "2017-12-12T00:00:00",
+    "companiesHouseNumber": "08425811",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12814955,
+        "dateAcademyJoinedTrust": "2019-02-18T00:00:00",
+        "establishmentName": "St. Peter\u0027s CE School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1608",
+        "schoolCapacity": "2838",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12818595,
+        "dateAcademyJoinedTrust": "2020-05-08T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2868",
+        "schoolCapacity": "2382",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "George Muller",
+      "email": "George.Muller@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jan Wunsch",
+      "email": "Jan.Wunsch@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1278",
+    "name": "ILLUMINATE MULTI-ACADEMY TRUST",
+    "groupId": "TR5332",
+    "ukprn": "10005853",
+    "type": "Multi-academy trust",
+    "address": "6122 Adelbert Views, Leanne Mills, Lempifort, SN4 7EO",
+    "openedDate": "2021-08-22T00:00:00",
+    "companiesHouseNumber": "09025306",
+    "regionAndTerritory": "East Midlands",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Phyllis Kling",
+      "email": "Phyllis.Kling@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Erick Kassulke",
+      "email": "Erick.Kassulke@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1235",
+    "name": "INNOVATE ACADEMY TRUST",
+    "groupId": "TR2511",
+    "ukprn": "10069274",
+    "type": "Multi-academy trust",
+    "address": "7084 Gladys Glen, East Earlene, SL75 2AS",
+    "openedDate": "2015-09-06T00:00:00",
+    "companiesHouseNumber": "05330947",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12358257,
+        "dateAcademyJoinedTrust": "2017-06-01T00:00:00",
+        "establishmentName": "Barr and Community Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2313",
+        "schoolCapacity": "2894",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12357143,
+        "dateAcademyJoinedTrust": "2020-11-03T00:00:00",
+        "establishmentName": "Momentum Community R.C. Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1186",
+        "schoolCapacity": "1152",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12356009,
+        "dateAcademyJoinedTrust": "2017-04-02T00:00:00",
+        "establishmentName": "St. Peter\u0027s Church of England Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "481",
+        "schoolCapacity": "575",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12354516,
+        "dateAcademyJoinedTrust": "2017-12-09T00:00:00",
+        "establishmentName": "St. James\u0027s R.C. Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "556",
+        "schoolCapacity": "770",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12357853,
+        "dateAcademyJoinedTrust": "2020-09-26T00:00:00",
+        "establishmentName": "Harris R.C. Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "366",
+        "schoolCapacity": "390",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12359304,
+        "dateAcademyJoinedTrust": "2020-10-29T00:00:00",
+        "establishmentName": "Malbank CE School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1687",
+        "schoolCapacity": "1649",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12353965,
+        "dateAcademyJoinedTrust": "2016-08-08T00:00:00",
+        "establishmentName": "Harris Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1058",
+        "schoolCapacity": "950",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12354997,
+        "dateAcademyJoinedTrust": "2022-10-22T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Church of England Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "161",
+        "schoolCapacity": "267",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lamar Kulas",
+      "email": "Lamar.Kulas@education.gov.uk"
+    },
+    "sfsoLead": null
+  },
+  {
+    "uid": "1261",
+    "name": "INSPIRE MULTI-ACADEMY TRUST",
+    "groupId": "TR912",
+    "ukprn": "10026018",
+    "type": "Multi-academy trust",
+    "address": "645 Feeney Mount, RQ97 5JF",
+    "openedDate": "2016-07-25T00:00:00",
+    "companiesHouseNumber": "07931015",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 12616537,
+        "dateAcademyJoinedTrust": "2016-09-11T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Cofe School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1157",
+        "schoolCapacity": "1491",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12618197,
+        "dateAcademyJoinedTrust": "2017-04-26T00:00:00",
+        "establishmentName": "St. Anne\u0027s R.C. Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1121",
+        "schoolCapacity": "1102",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12616069,
+        "dateAcademyJoinedTrust": "2021-05-13T00:00:00",
+        "establishmentName": "Queensbridge CE Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "880",
+        "schoolCapacity": "862",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12619654,
+        "dateAcademyJoinedTrust": "2022-01-27T00:00:00",
+        "establishmentName": "Glyn Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1420",
+        "schoolCapacity": "2559",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12615298,
+        "dateAcademyJoinedTrust": "2018-12-08T00:00:00",
+        "establishmentName": "Peacehaven Community Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "160",
+        "schoolCapacity": "205",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12613472,
+        "dateAcademyJoinedTrust": "2022-08-20T00:00:00",
+        "establishmentName": "St. Paul\u0027s CE Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1623",
+        "schoolCapacity": "2123",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": null,
+    "sfsoLead": {
+      "fullName": "Vickie Gulgowski",
+      "email": "Vickie.Gulgowski@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1255",
+    "name": "INTREPID EDUCATION TRUST",
+    "groupId": "TR7559",
+    "ukprn": "10021534",
+    "type": "Multi-academy trust",
+    "address": "05153 Bernhard Knoll, Bailey Prairie, Eladioland, XI31 4CX",
+    "openedDate": "2018-05-06T00:00:00",
+    "companiesHouseNumber": "04203414",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12559053,
+        "dateAcademyJoinedTrust": "2020-11-19T00:00:00",
+        "establishmentName": "Harris C of E Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "291",
+        "schoolCapacity": "383",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12557888,
+        "dateAcademyJoinedTrust": "2019-07-05T00:00:00",
         "establishmentName": "St. Anne\u0027s Catholic School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": "1101",
@@ -5350,17 +2882,465 @@
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Ramona O\u0027Keefe",
+      "email": "Ramona.O\u0027Keefe@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Oscar Goldner",
+      "email": "Oscar.Goldner@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1249",
+    "name": "LEGACY EDUCATION TRUST",
+    "groupId": "TR6758",
+    "ukprn": "10005981",
+    "type": "Multi-academy trust",
+    "address": "9323 Gilda Harbor, Lake Arlene, VB5 9EC",
+    "openedDate": "2015-10-01T00:00:00",
+    "companiesHouseNumber": "02056762",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 12497841,
+        "dateAcademyJoinedTrust": "2022-02-19T00:00:00",
+        "establishmentName": "Lampton CE Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "679",
+        "schoolCapacity": "1397",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
       },
       {
-        "urn": 13005152,
-        "dateAcademyJoinedTrust": "2021-07-07T00:00:00",
-        "establishmentName": "St. Mary\u0027s Catholic Academy",
+        "urn": 12499300,
+        "dateAcademyJoinedTrust": "2021-11-24T00:00:00",
+        "establishmentName": "Horizon School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1251",
+        "schoolCapacity": "2415",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lynn Rodriguez",
+      "email": "Lynn.Rodriguez@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Suzanne Conroy",
+      "email": "Suzanne.Conroy@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1246",
+    "name": "MERIT ACADEMY TRUST",
+    "groupId": "TR4895",
+    "ukprn": "10066911",
+    "type": "Multi-academy trust",
+    "address": "2392 Carley Corner, Niko Ports, AY38 1ZH",
+    "openedDate": "2022-09-10T00:00:00",
+    "companiesHouseNumber": "01621172",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12461366,
+        "dateAcademyJoinedTrust": "2023-10-14T00:00:00",
+        "establishmentName": "Harris Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1721",
+        "schoolCapacity": "2237",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12469700,
+        "dateAcademyJoinedTrust": "2023-06-16T00:00:00",
+        "establishmentName": "St. James\u0027s CE School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1166",
+        "schoolCapacity": "2106",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12463519,
+        "dateAcademyJoinedTrust": "2023-03-29T00:00:00",
+        "establishmentName": "St. Mary\u0027s Church of England Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "755",
+        "schoolCapacity": "1019",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12465924,
+        "dateAcademyJoinedTrust": "2023-08-11T00:00:00",
+        "establishmentName": "Longhill School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2265",
+        "schoolCapacity": "2613",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12465595,
+        "dateAcademyJoinedTrust": "2022-11-22T00:00:00",
+        "establishmentName": "Harris C of E Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "283",
+        "schoolCapacity": "557",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lamar Kulas",
+      "email": "Lamar.Kulas@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Erick Kassulke",
+      "email": "Erick.Kassulke@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1258",
+    "name": "MILESTONE MULTI-ACADEMY TRUST",
+    "groupId": "TR5227",
+    "ukprn": "10021710",
+    "type": "Multi-academy trust",
+    "address": "12402 Emmalee Circle, New Kaiafort, XG34 4HJ",
+    "openedDate": "2016-10-06T00:00:00",
+    "companiesHouseNumber": "04773486",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 12584731,
+        "dateAcademyJoinedTrust": "2016-10-31T00:00:00",
+        "establishmentName": "Harris Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3308",
+        "schoolCapacity": "2939",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12586696,
+        "dateAcademyJoinedTrust": "2022-11-06T00:00:00",
+        "establishmentName": "Stehr Glen Cofe School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1420",
+        "schoolCapacity": "2482",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12584344,
+        "dateAcademyJoinedTrust": "2018-12-30T00:00:00",
+        "establishmentName": "St. James\u0027s Church of England Academy",
         "typeOfEstablishment": "Academy converter",
         "localAuthority": "Bradford",
         "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "722",
+        "schoolCapacity": "705",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12589199,
+        "dateAcademyJoinedTrust": "2021-04-13T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Catholic Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "360",
-        "schoolCapacity": "485",
+        "numberOfPupils": "764",
+        "schoolCapacity": "874",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12588383,
+        "dateAcademyJoinedTrust": "2020-04-06T00:00:00",
+        "establishmentName": "Barr and Community School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "416",
+        "schoolCapacity": "607",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12583766,
+        "dateAcademyJoinedTrust": "2017-10-20T00:00:00",
+        "establishmentName": "Beacon Church of England Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3115",
+        "schoolCapacity": "2496",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12589716,
+        "dateAcademyJoinedTrust": "2017-08-26T00:00:00",
+        "establishmentName": "Peacehaven Community School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "502",
+        "schoolCapacity": "1206",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12585048,
+        "dateAcademyJoinedTrust": "2020-05-15T00:00:00",
+        "establishmentName": "Meridian Catholic School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2041",
+        "schoolCapacity": "1761",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12586694,
+        "dateAcademyJoinedTrust": "2017-01-20T00:00:00",
+        "establishmentName": "Oasis Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "923",
+        "schoolCapacity": "748",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Annette Breitenberg",
+      "email": "Annette.Breitenberg@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Natasha Borer",
+      "email": "Natasha.Borer@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1236",
+    "name": "MOMENTUM MULTI-ACADEMY TRUST",
+    "groupId": "TR9338",
+    "ukprn": "10029242",
+    "type": "Multi-academy trust",
+    "address": "28469 Nienow Mountains, Zieme Drive, Quigleyburgh, XO11 3GP",
+    "openedDate": "2019-01-28T00:00:00",
+    "companiesHouseNumber": "05180186",
+    "regionAndTerritory": "East Midlands",
+    "academies": [
+      {
+        "urn": 12361768,
+        "dateAcademyJoinedTrust": "2022-02-11T00:00:00",
+        "establishmentName": "St. James\u0027s Catholic Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1314",
+        "schoolCapacity": "1598",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12369768,
+        "dateAcademyJoinedTrust": "2020-09-15T00:00:00",
+        "establishmentName": "St. James\u0027s C of E School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2506",
+        "schoolCapacity": "2728",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12365221,
+        "dateAcademyJoinedTrust": "2019-06-24T00:00:00",
+        "establishmentName": "Harris Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3143",
+        "schoolCapacity": "2468",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12362190,
+        "dateAcademyJoinedTrust": "2023-09-01T00:00:00",
+        "establishmentName": "Longhill Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1833",
+        "schoolCapacity": "2354",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12361019,
+        "dateAcademyJoinedTrust": "2020-03-11T00:00:00",
+        "establishmentName": "St. Anne\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "324",
+        "schoolCapacity": "610",
         "percentageFreeSchoolMeals": "10",
         "ageRange": {
           "minimum": 4,
@@ -5368,154 +3348,32 @@
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      },
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lyle Baumbach",
+      "email": "Lyle.Baumbach@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Misty Anderson",
+      "email": "Misty.Anderson@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1257",
+    "name": "NEW HORIZONS TRUST",
+    "groupId": "TR5213",
+    "ukprn": "10027611",
+    "type": "Multi-academy trust",
+    "address": "80927 Vern Orchard, Mckenna Common, Roobchester, NK0 4KU",
+    "openedDate": "2016-10-19T00:00:00",
+    "companiesHouseNumber": "03042382",
+    "regionAndTerritory": "",
+    "academies": [
       {
-        "urn": 13003215,
-        "dateAcademyJoinedTrust": "2020-08-08T00:00:00",
-        "establishmentName": "Co-op Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "261",
-        "schoolCapacity": "236",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13002015,
-        "dateAcademyJoinedTrust": "2019-02-05T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Catholic Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2162",
-        "schoolCapacity": "2489",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13003134,
-        "dateAcademyJoinedTrust": "2019-12-17T00:00:00",
-        "establishmentName": "Lampton R.C. Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1080",
-        "schoolCapacity": "879",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13006237,
-        "dateAcademyJoinedTrust": "2022-12-11T00:00:00",
-        "establishmentName": "Co-op Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "417",
-        "schoolCapacity": "622",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13002996,
-        "dateAcademyJoinedTrust": "2020-07-27T00:00:00",
-        "establishmentName": "St. Mary\u0027s Cofe Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "229",
-        "schoolCapacity": "257",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13004550,
-        "dateAcademyJoinedTrust": "2019-11-08T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1164",
-        "schoolCapacity": "2887",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13001253,
-        "dateAcademyJoinedTrust": "2019-09-11T00:00:00",
-        "establishmentName": "Mulberry School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "835",
-        "schoolCapacity": "662",
-        "percentageFreeSchoolMeals": "17",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13005578,
-        "dateAcademyJoinedTrust": "2018-10-29T00:00:00",
-        "establishmentName": "Limehurst Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1438",
-        "schoolCapacity": "1307",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13002735,
-        "dateAcademyJoinedTrust": "2021-11-15T00:00:00",
+        "urn": 12572735,
+        "dateAcademyJoinedTrust": "2022-12-27T00:00:00",
         "establishmentName": "Peacehaven Community Primary Academy",
         "typeOfEstablishment": "Free school",
         "localAuthority": "Bradford",
@@ -5530,86 +3388,18 @@
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1301",
-    "name": "THE DIOCESE OF CHELMSFORD VINE SCHOOLS TRUST",
-    "groupId": "TR1276",
-    "ukprn": "10021190",
-    "type": "Multi-academy trust",
-    "address": "447 Ken Branch, Keonview, VQ82 1PA",
-    "openedDate": "2014-10-29T00:00:00",
-    "companiesHouseNumber": "02816021",
-    "regionAndTerritory": "North East",
-    "academies": [
-      {
-        "urn": 13016001,
-        "dateAcademyJoinedTrust": "2018-06-14T00:00:00",
-        "establishmentName": "Horizon C of E School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "271",
-        "schoolCapacity": "300",
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1302",
-    "name": "THE DIOCESE OF COVENTRY MULTI-ACADEMY TRUST",
-    "groupId": "TR9913",
-    "ukprn": "10047215",
-    "type": "Multi-academy trust",
-    "address": "4880 Jacey Mission, Port Daynestad, JV1 7OB",
-    "openedDate": "2019-07-17T00:00:00",
-    "companiesHouseNumber": "04111124",
-    "regionAndTerritory": "North West",
-    "academies": [
-      {
-        "urn": 13029770,
-        "dateAcademyJoinedTrust": "2020-03-08T00:00:00",
-        "establishmentName": "St. John\u0027s CE Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1210",
-        "schoolCapacity": "2267",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
       },
       {
-        "urn": 13028473,
-        "dateAcademyJoinedTrust": "2021-02-21T00:00:00",
-        "establishmentName": "Mulberry C of E School",
+        "urn": 12571367,
+        "dateAcademyJoinedTrust": "2017-05-24T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Cofe School",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Kingston upon Hull, City of",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "626",
-        "schoolCapacity": "866",
-        "percentageFreeSchoolMeals": "2",
+        "numberOfPupils": "1010",
+        "schoolCapacity": "881",
+        "percentageFreeSchoolMeals": "12",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -5618,15 +3408,105 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13028237,
-        "dateAcademyJoinedTrust": "2022-10-16T00:00:00",
-        "establishmentName": "Meridian Cofe Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
+        "urn": 12578124,
+        "dateAcademyJoinedTrust": "2023-10-29T00:00:00",
+        "establishmentName": "Co-op Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "928",
+        "schoolCapacity": "2234",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12573187,
+        "dateAcademyJoinedTrust": "2019-11-05T00:00:00",
+        "establishmentName": "Harris Catholic Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1191",
-        "schoolCapacity": "2264",
+        "numberOfPupils": "1559",
+        "schoolCapacity": "2719",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12576305,
+        "dateAcademyJoinedTrust": "2022-08-02T00:00:00",
+        "establishmentName": "Co-op Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2827",
+        "schoolCapacity": "2455",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12578392,
+        "dateAcademyJoinedTrust": "2022-08-05T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Catholic Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1214",
+        "schoolCapacity": "1416",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12578512,
+        "dateAcademyJoinedTrust": "2018-03-27T00:00:00",
+        "establishmentName": "Deion Square Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "240",
+        "schoolCapacity": "304",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12572338,
+        "dateAcademyJoinedTrust": "2020-01-02T00:00:00",
+        "establishmentName": "Horizon Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1152",
+        "schoolCapacity": "2334",
         "percentageFreeSchoolMeals": "3",
         "ageRange": {
           "minimum": 4,
@@ -5636,52 +3516,34 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13025571,
-        "dateAcademyJoinedTrust": "2021-05-06T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 CE Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1564",
-        "schoolCapacity": "1638",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13027063,
-        "dateAcademyJoinedTrust": "2021-12-30T00:00:00",
-        "establishmentName": "George Abbey CE School",
+        "urn": 12571384,
+        "dateAcademyJoinedTrust": "2019-10-21T00:00:00",
+        "establishmentName": "Oasis Secondary School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban minor conurbation",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "446",
-        "schoolCapacity": "344",
-        "percentageFreeSchoolMeals": "13",
+        "numberOfPupils": "2710",
+        "schoolCapacity": "2519",
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 11,
-          "maximum": 16
+          "maximum": 18
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 13022728,
-        "dateAcademyJoinedTrust": "2020-06-10T00:00:00",
-        "establishmentName": "Malbank C of E Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban city and town",
+        "urn": 12572261,
+        "dateAcademyJoinedTrust": "2018-01-18T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Catholic Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "538",
-        "schoolCapacity": "894",
-        "percentageFreeSchoolMeals": "10",
+        "numberOfPupils": "510",
+        "schoolCapacity": "549",
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -5690,15 +3552,109 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13026479,
-        "dateAcademyJoinedTrust": "2022-07-13T00:00:00",
-        "establishmentName": "Northwood Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Doncaster",
+        "urn": 12575773,
+        "dateAcademyJoinedTrust": "2019-03-13T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
         "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1499",
+        "schoolCapacity": "2927",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Phyllis Kling",
+      "email": "Phyllis.Kling@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Amanda McGlynn",
+      "email": "Amanda.McGlynn@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1245",
+    "name": "NEXUS MULTI-ACADEMY TRUST",
+    "groupId": "TR3760",
+    "ukprn": "10040753",
+    "type": "Multi-academy trust",
+    "address": "426 Bernard Turnpike, Abdiel Streets, SO8 1XS",
+    "openedDate": "2018-11-27T00:00:00",
+    "companiesHouseNumber": "03050926",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 12458126,
+        "dateAcademyJoinedTrust": "2023-01-19T00:00:00",
+        "establishmentName": "St. Peter\u0027s CE Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1069",
-        "schoolCapacity": "1328",
+        "numberOfPupils": "1938",
+        "schoolCapacity": "2502",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12455595,
+        "dateAcademyJoinedTrust": "2020-12-31T00:00:00",
+        "establishmentName": "St. Anne\u0027s Church of England Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "575",
+        "schoolCapacity": "674",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12454482,
+        "dateAcademyJoinedTrust": "2023-08-26T00:00:00",
+        "establishmentName": "Northwood Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "793",
+        "schoolCapacity": "1251",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12458502,
+        "dateAcademyJoinedTrust": "2023-09-24T00:00:00",
+        "establishmentName": "Greensward Cofe Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2642",
+        "schoolCapacity": "2526",
         "percentageFreeSchoolMeals": "9",
         "ageRange": {
           "minimum": 4,
@@ -5708,34 +3664,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13021500,
-        "dateAcademyJoinedTrust": "2020-08-25T00:00:00",
-        "establishmentName": "Longhill Catholic Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1665",
-        "schoolCapacity": "2191",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13028981,
-        "dateAcademyJoinedTrust": "2022-01-27T00:00:00",
-        "establishmentName": "Peacehaven Community R.C. Primary Academy",
+        "urn": 12455771,
+        "dateAcademyJoinedTrust": "2022-02-03T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Cofe Primary Academy",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Doncaster",
-        "urbanRural": "Urban minor conurbation",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2606",
-        "schoolCapacity": "2387",
-        "percentageFreeSchoolMeals": "25",
+        "numberOfPupils": "293",
+        "schoolCapacity": "406",
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -5745,30 +3683,36 @@
       }
     ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "Annette Breitenberg",
+      "email": "Annette.Breitenberg@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jennie Greenholt",
+      "email": "Jennie.Greenholt@education.gov.uk"
+    }
   },
   {
-    "uid": "1303",
-    "name": "THE DIOCESE OF ELY MULTI-ACADEMY TRUST",
-    "groupId": "TR1105",
-    "ukprn": "10046920",
+    "uid": "1273",
+    "name": "PATHFINDER MULTI-ACADEMY TRUST",
+    "groupId": "TR4046",
+    "ukprn": "10099740",
     "type": "Multi-academy trust",
-    "address": "2085 Tamara Causeway, DN3 7RV",
-    "openedDate": "2019-03-09T00:00:00",
-    "companiesHouseNumber": "02565594",
-    "regionAndTerritory": "",
+    "address": "1823 Herzog Row, West Destineeville, BI4 8ZX",
+    "openedDate": "2018-10-29T00:00:00",
+    "companiesHouseNumber": "04622209",
+    "regionAndTerritory": "North East",
     "academies": [
       {
-        "urn": 13039458,
-        "dateAcademyJoinedTrust": "2020-11-03T00:00:00",
-        "establishmentName": "St. John\u0027s Cofe Academy",
+        "urn": 12739764,
+        "dateAcademyJoinedTrust": "2023-03-28T00:00:00",
+        "establishmentName": "St. Mary\u0027s Cofe Academy",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban major conurbation",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1007",
-        "schoolCapacity": "1121",
+        "numberOfPupils": "1525",
+        "schoolCapacity": "1630",
         "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 5,
@@ -5778,16 +3722,150 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13038599,
-        "dateAcademyJoinedTrust": "2022-12-16T00:00:00",
-        "establishmentName": "Co-op School",
+        "urn": 12734541,
+        "dateAcademyJoinedTrust": "2019-06-07T00:00:00",
+        "establishmentName": "St. Peter\u0027s CE Primary School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Rotherham",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "801",
-        "schoolCapacity": "1183",
-        "percentageFreeSchoolMeals": "4",
+        "numberOfPupils": "242",
+        "schoolCapacity": "280",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12732755,
+        "dateAcademyJoinedTrust": "2019-04-23T00:00:00",
+        "establishmentName": "Beacon School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1394",
+        "schoolCapacity": "2867",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Mae Bradtke",
+      "email": "Mae.Bradtke@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Roman Torp",
+      "email": "Roman.Torp@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1248",
+    "name": "PEAK MULTI-ACADEMY TRUST",
+    "groupId": "TR1061",
+    "ukprn": "10017192",
+    "type": "Multi-academy trust",
+    "address": "58450 Brant Spring, Lake Johnside, VX4 0BX",
+    "openedDate": "2014-02-08T00:00:00",
+    "companiesHouseNumber": "02690120",
+    "regionAndTerritory": "West Midlands",
+    "academies": [
+      {
+        "urn": 12481029,
+        "dateAcademyJoinedTrust": "2014-10-11T00:00:00",
+        "establishmentName": "Harris School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1945",
+        "schoolCapacity": "2737",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12485306,
+        "dateAcademyJoinedTrust": "2017-07-21T00:00:00",
+        "establishmentName": "Longhill Cofe Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "822",
+        "schoolCapacity": "860",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12484507,
+        "dateAcademyJoinedTrust": "2022-04-30T00:00:00",
+        "establishmentName": "North East Lincolnshire Church of England Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "451",
+        "schoolCapacity": "759",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Mae Bradtke",
+      "email": "Mae.Bradtke@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Rachel Volkman",
+      "email": "Rachel.Volkman@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1251",
+    "name": "PINNACLE EDUCATION TRUST",
+    "groupId": "TR7534",
+    "ukprn": "10004968",
+    "type": "Multi-academy trust",
+    "address": "07500 Lisa Knolls, TF9 0XB",
+    "openedDate": "2022-08-17T00:00:00",
+    "companiesHouseNumber": "03231362",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 12519095,
+        "dateAcademyJoinedTrust": "2023-05-30T00:00:00",
+        "establishmentName": "St. Peter\u0027s CE School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1715",
+        "schoolCapacity": "2582",
+        "percentageFreeSchoolMeals": "12",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -5796,103 +3874,33 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13036340,
-        "dateAcademyJoinedTrust": "2023-07-07T00:00:00",
-        "establishmentName": "Oasis Cofe Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "344",
-        "schoolCapacity": "291",
-        "percentageFreeSchoolMeals": "19",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13036263,
-        "dateAcademyJoinedTrust": "2020-04-15T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 R.C. Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1171",
-        "schoolCapacity": "2193",
-        "percentageFreeSchoolMeals": "19",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13035221,
-        "dateAcademyJoinedTrust": "2021-12-08T00:00:00",
-        "establishmentName": "Momentum Community Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3152",
-        "schoolCapacity": "2467",
-        "percentageFreeSchoolMeals": "6",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13035579,
-        "dateAcademyJoinedTrust": "2022-10-10T00:00:00",
-        "establishmentName": "Tommie Way Cofe School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "East Riding of Yorkshire",
+        "urn": 12517681,
+        "dateAcademyJoinedTrust": "2023-05-25T00:00:00",
+        "establishmentName": "Mulberry Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "249",
-        "schoolCapacity": "210",
-        "percentageFreeSchoolMeals": "12",
+        "numberOfPupils": "148",
+        "schoolCapacity": "129",
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
           "minimum": 11,
-          "maximum": 18
+          "maximum": 16
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1304",
-    "name": "THE DIOCESE OF GLOUCESTER ACADEMIES TRUST",
-    "groupId": "TR3451",
-    "ukprn": "10018906",
-    "type": "Multi-academy trust",
-    "address": "5172 Glen Meadow, Bashirianstad, FX9 2LW",
-    "openedDate": "2018-12-07T00:00:00",
-    "companiesHouseNumber": "06723136",
-    "regionAndTerritory": "West Midlands",
-    "academies": [
+      },
       {
-        "urn": 13049272,
-        "dateAcademyJoinedTrust": "2020-03-23T00:00:00",
-        "establishmentName": "Greensward Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban minor conurbation",
+        "urn": 12518957,
+        "dateAcademyJoinedTrust": "2023-01-23T00:00:00",
+        "establishmentName": "St. James\u0027s Church of England Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1223",
-        "schoolCapacity": "1792",
+        "numberOfPupils": "645",
+        "schoolCapacity": "702",
         "percentageFreeSchoolMeals": "8",
         "ageRange": {
           "minimum": 11,
@@ -5902,34 +3910,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13049763,
-        "dateAcademyJoinedTrust": "2022-04-30T00:00:00",
-        "establishmentName": "Limehurst R.C. Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
+        "urn": 12519823,
+        "dateAcademyJoinedTrust": "2022-12-01T00:00:00",
+        "establishmentName": "Barr and Community Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "532",
-        "schoolCapacity": "731",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13046141,
-        "dateAcademyJoinedTrust": "2019-10-24T00:00:00",
-        "establishmentName": "Co-op School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "311",
-        "schoolCapacity": "385",
-        "percentageFreeSchoolMeals": "9",
+        "numberOfPupils": "392",
+        "schoolCapacity": "800",
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -5938,34 +3928,34 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13043135,
-        "dateAcademyJoinedTrust": "2019-12-25T00:00:00",
-        "establishmentName": "Limehurst Academy",
+        "urn": 12516496,
+        "dateAcademyJoinedTrust": "2023-02-08T00:00:00",
+        "establishmentName": "St. Mary\u0027s R.C. School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1718",
-        "schoolCapacity": "1711",
-        "percentageFreeSchoolMeals": "17",
+        "numberOfPupils": "1285",
+        "schoolCapacity": "2861",
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
-          "minimum": 4,
+          "minimum": 5,
           "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       },
       {
-        "urn": 13048930,
-        "dateAcademyJoinedTrust": "2022-08-26T00:00:00",
-        "establishmentName": "Queensbridge R.C. Secondary School",
+        "urn": 12515674,
+        "dateAcademyJoinedTrust": "2022-11-28T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Secondary School",
         "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "590",
-        "schoolCapacity": "622",
-        "percentageFreeSchoolMeals": "27",
+        "numberOfPupils": "1526",
+        "schoolCapacity": "2873",
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -5974,34 +3964,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13048808,
-        "dateAcademyJoinedTrust": "2020-07-04T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
+        "urn": 12514169,
+        "dateAcademyJoinedTrust": "2023-09-08T00:00:00",
+        "establishmentName": "Horizon Church of England School",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "807",
-        "schoolCapacity": "776",
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13043087,
-        "dateAcademyJoinedTrust": "2022-11-24T00:00:00",
-        "establishmentName": "Longhill Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban major conurbation",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1025",
-        "schoolCapacity": "1091",
-        "percentageFreeSchoolMeals": "19",
+        "numberOfPupils": "1677",
+        "schoolCapacity": "2239",
+        "percentageFreeSchoolMeals": "1",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -6010,34 +3982,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13044327,
-        "dateAcademyJoinedTrust": "2023-07-10T00:00:00",
-        "establishmentName": "Halewood School",
+        "urn": 12515911,
+        "dateAcademyJoinedTrust": "2023-06-18T00:00:00",
+        "establishmentName": "St. Peter\u0027s Catholic Primary School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2082",
-        "schoolCapacity": "1637",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13045315,
-        "dateAcademyJoinedTrust": "2019-08-08T00:00:00",
-        "establishmentName": "Malbank Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
+        "localAuthority": "Calderdale",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1850",
-        "schoolCapacity": "2331",
-        "percentageFreeSchoolMeals": "3",
+        "numberOfPupils": "1696",
+        "schoolCapacity": "1518",
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -6046,16 +4000,74 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13044110,
-        "dateAcademyJoinedTrust": "2021-03-14T00:00:00",
-        "establishmentName": "Lampton Primary Academy",
+        "urn": 12511340,
+        "dateAcademyJoinedTrust": "2023-11-04T00:00:00",
+        "establishmentName": "St. Catherine\u0027s R.C. Secondary Academy",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "716",
+        "schoolCapacity": "1553",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Roberto Grimes",
+      "email": "Roberto.Grimes@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Roman Torp",
+      "email": "Roman.Torp@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1265",
+    "name": "POTENTIAL LEARNING TRUST",
+    "groupId": "TR6698",
+    "ukprn": "10035005",
+    "type": "Multi-academy trust",
+    "address": "9390 Kuvalis Ford, Reece Corners, North Bethelhaven, DD94 1YU",
+    "openedDate": "2020-08-04T00:00:00",
+    "companiesHouseNumber": "07382092",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12654494,
+        "dateAcademyJoinedTrust": "2023-06-26T00:00:00",
+        "establishmentName": "Mulberry Cofe Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2316",
+        "schoolCapacity": "2341",
+        "percentageFreeSchoolMeals": "12",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12656485,
+        "dateAcademyJoinedTrust": "2023-01-14T00:00:00",
+        "establishmentName": "Malbank Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2300",
-        "schoolCapacity": "2112",
-        "percentageFreeSchoolMeals": "30",
+        "numberOfPupils": "262",
+        "schoolCapacity": "228",
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -6065,31 +4077,37 @@
       }
     ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "Ramona O\u0027Keefe",
+      "email": "Ramona.O\u0027Keefe@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Ramon Wehner",
+      "email": "Ramon.Wehner@education.gov.uk"
+    }
   },
   {
-    "uid": "1305",
-    "name": "THE DIOCESE OF NORWICH EDUCATION AND ACADEMIES TRUST",
-    "groupId": "TR4912",
-    "ukprn": "10070170",
+    "uid": "1238",
+    "name": "PROGRESSIVE EDUCATION TRUST",
+    "groupId": "TR1606",
+    "ukprn": "10067697",
     "type": "Multi-academy trust",
-    "address": "979 Rosemary Drive, VM71 8AL",
-    "openedDate": "2022-10-03T00:00:00",
-    "companiesHouseNumber": "01662784",
+    "address": "992 Marvin Path, Bahringer Stravenue, South Beaulah, EF17 7KZ",
+    "openedDate": "2023-07-03T00:00:00",
+    "companiesHouseNumber": "06823179",
     "regionAndTerritory": "South East",
     "academies": [
       {
-        "urn": 13053611,
-        "dateAcademyJoinedTrust": "2023-05-08T00:00:00",
-        "establishmentName": "St. Marys Catholic Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
+        "urn": 12389411,
+        "dateAcademyJoinedTrust": "2023-10-19T00:00:00",
+        "establishmentName": "Momentum Community School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1706",
-        "schoolCapacity": "1396",
-        "percentageFreeSchoolMeals": "9",
+        "numberOfPupils": "691",
+        "schoolCapacity": "880",
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -6098,16 +4116,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13057948,
-        "dateAcademyJoinedTrust": "2023-07-07T00:00:00",
-        "establishmentName": "Lampton School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Urban city and town",
+        "urn": 12389223,
+        "dateAcademyJoinedTrust": "2023-08-30T00:00:00",
+        "establishmentName": "St. John\u0027s Cofe School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "397",
-        "schoolCapacity": "400",
-        "percentageFreeSchoolMeals": "23",
+        "numberOfPupils": "1503",
+        "schoolCapacity": "1187",
+        "percentageFreeSchoolMeals": "9",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -6116,15 +4134,33 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13051445,
-        "dateAcademyJoinedTrust": "2023-03-27T00:00:00",
-        "establishmentName": "Cole Circles R.C. Secondary School",
+        "urn": 12382939,
+        "dateAcademyJoinedTrust": "2023-10-23T00:00:00",
+        "establishmentName": "St. Joseph\u0027s R.C. Academy",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "756",
-        "schoolCapacity": "1375",
+        "numberOfPupils": "2338",
+        "schoolCapacity": "2234",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12381624,
+        "dateAcademyJoinedTrust": "2023-07-10T00:00:00",
+        "establishmentName": "Limehurst Church of England Secondary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "352",
+        "schoolCapacity": "354",
         "percentageFreeSchoolMeals": "15",
         "ageRange": {
           "minimum": 11,
@@ -6134,16 +4170,34 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13056385,
-        "dateAcademyJoinedTrust": "2023-09-13T00:00:00",
-        "establishmentName": "Beacon Academy",
+        "urn": 12388773,
+        "dateAcademyJoinedTrust": "2023-08-29T00:00:00",
+        "establishmentName": "St. John\u0027s Church of England Primary School",
         "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Wakefield",
+        "localAuthority": "Rotherham",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2159",
-        "schoolCapacity": "2599",
-        "percentageFreeSchoolMeals": "19",
+        "numberOfPupils": "1517",
+        "schoolCapacity": "2332",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12388017,
+        "dateAcademyJoinedTrust": "2023-09-20T00:00:00",
+        "establishmentName": "Beacon C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1068",
+        "schoolCapacity": "1956",
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -6152,16 +4206,204 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13058125,
-        "dateAcademyJoinedTrust": "2023-06-11T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 Primary Academy",
+        "urn": 12382336,
+        "dateAcademyJoinedTrust": "2023-11-07T00:00:00",
+        "establishmentName": "St. Paul\u0027s R.C. Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "608",
+        "schoolCapacity": "908",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12386903,
+        "dateAcademyJoinedTrust": "2023-10-16T00:00:00",
+        "establishmentName": "St. Anne\u0027s C of E Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1188",
+        "schoolCapacity": "1660",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12387398,
+        "dateAcademyJoinedTrust": "2023-08-14T00:00:00",
+        "establishmentName": "Mulberry R.C. School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1716",
+        "schoolCapacity": "1712",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12382823,
+        "dateAcademyJoinedTrust": "2023-09-14T00:00:00",
+        "establishmentName": "Wilton Parks Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1106",
-        "schoolCapacity": "2616",
-        "percentageFreeSchoolMeals": "19",
+        "numberOfPupils": "333",
+        "schoolCapacity": "393",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Rudy McClure",
+      "email": "Rudy.McClure@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Misty Anderson",
+      "email": "Misty.Anderson@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1256",
+    "name": "PROSPECT MULTI-ACADEMY TRUST",
+    "groupId": "TR4017",
+    "ukprn": "10059649",
+    "type": "Multi-academy trust",
+    "address": "33307 Adelbert Parks, Rowe Coves, Markview, BD05 8KN",
+    "openedDate": "2023-05-27T00:00:00",
+    "companiesHouseNumber": "02035444",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12564726,
+        "dateAcademyJoinedTrust": "2023-07-13T00:00:00",
+        "establishmentName": "St. Marys Cofe Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1852",
+        "schoolCapacity": "1968",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12562406,
+        "dateAcademyJoinedTrust": "2023-08-02T00:00:00",
+        "establishmentName": "Queensbridge Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1867",
+        "schoolCapacity": "1542",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12566783,
+        "dateAcademyJoinedTrust": "2023-11-04T00:00:00",
+        "establishmentName": "Limehurst Church of England School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1557",
+        "schoolCapacity": "1263",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12562989,
+        "dateAcademyJoinedTrust": "2023-10-23T00:00:00",
+        "establishmentName": "Malbank Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1077",
+        "schoolCapacity": "898",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Silvia Berge",
+      "email": "Silvia.Berge@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Suzanne Conroy",
+      "email": "Suzanne.Conroy@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1272",
+    "name": "PROSPERITY EDUCATION TRUST",
+    "groupId": "TR9824",
+    "ukprn": "10056922",
+    "type": "Multi-academy trust",
+    "address": "1992 Cindy Plains, Kirlinmouth, VP21 9NX",
+    "openedDate": "2023-04-18T00:00:00",
+    "companiesHouseNumber": "05762920",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12728202,
+        "dateAcademyJoinedTrust": "2023-08-18T00:00:00",
+        "establishmentName": "Peacehaven Community Church of England Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1461",
+        "schoolCapacity": "2295",
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -6170,15 +4412,742 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 13055673,
-        "dateAcademyJoinedTrust": "2022-12-15T00:00:00",
-        "establishmentName": "Meridian Primary Academy",
+        "urn": 12726105,
+        "dateAcademyJoinedTrust": "2023-06-16T00:00:00",
+        "establishmentName": "North East Lincolnshire Catholic Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "956",
+        "schoolCapacity": "1274",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12721571,
+        "dateAcademyJoinedTrust": "2023-10-20T00:00:00",
+        "establishmentName": "St. John\u0027s C of E Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2240",
+        "schoolCapacity": "2464",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12729999,
+        "dateAcademyJoinedTrust": "2023-05-17T00:00:00",
+        "establishmentName": "Momentum Community Cofe School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "216",
+        "schoolCapacity": "286",
+        "percentageFreeSchoolMeals": "17",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12722761,
+        "dateAcademyJoinedTrust": "2023-04-28T00:00:00",
+        "establishmentName": "St. John\u0027s R.C. Secondary School",
         "typeOfEstablishment": "Academy sponsor led",
         "localAuthority": "Wakefield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2270",
+        "schoolCapacity": "2108",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12725537,
+        "dateAcademyJoinedTrust": "2023-08-09T00:00:00",
+        "establishmentName": "St. John\u0027s C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1104",
+        "schoolCapacity": "2309",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12722028,
+        "dateAcademyJoinedTrust": "2023-08-27T00:00:00",
+        "establishmentName": "Northwood Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2908",
-        "schoolCapacity": "2422",
+        "numberOfPupils": "691",
+        "schoolCapacity": "1616",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12722423,
+        "dateAcademyJoinedTrust": "2023-05-23T00:00:00",
+        "establishmentName": "Halewood Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "477",
+        "schoolCapacity": "382",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12721373,
+        "dateAcademyJoinedTrust": "2023-08-21T00:00:00",
+        "establishmentName": "St. Catherine\u0027s C of E School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2628",
+        "schoolCapacity": "2063",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Cindy Bergstrom",
+      "email": "Cindy.Bergstrom@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Oscar Goldner",
+      "email": "Oscar.Goldner@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1267",
+    "name": "RISE EDUCATION TRUST",
+    "groupId": "TR8608",
+    "ukprn": "10049899",
+    "type": "Multi-academy trust",
+    "address": "071 Colt Overpass, Kemmer Ramp, XA4 7CR",
+    "openedDate": "2022-10-14T00:00:00",
+    "companiesHouseNumber": "03264715",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 12678009,
+        "dateAcademyJoinedTrust": "2023-04-06T00:00:00",
+        "establishmentName": "Co-op Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2739",
+        "schoolCapacity": "2479",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12673436,
+        "dateAcademyJoinedTrust": "2023-06-13T00:00:00",
+        "establishmentName": "Glyn Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3039",
+        "schoolCapacity": "2588",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12674603,
+        "dateAcademyJoinedTrust": "2022-12-28T00:00:00",
+        "establishmentName": "Halewood C of E School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "705",
+        "schoolCapacity": "1143",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12675928,
+        "dateAcademyJoinedTrust": "2023-07-01T00:00:00",
+        "establishmentName": "Peacehaven Community R.C. School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3532",
+        "schoolCapacity": "2805",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12679865,
+        "dateAcademyJoinedTrust": "2023-04-17T00:00:00",
+        "establishmentName": "Beacon Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "433",
+        "schoolCapacity": "1013",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12678712,
+        "dateAcademyJoinedTrust": "2022-12-27T00:00:00",
+        "establishmentName": "George Abbey C of E Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2112",
+        "schoolCapacity": "2573",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12671155,
+        "dateAcademyJoinedTrust": "2023-06-22T00:00:00",
+        "establishmentName": "Beacon School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "877",
+        "schoolCapacity": "1439",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12675032,
+        "dateAcademyJoinedTrust": "2023-01-09T00:00:00",
+        "establishmentName": "Meridian C of E Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1954",
+        "schoolCapacity": "2649",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12673743,
+        "dateAcademyJoinedTrust": "2023-07-27T00:00:00",
+        "establishmentName": "Halewood Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1500",
+        "schoolCapacity": "1985",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lindsey Von",
+      "email": "Lindsey.Von@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Ramon Wehner",
+      "email": "Ramon.Wehner@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1310",
+    "name": "SHEFFIELD SOUTH EAST TRUST",
+    "groupId": "TR7466",
+    "ukprn": "10052979",
+    "type": "Multi-academy trust",
+    "address": "475 Hoppe Ridge, NY6 5HY",
+    "openedDate": "2018-08-17T00:00:00",
+    "companiesHouseNumber": "01576727",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 13108410,
+        "dateAcademyJoinedTrust": "2023-08-21T00:00:00",
+        "establishmentName": "Halewood Church of England Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3739",
+        "schoolCapacity": "2960",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13106934,
+        "dateAcademyJoinedTrust": "2023-10-26T00:00:00",
+        "establishmentName": "Meridian Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "518",
+        "schoolCapacity": "951",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13109407,
+        "dateAcademyJoinedTrust": "2023-09-19T00:00:00",
+        "establishmentName": "George Abbey Catholic School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3202",
+        "schoolCapacity": "2772",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13109970,
+        "dateAcademyJoinedTrust": "2023-10-31T00:00:00",
+        "establishmentName": "Beacon Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1611",
+        "schoolCapacity": "1837",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13103645,
+        "dateAcademyJoinedTrust": "2020-08-12T00:00:00",
+        "establishmentName": "Halewood Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2995",
+        "schoolCapacity": "2488",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13106978,
+        "dateAcademyJoinedTrust": "2022-01-12T00:00:00",
+        "establishmentName": "Northwood C of E School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3693",
+        "schoolCapacity": "2932",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13104827,
+        "dateAcademyJoinedTrust": "2023-09-12T00:00:00",
+        "establishmentName": "Greensward Cofe Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1763",
+        "schoolCapacity": "1965",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13107324,
+        "dateAcademyJoinedTrust": "2020-06-20T00:00:00",
+        "establishmentName": "St. Marys C of E School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "97",
+        "schoolCapacity": "137",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13105814,
+        "dateAcademyJoinedTrust": "2019-11-25T00:00:00",
+        "establishmentName": "Longhill Cofe Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "998",
+        "schoolCapacity": "2381",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13107663,
+        "dateAcademyJoinedTrust": "2020-06-16T00:00:00",
+        "establishmentName": "Horizon Secondary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2053",
+        "schoolCapacity": "2662",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13109244,
+        "dateAcademyJoinedTrust": "2022-01-02T00:00:00",
+        "establishmentName": "Krajcik Ville CE Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2343",
+        "schoolCapacity": "2191",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Cindy Bergstrom",
+      "email": "Cindy.Bergstrom@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Erick Kassulke",
+      "email": "Erick.Kassulke@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1283",
+    "name": "ST MARY\u0027S ACADEMY TRUST",
+    "groupId": "TR9298",
+    "ukprn": "10043743",
+    "type": "Single-academy trust",
+    "address": "811 McDermott Springs, Dillan Prairie, KM5 4JB",
+    "openedDate": "2020-07-14T00:00:00",
+    "companiesHouseNumber": "09920255",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12833136,
+        "dateAcademyJoinedTrust": "2023-07-20T00:00:00",
+        "establishmentName": "St. Mary\u0027s Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1192",
+        "schoolCapacity": "1855",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Margie Skiles",
+      "email": "Margie.Skiles@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Lillian Hand",
+      "email": "Lillian.Hand@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1284",
+    "name": "ST MARY\u0027S ANGLICAN ACADEMY",
+    "groupId": "TR1761",
+    "ukprn": "10088941",
+    "type": "Single-academy trust",
+    "address": "84695 Sanford Fords, Rachelle Plaza, KT3 0JE",
+    "openedDate": "2015-08-26T00:00:00",
+    "companiesHouseNumber": "06925231",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12846302,
+        "dateAcademyJoinedTrust": "2020-01-07T00:00:00",
+        "establishmentName": "St. Mary\u0027s Anglican Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "816",
+        "schoolCapacity": "1012",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lynda Ziemann",
+      "email": "Lynda.Ziemann@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jennie Greenholt",
+      "email": "Jennie.Greenholt@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1285",
+    "name": "ST MARY\u0027S CATHOLIC HIGH SCHOOL ACADEMY TRUST",
+    "groupId": "TR8827",
+    "ukprn": "10051273",
+    "type": "Single-academy trust",
+    "address": "4544 Dianna Spurs, South Bradenside, JY2 2WU",
+    "openedDate": "2017-10-28T00:00:00",
+    "companiesHouseNumber": "07344251",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12855826,
+        "dateAcademyJoinedTrust": "2020-06-08T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic High School Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Sheffield",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "734",
+        "schoolCapacity": "970",
+        "percentageFreeSchoolMeals": "4",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "George Muller",
+      "email": "George.Muller@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jan Wunsch",
+      "email": "Jan.Wunsch@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1286",
+    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL",
+    "groupId": "TR5683",
+    "ukprn": "10039180",
+    "type": "Single-academy trust",
+    "address": "839 Dangelo Drive, NW68 6HZ",
+    "openedDate": "2016-04-06T00:00:00",
+    "companiesHouseNumber": "08364397",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12862901,
+        "dateAcademyJoinedTrust": "2017-12-12T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "981",
+        "schoolCapacity": "1188",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lynda Ziemann",
+      "email": "Lynda.Ziemann@education.gov.uk"
+    },
+    "sfsoLead": null
+  },
+  {
+    "uid": "1287",
+    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (ACADEMY TRUST), SWINDON",
+    "groupId": "TR5711",
+    "ukprn": "10014809",
+    "type": "Single-academy trust",
+    "address": "335 Cremin Garden, Lake Keshawn, MF07 7EO",
+    "openedDate": "2017-06-25T00:00:00",
+    "companiesHouseNumber": "07687903",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 12875107,
+        "dateAcademyJoinedTrust": "2021-10-19T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1317",
+        "schoolCapacity": "1409",
         "percentageFreeSchoolMeals": "6",
         "ageRange": {
           "minimum": 4,
@@ -6189,309 +5158,210 @@
       }
     ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "Lana Mueller",
+      "email": "Lana.Mueller@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jaime Russel",
+      "email": "Jaime.Russel@education.gov.uk"
+    }
   },
   {
-    "uid": "1306",
-    "name": "THE DIOCESE OF NORWICH ST BENET\u0027S MULTI-ACADEMY TRUST",
-    "groupId": "TR804",
-    "ukprn": "10057326",
-    "type": "Multi-academy trust",
-    "address": "213 Bayer Road, JX05 8NW",
-    "openedDate": "2017-05-15T00:00:00",
-    "companiesHouseNumber": "07242754",
+    "uid": "1288",
+    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (HERRINGTHORPE), A CATHOLIC VOLUNTARY ACADEMY",
+    "groupId": "TR2036",
+    "ukprn": "10090211",
+    "type": "Single-academy trust",
+    "address": "545 Gilberto Gateway, Roob Locks, VB11 3HL",
+    "openedDate": "2021-04-14T00:00:00",
+    "companiesHouseNumber": "07081663",
     "regionAndTerritory": "London",
     "academies": [
       {
-        "urn": 13067881,
-        "dateAcademyJoinedTrust": "2019-07-01T00:00:00",
-        "establishmentName": "Limehurst Catholic Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1013",
-        "schoolCapacity": "1175",
-        "percentageFreeSchoolMeals": "23",
+        "urn": 12888619,
+        "dateAcademyJoinedTrust": "2022-06-08T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "471",
+        "schoolCapacity": "543",
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
       }
     ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "Josh D\u0027Amore",
+      "email": "Josh.D\u0027Amore@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Vickie Gulgowski",
+      "email": "Vickie.Gulgowski@education.gov.uk"
+    }
   },
   {
-    "uid": "1307",
-    "name": "THE DIOCESE OF SHEFFIELD ACADEMIES TRUST",
-    "groupId": "TR1900",
-    "ukprn": "10053379",
-    "type": "Multi-academy trust",
-    "address": "22000 Gerlach Road, Abbott Point, South Joshua, VZ19 4AY",
-    "openedDate": "2014-11-29T00:00:00",
-    "companiesHouseNumber": "06492053",
-    "regionAndTerritory": "South West",
+    "uid": "1289",
+    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL (MALTBY)",
+    "groupId": "TR6939",
+    "ukprn": "10077717",
+    "type": "Single-academy trust",
+    "address": "94369 Clementina Neck, Kellen Key, LM7 2OD",
+    "openedDate": "2015-08-29T00:00:00",
+    "companiesHouseNumber": "05868816",
+    "regionAndTerritory": "North East",
     "academies": [
       {
-        "urn": 13078979,
-        "dateAcademyJoinedTrust": "2017-02-25T00:00:00",
-        "establishmentName": "St. John\u0027s R.C. Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Sheffield",
+        "urn": 12896976,
+        "dateAcademyJoinedTrust": "2021-12-05T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "232",
-        "schoolCapacity": "261",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13071326,
-        "dateAcademyJoinedTrust": "2020-04-06T00:00:00",
-        "establishmentName": "St. Joseph\u0027s CE Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "881",
-        "schoolCapacity": "1509",
-        "percentageFreeSchoolMeals": "12",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13078269,
-        "dateAcademyJoinedTrust": "2022-05-15T00:00:00",
-        "establishmentName": "Limehurst Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "342",
-        "schoolCapacity": "819",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13074992,
-        "dateAcademyJoinedTrust": "2020-04-23T00:00:00",
-        "establishmentName": "Northwood CE Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "797",
-        "schoolCapacity": "1274",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13072877,
-        "dateAcademyJoinedTrust": "2018-03-03T00:00:00",
-        "establishmentName": "Sheffield Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Sheffield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1280",
-        "schoolCapacity": "1230",
+        "numberOfPupils": "273",
+        "schoolCapacity": "666",
         "percentageFreeSchoolMeals": "1",
         "ageRange": {
-          "minimum": 4,
+          "minimum": 5,
           "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      },
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Ramona O\u0027Keefe",
+      "email": "Ramona.O\u0027Keefe@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Shelly Mayert",
+      "email": "Shelly.Mayert@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1290",
+    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOL, CHURCHDOWN",
+    "groupId": "TR8704",
+    "ukprn": "10052640",
+    "type": "Single-academy trust",
+    "address": "09823 Donnelly Lane, Gerlachfort, RB76 7LI",
+    "openedDate": "2021-12-08T00:00:00",
+    "companiesHouseNumber": "05937225",
+    "regionAndTerritory": "North East",
+    "academies": [
       {
-        "urn": 13076520,
-        "dateAcademyJoinedTrust": "2020-07-14T00:00:00",
-        "establishmentName": "Barr and Community Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
+        "urn": 12907076,
+        "dateAcademyJoinedTrust": "2022-02-22T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "642",
-        "schoolCapacity": "755",
-        "percentageFreeSchoolMeals": "17",
+        "numberOfPupils": "1545",
+        "schoolCapacity": "1948",
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      },
-      {
-        "urn": 13074151,
-        "dateAcademyJoinedTrust": "2022-08-21T00:00:00",
-        "establishmentName": "Northwood C of E Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1727",
-        "schoolCapacity": "1607",
-        "percentageFreeSchoolMeals": "2",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13076723,
-        "dateAcademyJoinedTrust": "2020-09-11T00:00:00",
-        "establishmentName": "George Abbey School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "83",
-        "schoolCapacity": "100",
-        "percentageFreeSchoolMeals": "22",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
       }
     ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "Lynn Rodriguez",
+      "email": "Lynn.Rodriguez@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jonathon Littel",
+      "email": "Jonathon.Littel@education.gov.uk"
+    }
   },
   {
-    "uid": "1308",
-    "name": "THE DIOCESE OF WESTMINSTER ACADEMY TRUST",
-    "groupId": "TR8822",
-    "ukprn": "10000118",
+    "uid": "1291",
+    "name": "ST MARY\u0027S CATHOLIC PRIMARY SCHOOLS TRUST",
+    "groupId": "TR4642",
+    "ukprn": "10035186",
     "type": "Multi-academy trust",
-    "address": "67733 Christiansen Camp, Abernathy Radial, ZN2 3VC",
-    "openedDate": "2023-07-12T00:00:00",
-    "companiesHouseNumber": "02302768",
-    "regionAndTerritory": "",
-    "academies": [],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1309",
-    "name": "THE DIOCESE OF WORCESTER MULTI ACADEMY TRUST",
-    "groupId": "TR9806",
-    "ukprn": "10014446",
-    "type": "Multi-academy trust",
-    "address": "94197 Megane Track, RU63 7RU",
-    "openedDate": "2017-01-30T00:00:00",
-    "companiesHouseNumber": "07673659",
-    "regionAndTerritory": "",
-    "academies": [
-      {
-        "urn": 13091319,
-        "dateAcademyJoinedTrust": "2018-10-12T00:00:00",
-        "establishmentName": "Limehurst School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "492",
-        "schoolCapacity": "1118",
-        "percentageFreeSchoolMeals": "25",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13095065,
-        "dateAcademyJoinedTrust": "2019-01-09T00:00:00",
-        "establishmentName": "Momentum Community Church of England Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1849",
-        "schoolCapacity": "2589",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 13093349,
-        "dateAcademyJoinedTrust": "2019-03-07T00:00:00",
-        "establishmentName": "Beacon Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "314",
-        "schoolCapacity": "260",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1252",
-    "name": "THRIVE MULTI-ACADEMY TRUST",
-    "groupId": "TR8646",
-    "ukprn": "10053542",
-    "type": "Multi-academy trust",
-    "address": "48963 Aisha Stravenue, KH01 1ID",
-    "openedDate": "2016-08-02T00:00:00",
-    "companiesHouseNumber": "03818391",
+    "address": "3979 Lizzie Glens, South Lacy, FO47 5TB",
+    "openedDate": "2017-11-01T00:00:00",
+    "companiesHouseNumber": "03073796",
     "regionAndTerritory": "Yorkshire and the Humber",
     "academies": [
       {
-        "urn": 12522860,
-        "dateAcademyJoinedTrust": "2019-03-01T00:00:00",
-        "establishmentName": "St. Joseph\u0027s CE Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Wakefield",
+        "urn": 12914972,
+        "dateAcademyJoinedTrust": "2019-08-16T00:00:00",
+        "establishmentName": "St Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2495",
+        "schoolCapacity": "2470",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12912758,
+        "dateAcademyJoinedTrust": "2023-06-28T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "366",
-        "schoolCapacity": "559",
+        "numberOfPupils": "2121",
+        "schoolCapacity": "1983",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12914521,
+        "dateAcademyJoinedTrust": "2020-04-23T00:00:00",
+        "establishmentName": "St. Marys Catholic Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "207",
+        "schoolCapacity": "223",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12919148,
+        "dateAcademyJoinedTrust": "2023-11-08T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1190",
+        "schoolCapacity": "2659",
         "percentageFreeSchoolMeals": "18",
         "ageRange": {
           "minimum": 4,
@@ -6501,87 +5371,33 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12529505,
-        "dateAcademyJoinedTrust": "2022-08-13T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "298",
-        "schoolCapacity": "320",
-        "percentageFreeSchoolMeals": "16",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12523863,
-        "dateAcademyJoinedTrust": "2019-04-25T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 R.C. School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1343",
-        "schoolCapacity": "1068",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12521835,
-        "dateAcademyJoinedTrust": "2023-07-28T00:00:00",
-        "establishmentName": "Greensward Secondary School",
+        "urn": 12912202,
+        "dateAcademyJoinedTrust": "2017-12-17T00:00:00",
+        "establishmentName": "St Marys Catholic Primary School",
         "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1344",
-        "schoolCapacity": "1215",
-        "percentageFreeSchoolMeals": "19",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12528989,
-        "dateAcademyJoinedTrust": "2019-01-12T00:00:00",
-        "establishmentName": "North East Lincolnshire School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "794",
-        "schoolCapacity": "667",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12527650,
-        "dateAcademyJoinedTrust": "2021-04-25T00:00:00",
-        "establishmentName": "Glyn R.C. Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Wakefield",
+        "localAuthority": "North Lincolnshire",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2155",
-        "schoolCapacity": "2476",
+        "numberOfPupils": "2098",
+        "schoolCapacity": "1828",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12912203,
+        "dateAcademyJoinedTrust": "2023-06-02T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1265",
+        "schoolCapacity": "2280",
         "percentageFreeSchoolMeals": "29",
         "ageRange": {
           "minimum": 4,
@@ -6591,532 +5407,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12527212,
-        "dateAcademyJoinedTrust": "2023-05-02T00:00:00",
-        "establishmentName": "Hoeger Islands Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "344",
-        "schoolCapacity": "383",
-        "percentageFreeSchoolMeals": "7",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12521680,
-        "dateAcademyJoinedTrust": "2022-08-09T00:00:00",
-        "establishmentName": "St. Marys Catholic School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1296",
-        "schoolCapacity": "2845",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12526589,
-        "dateAcademyJoinedTrust": "2017-05-02T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Catholic Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
+        "urn": 12915141,
+        "dateAcademyJoinedTrust": "2022-08-23T00:00:00",
+        "establishmentName": "St. Mary\u0027s RC Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "428",
-        "schoolCapacity": "687",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12529846,
-        "dateAcademyJoinedTrust": "2023-09-03T00:00:00",
-        "establishmentName": "Lampton Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "3452",
-        "schoolCapacity": "2746",
-        "percentageFreeSchoolMeals": "10",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1276",
-    "name": "TRANSCENDENCE EDUCATION TRUST",
-    "groupId": "TR37",
-    "ukprn": "10061397",
-    "type": "Multi-academy trust",
-    "address": "22044 Devon Divide, Baumbach Parkways, JS53 7HG",
-    "openedDate": "2015-08-28T00:00:00",
-    "companiesHouseNumber": "09000164",
-    "regionAndTerritory": "South West",
-    "academies": [
-      {
-        "urn": 12762215,
-        "dateAcademyJoinedTrust": "2016-10-22T00:00:00",
-        "establishmentName": "Longhill CE Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2688",
-        "schoolCapacity": "2175",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12769406,
-        "dateAcademyJoinedTrust": "2017-06-04T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 R.C. Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "450",
-        "schoolCapacity": "977",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12764983,
-        "dateAcademyJoinedTrust": "2023-07-19T00:00:00",
-        "establishmentName": "St. Marys R.C. Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Bradford",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "971",
-        "schoolCapacity": "1061",
-        "percentageFreeSchoolMeals": "21",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12766346,
-        "dateAcademyJoinedTrust": "2023-01-29T00:00:00",
-        "establishmentName": "St. Anne\u0027s Catholic Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "746",
-        "schoolCapacity": "649",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12768113,
-        "dateAcademyJoinedTrust": "2017-02-11T00:00:00",
-        "establishmentName": "Oasis School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1823",
-        "schoolCapacity": "2002",
-        "percentageFreeSchoolMeals": "19",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12761128,
-        "dateAcademyJoinedTrust": "2022-08-03T00:00:00",
-        "establishmentName": "Lampton CE Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1779",
-        "schoolCapacity": "2543",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12769251,
-        "dateAcademyJoinedTrust": "2020-08-31T00:00:00",
-        "establishmentName": "Greensward Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "178",
-        "schoolCapacity": "191",
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12762853,
-        "dateAcademyJoinedTrust": "2018-02-23T00:00:00",
-        "establishmentName": "Malbank Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "349",
-        "schoolCapacity": "362",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12767641,
-        "dateAcademyJoinedTrust": "2018-11-13T00:00:00",
-        "establishmentName": "Limehurst Church of England Secondary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "983",
-        "schoolCapacity": "1891",
-        "percentageFreeSchoolMeals": "30",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12761219,
-        "dateAcademyJoinedTrust": "2019-05-10T00:00:00",
-        "establishmentName": "St. James\u0027s CE Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "486",
-        "schoolCapacity": "468",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12765192,
-        "dateAcademyJoinedTrust": "2020-08-31T00:00:00",
-        "establishmentName": "Peacehaven Community Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "725",
-        "schoolCapacity": "568",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1269",
-    "name": "UNITY LEARNING TRUST",
-    "groupId": "TR9119",
-    "ukprn": "10068189",
-    "type": "Multi-academy trust",
-    "address": "8531 Braun Knolls, Libby Center, Lake Oda, VT64 9YR",
-    "openedDate": "2023-03-28T00:00:00",
-    "companiesHouseNumber": "02503797",
-    "regionAndTerritory": "",
-    "academies": [
-      {
-        "urn": 12699099,
-        "dateAcademyJoinedTrust": "2023-10-05T00:00:00",
-        "establishmentName": "St. James\u0027s Church of England School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1305",
-        "schoolCapacity": "2937",
-        "percentageFreeSchoolMeals": "14",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12697432,
-        "dateAcademyJoinedTrust": "2023-06-05T00:00:00",
-        "establishmentName": "Momentum Community Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1341",
-        "schoolCapacity": "2713",
-        "percentageFreeSchoolMeals": "9",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12698380,
-        "dateAcademyJoinedTrust": "2023-06-21T00:00:00",
-        "establishmentName": "Limehurst Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "833",
-        "schoolCapacity": "727",
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12697667,
-        "dateAcademyJoinedTrust": "2023-05-08T00:00:00",
-        "establishmentName": "St. Peter\u0027s Church of England Secondary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2759",
-        "schoolCapacity": "2231",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12693362,
-        "dateAcademyJoinedTrust": "2023-05-29T00:00:00",
-        "establishmentName": "St. Marys R.C. Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1043",
-        "schoolCapacity": "1244",
+        "numberOfPupils": "1310",
+        "schoolCapacity": "2688",
         "percentageFreeSchoolMeals": "5",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12691189,
-        "dateAcademyJoinedTrust": "2023-10-04T00:00:00",
-        "establishmentName": "St. Anne\u0027s CE School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "473",
-        "schoolCapacity": "705",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1237",
-    "name": "VANGUARD LEARNING TRUST",
-    "groupId": "TR2875",
-    "ukprn": "10091225",
-    "type": "Multi-academy trust",
-    "address": "519 Brandyn Key, Xanderville, YV3 8EH",
-    "openedDate": "2023-11-03T00:00:00",
-    "companiesHouseNumber": "09994759",
-    "regionAndTerritory": "London",
-    "academies": [
-      {
-        "urn": 12377102,
-        "dateAcademyJoinedTrust": "2023-11-05T00:00:00",
-        "establishmentName": "St. Paul\u0027s R.C. Academy",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "645",
-        "schoolCapacity": "1262",
-        "percentageFreeSchoolMeals": "4",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12375381,
-        "dateAcademyJoinedTrust": "2023-11-03T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "York",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "2624",
-        "schoolCapacity": "2933",
-        "percentageFreeSchoolMeals": "15",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12374797,
-        "dateAcademyJoinedTrust": "2023-11-05T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "2551",
-        "schoolCapacity": "2119",
-        "percentageFreeSchoolMeals": "20",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12373821,
-        "dateAcademyJoinedTrust": "2023-11-03T00:00:00",
-        "establishmentName": "Peacehaven Community Primary School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "207",
-        "schoolCapacity": "293",
-        "percentageFreeSchoolMeals": "27",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12379770,
-        "dateAcademyJoinedTrust": "2023-11-07T00:00:00",
-        "establishmentName": "Peacehaven Community School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Leeds",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1749",
-        "schoolCapacity": "2416",
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      },
-      {
-        "urn": 12375237,
-        "dateAcademyJoinedTrust": "2023-11-05T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Church of England School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "1575",
-        "schoolCapacity": "2724",
-        "percentageFreeSchoolMeals": "9",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -7125,15 +5425,1473 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12379648,
-        "dateAcademyJoinedTrust": "2023-11-05T00:00:00",
-        "establishmentName": "George Abbey Church of England Secondary School",
+        "urn": 12912854,
+        "dateAcademyJoinedTrust": "2022-04-01T00:00:00",
+        "establishmentName": "St. Mary\u0027s Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1481",
+        "schoolCapacity": "2896",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12911372,
+        "dateAcademyJoinedTrust": "2018-11-13T00:00:00",
+        "establishmentName": "St. Mary\u0027s Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1093",
+        "schoolCapacity": "2687",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lynda Ziemann",
+      "email": "Lynda.Ziemann@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Walter Boyle",
+      "email": "Walter.Boyle@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1292",
+    "name": "ST MARY\u0027S CE ACADEMY, CHESHUNT",
+    "groupId": "TR2362",
+    "ukprn": "10084627",
+    "type": "Single-academy trust",
+    "address": "23502 Fadel Dale, Hansen Parks, Hermanhaven, SP4 2HX",
+    "openedDate": "2014-04-28T00:00:00",
+    "companiesHouseNumber": "07202060",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 12923496,
+        "dateAcademyJoinedTrust": "2017-03-04T00:00:00",
+        "establishmentName": "St Mary\u0027s CE Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3103",
+        "schoolCapacity": "2937",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lyle Baumbach",
+      "email": "Lyle.Baumbach@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jan Wunsch",
+      "email": "Jan.Wunsch@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1293",
+    "name": "ST MARY\u0027S CHURCH OF ENGLAND ACADEMY TRUST",
+    "groupId": "TR388",
+    "ukprn": "10097113",
+    "type": "Single-academy trust",
+    "address": "4450 Hansen Locks, New Felicity, YN9 8VT",
+    "openedDate": "2021-07-07T00:00:00",
+    "companiesHouseNumber": "05465093",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 12933210,
+        "dateAcademyJoinedTrust": "2021-09-02T00:00:00",
+        "establishmentName": "St Mary\u0027s Church of England Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1314",
+        "schoolCapacity": "2150",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Cindy Bergstrom",
+      "email": "Cindy.Bergstrom@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Suzanne Conroy",
+      "email": "Suzanne.Conroy@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1294",
+    "name": "ST MARY\u0027S CHURCH OF ENGLAND ACADEMY, STOTFOLD",
+    "groupId": "TR771",
+    "ukprn": "10088352",
+    "type": "Single-academy trust",
+    "address": "0133 Reilly Streets, QS9 7ZR",
+    "openedDate": "2018-02-28T00:00:00",
+    "companiesHouseNumber": "01438959",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12947863,
+        "dateAcademyJoinedTrust": "2022-11-13T00:00:00",
+        "establishmentName": "St Mary\u0027s Cofe Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "373",
+        "schoolCapacity": "317",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Tommy Lubowitz",
+      "email": "Tommy.Lubowitz@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Ginger Dietrich",
+      "email": "Ginger.Dietrich@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1295",
+    "name": "ST MARY\u0027S CHURCH OF ENGLAND JUNIOR SCHOOL",
+    "groupId": "TR1570",
+    "ukprn": "10015235",
+    "type": "Single-academy trust",
+    "address": "064 Giovanni Radial, Heller Coves, West Kraig, NU1 3KL",
+    "openedDate": "2016-03-01T00:00:00",
+    "companiesHouseNumber": "08392292",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12959099,
+        "dateAcademyJoinedTrust": "2022-04-20T00:00:00",
+        "establishmentName": "St Mary\u0027s C.E. Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2390",
+        "schoolCapacity": "2966",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lynn Rodriguez",
+      "email": "Lynn.Rodriguez@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Amanda McGlynn",
+      "email": "Amanda.McGlynn@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1296",
+    "name": "ST MARY\u0027S CHURCH OF ENGLAND PRIMARY ACADEMY, DILWYN",
+    "groupId": "TR997",
+    "ukprn": "10038823",
+    "type": "Single-academy trust",
+    "address": "6414 Yost Hollow, East Peyton, QE24 1GN",
+    "openedDate": "2015-10-13T00:00:00",
+    "companiesHouseNumber": "07975646",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12962141,
+        "dateAcademyJoinedTrust": "2017-05-02T00:00:00",
+        "establishmentName": "St Mary\u0027s C/E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1090",
+        "schoolCapacity": "857",
+        "percentageFreeSchoolMeals": "11",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Amelia Mitchell",
+      "email": "Amelia.Mitchell@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Bertha Stanton",
+      "email": "Bertha.Stanton@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1297",
+    "name": "ST MARY\u0027S CHURCH OF ENGLAND SCHOOL, NORWOOD GREEN",
+    "groupId": "TR33",
+    "ukprn": "10076934",
+    "type": "Single-academy trust",
+    "address": "7673 Nitzsche Terrace, Lake Cortney, FX34 2ER",
+    "openedDate": "2021-04-06T00:00:00",
+    "companiesHouseNumber": "01301373",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12973686,
+        "dateAcademyJoinedTrust": "2022-11-12T00:00:00",
+        "establishmentName": "St Mary\u0027s C of E Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1008",
+        "schoolCapacity": "2081",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lamar Kulas",
+      "email": "Lamar.Kulas@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jennie Greenholt",
+      "email": "Jennie.Greenholt@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1298",
+    "name": "ST MARY\u0027S CHURCH OF ENGLAND VA PRIMARY ACADEMY",
+    "groupId": "TR6921",
+    "ukprn": "10091961",
+    "type": "Single-academy trust",
+    "address": "57276 Mathias Groves, EJ43 4PX",
+    "openedDate": "2014-10-15T00:00:00",
+    "companiesHouseNumber": "05656636",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12989794,
+        "dateAcademyJoinedTrust": "2021-12-17T00:00:00",
+        "establishmentName": "St Mary\u0027s Church of England VA Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1306",
+        "schoolCapacity": "1342",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Margie Skiles",
+      "email": "Margie.Skiles@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jonathon Littel",
+      "email": "Jonathon.Littel@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1299",
+    "name": "ST MARY\u0027S PRIMARY SCHOOL, A CATHOLIC VOLUNTARY ACADEMY",
+    "groupId": "TR8415",
+    "ukprn": "10072860",
+    "type": "Single-academy trust",
+    "address": "02347 Jalyn Estates, East Enidhaven, GH0 0AE",
+    "openedDate": "2019-11-17T00:00:00",
+    "companiesHouseNumber": "05420361",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12996150,
+        "dateAcademyJoinedTrust": "2022-01-31T00:00:00",
+        "establishmentName": "St Mary\u0027s Primary School, A Catholic Voluntary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "891",
+        "schoolCapacity": "1790",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Arturo Purdy",
+      "email": "Arturo.Purdy@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Natasha Borer",
+      "email": "Natasha.Borer@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1262",
+    "name": "SUCCESS MULTI-ACADEMY TRUST",
+    "groupId": "TR7798",
+    "ukprn": "10053812",
+    "type": "Multi-academy trust",
+    "address": "8841 Sheldon Parks, Idell Drive, Josephineland, FV30 9PO",
+    "openedDate": "2017-09-16T00:00:00",
+    "companiesHouseNumber": "03387253",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12624375,
+        "dateAcademyJoinedTrust": "2020-09-23T00:00:00",
+        "establishmentName": "Lampton Church of England Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1079",
+        "schoolCapacity": "970",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12627895,
+        "dateAcademyJoinedTrust": "2018-01-18T00:00:00",
+        "establishmentName": "Co-op School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1589",
+        "schoolCapacity": "1606",
+        "percentageFreeSchoolMeals": "8",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12628408,
+        "dateAcademyJoinedTrust": "2021-01-19T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 Secondary School",
         "typeOfEstablishment": "Free school",
         "localAuthority": "York",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "638",
-        "schoolCapacity": "1276",
+        "numberOfPupils": "1703",
+        "schoolCapacity": "1669",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12625556,
+        "dateAcademyJoinedTrust": "2021-08-16T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "909",
+        "schoolCapacity": "1402",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12625808,
+        "dateAcademyJoinedTrust": "2019-07-29T00:00:00",
+        "establishmentName": "Barr and Community School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2023",
+        "schoolCapacity": "1981",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12627869,
+        "dateAcademyJoinedTrust": "2022-03-14T00:00:00",
+        "establishmentName": "Barr and Community Catholic Secondary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "397",
+        "schoolCapacity": "407",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12621272,
+        "dateAcademyJoinedTrust": "2020-10-23T00:00:00",
+        "establishmentName": "Halewood Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "884",
+        "schoolCapacity": "849",
+        "percentageFreeSchoolMeals": "25",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12629874,
+        "dateAcademyJoinedTrust": "2018-05-28T00:00:00",
+        "establishmentName": "St. Mary\u0027s C of E School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "162",
+        "schoolCapacity": "130",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Rudy McClure",
+      "email": "Rudy.McClure@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Vickie Gulgowski",
+      "email": "Vickie.Gulgowski@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1300",
+    "name": "THE DIOCESE OF CANTERBURY ACADEMIES TRUST",
+    "groupId": "TR9778",
+    "ukprn": "10009892",
+    "type": "Multi-academy trust",
+    "address": "8072 Elisha Plains, Kole Lights, East Candicetown, DK9 7YG",
+    "openedDate": "2015-09-28T00:00:00",
+    "companiesHouseNumber": "06944068",
+    "regionAndTerritory": "North East",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "George Muller",
+      "email": "George.Muller@education.gov.uk"
+    },
+    "sfsoLead": null
+  },
+  {
+    "uid": "1301",
+    "name": "THE DIOCESE OF CHELMSFORD VINE SCHOOLS TRUST",
+    "groupId": "TR9187",
+    "ukprn": "10035221",
+    "type": "Multi-academy trust",
+    "address": "3770 Rosina Fords, Collier Fall, LO19 9UX",
+    "openedDate": "2017-11-09T00:00:00",
+    "companiesHouseNumber": "07232979",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 13018755,
+        "dateAcademyJoinedTrust": "2021-10-10T00:00:00",
+        "establishmentName": "Lampton Church of England Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "936",
+        "schoolCapacity": "1919",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lynn Rodriguez",
+      "email": "Lynn.Rodriguez@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Ginger Dietrich",
+      "email": "Ginger.Dietrich@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1302",
+    "name": "THE DIOCESE OF COVENTRY MULTI-ACADEMY TRUST",
+    "groupId": "TR3048",
+    "ukprn": "10047401",
+    "type": "Multi-academy trust",
+    "address": "445 Dach Hill, LG93 6AK",
+    "openedDate": "2014-01-29T00:00:00",
+    "companiesHouseNumber": "06796598",
+    "regionAndTerritory": "East of England",
+    "academies": [
+      {
+        "urn": 13027003,
+        "dateAcademyJoinedTrust": "2022-02-25T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Cofe School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1001",
+        "schoolCapacity": "1326",
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13025689,
+        "dateAcademyJoinedTrust": "2019-04-28T00:00:00",
+        "establishmentName": "Holly Lodge Girls\u0027 School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2622",
+        "schoolCapacity": "2058",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13029767,
+        "dateAcademyJoinedTrust": "2014-04-30T00:00:00",
+        "establishmentName": "St. Joseph\u0027s Church of England Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1708",
+        "schoolCapacity": "2952",
+        "percentageFreeSchoolMeals": "7",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Tommy Lubowitz",
+      "email": "Tommy.Lubowitz@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Rachel Volkman",
+      "email": "Rachel.Volkman@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1303",
+    "name": "THE DIOCESE OF ELY MULTI-ACADEMY TRUST",
+    "groupId": "TR8935",
+    "ukprn": "10030162",
+    "type": "Multi-academy trust",
+    "address": "947 Huel Village, XI00 8DK",
+    "openedDate": "2016-09-30T00:00:00",
+    "companiesHouseNumber": "07146483",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 13031429,
+        "dateAcademyJoinedTrust": "2022-01-14T00:00:00",
+        "establishmentName": "Rico Pines School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1503",
+        "schoolCapacity": "1334",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13039123,
+        "dateAcademyJoinedTrust": "2018-05-12T00:00:00",
+        "establishmentName": "St. James\u0027s Church of England Primary School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "421",
+        "schoolCapacity": "833",
+        "percentageFreeSchoolMeals": "26",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Roberto Grimes",
+      "email": "Roberto.Grimes@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jonathon Littel",
+      "email": "Jonathon.Littel@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1304",
+    "name": "THE DIOCESE OF GLOUCESTER ACADEMIES TRUST",
+    "groupId": "TR1945",
+    "ukprn": "10023025",
+    "type": "Multi-academy trust",
+    "address": "14577 Emmy Squares, Wyman Tunnel, Ricomouth, YY15 7OG",
+    "openedDate": "2023-05-18T00:00:00",
+    "companiesHouseNumber": "02368147",
+    "regionAndTerritory": "",
+    "academies": [
+      {
+        "urn": 13043204,
+        "dateAcademyJoinedTrust": "2023-09-14T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "310",
+        "schoolCapacity": "644",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13048936,
+        "dateAcademyJoinedTrust": "2023-07-21T00:00:00",
+        "establishmentName": "Limehurst R.C. Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "387",
+        "schoolCapacity": "865",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13042234,
+        "dateAcademyJoinedTrust": "2023-09-19T00:00:00",
+        "establishmentName": "Greensward School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1450",
+        "schoolCapacity": "1222",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13046144,
+        "dateAcademyJoinedTrust": "2023-09-14T00:00:00",
+        "establishmentName": "Beacon Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "504",
+        "schoolCapacity": "599",
+        "percentageFreeSchoolMeals": "6",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13048068,
+        "dateAcademyJoinedTrust": "2023-11-06T00:00:00",
+        "establishmentName": "Co-op R.C. Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2247",
+        "schoolCapacity": "2659",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13049030,
+        "dateAcademyJoinedTrust": "2023-10-13T00:00:00",
+        "establishmentName": "Leeds Catholic School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1010",
+        "schoolCapacity": "1421",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13047366,
+        "dateAcademyJoinedTrust": "2023-07-23T00:00:00",
+        "establishmentName": "Oasis School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1229",
+        "schoolCapacity": "2620",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13047568,
+        "dateAcademyJoinedTrust": "2023-06-30T00:00:00",
+        "establishmentName": "Co-op Catholic Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1438",
+        "schoolCapacity": "2064",
+        "percentageFreeSchoolMeals": "1",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13046351,
+        "dateAcademyJoinedTrust": "2023-06-21T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Church of England Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Leeds",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "693",
+        "schoolCapacity": "1645",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lindsey Von",
+      "email": "Lindsey.Von@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Sharon Roob",
+      "email": "Sharon.Roob@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1305",
+    "name": "THE DIOCESE OF NORWICH EDUCATION AND ACADEMIES TRUST",
+    "groupId": "TR9558",
+    "ukprn": "10074724",
+    "type": "Multi-academy trust",
+    "address": "66718 Barton Mews, New Joana, PD9 9HQ",
+    "openedDate": "2021-07-05T00:00:00",
+    "companiesHouseNumber": "05354525",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 13058724,
+        "dateAcademyJoinedTrust": "2022-07-18T00:00:00",
+        "establishmentName": "Oasis CE Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1152",
+        "schoolCapacity": "1338",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13056349,
+        "dateAcademyJoinedTrust": "2022-10-25T00:00:00",
+        "establishmentName": "Mulberry Cofe Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "402",
+        "schoolCapacity": "989",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13058058,
+        "dateAcademyJoinedTrust": "2022-05-10T00:00:00",
+        "establishmentName": "Longhill R.C. Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Bradford",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "590",
+        "schoolCapacity": "611",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13058180,
+        "dateAcademyJoinedTrust": "2022-04-02T00:00:00",
+        "establishmentName": "Meridian Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Bradford",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1467",
+        "schoolCapacity": "1700",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Arturo Purdy",
+      "email": "Arturo.Purdy@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Amanda McGlynn",
+      "email": "Amanda.McGlynn@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1306",
+    "name": "THE DIOCESE OF NORWICH ST BENET\u0027S MULTI-ACADEMY TRUST",
+    "groupId": "TR415",
+    "ukprn": "10041812",
+    "type": "Multi-academy trust",
+    "address": "86034 Johnpaul Ferry, Crist Square, Brownchester, ZA7 3CU",
+    "openedDate": "2018-09-20T00:00:00",
+    "companiesHouseNumber": "09230599",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 13064417,
+        "dateAcademyJoinedTrust": "2019-05-16T00:00:00",
+        "establishmentName": "Harris Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "819",
+        "schoolCapacity": "1545",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13067653,
+        "dateAcademyJoinedTrust": "2018-12-25T00:00:00",
+        "establishmentName": "Queensbridge CE Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "203",
+        "schoolCapacity": "203",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13063912,
+        "dateAcademyJoinedTrust": "2019-07-07T00:00:00",
+        "establishmentName": "St. Paul\u0027s Cofe Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "690",
+        "schoolCapacity": "650",
+        "percentageFreeSchoolMeals": "10",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13065004,
+        "dateAcademyJoinedTrust": "2022-05-02T00:00:00",
+        "establishmentName": "Malbank C of E Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Barnsley",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2209",
+        "schoolCapacity": "2790",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13067069,
+        "dateAcademyJoinedTrust": "2022-04-03T00:00:00",
+        "establishmentName": "Malbank Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "East Riding of Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1660",
+        "schoolCapacity": "1855",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Ramona O\u0027Keefe",
+      "email": "Ramona.O\u0027Keefe@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Marion MacGyver",
+      "email": "Marion.MacGyver@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1307",
+    "name": "THE DIOCESE OF SHEFFIELD ACADEMIES TRUST",
+    "groupId": "TR9542",
+    "ukprn": "10088823",
+    "type": "Multi-academy trust",
+    "address": "5557 Beatty Dam, NP12 8ZG",
+    "openedDate": "2014-07-14T00:00:00",
+    "companiesHouseNumber": "09884347",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 13077599,
+        "dateAcademyJoinedTrust": "2021-11-15T00:00:00",
+        "establishmentName": "Harris Church of England Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3283",
+        "schoolCapacity": "2898",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13074559,
+        "dateAcademyJoinedTrust": "2014-07-19T00:00:00",
+        "establishmentName": "Malbank Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1722",
+        "schoolCapacity": "1999",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13078571,
+        "dateAcademyJoinedTrust": "2022-06-20T00:00:00",
+        "establishmentName": "St. Paul\u0027s C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2723",
+        "schoolCapacity": "2442",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13076691,
+        "dateAcademyJoinedTrust": "2021-03-30T00:00:00",
+        "establishmentName": "St. Mary\u0027s Cofe Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1134",
+        "schoolCapacity": "945",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13076280,
+        "dateAcademyJoinedTrust": "2017-02-21T00:00:00",
+        "establishmentName": "Glyn CE Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "770",
+        "schoolCapacity": "1397",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13071578,
+        "dateAcademyJoinedTrust": "2020-10-28T00:00:00",
+        "establishmentName": "Greensward Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1876",
+        "schoolCapacity": "2514",
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13071694,
+        "dateAcademyJoinedTrust": "2022-06-10T00:00:00",
+        "establishmentName": "George Abbey Primary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "320",
+        "schoolCapacity": "539",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13075320,
+        "dateAcademyJoinedTrust": "2020-01-07T00:00:00",
+        "establishmentName": "Horizon Church of England School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "679",
+        "schoolCapacity": "1232",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lindsey Von",
+      "email": "Lindsey.Von@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Vickie Gulgowski",
+      "email": "Vickie.Gulgowski@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1308",
+    "name": "THE DIOCESE OF WESTMINSTER ACADEMY TRUST",
+    "groupId": "TR1115",
+    "ukprn": "10088919",
+    "type": "Multi-academy trust",
+    "address": "555 Jordane View, Jakob Green, Port Reilly, MI6 6EB",
+    "openedDate": "2015-09-26T00:00:00",
+    "companiesHouseNumber": "03491410",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 13084843,
+        "dateAcademyJoinedTrust": "2016-03-13T00:00:00",
+        "establishmentName": "Co-op School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "3109",
+        "schoolCapacity": "2790",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13081267,
+        "dateAcademyJoinedTrust": "2023-04-16T00:00:00",
+        "establishmentName": "Malbank Catholic Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2012",
+        "schoolCapacity": "1586",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13081013,
+        "dateAcademyJoinedTrust": "2016-06-08T00:00:00",
+        "establishmentName": "St. John\u0027s Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "84",
+        "schoolCapacity": "104",
+        "percentageFreeSchoolMeals": "14",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Jessica Legros",
+      "email": "Jessica.Legros@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Ginger Dietrich",
+      "email": "Ginger.Dietrich@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1309",
+    "name": "THE DIOCESE OF WORCESTER MULTI ACADEMY TRUST",
+    "groupId": "TR1542",
+    "ukprn": "10032472",
+    "type": "Multi-academy trust",
+    "address": "485 Dibbert Mountains, South Mireya, LA8 6WQ",
+    "openedDate": "2017-03-01T00:00:00",
+    "companiesHouseNumber": "02211996",
+    "regionAndTerritory": "North East",
+    "academies": [
+      {
+        "urn": 13096524,
+        "dateAcademyJoinedTrust": "2017-09-08T00:00:00",
+        "establishmentName": "George Abbey Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "127",
+        "schoolCapacity": "272",
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13098513,
+        "dateAcademyJoinedTrust": "2022-03-17T00:00:00",
+        "establishmentName": "Harris Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1359",
+        "schoolCapacity": "1691",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13095058,
+        "dateAcademyJoinedTrust": "2020-05-27T00:00:00",
+        "establishmentName": "North Yorkshire C of E School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1325",
+        "schoolCapacity": "1888",
+        "percentageFreeSchoolMeals": "13",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13095301,
+        "dateAcademyJoinedTrust": "2017-04-22T00:00:00",
+        "establishmentName": "Co-op Primary Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "367",
+        "schoolCapacity": "748",
+        "percentageFreeSchoolMeals": "5",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13094373,
+        "dateAcademyJoinedTrust": "2018-09-27T00:00:00",
+        "establishmentName": "George Abbey Catholic Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2834",
+        "schoolCapacity": "2603",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13093233,
+        "dateAcademyJoinedTrust": "2019-04-11T00:00:00",
+        "establishmentName": "St. Catherine\u0027s Catholic School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kingston upon Hull, City of",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "809",
+        "schoolCapacity": "1339",
         "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 11,
@@ -7143,16 +6901,98 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12376082,
-        "dateAcademyJoinedTrust": "2023-11-07T00:00:00",
-        "establishmentName": "Longhill School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Leeds",
+        "urn": 13093504,
+        "dateAcademyJoinedTrust": "2023-07-03T00:00:00",
+        "establishmentName": "St. Anne\u0027s C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "927",
-        "schoolCapacity": "1903",
-        "percentageFreeSchoolMeals": "24",
+        "numberOfPupils": "1654",
+        "schoolCapacity": "2118",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Patty Streich",
+      "email": "Patty.Streich@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Vickie Gulgowski",
+      "email": "Vickie.Gulgowski@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1252",
+    "name": "THRIVE MULTI-ACADEMY TRUST",
+    "groupId": "TR1125",
+    "ukprn": "10042404",
+    "type": "Multi-academy trust",
+    "address": "78136 Greenfelder Knoll, Sarah Loaf, Boehmton, FN96 4LZ",
+    "openedDate": "2013-11-22T00:00:00",
+    "companiesHouseNumber": "01124592",
+    "regionAndTerritory": "North East",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Annette Breitenberg",
+      "email": "Annette.Breitenberg@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Natasha Borer",
+      "email": "Natasha.Borer@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1276",
+    "name": "TRANSCENDENCE EDUCATION TRUST",
+    "groupId": "TR3060",
+    "ukprn": "10092879",
+    "type": "Multi-academy trust",
+    "address": "72516 Cummings Groves, Russ Locks, XB7 5VN",
+    "openedDate": "2021-07-02T00:00:00",
+    "companiesHouseNumber": "03974334",
+    "regionAndTerritory": "West Midlands",
+    "academies": [],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Jessica Legros",
+      "email": "Jessica.Legros@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Cecilia Crona",
+      "email": "Cecilia.Crona@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1269",
+    "name": "UNITY LEARNING TRUST",
+    "groupId": "TR9978",
+    "ukprn": "10051627",
+    "type": "Multi-academy trust",
+    "address": "4612 Barbara Park, Considine Squares, EL9 3KQ",
+    "openedDate": "2021-10-07T00:00:00",
+    "companiesHouseNumber": "09231053",
+    "regionAndTerritory": "South West",
+    "academies": [
+      {
+        "urn": 12696922,
+        "dateAcademyJoinedTrust": "2022-09-30T00:00:00",
+        "establishmentName": "Oasis Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North East Lincolnshire",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "202",
+        "schoolCapacity": "170",
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -7161,16 +7001,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12377317,
-        "dateAcademyJoinedTrust": "2023-11-03T00:00:00",
-        "establishmentName": "Harris Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "urn": 12697394,
+        "dateAcademyJoinedTrust": "2023-07-11T00:00:00",
+        "establishmentName": "Oasis Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "3270",
-        "schoolCapacity": "2720",
-        "percentageFreeSchoolMeals": "11",
+        "numberOfPupils": "309",
+        "schoolCapacity": "584",
+        "percentageFreeSchoolMeals": "25",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -7179,50 +7019,16 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12376287,
-        "dateAcademyJoinedTrust": "2023-11-08T00:00:00",
-        "establishmentName": "St. Anne\u0027s CE Primary School",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "York",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "208",
-        "schoolCapacity": "163",
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": null,
-        "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1241",
-    "name": "VISIONARY ACADEMY TRUST",
-    "groupId": "TR4599",
-    "ukprn": "10047712",
-    "type": "Multi-academy trust",
-    "address": "57293 Barton Terrace, Huel Locks, IM84 7VE",
-    "openedDate": "2017-03-15T00:00:00",
-    "companiesHouseNumber": "03447860",
-    "regionAndTerritory": "South East",
-    "academies": [
-      {
-        "urn": 12417590,
-        "dateAcademyJoinedTrust": "2022-04-19T00:00:00",
-        "establishmentName": "Horizon Catholic School",
+        "urn": 12693777,
+        "dateAcademyJoinedTrust": "2023-02-02T00:00:00",
+        "establishmentName": "Longhill Church of England Secondary Academy",
         "typeOfEstablishment": "Academy converter",
         "localAuthority": "Kirklees",
-        "urbanRural": "Urban minor conurbation",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": "1148",
-        "schoolCapacity": "2368",
-        "percentageFreeSchoolMeals": "1",
+        "numberOfPupils": "1014",
+        "schoolCapacity": "803",
+        "percentageFreeSchoolMeals": "4",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -7231,16 +7037,110 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12413125,
-        "dateAcademyJoinedTrust": "2018-10-14T00:00:00",
-        "establishmentName": "St. Marys CE Primary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
+        "urn": 12697259,
+        "dateAcademyJoinedTrust": "2023-03-20T00:00:00",
+        "establishmentName": "St. Mary\u0027s C of E Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "2933",
-        "schoolCapacity": "2623",
-        "percentageFreeSchoolMeals": "29",
+        "numberOfPupils": "1554",
+        "schoolCapacity": "2099",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12693897,
+        "dateAcademyJoinedTrust": "2023-01-01T00:00:00",
+        "establishmentName": "Greensward Cofe Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "301",
+        "schoolCapacity": "706",
+        "percentageFreeSchoolMeals": "23",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12692745,
+        "dateAcademyJoinedTrust": "2022-08-06T00:00:00",
+        "establishmentName": "Beacon Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2624",
+        "schoolCapacity": "2741",
+        "percentageFreeSchoolMeals": "30",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lamar Kulas",
+      "email": "Lamar.Kulas@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jan Wunsch",
+      "email": "Jan.Wunsch@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1237",
+    "name": "VANGUARD LEARNING TRUST",
+    "groupId": "TR3116",
+    "ukprn": "10039020",
+    "type": "Multi-academy trust",
+    "address": "66585 Addison Trail, KJ27 3WE",
+    "openedDate": "2016-08-10T00:00:00",
+    "companiesHouseNumber": "02294370",
+    "regionAndTerritory": "London",
+    "academies": [
+      {
+        "urn": 12375557,
+        "dateAcademyJoinedTrust": "2018-07-31T00:00:00",
+        "establishmentName": "Oasis Secondary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "York",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "107",
+        "schoolCapacity": "128",
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12378586,
+        "dateAcademyJoinedTrust": "2020-05-24T00:00:00",
+        "establishmentName": "George Abbey Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Rotherham",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1298",
+        "schoolCapacity": "1145",
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -7249,50 +7149,88 @@
         "previousOfstedRating": null
       },
       {
-        "urn": 12418411,
-        "dateAcademyJoinedTrust": "2019-11-28T00:00:00",
-        "establishmentName": "Horizon Catholic School",
-        "typeOfEstablishment": "Academy converter",
+        "urn": 12377852,
+        "dateAcademyJoinedTrust": "2020-01-12T00:00:00",
+        "establishmentName": "Co-op Cofe Secondary School",
+        "typeOfEstablishment": "Free school",
         "localAuthority": "Kirklees",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": "232",
-        "schoolCapacity": "187",
-        "percentageFreeSchoolMeals": "7",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "306",
+        "schoolCapacity": "245",
+        "percentageFreeSchoolMeals": "11",
         "ageRange": {
-          "minimum": 5,
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12375718,
+        "dateAcademyJoinedTrust": "2022-11-07T00:00:00",
+        "establishmentName": "Northwood C of E Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "York",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "892",
+        "schoolCapacity": "1324",
+        "percentageFreeSchoolMeals": "21",
+        "ageRange": {
+          "minimum": 4,
           "maximum": 11
         },
         "currentOfstedRating": null,
         "previousOfstedRating": null
-      }
-    ],
-    "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
-  },
-  {
-    "uid": "1274",
-    "name": "VITALITY ACADEMY TRUST",
-    "groupId": "TR3038",
-    "ukprn": "10031057",
-    "type": "Multi-academy trust",
-    "address": "3900 Henri Cliff, Port Avery, XR06 0UK",
-    "openedDate": "2023-07-12T00:00:00",
-    "companiesHouseNumber": "03566292",
-    "regionAndTerritory": "East Midlands",
-    "academies": [
+      },
       {
-        "urn": 12747391,
-        "dateAcademyJoinedTrust": "2023-10-05T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Catholic Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Lincolnshire",
+        "urn": 12371430,
+        "dateAcademyJoinedTrust": "2018-09-15T00:00:00",
+        "establishmentName": "York Church of England Primary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "York",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1476",
+        "schoolCapacity": "1219",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12373181,
+        "dateAcademyJoinedTrust": "2021-09-28T00:00:00",
+        "establishmentName": "St. Mary\u0027s Catholic Primary Academy",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "1322",
+        "schoolCapacity": "1084",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12371293,
+        "dateAcademyJoinedTrust": "2021-03-09T00:00:00",
+        "establishmentName": "Momentum Community Cofe Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Yorkshire",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": "1488",
-        "schoolCapacity": "2188",
-        "percentageFreeSchoolMeals": "11",
+        "numberOfPupils": "983",
+        "schoolCapacity": "1874",
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -7302,22 +7240,223 @@
       }
     ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "Arturo Purdy",
+      "email": "Arturo.Purdy@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Oscar Goldner",
+      "email": "Oscar.Goldner@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1241",
+    "name": "VISIONARY ACADEMY TRUST",
+    "groupId": "TR6235",
+    "ukprn": "10003639",
+    "type": "Multi-academy trust",
+    "address": "24616 Darrin Springs, Efren Shoal, Port Candidoside, AC37 5FX",
+    "openedDate": "2015-11-22T00:00:00",
+    "companiesHouseNumber": "03676412",
+    "regionAndTerritory": "Yorkshire and the Humber",
+    "academies": [
+      {
+        "urn": 12413280,
+        "dateAcademyJoinedTrust": "2018-06-18T00:00:00",
+        "establishmentName": "Oasis Primary School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": "2454",
+        "schoolCapacity": "2310",
+        "percentageFreeSchoolMeals": "28",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12416656,
+        "dateAcademyJoinedTrust": "2017-04-10T00:00:00",
+        "establishmentName": "St. Paul\u0027s CE School",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "3588",
+        "schoolCapacity": "2847",
+        "percentageFreeSchoolMeals": "15",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Mae Bradtke",
+      "email": "Mae.Bradtke@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jonathon Littel",
+      "email": "Jonathon.Littel@education.gov.uk"
+    }
+  },
+  {
+    "uid": "1274",
+    "name": "VITALITY ACADEMY TRUST",
+    "groupId": "TR1215",
+    "ukprn": "10065648",
+    "type": "Multi-academy trust",
+    "address": "241 Carolanne Station, VH4 6AD",
+    "openedDate": "2021-11-21T00:00:00",
+    "companiesHouseNumber": "03237671",
+    "regionAndTerritory": "South East",
+    "academies": [
+      {
+        "urn": 12742324,
+        "dateAcademyJoinedTrust": "2022-02-06T00:00:00",
+        "establishmentName": "St. Peter\u0027s R.C. Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1699",
+        "schoolCapacity": "1573",
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12741752,
+        "dateAcademyJoinedTrust": "2023-04-09T00:00:00",
+        "establishmentName": "Queen Elizabeth\u0027s Secondary School",
+        "typeOfEstablishment": "Academy sponsor led",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1031",
+        "schoolCapacity": "922",
+        "percentageFreeSchoolMeals": "20",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 12742916,
+        "dateAcademyJoinedTrust": "2023-09-14T00:00:00",
+        "establishmentName": "Glyn School",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Doncaster",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2280",
+        "schoolCapacity": "2754",
+        "percentageFreeSchoolMeals": "3",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
+    "governors": [],
+    "trustRelationshipManager": {
+      "fullName": "Lana Mueller",
+      "email": "Lana.Mueller@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Shelly Mayert",
+      "email": "Shelly.Mayert@education.gov.uk"
+    }
   },
   {
     "uid": "1312",
     "name": "WESTMINSTER ACADEMY TRUST",
-    "groupId": "TR7981",
-    "ukprn": "10015879",
+    "groupId": "TR5276",
+    "ukprn": "10014123",
     "type": "Multi-academy trust",
-    "address": "24161 Janice Estates, Vandervort Curve, Millerland, LQ43 3QJ",
-    "openedDate": "2015-04-27T00:00:00",
-    "companiesHouseNumber": "01137899",
-    "regionAndTerritory": "South East",
-    "academies": [],
+    "address": "028 Letitia Forks, QK35 4WR",
+    "openedDate": "2023-04-27T00:00:00",
+    "companiesHouseNumber": "07765983",
+    "regionAndTerritory": "North West",
+    "academies": [
+      {
+        "urn": 13121724,
+        "dateAcademyJoinedTrust": "2023-08-30T00:00:00",
+        "establishmentName": "St. James\u0027 Church of England Secondary Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "1779",
+        "schoolCapacity": "1678",
+        "percentageFreeSchoolMeals": "18",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13124258,
+        "dateAcademyJoinedTrust": "2023-07-06T00:00:00",
+        "establishmentName": "Oasis Cofe Academy",
+        "typeOfEstablishment": "Free school",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "2729",
+        "schoolCapacity": "2142",
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      },
+      {
+        "urn": 13124469,
+        "dateAcademyJoinedTrust": "2023-05-05T00:00:00",
+        "establishmentName": "Halewood Church of England Academy",
+        "typeOfEstablishment": "Academy converter",
+        "localAuthority": "Wakefield",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": "721",
+        "schoolCapacity": "557",
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": null,
+        "previousOfstedRating": null
+      }
+    ],
     "governors": [],
-    "trustRelationshipManager": null,
-    "sfsoLead": null
+    "trustRelationshipManager": {
+      "fullName": "Arturo Purdy",
+      "email": "Arturo.Purdy@education.gov.uk"
+    },
+    "sfsoLead": {
+      "fullName": "Jonathon Littel",
+      "email": "Jonathon.Littel@education.gov.uk"
+    }
   }
 ]


### PR DESCRIPTION
Adds trust relationship manager and SFSO lead to the fake data used by UI tests

[User Story 146083](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/146083): Build: Get all the data we need from Academies DB for MVP

## Changes

* Add `CdmAccount` and `CdmSystemuser` fake data generation to create the trust relationship manager and SFSO lead.
* Change `JsonGenerator` to use the trust provider and an `IAcademiesDbContext` version of  `AcademiesDbData` - this greatly simplifies upkeep of the fake data generator

## Checklist

- [n/a] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [n/a] Update the ADR decision log if needed
