### PR TITLE
Populate academies in trust details page with trust data

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/OtherServicesLinkBuilder.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/OtherServicesLinkBuilder.cs
@@ -5,6 +5,7 @@ namespace DfE.FindInformationAcademiesTrusts.Pages;
 public interface IOtherServicesLinkBuilder
 {
     string? GetInformationAboutSchoolsListingLink(Trust trust);
+    string GetInformationAboutSchoolsListingLink(Academy academy);
     string? CompaniesHouseListingLink(Trust trust);
     string? SchoolFinancialBenchmarkingServiceListingLink(Trust trust);
     string? FindSchoolPerformanceDataListingLink(Trust trust);
@@ -31,6 +32,11 @@ public class OtherServicesLinkBuilder : IOtherServicesLinkBuilder
         }
 
         return null;
+    }
+
+    public string GetInformationAboutSchoolsListingLink(Academy academy)
+    {
+        return $"{GetInformationAboutSchoolsBaseUrl}/Establishments/Establishment/Details/{academy.Urn}";
     }
 
     public string? CompaniesHouseListingLink(Trust trust)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml
@@ -28,7 +28,7 @@
           <td class="govuk-body govuk-table__cell">@academy.TypeOfEstablishment</td>
           <td class="govuk-body govuk-table__cell">@academy.UrbanRural</td>
           <td class="govuk-body govuk-table__cell">
-            <a href="" class="govuk-link" aria-label="@academy.EstablishmentName on Get information about schools (opens in new tab)">
+            <a href="@Model.LinkBuilder.GetInformationAboutSchoolsListingLink(academy)" class="govuk-link" rel="noreferrer noopener" target="_blank" aria-label="@academy.EstablishmentName on Get information about schools (opens in new tab)">
               More information
             </a>
           </td>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml
@@ -18,45 +18,22 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <tr class="govuk-table__row" data-testid="academy-row">
-        <th scope="row" class="govuk-body govuk-table__header" data-sort-value="Barr and Community R.C. School">
-          Barr and Community R.C. School<br/><span class="govuk-!-font-weight-regular">URN: 109174</span>
-        </th>
-        <td class="govuk-body govuk-table__cell">Kingston upon Hull, City of</td>
-        <td class="govuk-body govuk-table__cell">Academy converter</td>
-        <td class="govuk-body govuk-table__cell">Urban minor conurbation</td>
-        <td class="govuk-body govuk-table__cell">
-          <a href="" class="govuk-link" aria-label="Barr and Community R.C. School on Get information about schools (opens in new tab)">
-            More information
-          </a>
-        </td>
-      </tr>
-      <tr class="govuk-table__row" data-testid="academy-row">
-        <th scope="row" class="govuk-body govuk-table__header" data-sort-value="Beacon School">
-          Beacon School<br/><span class="govuk-!-font-weight-regular">URN: 118872</span>
-        </th>
-        <td class="govuk-body govuk-table__cell">North East Lincolnshire</td>
-        <td class="govuk-body govuk-table__cell">Academy sponsor led</td>
-        <td class="govuk-body govuk-table__cell">Urban city and town</td>
-        <td class="govuk-body govuk-table__cell">
-          <a href="" class="govuk-link" aria-label="Beacon School on Get information about schools (opens in new tab)">
-            More information
-          </a>
-        </td>
-      </tr>
-      <tr class="govuk-table__row" data-testid="academy-row">
-        <th scope="row" class="govuk-body govuk-table__header" data-sort-value="George Abbey Secondary Academy">
-          George Abbey Secondary Academy<br/><span class="govuk-!-font-weight-regular">URN: 138867</span>
-        </th>
-        <td class="govuk-body govuk-table__cell">Leeds</td>
-        <td class="govuk-body govuk-table__cell">Academy converter</td>
-        <td class="govuk-body govuk-table__cell">Rural town and fringe</td>
-        <td class="govuk-body govuk-table__cell">
-          <a href="" class="govuk-link" aria-label="George Abbey Secondary Academy on Get information about schools (opens in new tab)">
-            More information
-          </a>
-        </td>
-      </tr>
+      @foreach (var academy in Model.Trust.Academies)
+      {
+        <tr class="govuk-table__row" data-testid="academy-row">
+          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@academy.EstablishmentName">
+            @academy.EstablishmentName<br/><span class="govuk-!-font-weight-regular">URN: @academy.Urn</span>
+          </th>
+          <td class="govuk-body govuk-table__cell">@academy.LocalAuthority</td>
+          <td class="govuk-body govuk-table__cell">@academy.TypeOfEstablishment</td>
+          <td class="govuk-body govuk-table__cell">@academy.UrbanRural</td>
+          <td class="govuk-body govuk-table__cell">
+            <a href="" class="govuk-link" aria-label="@academy.EstablishmentName on Get information about schools (opens in new tab)">
+              More information
+            </a>
+          </td>
+        </tr>
+      }
     </tbody>
   </table>
 </section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml.cs
