### PR TITLE
Fix invalid branch name on CI tests

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -24,9 +24,21 @@ jobs:
       environment: ${{ steps.var.outputs.environment }}
       branch: ${{ steps.var.outputs.branch }}
     steps:
+      - if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        name: Get branch name for push/dispatch event
+        run: |
+          GIT_REF=${{ github.ref_name }}
+          echo "branch_ref=${GIT_REF}" >> $GITHUB_ENV
+
+      - if: github.event_name == 'pull_request'
+        name: Get source branch for pull request
+        run: |
+          GIT_REF=${{ github.head_ref }}
+          echo "branch_ref=${GIT_REF}" >> $GITHUB_ENV
+
       - id: var
         run: |
-          GIT_REF=${{ github.ref }}
+          GIT_REF=${{ env.branch_ref }}
           GIT_BRANCH=${GIT_REF##*/}
           INPUT=${{ github.event.inputs.environment }}
           ENVIRONMENT=${INPUT:-"development"}

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -86,12 +86,10 @@ jobs:
         with:
           azcliversion: 2.53.0
           inlineScript: |
-            GIT_REF=${{ github.base_ref }}
-            GIT_BRANCH=${GIT_REF//\//-}
             az storage blob upload \
               --container-name ${{ secrets.CI_REPORTS_STORAGE_CONTAINER_NAME }} \
               --account-name ${{ secrets.CI_REPORTS_STORAGE_ACCOUNT_NAME }} \
               --file "./tests/playwright/${{ inputs.environment }}-${{ env.LAST_COMMIT_SHA }}.zip" \
-              --name "Dfe.FindInformationAcademiesTrusts/$GIT_BRANCH/test-deployment-${{ env.LAST_COMMIT_SHA }}.zip" \
+              --name "Dfe.FindInformationAcademiesTrusts/${{ inputs.branch-name }}/test-deployment-${{ env.LAST_COMMIT_SHA }}.zip" \
               --auth-mode login \
               --overwrite

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -85,12 +85,10 @@ jobs:
         with:
           azcliversion: 2.53.0
           inlineScript: |
-            GIT_REF=${{ github.base_ref }}
-            GIT_BRANCH=${GIT_REF//\//-}
             az storage blob upload \
               --container-name ${{ secrets.CI_REPORTS_STORAGE_CONTAINER_NAME }} \
               --account-name ${{ secrets.CI_REPORTS_STORAGE_ACCOUNT_NAME }} \
               --file "./tests/playwright/${{ inputs.environment }}-${{ env.LAST_COMMIT_SHA }}.zip" \
-              --name "Dfe.FindInformationAcademiesTrusts/$GIT_BRANCH/test-deployment-${{ env.LAST_COMMIT_SHA }}.zip" \
+              --name "Dfe.FindInformationAcademiesTrusts/${{ inputs.branch-name }}/test-deployment-${{ env.LAST_COMMIT_SHA }}.zip" \
               --auth-mode login \
               --overwrite

--- a/.github/workflows/test-isolated-ui.yml
+++ b/.github/workflows/test-isolated-ui.yml
@@ -10,6 +10,7 @@ on:
 env:
   NODE_VERSION: 18.13.0
   LAST_COMMIT_SHA: default
+  BRANCH_NAME: main
 
 jobs:
   playwright:
@@ -23,6 +24,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+
+      - if: github.event_name == 'pull_request'
+        name: Get source branch for pull request
+        run: |
+          GIT_REF=${{ github.head_ref }}
+          echo "BRANCH_NAME=${GIT_REF}" >> $GITHUB_ENV
 
       - name: Set SHA environment variable
         run: |
@@ -88,13 +95,11 @@ jobs:
         with:
           azcliversion: 2.53.0
           inlineScript: |
-            GIT_REF=${{ github.base_ref }}
-            GIT_BRANCH=${GIT_REF//\//-}
             az storage blob upload \
               --container-name ${{ secrets.CI_REPORTS_STORAGE_CONTAINER_NAME }} \
               --account-name ${{ secrets.CI_REPORTS_STORAGE_ACCOUNT_NAME }} \
               --file "./tests/playwright/${{ env.LAST_COMMIT_SHA }}.zip" \
-              --name "Dfe.FindInformationAcademiesTrusts/$GIT_BRANCH/test-ui-${{ env.LAST_COMMIT_SHA }}.zip" \
+              --name "Dfe.FindInformationAcademiesTrusts/${{ env.BRANCH_NAME }}/test-ui-${{ env.LAST_COMMIT_SHA }}.zip" \
               --auth-mode login \
               --overwrite
 

--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -120,13 +120,11 @@ jobs:
         with:
           azcliversion: 2.53.0
           inlineScript: |
-            GIT_REF=${{ github.base_ref }}
-            GIT_BRANCH=${GIT_REF//\//-}
             az storage blob upload \
               --container-name ${{ secrets.CI_REPORTS_STORAGE_CONTAINER_NAME }} \
               --account-name ${{ secrets.CI_REPORTS_STORAGE_ACCOUNT_NAME }} \
               --file "./tests/playwright/${{ inputs.environment }}-${{ env.LAST_COMMIT_SHA }}.zip" \
-              --name "Dfe.FindInformationAcademiesTrusts/$GIT_BRANCH/test-security-${{ env.LAST_COMMIT_SHA }}.zip" \
+              --name "Dfe.FindInformationAcademiesTrusts/${{ github.ref_name }}/test-security-${{ env.LAST_COMMIT_SHA }}.zip" \
               --auth-mode login \
               --overwrite
 


### PR DESCRIPTION
When the deployment to Azure completes, the correct branch name isn't always carried over into the invoked workflow calls for testing, which means that the report files that are generated in the tests do not get correctly filed in their appropriate directory structure when they're uploaded to the Azure Storage Container.

Github branch references are different depending on whether you are invoking the workflow during a push/dispatch event vs a pull request event.
