### PR TITLE
Remove volumes in docker down script

### DIFF
--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -14,7 +14,7 @@
     "test:deployment": "npx playwright test --project=\"deployment-tests\"",
     "test:integration": "npx playwright test --project=\"integration-tests\"",
     "docker:start": "docker compose -f ../../docker/docker-compose.ci.yml up -d --build",
-    "docker:stop": "docker compose -f ../../docker/docker-compose.ci.yml down",
+    "docker:stop": "docker compose -f ../../docker/docker-compose.ci.yml down -v",
     "docker:restart": "npm run docker:stop && npm run docker:start"
   },
   "keywords": [],


### PR DESCRIPTION
We are using a shared volume when running the Faker, but this will not be overriden by the `FakeDataGenerator.Dockerfile` in between running the `docker-compose.ci.yml` file locally. Here, adding a -v flag to `docker compose down` in our npm script to stop and restart the docker containers.

If the developer stops the docker containers inside the Docker app without using the npm script, they will need to manually delete the containers and the volume: `docker_testdb-volume`.

Alternatively running `npm run docker:stop` (or `npm run docker:restart`) will automate both of these actions. 

## Checklist

- [n/a] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [n/a] Update the ADR decision log if needed