@@ -1,11 +1,16 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
 public class AcademiesDetailsModel : TrustsAreaModel, IAcademiesAreaModel
 {
-    public AcademiesDetailsModel(ITrustProvider trustProvider) : base(trustProvider, "Academies in this trust")
+    public IOtherServicesLinkBuilder LinkBuilder { get; }
+
+    public AcademiesDetailsModel(ITrustProvider trustProvider, IOtherServicesLinkBuilder linkBuilder) :
+        base(trustProvider, "Academies in this trust")
     {
         PageTitle = "Academies details";
+        LinkBuilder = linkBuilder;
     }
 
     public string TabName => "Details";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
@@ -35,7 +35,7 @@
         </li>
         <li class="ds_side-navigation__item app-side-navigation-highlight-item">
           <a asp-page="/Trusts/Academies/Details" asp-route-uid="@Model.Trust.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Academies details")">
-            Academies in this trust (3)
+            Academies in this trust (@Model.Trust.Academies.Length)
           </a>
         </li>
       </ul>

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/OtherServicesLinkBuilderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/OtherServicesLinkBuilderTests.cs
@@ -40,6 +40,14 @@ public class OtherServicesLinkBuilderTests
         result.Should().BeNull();
     }
 
+    [Fact]
+    public void GetInformationAboutSchoolsListingLink_should_return_academy_urn_if_academy_is_provided()
+    {
+        var dummyAcademy = DummyAcademyFactory.GetDummyAcademy(111);
+        var result = _sut.GetInformationAboutSchoolsListingLink(dummyAcademy);
+        result.Should().Contain("/Establishments/Establishment/Details/111");
+    }
+
     [Theory]
     [InlineData("Multi-academy trust", 0)]
     [InlineData("Multi-academy trust", 2)]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/AcademiesDetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/AcademiesDetailsModelTests.cs
