### PR TITLE
Move Factory mocks to data test project

### DIFF
--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj
@@ -27,7 +27,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj"/>
-        <ProjectReference Include="..\DfE.FindInformationAcademiesTrusts.UnitTests\DfE.FindInformationAcademiesTrusts.UnitTests.csproj"/>
+        <ProjectReference Include="..\DfE.FindInformationAcademiesTrusts.Data.UnitTests\DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/TrustFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/TrustFactoryTests.cs
@@ -1,7 +1,7 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
-using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+using DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Factories;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
@@ -3,7 +3,7 @@ using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Cdm;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
-using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+using DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj
@@ -27,7 +27,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\DfE.FindInformationAcademiesTrusts.Data\DfE.FindInformationAcademiesTrusts.Data.csproj"/>
-        <ProjectReference Include="..\DfE.FindInformationAcademiesTrusts.UnitTests\DfE.FindInformationAcademiesTrusts.UnitTests.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyAcademyFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyAcademyFactory.cs
@@ -1,6 +1,4 @@
-using DfE.FindInformationAcademiesTrusts.Data;
-
-namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+namespace DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 
 public class DummyAcademyFactory
 {

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyGovernorFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyGovernorFactory.cs
@@ -1,6 +1,4 @@
-using DfE.FindInformationAcademiesTrusts.Data;
-
-namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+namespace DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 
 public class DummyGovernorFactory
 {

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyTrustFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyTrustFactory.cs
@@ -1,6 +1,4 @@
-using DfE.FindInformationAcademiesTrusts.Data;
-
-namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+namespace DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 
 public class DummyTrustFactory
 {

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/TrustTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/TrustTests.cs
@@ -1,4 +1,4 @@
-using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+using DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.UnitTests;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
@@ -27,6 +27,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\DfE.FindInformationAcademiesTrusts\DfE.FindInformationAcademiesTrusts.csproj" />
+        <ProjectReference Include="..\DfE.FindInformationAcademiesTrusts.Data.UnitTests\DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/OtherServicesLinkBuilderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/OtherServicesLinkBuilderTests.cs
@@ -1,5 +1,5 @@
+using DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Pages;
-using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/SearchModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/SearchModelTests.cs
@@ -1,6 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Pages;
-using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/DetailsModelTests.cs
@@ -1,7 +1,7 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
-using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
@@ -1,6 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
-using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;


### PR DESCRIPTION
When we created the Dummy Factory pattern to mock our models we did not have a test project for the Data project, as it was purely holding POCOs.

Now that we have tests for this project, it makes more sense to place these Mocks here, as they are more closely related to the models stored in this project.

This is following on from a reference introduced in #269: Add links to other services

## Changes

- Removed the reference to the web app test project from the Data unit tests project (introduced in #269)
- Added a reference to the Data unit tests project from the Web app test project - so that we can continue to use the Dummy Factories in our web app unit tests.
- Replaced the reference in the `Data.AcademiesDb.UnitTests` project - this can now just be a reference to the Data test project

## Screenshots of UI changes

N/A

## Checklist

- [N/A] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [N/A] Update the ADR decision log if needed