@@ -7,12 +7,12 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies;
 public class AcademiesDetailsModelTests
 {
     private readonly AcademiesDetailsModel _sut;
+    private readonly Mock<IOtherServicesLinkBuilder> _mockLinkBuilder = new();
 
     public AcademiesDetailsModelTests()
     {
         var mockTrustProvider = new Mock<ITrustProvider>();
-        var mockLinkBuilder = new Mock<IOtherServicesLinkBuilder>();
-        _sut = new AcademiesDetailsModel(mockTrustProvider.Object, mockLinkBuilder.Object);
+        _sut = new AcademiesDetailsModel(mockTrustProvider.Object, _mockLinkBuilder.Object);
     }
 
     [Fact]
@@ -25,5 +25,11 @@ public class AcademiesDetailsModelTests
     public void TabName_should_be_Details()
     {
         _sut.TabName.Should().Be("Details");
+    }
+
+    [Fact]
+    public void OtherServicesLinkBuilder_should_be_injected()
+    {
+        _sut.LinkBuilder.Should().Be(_mockLinkBuilder.Object);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/AcademiesDetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/AcademiesDetailsModelTests.cs
@@ -28,6 +28,12 @@ public class AcademiesDetailsModelTests
     }
 
     [Fact]
+    public void PageName_should_be_AcademiesInThisTrust()
+    {
+        _sut.PageName.Should().Be("Academies in this trust");
+    }
+
+    [Fact]
     public void OtherServicesLinkBuilder_should_be_injected()
     {
         _sut.LinkBuilder.Should().Be(_mockLinkBuilder.Object);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/AcademiesDetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/AcademiesDetailsModelTests.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies;
@@ -10,7 +11,8 @@ public class AcademiesDetailsModelTests
     public AcademiesDetailsModelTests()
     {
         var mockTrustProvider = new Mock<ITrustProvider>();
-        _sut = new AcademiesDetailsModel(mockTrustProvider.Object);
+        var mockLinkBuilder = new Mock<IOtherServicesLinkBuilder>();
+        _sut = new AcademiesDetailsModel(mockTrustProvider.Object, mockLinkBuilder.Object);
     }
 
     [Fact]

--- a/tests/playwright/fake-data/fake-test-data.ts
+++ b/tests/playwright/fake-data/fake-test-data.ts
@@ -11,12 +11,15 @@ export interface FakeTrust {
   companiesHouseNumber: string
   regionAndTerritory: string
   status: string
-  academies: FakeAcademies[]
+  academies: FakeAcademy[]
 }
 
-export interface FakeAcademies {
+export interface FakeAcademy {
   urn: number
   establishmentName: string
+  typeOfEstablishment: string
+  localAuthority: string
+  urbanRural: string
 }
 
 export class FakeTestData {
@@ -79,5 +82,13 @@ export class FakeTestData {
       throw new Error(`No trusts with type ${type} found in test data`)
     }
     return trust
+  }
+
+  static getTrustAcademyByUrn (trust: FakeTrust, urn: number): FakeAcademy {
+    const academy = trust.academies.find(academy => academy.urn === urn)
+    if (academy === undefined) {
+      throw new Error(`Expected to find academy in the test data containing URN: ${urn}, but it was not found`)
+    }
+    return academy
   }
 }

--- a/tests/playwright/page-object-model/shared/table-component.ts
+++ b/tests/playwright/page-object-model/shared/table-component.ts
@@ -12,6 +12,10 @@ export class TableComponent {
   getRowComponentAt (rowNumber: number): RowComponent {
     return new RowComponent(this.rowsLocator.nth(rowNumber))
   }
+
+  async getRowCount (): Promise<number> {
+    return await this.rowsLocator.count()
+  }
 }
 
 export class RowComponent {

--- a/tests/playwright/page-object-model/trust/academies/base-academies-page.ts
+++ b/tests/playwright/page-object-model/trust/academies/base-academies-page.ts
@@ -1,5 +1,5 @@
 import { Locator, Page, expect } from '@playwright/test'
-import { FakeTestData } from '../../../fake-data/fake-test-data'
+import { FakeAcademy, FakeTestData } from '../../../fake-data/fake-test-data'
 import { BaseTrustPage, BaseTrustPageAssertions } from '../base-trust-page'
 import { NavigationComponent } from '../../shared/navigation-component'
 import { TableComponent } from '../../shared/table-component'
@@ -17,6 +17,12 @@ export class BaseAcademiesPage extends BaseTrustPage {
     this.academiesRowLocator = this.academiesTable.locator.getByTestId('academy-row')
     this.subNavigation = new NavigationComponent(page, 'Academies tabs')
   }
+
+  async getExpectedAcademyMatching (element: Locator): Promise<FakeAcademy> {
+    const urn = (await element.textContent())?.split('URN:')[1]?.trim() ?? ''
+    expect(urn, 'Expected result to contain a urn value, but it did not').toBeTruthy()
+    return FakeTestData.getTrustAcademyByUrn(this.currentTrust, +urn)
+  }
 }
 
 export class BaseAcademiesPageAssertions extends BaseTrustPageAssertions {
@@ -29,6 +35,6 @@ export class BaseAcademiesPageAssertions extends BaseTrustPageAssertions {
   }
 
   async toDisplayInformationForAllAcademiesInThatTrust (): Promise<void> {
-    await expect(this.academiesPage.academiesRowLocator).toHaveCount(3)
+    await expect(this.academiesPage.academiesRowLocator).toHaveCount(this.trustPage.currentTrust.academies.length)
   }
 }

--- a/tests/playwright/page-object-model/trust/academies/ofsted-ratings-page.ts
+++ b/tests/playwright/page-object-model/trust/academies/ofsted-ratings-page.ts
@@ -26,6 +26,12 @@ class AcademiesOfstedRatingsPageAssertions extends BaseAcademiesPageAssertions {
     await expect(this.ofstedRatingsPage.page).toHaveTitle(/Ofsted ratings/)
   }
 
+  // Once the page is updated with real data this override can be deleted
+  // so that the method on the page object model is called with the real academy count.
+  async toDisplayInformationForAllAcademiesInThatTrust (): Promise<void> {
+    await expect(this.academiesPage.academiesRowLocator).toHaveCount(3)
+  }
+
   async toDisplayCorrectInformationAboutAcademiesInThatTrust (): Promise<void> {
     // start at 1 (rather than 0) because the first row will be the header
     const firstRowComponent = this.ofstedRatingsPage.academiesTable.getRowComponentAt(1)


### PR DESCRIPTION
This change follows on from #241  and adds data about Academies in a trust to the Academies - Details table

- The table contains a row for every academy in a trust, with the correct data for each academy
- The academy count in the trust navigation reflects the number of academies in the trust ('Academies in this trust (x)')
- The 'More information' link in the Get information about schools column leads to the respective establishment listing on Get Information about academies and trusts.

Related to [User Story 136440](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/136440?McasTsid=26110&McasCtx=4): Build: Academies in Trust Page - Details: data

## Changes
- Update other services link builder with a method to build an establishment link, using an academy object
- Update UI tests to loop through the rows in the details table, and check each row against the matching record in the trusts.json

## Pending work
If an academy has no trusts an empty table is shown on the details tab, and other table tabs are shown. This will be dealt with in a future user story.

## Screenshots of UI changes

Screenshots of Academies in trust - details table on different trust pages, showing different numbers of academies:

<img width="1356" alt="" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/8d1dd88b-9dee-4b23-9e9e-bb3156cd0057">


<img width="1314" alt="" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/b9caa98f-a1b4-458c-badd-f0ed6600aaee">

Screenshot of the Academies in trust details table when no academies are present: 

<img width="1364" alt="" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/e3854c4a-5bb0-41c9-bba4-e7eba9e16277">

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed