### PR TITLE
Add academies free school meals table

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Extensions/StringExtensions.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Extensions/StringExtensions.cs
@@ -29,4 +29,9 @@ public static class StringExtensions
     {
         return int.TryParse(numberString, out var number) ? number : null;
     }
+
+    public static double? ParseAsNullableDouble(this string? numberString)
+    {
+        return double.TryParse(numberString, out var number) ? number : null;
+    }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/AcademyFactory.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/AcademyFactory.cs
@@ -28,7 +28,7 @@ public class AcademyFactory : IAcademyFactory
             giasEstablishment.PhaseOfEducationName,
             giasEstablishment.NumberOfPupils.ParseAsNullableInt(),
             giasEstablishment.SchoolCapacity.ParseAsNullableInt(),
-            giasEstablishment.PercentageFsm,
+            giasEstablishment.PercentageFsm.ParseAsNullableDouble(),
             new AgeRange(giasEstablishment.StatutoryLowAge!, giasEstablishment.StatutoryHighAge!),
             GetCurrentOfstedRating(misEstablishmentCurrentOfsted, misFurtherEducationEstablishment),
             GetPreviousOfstedRating(misEstablishmentPreviousOfsted, misFurtherEducationEstablishment),

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/AcademyFactory.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/AcademyFactory.cs
@@ -31,7 +31,8 @@ public class AcademyFactory : IAcademyFactory
             giasEstablishment.PercentageFsm,
             new AgeRange(giasEstablishment.StatutoryLowAge!, giasEstablishment.StatutoryHighAge!),
             GetCurrentOfstedRating(misEstablishmentCurrentOfsted, misFurtherEducationEstablishment),
-            GetPreviousOfstedRating(misEstablishmentPreviousOfsted, misFurtherEducationEstablishment)
+            GetPreviousOfstedRating(misEstablishmentPreviousOfsted, misFurtherEducationEstablishment),
+            int.Parse(giasEstablishment.LaCode!)
         );
     }
 

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.csproj
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\DfE.FindInformationAcademiesTrusts.Data\DfE.FindInformationAcademiesTrusts.Data.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/ExploreEducationStatisticsPhaseType.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/ExploreEducationStatisticsPhaseType.cs
@@ -1,0 +1,13 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Hardcoded;
+
+/// <summary>
+/// These types are taken from https://explore-education-statistics.service.gov.uk/data-tables/permalink/25bc8d0b-c700-4000-1b8a-08dbb99e3fd8
+/// We have only taken the types which are relevant to the Gias.Establishment table phases and types in the academies database
+/// </summary>
+public enum ExploreEducationStatisticsPhaseType
+{
+    StateFundedApSchool,
+    StateFundedPrimary,
+    StateFundedSecondary,
+    StateFundedSpecialSchool
+}

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverage.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverage.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.Hardcoded;
+
+public enum PhaseTypeGroup
+{
+    [Description("State-funded AP school")]
+    StateFundedApSchool,
+    [Description("State-funded primary")] StateFundedPrimary,
+
+    [Description("State-funded secondary")]
+    StateFundedSecondary,
+
+    [Description("State-funded special school")]
+    StateFundedSpecialSchool
+}
+
+public class FreeSchoolMealsAverage
+{
+    private int OldLaCode { get; }
+    private string LaName { get; }
+    private string NewLaCode { get; }
+
+    public Dictionary<PhaseTypeGroup, double> PercentOfPupilsByPhase { get; } = new();
+
+    public FreeSchoolMealsAverage(int oldLaCode, string laName, string newLaCode)
+    {
+        OldLaCode = oldLaCode;
+        LaName = laName;
+        NewLaCode = newLaCode;
+    }
+
+    public void Add(string phaseTypeGroupKey, double percentOfPupils)
+    {
+        var key = Enum.Parse<PhaseTypeGroup>(phaseTypeGroupKey);
+        PercentOfPupilsByPhase.Add(key, percentOfPupils);
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverage.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverage.cs
@@ -1,19 +1,4 @@
-using System.ComponentModel;
-
 namespace DfE.FindInformationAcademiesTrusts.Data.Hardcoded;
-
-public enum PhaseTypeGroup
-{
-    [Description("State-funded AP school")]
-    StateFundedApSchool,
-    [Description("State-funded primary")] StateFundedPrimary,
-
-    [Description("State-funded secondary")]
-    StateFundedSecondary,
-
-    [Description("State-funded special school")]
-    StateFundedSpecialSchool
-}
 
 public class FreeSchoolMealsAverage
 {
@@ -21,7 +6,7 @@ public class FreeSchoolMealsAverage
     private string LaName { get; }
     private string NewLaCode { get; }
 
-    public Dictionary<PhaseTypeGroup, double> PercentOfPupilsByPhase { get; } = new();
+    public Dictionary<ExploreEducationStatisticsPhaseType, double> PercentOfPupilsByPhase { get; } = new();
 
     public FreeSchoolMealsAverage(int oldLaCode, string laName, string newLaCode)
     {
@@ -32,7 +17,7 @@ public class FreeSchoolMealsAverage
 
     public void Add(string phaseTypeGroupKey, double percentOfPupils)
     {
-        var key = Enum.Parse<PhaseTypeGroup>(phaseTypeGroupKey);
+        var key = Enum.Parse<ExploreEducationStatisticsPhaseType>(phaseTypeGroupKey);
         PercentOfPupilsByPhase.Add(key, percentOfPupils);
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverage.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverage.cs
@@ -2,22 +2,16 @@ namespace DfE.FindInformationAcademiesTrusts.Data.Hardcoded;
 
 public class FreeSchoolMealsAverage
 {
-    private int OldLaCode { get; }
-    private string LaName { get; }
-    private string NewLaCode { get; }
+    public int OldLaCode { get; }
+    public string LaName { get; }
+    public string? NewLaCode { get; }
 
     public Dictionary<ExploreEducationStatisticsPhaseType, double> PercentOfPupilsByPhase { get; } = new();
 
-    public FreeSchoolMealsAverage(int oldLaCode, string laName, string newLaCode)
+    public FreeSchoolMealsAverage(int oldLaCode, string laName, string? newLaCode = null)
     {
         OldLaCode = oldLaCode;
         LaName = laName;
         NewLaCode = newLaCode;
-    }
-
-    public void Add(string phaseTypeGroupKey, double percentOfPupils)
-    {
-        var key = Enum.Parse<ExploreEducationStatisticsPhaseType>(phaseTypeGroupKey);
-        PercentOfPupilsByPhase.Add(key, percentOfPupils);
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverageProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverageProvider.cs
@@ -2,37 +2,19 @@ namespace DfE.FindInformationAcademiesTrusts.Data.Hardcoded;
 
 public class FreeSchoolMealsAverageProvider : IFreeSchoolMealsAverageProvider
 {
-    private readonly Dictionary<int, FreeSchoolMealsAverage> _fsmAverages2022To23 =
-        new();
-
     private const int NationalKey = -1;
 
-    public FreeSchoolMealsAverageProvider()
-    {
-        PopulateLocalAuthorities();
-        AddPercentagesByPhaseType();
-    }
-
-    private void PopulateLocalAuthorities()
-    {
-        _fsmAverages2022To23.Add(334, new FreeSchoolMealsAverage(334, "Solihull", "E08000029"));
-    }
-
-    private void AddPercentagesByPhaseType()
-    {
-        _fsmAverages2022To23[334].Add("StateFundedApSchool", 63.52941176);
-    }
 
     public double GetLaAverage(Academy academy)
     {
-        var key = ExploreEducationStatisticsPhaseType.StateFundedApSchool;
-        return _fsmAverages2022To23[334].PercentOfPupilsByPhase[key];
+        var key = GetPhaseTypeKey(academy);
+        return FreeSchoolMealsData.Averages2022To23[academy.OldLaCode].PercentOfPupilsByPhase[key];
     }
 
     public double GetNationalAverage(Academy academy)
     {
         var key = GetPhaseTypeKey(academy);
-        return _fsmAverages2022To23[NationalKey].PercentOfPupilsByPhase[key];
+        return FreeSchoolMealsData.Averages2022To23[NationalKey].PercentOfPupilsByPhase[key];
     }
 
     public static ExploreEducationStatisticsPhaseType GetPhaseTypeKey(Academy academy)

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverageProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverageProvider.cs
@@ -25,7 +25,7 @@ public class FreeSchoolMealsAverageProvider : IFreeSchoolMealsAverageProvider
 
     public double GetLaAverage(Academy academy)
     {
-        var key = PhaseTypeGroup.StateFundedApSchool;
+        var key = ExploreEducationStatisticsPhaseType.StateFundedApSchool;
         return _fsmAverages2022To23[334].PercentOfPupilsByPhase[key];
     }
 
@@ -35,7 +35,7 @@ public class FreeSchoolMealsAverageProvider : IFreeSchoolMealsAverageProvider
         return _fsmAverages2022To23[NationalKey].PercentOfPupilsByPhase[key];
     }
 
-    public static PhaseTypeGroup GetPhaseTypeKey(Academy academy)
+    public static ExploreEducationStatisticsPhaseType GetPhaseTypeKey(Academy academy)
     {
         var key = (academy.PhaseOfEducation, academy.TypeOfEstablishment) switch
         {
@@ -43,7 +43,8 @@ public class FreeSchoolMealsAverageProvider : IFreeSchoolMealsAverageProvider
                 or
                 "Voluntary Controlled School" or "Academy Sponsor Led" or "Academy Converter"
                 or "City Technology College" or
-                "Free Schools" or "University technical college" or "Studio schools") => PhaseTypeGroup
+                "Free Schools" or "University technical college"
+                or "Studio schools") => ExploreEducationStatisticsPhaseType
                     .StateFundedPrimary,
             ("Secondary" or "Middle Deemed Secondary" or "16 Plus" or "Not applicable" or "All Through" or "All-Through"
                 or
@@ -52,11 +53,13 @@ public class FreeSchoolMealsAverageProvider : IFreeSchoolMealsAverageProvider
                 or "Academy Converter" or
                 "City Technology College" or
                 "Free Schools" or "Free schools 16 to 19" or "University technical college" or "Studio schools" or
-                "Academy 16 to 19 sponsor led") => PhaseTypeGroup.StateFundedSecondary,
+                "Academy 16 to 19 sponsor led") => ExploreEducationStatisticsPhaseType.StateFundedSecondary,
             (_, "Foundation Special School" or "Community Special School" or "Academy Special Converter"
-                or "Academy Special Sponsor Led" or "Free Schools Special") => PhaseTypeGroup.StateFundedSpecialSchool,
+                or "Academy Special Sponsor Led" or "Free Schools Special") => ExploreEducationStatisticsPhaseType
+                    .StateFundedSpecialSchool,
             (_, "Pupil Referral Unit" or "Academy Alternative Provision Sponsor Led" or
-                "Free schools alternative provision" or "Academy Alternative Provision Converter") => PhaseTypeGroup
+                "Free schools alternative provision"
+                or "Academy Alternative Provision Converter") => ExploreEducationStatisticsPhaseType
                     .StateFundedApSchool,
             _ => throw new ArgumentOutOfRangeException(nameof(academy))
         };

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverageProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverageProvider.cs
@@ -19,31 +19,29 @@ public class FreeSchoolMealsAverageProvider : IFreeSchoolMealsAverageProvider
 
     public static ExploreEducationStatisticsPhaseType GetPhaseTypeKey(Academy academy)
     {
-        var key = (academy.PhaseOfEducation, academy.TypeOfEstablishment) switch
+        var key = (academy.PhaseOfEducation?.ToLower(), academy.TypeOfEstablishment?.ToLower()) switch
         {
-            ("Primary" or "Middle Deemed Primary", "Community School" or "Voluntary Aided School" or "Foundation School"
-                or
-                "Voluntary Controlled School" or "Academy Sponsor Led" or "Academy Converter"
-                or "City Technology College" or
-                "Free Schools" or "University technical college"
-                or "Studio schools") => ExploreEducationStatisticsPhaseType
-                    .StateFundedPrimary,
-            ("Secondary" or "Middle Deemed Secondary" or "16 Plus" or "Not applicable" or "All Through" or "All-Through"
-                or
-                "All-through" or "all-through", "Community School" or "Voluntary Aided School" or "Foundation School" or
-                "Voluntary Controlled School" or "Academy 16-19 Converter" or "Academy Sponsor Led"
-                or "Academy Converter" or
-                "City Technology College" or
-                "Free Schools" or "Free schools 16 to 19" or "University technical college" or "Studio schools" or
-                "Academy 16 to 19 sponsor led") => ExploreEducationStatisticsPhaseType.StateFundedSecondary,
-            (_, "Foundation Special School" or "Community Special School" or "Academy Special Converter"
-                or "Academy Special Sponsor Led" or "Free Schools Special") => ExploreEducationStatisticsPhaseType
-                    .StateFundedSpecialSchool,
-            (_, "Pupil Referral Unit" or "Academy Alternative Provision Sponsor Led" or
-                "Free schools alternative provision"
-                or "Academy Alternative Provision Converter") => ExploreEducationStatisticsPhaseType
-                    .StateFundedApSchool,
-            _ => throw new ArgumentOutOfRangeException(nameof(academy))
+            ("primary" or "middle deemed primary",
+                "community school" or "voluntary aided school" or "foundation school" or "voluntary controlled school"
+                or "academy sponsor led" or "academy converter" or "city technology college" or "free schools"
+                or "university technical college" or "studio schools")
+                => ExploreEducationStatisticsPhaseType.StateFundedPrimary,
+            ("secondary" or "middle deemed secondary" or "16 plus" or "not applicable" or "all-through",
+                "community school" or "voluntary aided school" or "foundation school" or "voluntary controlled school"
+                or "academy 16-19 converter" or "academy sponsor led" or "academy converter"
+                or "city technology college" or "free schools" or "free schools 16 to 19"
+                or "university technical college" or "studio schools" or "academy 16 to 19 sponsor led")
+                => ExploreEducationStatisticsPhaseType.StateFundedSecondary,
+            (_,
+                "foundation special school" or "community special school" or "academy special converter"
+                or "academy special sponsor led" or "free schools special")
+                => ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool,
+            (_,
+                "pupil referral unit" or "academy alternative provision sponsor led" or
+                "free schools alternative provision" or "academy alternative provision converter")
+                => ExploreEducationStatisticsPhaseType.StateFundedApSchool,
+            _ => throw new ArgumentOutOfRangeException(nameof(academy),
+                $"Can't get ExploreEducationStatisticsPhaseType for [{nameof(academy.PhaseOfEducation)}:{academy.PhaseOfEducation}, {nameof(academy.TypeOfEstablishment)}:{academy.TypeOfEstablishment}]")
         };
         return key;
     }

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverageProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverageProvider.cs
@@ -31,7 +31,35 @@ public class FreeSchoolMealsAverageProvider : IFreeSchoolMealsAverageProvider
 
     public double GetNationalAverage(Academy academy)
     {
-        var key = PhaseTypeGroup.StateFundedApSchool;
+        var key = GetPhaseTypeKey(academy);
         return _fsmAverages2022To23[NationalKey].PercentOfPupilsByPhase[key];
+    }
+
+    public static PhaseTypeGroup GetPhaseTypeKey(Academy academy)
+    {
+        var key = (academy.PhaseOfEducation, academy.TypeOfEstablishment) switch
+        {
+            ("Primary" or "Middle Deemed Primary", "Community School" or "Voluntary Aided School" or "Foundation School"
+                or
+                "Voluntary Controlled School" or "Academy Sponsor Led" or "Academy Converter"
+                or "City Technology College" or
+                "Free Schools" or "University technical college" or "Studio schools") => PhaseTypeGroup
+                    .StateFundedPrimary,
+            ("Secondary" or "Middle Deemed Secondary" or "16 Plus" or "Not applicable" or "All Through" or "All-Through"
+                or
+                "All-through" or "all-through", "Community School" or "Voluntary Aided School" or "Foundation School" or
+                "Voluntary Controlled School" or "Academy 16-19 Converter" or "Academy Sponsor Led"
+                or "Academy Converter" or
+                "City Technology College" or
+                "Free Schools" or "Free schools 16 to 19" or "University technical college" or "Studio schools" or
+                "Academy 16 to 19 sponsor led") => PhaseTypeGroup.StateFundedSecondary,
+            (_, "Foundation Special School" or "Community Special School" or "Academy Special Converter"
+                or "Academy Special Sponsor Led" or "Free Schools Special") => PhaseTypeGroup.StateFundedSpecialSchool,
+            (_, "Pupil Referral Unit" or "Academy Alternative Provision Sponsor Led" or
+                "Free schools alternative provision" or "Academy Alternative Provision Converter") => PhaseTypeGroup
+                    .StateFundedApSchool,
+            _ => throw new ArgumentOutOfRangeException(nameof(academy))
+        };
+        return key;
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverageProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverageProvider.cs
@@ -1,0 +1,37 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Hardcoded;
+
+public class FreeSchoolMealsAverageProvider : IFreeSchoolMealsAverageProvider
+{
+    private readonly Dictionary<int, FreeSchoolMealsAverage> _fsmAverages2022To23 =
+        new();
+
+    private const int NationalKey = -1;
+
+    public FreeSchoolMealsAverageProvider()
+    {
+        PopulateLocalAuthorities();
+        AddPercentagesByPhaseType();
+    }
+
+    private void PopulateLocalAuthorities()
+    {
+        _fsmAverages2022To23.Add(334, new FreeSchoolMealsAverage(334, "Solihull", "E08000029"));
+    }
+
+    private void AddPercentagesByPhaseType()
+    {
+        _fsmAverages2022To23[334].Add("StateFundedApSchool", 63.52941176);
+    }
+
+    public double GetLaAverage(Academy academy)
+    {
+        var key = PhaseTypeGroup.StateFundedApSchool;
+        return _fsmAverages2022To23[334].PercentOfPupilsByPhase[key];
+    }
+
+    public double GetNationalAverage(Academy academy)
+    {
+        var key = PhaseTypeGroup.StateFundedApSchool;
+        return _fsmAverages2022To23[NationalKey].PercentOfPupilsByPhase[key];
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsData.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsData.cs
@@ -1,0 +1,1366 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.Hardcoded;
+
+[ExcludeFromCodeCoverage]
+public static class FreeSchoolMealsData
+{
+    public static Dictionary<int, FreeSchoolMealsAverage> Averages2022To23 { get; } = new();
+
+    /// <summary>
+    /// Data store for School statistics data taken from https://explore-education-statistics.service.gov.uk/data-tables/permalink/25bc8d0b-c700-4000-1b8a-08dbb99e3fd8
+    /// </summary>
+    static FreeSchoolMealsData()
+    {
+        PopulateLocalAuthorities();
+        AddPercentagesByPhaseType();
+    }
+
+    private static void PopulateLocalAuthorities()
+    {
+        Averages2022To23.Add(334, new FreeSchoolMealsAverage(334, "Solihull", "E08000029"));
+        Averages2022To23.Add(202, new FreeSchoolMealsAverage(202, "Camden", "E09000007"));
+        Averages2022To23.Add(358, new FreeSchoolMealsAverage(358, "Trafford", "E08000009"));
+        Averages2022To23.Add(856, new FreeSchoolMealsAverage(856, "Leicester", "E06000016"));
+        Averages2022To23.Add(354, new FreeSchoolMealsAverage(354, "Rochdale", "E08000005"));
+        Averages2022To23.Add(860, new FreeSchoolMealsAverage(860, "Staffordshire", "E10000028"));
+        Averages2022To23.Add(839,
+            new FreeSchoolMealsAverage(839, "Bournemouth, Christchurch and Poole", "E06000058"));
+        Averages2022To23.Add(810, new FreeSchoolMealsAverage(810, "Kingston upon Hull, City of", "E06000010"));
+        Averages2022To23.Add(936, new FreeSchoolMealsAverage(936, "Surrey", "E10000030"));
+        Averages2022To23.Add(213, new FreeSchoolMealsAverage(213, "Westminster", "E09000033"));
+        Averages2022To23.Add(303, new FreeSchoolMealsAverage(303, "Bexley", "E09000004"));
+        Averages2022To23.Add(941, new FreeSchoolMealsAverage(941, "West Northamptonshire", "E06000062"));
+        Averages2022To23.Add(908, new FreeSchoolMealsAverage(908, "Cornwall", "E06000052"));
+        Averages2022To23.Add(359, new FreeSchoolMealsAverage(359, "Wigan", "E08000010"));
+        Averages2022To23.Add(876, new FreeSchoolMealsAverage(876, "Halton", "E06000006"));
+        Averages2022To23.Add(850, new FreeSchoolMealsAverage(850, "Hampshire", "E10000014"));
+        Averages2022To23.Add(935, new FreeSchoolMealsAverage(935, "Suffolk", "E10000029"));
+        Averages2022To23.Add(212, new FreeSchoolMealsAverage(212, "Wandsworth", "E09000032"));
+        Averages2022To23.Add(909, new FreeSchoolMealsAverage(909, "Cumbria", "E10000006"));
+        Averages2022To23.Add(332, new FreeSchoolMealsAverage(332, "Dudley", "E08000027"));
+        Averages2022To23.Add(313, new FreeSchoolMealsAverage(313, "Hounslow", "E09000018"));
+        Averages2022To23.Add(805, new FreeSchoolMealsAverage(805, "Hartlepool", "E06000001"));
+        Averages2022To23.Add(319, new FreeSchoolMealsAverage(319, "Sutton", "E09000029"));
+        Averages2022To23.Add(929, new FreeSchoolMealsAverage(929, "Northumberland", "E06000057"));
+        Averages2022To23.Add(822, new FreeSchoolMealsAverage(822, "Bedford", "E06000055"));
+        Averages2022To23.Add(320, new FreeSchoolMealsAverage(320, "Waltham Forest", "E09000031"));
+        Averages2022To23.Add(211, new FreeSchoolMealsAverage(211, "Tower Hamlets", "E09000030"));
+        Averages2022To23.Add(380, new FreeSchoolMealsAverage(380, "Bradford", "E08000032"));
+        Averages2022To23.Add(204, new FreeSchoolMealsAverage(204, "Hackney", "E09000012"));
+        Averages2022To23.Add(882, new FreeSchoolMealsAverage(882, "Southend-on-Sea", "E06000033"));
+        Averages2022To23.Add(883, new FreeSchoolMealsAverage(883, "Thurrock", "E06000034"));
+        Averages2022To23.Add(335, new FreeSchoolMealsAverage(335, "Walsall", "E08000030"));
+        Averages2022To23.Add(868, new FreeSchoolMealsAverage(868, "Windsor and Maidenhead", "E06000040"));
+        Averages2022To23.Add(311, new FreeSchoolMealsAverage(311, "Havering", "E09000016"));
+        Averages2022To23.Add(393, new FreeSchoolMealsAverage(393, "South Tyneside", "E08000023"));
+        Averages2022To23.Add(353, new FreeSchoolMealsAverage(353, "Oldham", "E08000004"));
+        Averages2022To23.Add(926, new FreeSchoolMealsAverage(926, "Norfolk", "E10000020"));
+        Averages2022To23.Add(357, new FreeSchoolMealsAverage(357, "Tameside", "E08000008"));
+        Averages2022To23.Add(867, new FreeSchoolMealsAverage(867, "Bracknell Forest", "E06000036"));
+        Averages2022To23.Add(330, new FreeSchoolMealsAverage(330, "Birmingham", "E08000025"));
+        Averages2022To23.Add(342, new FreeSchoolMealsAverage(342, "St. Helens", "E08000013"));
+        Averages2022To23.Add(893, new FreeSchoolMealsAverage(893, "Shropshire", "E06000051"));
+        Averages2022To23.Add(304, new FreeSchoolMealsAverage(304, "Brent", "E09000005"));
+        Averages2022To23.Add(861, new FreeSchoolMealsAverage(861, "Stoke-on-Trent", "E06000021"));
+        Averages2022To23.Add(351, new FreeSchoolMealsAverage(351, "Bury", "E08000002"));
+        Averages2022To23.Add(845, new FreeSchoolMealsAverage(845, "East Sussex", "E10000011"));
+        Averages2022To23.Add(331, new FreeSchoolMealsAverage(331, "Coventry", "E08000026"));
+        Averages2022To23.Add(821, new FreeSchoolMealsAverage(821, "Luton", "E06000032"));
+        Averages2022To23.Add(203, new FreeSchoolMealsAverage(203, "Greenwich", "E09000011"));
+        Averages2022To23.Add(382, new FreeSchoolMealsAverage(382, "Kirklees", "E08000034"));
+        Averages2022To23.Add(879, new FreeSchoolMealsAverage(879, "Plymouth", "E06000026"));
+        Averages2022To23.Add(813, new FreeSchoolMealsAverage(813, "North Lincolnshire", "E06000013"));
+        Averages2022To23.Add(831, new FreeSchoolMealsAverage(831, "Derby", "E06000015"));
+        Averages2022To23.Add(815, new FreeSchoolMealsAverage(815, "North Yorkshire", "E10000023"));
+        Averages2022To23.Add(869, new FreeSchoolMealsAverage(869, "West Berkshire", "E06000037"));
+        Averages2022To23.Add(838, new FreeSchoolMealsAverage(838, "Dorset", "E06000059"));
+        Averages2022To23.Add(302, new FreeSchoolMealsAverage(302, "Barnet", "E09000003"));
+        Averages2022To23.Add(874, new FreeSchoolMealsAverage(874, "Peterborough", "E06000031"));
+        Averages2022To23.Add(207, new FreeSchoolMealsAverage(207, "Kensington and Chelsea", "E09000020"));
+        Averages2022To23.Add(371, new FreeSchoolMealsAverage(371, "Doncaster", "E08000017"));
+        Averages2022To23.Add(890, new FreeSchoolMealsAverage(890, "Blackpool", "E06000009"));
+        Averages2022To23.Add(312, new FreeSchoolMealsAverage(312, "Hillingdon", "E09000017"));
+        Averages2022To23.Add(840, new FreeSchoolMealsAverage(840, "County Durham", "E06000047"));
+        Averages2022To23.Add(866, new FreeSchoolMealsAverage(866, "Swindon", "E06000030"));
+        Averages2022To23.Add(878, new FreeSchoolMealsAverage(878, "Devon", "E10000008"));
+        Averages2022To23.Add(336, new FreeSchoolMealsAverage(336, "Wolverhampton", "E08000031"));
+        Averages2022To23.Add(841, new FreeSchoolMealsAverage(841, "Darlington", "E06000005"));
+        Averages2022To23.Add(307, new FreeSchoolMealsAverage(307, "Ealing", "E09000009"));
+        Averages2022To23.Add(308, new FreeSchoolMealsAverage(308, "Enfield", "E09000010"));
+        Averages2022To23.Add(391, new FreeSchoolMealsAverage(391, "Newcastle upon Tyne", "E08000021"));
+        Averages2022To23.Add(392, new FreeSchoolMealsAverage(392, "North Tyneside", "E08000022"));
+        Averages2022To23.Add(811, new FreeSchoolMealsAverage(811, "East Riding of Yorkshire", "E06000011"));
+        Averages2022To23.Add(812, new FreeSchoolMealsAverage(812, "North East Lincolnshire", "E06000012"));
+        Averages2022To23.Add(807, new FreeSchoolMealsAverage(807, "Redcar and Cleveland", "E06000003"));
+        Averages2022To23.Add(808, new FreeSchoolMealsAverage(808, "Stockton-on-Tees", "E06000004"));
+        Averages2022To23.Add(823, new FreeSchoolMealsAverage(823, "Central Bedfordshire", "E06000056"));
+        Averages2022To23.Add(873, new FreeSchoolMealsAverage(873, "Cambridgeshire", "E10000003"));
+        Averages2022To23.Add(208, new FreeSchoolMealsAverage(208, "Lambeth", "E09000022"));
+        Averages2022To23.Add(305, new FreeSchoolMealsAverage(305, "Bromley", "E09000006"));
+        Averages2022To23.Add(938, new FreeSchoolMealsAverage(938, "West Sussex", "E10000032"));
+        Averages2022To23.Add(373, new FreeSchoolMealsAverage(373, "Sheffield", "E08000019"));
+        Averages2022To23.Add(352, new FreeSchoolMealsAverage(352, "Manchester", "E08000003"));
+        Averages2022To23.Add(895, new FreeSchoolMealsAverage(895, "Cheshire East", "E06000049"));
+        Averages2022To23.Add(896, new FreeSchoolMealsAverage(896, "Cheshire West and Chester", "E06000050"));
+        Averages2022To23.Add(870, new FreeSchoolMealsAverage(870, "Reading", "E06000038"));
+        Averages2022To23.Add(806, new FreeSchoolMealsAverage(806, "Middlesbrough", "E06000002"));
+        Averages2022To23.Add(892, new FreeSchoolMealsAverage(892, "Nottingham", "E06000018"));
+        Averages2022To23.Add(825, new FreeSchoolMealsAverage(825, "Buckinghamshire", "E06000060"));
+        Averages2022To23.Add(826, new FreeSchoolMealsAverage(826, "Milton Keynes", "E06000042"));
+        Averages2022To23.Add(889, new FreeSchoolMealsAverage(889, "Blackburn with Darwen", "E06000008"));
+        Averages2022To23.Add(210, new FreeSchoolMealsAverage(210, "Southwark", "E09000028"));
+        Averages2022To23.Add(310, new FreeSchoolMealsAverage(310, "Harrow", "E09000015"));
+        Averages2022To23.Add(816, new FreeSchoolMealsAverage(816, "York", "E06000014"));
+        Averages2022To23.Add(871, new FreeSchoolMealsAverage(871, "Slough", "E06000039"));
+        Averages2022To23.Add(317, new FreeSchoolMealsAverage(317, "Redbridge", "E09000026"));
+        Averages2022To23.Add(314, new FreeSchoolMealsAverage(314, "Kingston upon Thames", "E09000021"));
+        Averages2022To23.Add(872, new FreeSchoolMealsAverage(872, "Wokingham", "E06000041"));
+        Averages2022To23.Add(885, new FreeSchoolMealsAverage(885, "Worcestershire", "E10000034"));
+        Averages2022To23.Add(383, new FreeSchoolMealsAverage(383, "Leeds", "E08000035"));
+        Averages2022To23.Add(384, new FreeSchoolMealsAverage(384, "Wakefield", "E08000036"));
+        Averages2022To23.Add(372, new FreeSchoolMealsAverage(372, "Rotherham", "E08000018"));
+        Averages2022To23.Add(206, new FreeSchoolMealsAverage(206, "Islington", "E09000019"));
+        Averages2022To23.Add(309, new FreeSchoolMealsAverage(309, "Haringey", "E09000014"));
+        Averages2022To23.Add(855, new FreeSchoolMealsAverage(855, "Leicestershire", "E10000018"));
+        Averages2022To23.Add(340, new FreeSchoolMealsAverage(340, "Knowsley", "E08000011"));
+        Averages2022To23.Add(894, new FreeSchoolMealsAverage(894, "Telford and Wrekin", "E06000020"));
+        Averages2022To23.Add(803, new FreeSchoolMealsAverage(803, "South Gloucestershire", "E06000025"));
+        Averages2022To23.Add(880, new FreeSchoolMealsAverage(880, "Torbay", "E06000027"));
+        Averages2022To23.Add(884, new FreeSchoolMealsAverage(884, "Herefordshire, County of", "E06000019"));
+        Averages2022To23.Add(355, new FreeSchoolMealsAverage(355, "Salford", "E08000006"));
+        Averages2022To23.Add(356, new FreeSchoolMealsAverage(356, "Stockport", "E08000007"));
+        Averages2022To23.Add(888, new FreeSchoolMealsAverage(888, "Lancashire", "E10000017"));
+        Averages2022To23.Add(881, new FreeSchoolMealsAverage(881, "Essex", "E10000012"));
+        Averages2022To23.Add(316, new FreeSchoolMealsAverage(316, "Newham", "E09000025"));
+        Averages2022To23.Add(887, new FreeSchoolMealsAverage(887, "Medway", "E06000035"));
+        Averages2022To23.Add(886, new FreeSchoolMealsAverage(886, "Kent", "E10000016"));
+        Averages2022To23.Add(925, new FreeSchoolMealsAverage(925, "Lincolnshire", "E10000019"));
+        Averages2022To23.Add(381, new FreeSchoolMealsAverage(381, "Calderdale", "E08000033"));
+        Averages2022To23.Add(301, new FreeSchoolMealsAverage(301, "Barking and Dagenham", "E09000002"));
+        Averages2022To23.Add(801, new FreeSchoolMealsAverage(801, "Bristol, City of", "E06000023"));
+        Averages2022To23.Add(802, new FreeSchoolMealsAverage(802, "North Somerset", "E06000024"));
+        Averages2022To23.Add(394, new FreeSchoolMealsAverage(394, "Sunderland", "E08000024"));
+        Averages2022To23.Add(350, new FreeSchoolMealsAverage(350, "Bolton", "E08000001"));
+        Averages2022To23.Add(877, new FreeSchoolMealsAverage(877, "Warrington", "E06000007"));
+        Averages2022To23.Add(852, new FreeSchoolMealsAverage(852, "Southampton", "E06000045"));
+        Averages2022To23.Add(916, new FreeSchoolMealsAverage(916, "Gloucestershire", "E10000013"));
+        Averages2022To23.Add(933, new FreeSchoolMealsAverage(933, "Somerset", "E10000027"));
+        Averages2022To23.Add(315, new FreeSchoolMealsAverage(315, "Merton", "E09000024"));
+        Averages2022To23.Add(209, new FreeSchoolMealsAverage(209, "Lewisham", "E09000023"));
+        Averages2022To23.Add(333, new FreeSchoolMealsAverage(333, "Sandwell", "E08000028"));
+        Averages2022To23.Add(931, new FreeSchoolMealsAverage(931, "Oxfordshire", "E10000025"));
+        Averages2022To23.Add(390, new FreeSchoolMealsAverage(390, "Gateshead", "E08000037"));
+        Averages2022To23.Add(341, new FreeSchoolMealsAverage(341, "Liverpool", "E08000012"));
+        Averages2022To23.Add(919, new FreeSchoolMealsAverage(919, "Hertfordshire", "E10000015"));
+        Averages2022To23.Add(343, new FreeSchoolMealsAverage(343, "Sefton", "E08000014"));
+        Averages2022To23.Add(-1, new FreeSchoolMealsAverage(-1, "National"));
+        Averages2022To23.Add(846, new FreeSchoolMealsAverage(846, "Brighton and Hove", "E06000043"));
+        Averages2022To23.Add(205, new FreeSchoolMealsAverage(205, "Hammersmith and Fulham", "E09000013"));
+        Averages2022To23.Add(306, new FreeSchoolMealsAverage(306, "Croydon", "E09000008"));
+        Averages2022To23.Add(921, new FreeSchoolMealsAverage(921, "Isle of Wight", "E06000046"));
+        Averages2022To23.Add(370, new FreeSchoolMealsAverage(370, "Barnsley", "E08000016"));
+        Averages2022To23.Add(830, new FreeSchoolMealsAverage(830, "Derbyshire", "E10000007"));
+        Averages2022To23.Add(201, new FreeSchoolMealsAverage(201, "City of London", "E09000001"));
+        Averages2022To23.Add(851, new FreeSchoolMealsAverage(851, "Portsmouth", "E06000044"));
+        Averages2022To23.Add(891, new FreeSchoolMealsAverage(891, "Nottinghamshire", "E10000024"));
+        Averages2022To23.Add(857, new FreeSchoolMealsAverage(857, "Rutland", "E06000017"));
+        Averages2022To23.Add(800, new FreeSchoolMealsAverage(800, "Bath and North East Somerset", "E06000022"));
+        Averages2022To23.Add(937, new FreeSchoolMealsAverage(937, "Warwickshire", "E10000031"));
+        Averages2022To23.Add(344, new FreeSchoolMealsAverage(344, "Wirral", "E08000015"));
+        Averages2022To23.Add(865, new FreeSchoolMealsAverage(865, "Wiltshire", "E06000054"));
+        Averages2022To23.Add(940, new FreeSchoolMealsAverage(940, "North Northamptonshire", "E06000061"));
+        Averages2022To23.Add(318, new FreeSchoolMealsAverage(318, "Richmond upon Thames", "E09000027"));
+        Averages2022To23.Add(420, new FreeSchoolMealsAverage(420, "Isles of Scilly", "E06000053"));
+    }
+
+    /// <summary>
+    /// Hard-coding percentage of pupils eligible for free school meals per local authority by phase
+    /// Does not include phase group types which are not present in Academies db Gias.Establishment table
+    /// </summary>
+    private static void AddPercentagesByPhaseType()
+    {
+        Averages2022To23[334].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 63.52941176);
+        Averages2022To23[202].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 59.45945946);
+        Averages2022To23[358].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 56.41025641);
+        Averages2022To23[856].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 70.45454545);
+        Averages2022To23[354].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 59.3495935);
+        Averages2022To23[860].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 50.51020408);
+        Averages2022To23[839].PercentOfPupilsByPhase.Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 54);
+        Averages2022To23[810].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 57.06214689);
+        Averages2022To23[936].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 61.16504854);
+        Averages2022To23[213].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 72.72727273);
+        Averages2022To23[303].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 66.66666667);
+        Averages2022To23[941].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 54.07407407);
+        Averages2022To23[908].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 63.63636364);
+        Averages2022To23[359].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 61.2244898);
+        Averages2022To23[876].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 70.27027027);
+        Averages2022To23[850].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 52.54237288);
+        Averages2022To23[935].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 64.9122807);
+        Averages2022To23[212].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 60.6557377);
+        Averages2022To23[909].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 55.35714286);
+        Averages2022To23[332].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 94.44444444);
+        Averages2022To23[313].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 63.36633663);
+        Averages2022To23[805].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 66.66666667);
+        Averages2022To23[319].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 59.63302752);
+        Averages2022To23[929].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 76.19047619);
+        Averages2022To23[822].PercentOfPupilsByPhase.Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 52.5);
+        Averages2022To23[320].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 40.90909091);
+        Averages2022To23[211].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 57.46268657);
+        Averages2022To23[380].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 73.52941176);
+        Averages2022To23[204].PercentOfPupilsByPhase.Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 50);
+        Averages2022To23[882].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 63.79310345);
+        Averages2022To23[883].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 42.85714286);
+        Averages2022To23[335].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 66.91176471);
+        Averages2022To23[868].PercentOfPupilsByPhase.Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 52);
+        Averages2022To23[311].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 54.54545455);
+        Averages2022To23[393].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 71.42857143);
+        Averages2022To23[353].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 57.14285714);
+        Averages2022To23[926].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 64.1025641);
+        Averages2022To23[357].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 60.83916084);
+        Averages2022To23[867].PercentOfPupilsByPhase.Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 50);
+        Averages2022To23[330].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 71.03064067);
+        Averages2022To23[342].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 55.31914894);
+        Averages2022To23[893].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 59.64912281);
+        Averages2022To23[304].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 44.44444444);
+        Averages2022To23[861].PercentOfPupilsByPhase.Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 50);
+        Averages2022To23[351].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 62.99212598);
+        Averages2022To23[845].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 61.70212766);
+        Averages2022To23[331].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 59.75609756);
+        Averages2022To23[821].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 48.33333333);
+        Averages2022To23[203].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 23.4939759);
+        Averages2022To23[382].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 70.83333333);
+        Averages2022To23[879].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 53.39366516);
+        Averages2022To23[813].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 28.57142857);
+        Averages2022To23[831].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 63.93442623);
+        Averages2022To23[815].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 46.66666667);
+        Averages2022To23[869].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 41.81818182);
+        Averages2022To23[838].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 66.11570248);
+        Averages2022To23[302].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 59.09090909);
+        Averages2022To23[874].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 66.32653061);
+        Averages2022To23[207].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 53.19148936);
+        Averages2022To23[371].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 68.18181818);
+        Averages2022To23[890].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 67.10526316);
+        Averages2022To23[312].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 27.27272727);
+        Averages2022To23[840].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 66.10169492);
+        Averages2022To23[866].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 53.96825397);
+        Averages2022To23[878].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 48.17518248);
+        Averages2022To23[336].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 54.6875);
+        Averages2022To23[841].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 66.66666667);
+        Averages2022To23[307].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 43.33333333);
+        Averages2022To23[308].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 44.18604651);
+        Averages2022To23[391].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 52.57731959);
+        Averages2022To23[392].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 61.67664671);
+        Averages2022To23[811].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 63.93442623);
+        Averages2022To23[812].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 72.22222222);
+        Averages2022To23[807].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 80.88235294);
+        Averages2022To23[808].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 71.18644068);
+        Averages2022To23[823].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 66.12903226);
+        Averages2022To23[873].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 33.33333333);
+        Averages2022To23[208].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 45.76271186);
+        Averages2022To23[305].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 63.63636364);
+        Averages2022To23[938].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 51.4084507);
+        Averages2022To23[373].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 78.89447236);
+        Averages2022To23[352].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 79.05982906);
+        Averages2022To23[895].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 61.53846154);
+        Averages2022To23[896].PercentOfPupilsByPhase.Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 55);
+        Averages2022To23[870].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 59.45945946);
+        Averages2022To23[806].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 46.66666667);
+        Averages2022To23[892].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 55.06756757);
+        Averages2022To23[825].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 44.04761905);
+        Averages2022To23[826].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 46.875);
+        Averages2022To23[889].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 67.08860759);
+        Averages2022To23[210].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 52.08333333);
+        Averages2022To23[310].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 48.64864865);
+        Averages2022To23[816].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 52.23880597);
+        Averages2022To23[871].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 47.44525547);
+        Averages2022To23[317].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 39.75903614);
+        Averages2022To23[314].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 47.36842105);
+        Averages2022To23[872].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 57.14285714);
+        Averages2022To23[885].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 56.73758865);
+        Averages2022To23[383].PercentOfPupilsByPhase.Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 100);
+        Averages2022To23[384].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 55.32994924);
+        Averages2022To23[372].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 64.83516484);
+        Averages2022To23[206].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 66.29213483);
+        Averages2022To23[309].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 58.49056604);
+        Averages2022To23[855].PercentOfPupilsByPhase.Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 100);
+        Averages2022To23[340].PercentOfPupilsByPhase.Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 88);
+        Averages2022To23[894].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 69.6969697);
+        Averages2022To23[803].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 49.29577465);
+        Averages2022To23[880].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 60.46511628);
+        Averages2022To23[884].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 50.98039216);
+        Averages2022To23[355].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 71.83098592);
+        Averages2022To23[356].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 65.17857143);
+        Averages2022To23[888].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 59.2920354);
+        Averages2022To23[881].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 46.46017699);
+        Averages2022To23[316].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 37.26708075);
+        Averages2022To23[887].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 49.23076923);
+        Averages2022To23[886].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 14.28571429);
+        Averages2022To23[925].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 59.77011494);
+        Averages2022To23[381].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 73.68421053);
+        Averages2022To23[301].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 28.98550725);
+        Averages2022To23[801].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 56.73758865);
+        Averages2022To23[802].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 63.63636364);
+        Averages2022To23[394].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 75.51020408);
+        Averages2022To23[350].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 61.16504854);
+        Averages2022To23[877].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 55.55555556);
+        Averages2022To23[852].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 79.06976744);
+        Averages2022To23[916].PercentOfPupilsByPhase.Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 52.8);
+        Averages2022To23[933].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 62.87878788);
+        Averages2022To23[315].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 24.24242424);
+        Averages2022To23[209].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 46.66666667);
+        Averages2022To23[333].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 59.03614458);
+        Averages2022To23[931].PercentOfPupilsByPhase.Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 62.5);
+        Averages2022To23[390].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 55.55555556);
+        Averages2022To23[341].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 27.86377709);
+        Averages2022To23[919].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 37.77777778);
+        Averages2022To23[343].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 59.42028986);
+        Averages2022To23[-1].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 57.78940186);
+        Averages2022To23[846].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 73.86363636);
+        Averages2022To23[205].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 62.90322581);
+        Averages2022To23[306].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 46.06741573);
+        Averages2022To23[921].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 53.84615385);
+        Averages2022To23[370].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 67.85714286);
+        Averages2022To23[830].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedApSchool, 67.55555556);
+        Averages2022To23[334].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 22.38137452);
+        Averages2022To23[372].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 26.26287001);
+        Averages2022To23[885].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 19.33358434);
+        Averages2022To23[201].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 18.08118081);
+        Averages2022To23[358].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 15.36216734);
+        Averages2022To23[354].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 29.49967227);
+        Averages2022To23[860].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 18.87423826);
+        Averages2022To23[839].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 20.16339625);
+        Averages2022To23[810].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 33.16687638);
+        Averages2022To23[850].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 18.34419412);
+        Averages2022To23[851].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 33.27061775);
+        Averages2022To23[213].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 37.18562874);
+        Averages2022To23[303].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 19.291146);
+        Averages2022To23[941].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 15.73721475);
+        Averages2022To23[908].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 21.80772737);
+        Averages2022To23[341].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 33.89295451);
+        Averages2022To23[-1].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 23.99569177);
+        Averages2022To23[876].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 37.91144201);
+        Averages2022To23[935].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 21.44629254);
+        Averages2022To23[212].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 27.0734943);
+        Averages2022To23[909].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 18.08463599);
+        Averages2022To23[381].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 25.71686013);
+        Averages2022To23[332].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 24.58804636);
+        Averages2022To23[350].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 24.72310127);
+        Averages2022To23[805].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 35.61735261);
+        Averages2022To23[891].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 21.60948621);
+        Averages2022To23[319].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 16.83225267);
+        Averages2022To23[929].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 22.28610231);
+        Averages2022To23[306].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 28.72287509);
+        Averages2022To23[320].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 22.4846328);
+        Averages2022To23[883].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 21.97919445);
+        Averages2022To23[210].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 35.37725097);
+        Averages2022To23[380].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 27.0442018);
+        Averages2022To23[857].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 10.41592606);
+        Averages2022To23[882].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 25.62658228);
+        Averages2022To23[335].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 33.78429162);
+        Averages2022To23[373].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 33.01643639);
+        Averages2022To23[868].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 13.51403492);
+        Averages2022To23[311].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 18.4689572);
+        Averages2022To23[393].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 32.93887147);
+        Averages2022To23[384].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 23.22729368);
+        Averages2022To23[353].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 30.7489894);
+        Averages2022To23[359].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 27.70225828);
+        Averages2022To23[356].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 18.61504659);
+        Averages2022To23[357].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 30.97555403);
+        Averages2022To23[867].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 11.92322606);
+        Averages2022To23[938].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 15.43792256);
+        Averages2022To23[800].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 17.74811975);
+        Averages2022To23[391].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 39.9677574);
+        Averages2022To23[342].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 26.39139397);
+        Averages2022To23[888].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 23.05005821);
+        Averages2022To23[893].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 18.03945584);
+        Averages2022To23[317].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 14.29708315);
+        Averages2022To23[826].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 21.92822827);
+        Averages2022To23[889].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 25.26219192);
+        Averages2022To23[845].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 24.2348285);
+        Averages2022To23[330].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 39.61376467);
+        Averages2022To23[937].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 21.51311209);
+        Averages2022To23[821].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 25.38544591);
+        Averages2022To23[203].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 28.87645761);
+        Averages2022To23[382].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 24.73140987);
+        Averages2022To23[879].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 26.93513383);
+        Averages2022To23[813].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 28.35670622);
+        Averages2022To23[873].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 21.24094548);
+        Averages2022To23[869].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 14.63900783);
+        Averages2022To23[838].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 18.69982108);
+        Averages2022To23[202].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 41.82142187);
+        Averages2022To23[874].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 29.38224119);
+        Averages2022To23[207].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 32.63960135);
+        Averages2022To23[371].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 27.97104008);
+        Averages2022To23[211].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 36.6463318);
+        Averages2022To23[803].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 14.04733526);
+        Averages2022To23[840].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 32.23746973);
+        Averages2022To23[866].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 18.48405499);
+        Averages2022To23[878].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 18.78656852);
+        Averages2022To23[336].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 39.02411539);
+        Averages2022To23[841].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 28.56178258);
+        Averages2022To23[856].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 24.57321265);
+        Averages2022To23[307].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 24.57161651);
+        Averages2022To23[308].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 29.21348315);
+        Averages2022To23[392].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 27.34379809);
+        Averages2022To23[343].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 24.63518175);
+        Averages2022To23[811].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 19.18662377);
+        Averages2022To23[807].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 29.69876622);
+        Averages2022To23[808].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 26.81706872);
+        Averages2022To23[823].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 12.05454241);
+        Averages2022To23[304].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 20.04042407);
+        Averages2022To23[936].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 14.40815531);
+        Averages2022To23[890].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 38.67730314);
+        Averages2022To23[344].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 29.18157424);
+        Averages2022To23[352].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 42.18689982);
+        Averages2022To23[895].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 15.80283746);
+        Averages2022To23[896].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 19.00047955);
+        Averages2022To23[870].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 22.76428471);
+        Averages2022To23[925].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 27.01659115);
+        Averages2022To23[351].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 21.57486693);
+        Averages2022To23[892].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 35.87401575);
+        Averages2022To23[894].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 27.15737498);
+        Averages2022To23[825].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 15.26887348);
+        Averages2022To23[209].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 24.5918144);
+        Averages2022To23[310].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 14.84634646);
+        Averages2022To23[816].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 15.87657176);
+        Averages2022To23[871].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 19.6840896);
+        Averages2022To23[301].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 25.7426953);
+        Averages2022To23[313].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 21.05395337);
+        Averages2022To23[872].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 9.254467036);
+        Averages2022To23[383].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 25.30904973);
+        Averages2022To23[802].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 16.04720803);
+        Averages2022To23[208].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 37.10252752);
+        Averages2022To23[822].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 20.43220841);
+        Averages2022To23[206].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 41.59765482);
+        Averages2022To23[309].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 24.2593922);
+        Averages2022To23[815].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 17.63115197);
+        Averages2022To23[831].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 33.16458772);
+        Averages2022To23[340].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 36.24916276);
+        Averages2022To23[204].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 37.94902451);
+        Averages2022To23[880].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 29.69365217);
+        Averages2022To23[884].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 18.35401219);
+        Averages2022To23[926].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 22.82055967);
+        Averages2022To23[355].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 33.00036996);
+        Averages2022To23[855].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 15.32754912);
+        Averages2022To23[316].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 28.73097335);
+        Averages2022To23[806].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 38.09702896);
+        Averages2022To23[865].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 16.18125504);
+        Averages2022To23[940].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 19.65128474);
+        Averages2022To23[886].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 23.87715902);
+        Averages2022To23[318].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 12.13391627);
+        Averages2022To23[861].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 38.42585122);
+        Averages2022To23[887].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 25.19944567);
+        Averages2022To23[801].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 27.28615213);
+        Averages2022To23[394].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 27.82770241);
+        Averages2022To23[852].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 33.27862967);
+        Averages2022To23[916].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 18.65336658);
+        Averages2022To23[933].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 20.34462211);
+        Averages2022To23[314].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 14.53741351);
+        Averages2022To23[315].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 23.49084465);
+        Averages2022To23[881].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 19.74160585);
+        Averages2022To23[333].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 30.82145282);
+        Averages2022To23[302].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 20.13936375);
+        Averages2022To23[931].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 15.6483453);
+        Averages2022To23[390].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 28.18622819);
+        Averages2022To23[919].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 15.23452916);
+        Averages2022To23[312].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 21.14847845);
+        Averages2022To23[846].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 24.08158666);
+        Averages2022To23[205].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 30.80802661);
+        Averages2022To23[305].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 15.39153268);
+        Averages2022To23[331].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 25.15925463);
+        Averages2022To23[921].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 24.67398765);
+        Averages2022To23[370].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 29.16470033);
+        Averages2022To23[812].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 31.19932905);
+        Averages2022To23[877].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 23.30226365);
+        Averages2022To23[830].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedPrimary, 28.29019262);
+        Averages2022To23[885].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 18.71397128);
+        Averages2022To23[358].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 14.14826818);
+        Averages2022To23[354].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 31.71536949);
+        Averages2022To23[334].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 24.60313101);
+        Averages2022To23[810].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 31.04638489);
+        Averages2022To23[850].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 17.36301554);
+        Averages2022To23[851].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 32.3662738);
+        Averages2022To23[213].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 37.44991751);
+        Averages2022To23[830].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 23.62700602);
+        Averages2022To23[886].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 19.20476682);
+        Averages2022To23[303].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 17.32784798);
+        Averages2022To23[941].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 15.72008443);
+        Averages2022To23[880].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 20.92998166);
+        Averages2022To23[908].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 21.50447607);
+        Averages2022To23[341].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 31.58163572);
+        Averages2022To23[-1].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 22.69174097);
+        Averages2022To23[316].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 35.88520055);
+        Averages2022To23[876].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 38.06380638);
+        Averages2022To23[212].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 26.88430871);
+        Averages2022To23[896].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 18.78219706);
+        Averages2022To23[909].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 17.26413583);
+        Averages2022To23[381].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 23.8491761);
+        Averages2022To23[350].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 26.93806446);
+        Averages2022To23[312].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 21.46837682);
+        Averages2022To23[394].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 32.7627341);
+        Averages2022To23[891].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 20.326069);
+        Averages2022To23[319].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 14.15546574);
+        Averages2022To23[929].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 20.62056176);
+        Averages2022To23[821].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 26.01003764);
+        Averages2022To23[306].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 30.1636244);
+        Averages2022To23[883].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 22.20237128);
+        Averages2022To23[210].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 35.1995114);
+        Averages2022To23[373].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 29.82446348);
+        Averages2022To23[380].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 29.89661183);
+        Averages2022To23[203].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 26.32035101);
+        Averages2022To23[857].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 12.81973203);
+        Averages2022To23[882].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 18.48456249);
+        Averages2022To23[335].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 32.63620387);
+        Averages2022To23[868].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 12.54142238);
+        Averages2022To23[311].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 20.31360528);
+        Averages2022To23[393].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 29.12307194);
+        Averages2022To23[384].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 24.10793621);
+        Averages2022To23[353].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 30.79308094);
+        Averages2022To23[356].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 20.92359258);
+        Averages2022To23[852].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 33.84500745);
+        Averages2022To23[938].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 14.10733629);
+        Averages2022To23[420].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 3.041825095);
+        Averages2022To23[800].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 14.61756797);
+        Averages2022To23[391].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 38.11513719);
+        Averages2022To23[342].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 26.07296137);
+        Averages2022To23[888].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 22.22544871);
+        Averages2022To23[893].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 17.22349536);
+        Averages2022To23[359].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 25.09020684);
+        Averages2022To23[317].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 18.59245886);
+        Averages2022To23[860].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 17.56039967);
+        Averages2022To23[826].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 20.54510116);
+        Averages2022To23[889].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 24.34281005);
+        Averages2022To23[845].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 21.53020599);
+        Averages2022To23[330].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 36.48543601);
+        Averages2022To23[937].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 18.22165928);
+        Averages2022To23[879].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 23.74871736);
+        Averages2022To23[812].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 29.51954831);
+        Averages2022To23[873].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 18.60946262);
+        Averages2022To23[869].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 13.07504143);
+        Averages2022To23[202].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 39.67622834);
+        Averages2022To23[874].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 24.84315513);
+        Averages2022To23[207].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 32.85645395);
+        Averages2022To23[332].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 25.50111967);
+        Averages2022To23[371].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 27.37806805);
+        Averages2022To23[211].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 42.38501371);
+        Averages2022To23[803].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 15.8677686);
+        Averages2022To23[840].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 27.64719269);
+        Averages2022To23[866].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 21.52763683);
+        Averages2022To23[878].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 17.95471147);
+        Averages2022To23[336].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 37.71574083);
+        Averages2022To23[841].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 25.00740302);
+        Averages2022To23[856].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 26.63798809);
+        Averages2022To23[838].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 19.49013799);
+        Averages2022To23[307].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 25.49011122);
+        Averages2022To23[308].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 27.83894559);
+        Averages2022To23[390].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 25.36541304);
+        Averages2022To23[392].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 21.52472722);
+        Averages2022To23[811].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 20.48922015);
+        Averages2022To23[807].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 29.06682721);
+        Averages2022To23[808].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 26.51569903);
+        Averages2022To23[823].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 13.37128455);
+        Averages2022To23[320].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 27.15887405);
+        Averages2022To23[304].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 21.26499455);
+        Averages2022To23[318].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 13.91348343);
+        Averages2022To23[936].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 12.11020645);
+        Averages2022To23[890].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 43.86125654);
+        Averages2022To23[344].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 26.14179501);
+        Averages2022To23[372].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 25.49050385);
+        Averages2022To23[352].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 42.39984453);
+        Averages2022To23[895].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 14.72360598);
+        Averages2022To23[925].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 21.52559035);
+        Averages2022To23[343].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 24.2408098);
+        Averages2022To23[351].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 23.74328726);
+        Averages2022To23[892].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 37.14522478);
+        Averages2022To23[894].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 24.12991354);
+        Averages2022To23[825].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 11.20111196);
+        Averages2022To23[805].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 38.80315501);
+        Averages2022To23[209].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 29.86120847);
+        Averages2022To23[310].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 20.65679871);
+        Averages2022To23[816].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 14.26057887);
+        Averages2022To23[870].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 17.74945601);
+        Averages2022To23[865].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 14.31258768);
+        Averages2022To23[301].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 27.53452258);
+        Averages2022To23[313].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 24.41236526);
+        Averages2022To23[871].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 18.04612428);
+        Averages2022To23[872].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 9.314478943);
+        Averages2022To23[383].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 26.14528381);
+        Averages2022To23[813].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 27.8007899);
+        Averages2022To23[205].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 25.4082039);
+        Averages2022To23[206].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 44.24579809);
+        Averages2022To23[309].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 25.94621207);
+        Averages2022To23[815].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 15.10264323);
+        Averages2022To23[831].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 27.30335896);
+        Averages2022To23[802].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 14.88587732);
+        Averages2022To23[340].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 48.53245856);
+        Averages2022To23[357].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 28.67293767);
+        Averages2022To23[822].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 19.35203305);
+        Averages2022To23[204].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 42.62740042);
+        Averages2022To23[382].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 26.89783456);
+        Averages2022To23[884].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 17.00471215);
+        Averages2022To23[926].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 21.07594317);
+        Averages2022To23[855].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 14.92415851);
+        Averages2022To23[806].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 41.74597965);
+        Averages2022To23[839].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 16.9647893);
+        Averages2022To23[940].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 18.323482);
+        Averages2022To23[935].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 19.63937087);
+        Averages2022To23[355].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 34.48013396);
+        Averages2022To23[861].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 31.99300699);
+        Averages2022To23[887].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 19.80207092);
+        Averages2022To23[801].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 28.52979921);
+        Averages2022To23[867].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 12.56632899);
+        Averages2022To23[916].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 15.27767944);
+        Averages2022To23[933].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 19.71261787);
+        Averages2022To23[314].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 12.48211162);
+        Averages2022To23[315].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 26.10837438);
+        Averages2022To23[881].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 16.87018876);
+        Averages2022To23[208].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 36.23602642);
+        Averages2022To23[333].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 32.19643647);
+        Averages2022To23[302].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 19.46335079);
+        Averages2022To23[931].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 14.04952961);
+        Averages2022To23[919].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 12.82789814);
+        Averages2022To23[846].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 21.45614577);
+        Averages2022To23[305].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 15.0785554);
+        Averages2022To23[331].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 26.92920918);
+        Averages2022To23[921].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 22.83474853);
+        Averages2022To23[370].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 27.82570228);
+        Averages2022To23[877].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSecondary, 18.39615881);
+        Averages2022To23[885].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 41.15566038);
+        Averages2022To23[935].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 41.42287234);
+        Averages2022To23[358].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 40.87677725);
+        Averages2022To23[850].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 39.32038835);
+        Averages2022To23[851].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 53.97301349);
+        Averages2022To23[212].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 51.856018);
+        Averages2022To23[213].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 61.38211382);
+        Averages2022To23[800].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 48.28209765);
+        Averages2022To23[886].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 41.68044988);
+        Averages2022To23[941].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 38.23781009);
+        Averages2022To23[880].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 54.66893039);
+        Averages2022To23[908].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 51.28205128);
+        Averages2022To23[341].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 57.16814159);
+        Averages2022To23[-1].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 45.98689461);
+        Averages2022To23[211].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 54.42708333);
+        Averages2022To23[896].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 44.21338156);
+        Averages2022To23[909].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 39.04109589);
+        Averages2022To23[381].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 41.30434783);
+        Averages2022To23[350].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 45.13018322);
+        Averages2022To23[312].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 42.30377166);
+        Averages2022To23[394].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 54.96342738);
+        Averages2022To23[857].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 12.5);
+        Averages2022To23[891].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 44.99165275);
+        Averages2022To23[319].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 46.34525661);
+        Averages2022To23[821].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 35.58673469);
+        Averages2022To23[306].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 51.30368098);
+        Averages2022To23[883].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 32.32931727);
+        Averages2022To23[210].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 51.90023753);
+        Averages2022To23[373].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 56.17479417);
+        Averages2022To23[203].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 51.06382979);
+        Averages2022To23[303].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 42.66304348);
+        Averages2022To23[882].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 51.31782946);
+        Averages2022To23[334].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 47.15984148);
+        Averages2022To23[335].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 57.35294118);
+        Averages2022To23[867].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 35.85858586);
+        Averages2022To23[310].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 35.77075099);
+        Averages2022To23[855].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 35.03733487);
+        Averages2022To23[316].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 53.50877193);
+        Averages2022To23[353].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 47.38415546);
+        Averages2022To23[919].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 39.18149466);
+        Averages2022To23[356].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 40.56987788);
+        Averages2022To23[852].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 53.27963176);
+        Averages2022To23[938].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 36.5901319);
+        Averages2022To23[933].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 43.46116028);
+        Averages2022To23[342].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 50.87719298);
+        Averages2022To23[359].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 46.58848614);
+        Averages2022To23[317].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 41.96018377);
+        Averages2022To23[893].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 41.51696607);
+        Averages2022To23[384].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 46.92307692);
+        Averages2022To23[860].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 40.62068966);
+        Averages2022To23[826].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 39.4707828);
+        Averages2022To23[330].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 52.98097252);
+        Averages2022To23[202].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 46.88995215);
+        Averages2022To23[921].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 49.5049505);
+        Averages2022To23[879].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 48.84667571);
+        Averages2022To23[812].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 49.57983193);
+        Averages2022To23[830].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 48.01324503);
+        Averages2022To23[813].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 42.07492795);
+        Averages2022To23[371].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 45.23809524);
+        Averages2022To23[889].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 40.81081081);
+        Averages2022To23[868].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 26.63316583);
+        Averages2022To23[311].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 38.46153846);
+        Averages2022To23[803].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 30.49403748);
+        Averages2022To23[352].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 56.84754522);
+        Averages2022To23[866].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 43.16546763);
+        Averages2022To23[878].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 44.13580247);
+        Averages2022To23[336].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 56.43564356);
+        Averages2022To23[841].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 53.39233038);
+        Averages2022To23[856].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 46.91075515);
+        Averages2022To23[838].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 40.80188679);
+        Averages2022To23[307].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 44.90010515);
+        Averages2022To23[390].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 53.64864865);
+        Averages2022To23[392].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 51.32075472);
+        Averages2022To23[811].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 38.46153846);
+        Averages2022To23[807].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 54.10526316);
+        Averages2022To23[808].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 49.6941896);
+        Averages2022To23[823].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 36.24401914);
+        Averages2022To23[207].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 42.71523179);
+        Averages2022To23[304].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 41.86602871);
+        Averages2022To23[318].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 32.63473054);
+        Averages2022To23[810].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 54.28954424);
+        Averages2022To23[936].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 35.12895854);
+        Averages2022To23[890].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 61.61790017);
+        Averages2022To23[343].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 51.89873418);
+        Averages2022To23[372].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 49.86175115);
+        Averages2022To23[895].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 39.05996759);
+        Averages2022To23[925].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 49.07321594);
+        Averages2022To23[805].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 54.57627119);
+        Averages2022To23[351].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 40.58577406);
+        Averages2022To23[873].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 45.54102259);
+        Averages2022To23[894].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 47.35336195);
+        Averages2022To23[825].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 34.96420048);
+        Averages2022To23[888].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 44.4057971);
+        Averages2022To23[209].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 49.47368421);
+        Averages2022To23[815].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 40.58219178);
+        Averages2022To23[816].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 31.08974359);
+        Averages2022To23[870].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 46.64723032);
+        Averages2022To23[865].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 41.22137405);
+        Averages2022To23[301].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 43.44422701);
+        Averages2022To23[313].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 40.61135371);
+        Averages2022To23[871].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 39.9463807);
+        Averages2022To23[383].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 49.71981661);
+        Averages2022To23[869].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 37.77239709);
+        Averages2022To23[308].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 53.16239316);
+        Averages2022To23[205].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 57.09219858);
+        Averages2022To23[206].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 61.47110333);
+        Averages2022To23[309].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 51.63511188);
+        Averages2022To23[391].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 63.70875995);
+        Averages2022To23[831].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 50.58139535);
+        Averages2022To23[802].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 39.39393939);
+        Averages2022To23[929].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 49.87794955);
+        Averages2022To23[340].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 56.47058824);
+        Averages2022To23[357].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 47.24711908);
+        Averages2022To23[822].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 39.26829268);
+        Averages2022To23[204].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 61.00628931);
+        Averages2022To23[887].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 42.4904943);
+        Averages2022To23[937].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 41.67150319);
+        Averages2022To23[382].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 49.21020656);
+        Averages2022To23[884].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 46.95431472);
+        Averages2022To23[926].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 46.51882414);
+        Averages2022To23[354].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 49.01365706);
+        Averages2022To23[344].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 54.85232068);
+        Averages2022To23[874].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 45.95375723);
+        Averages2022To23[315].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 49.59839357);
+        Averages2022To23[806].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 58.20668693);
+        Averages2022To23[839].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 48.26132771);
+        Averages2022To23[940].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 39.49790795);
+        Averages2022To23[872].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 23.29192547);
+        Averages2022To23[840].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 56.37342908);
+        Averages2022To23[892].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 59.18367347);
+        Averages2022To23[355].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 59.02702703);
+        Averages2022To23[861].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 52.43362832);
+        Averages2022To23[380].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 41.93328795);
+        Averages2022To23[845].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 44.69230769);
+        Averages2022To23[801].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 57.72171254);
+        Averages2022To23[393].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 55.53772071);
+        Averages2022To23[916].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 41.84100418);
+        Averages2022To23[314].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 32.69230769);
+        Averages2022To23[881].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 39.68660969);
+        Averages2022To23[208].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 63.32378223);
+        Averages2022To23[332].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 43.40425532);
+        Averages2022To23[333].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 52.09656925);
+        Averages2022To23[302].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 41.19205298);
+        Averages2022To23[931].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 38.25095057);
+        Averages2022To23[320].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 43.33333333);
+        Averages2022To23[876].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 57.64705882);
+        Averages2022To23[846].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 48.29931973);
+        Averages2022To23[305].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 47.35023041);
+        Averages2022To23[331].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 45.40229885);
+        Averages2022To23[370].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 55.02283105);
+        Averages2022To23[877].PercentOfPupilsByPhase
+            .Add(ExploreEducationStatisticsPhaseType.StateFundedSpecialSchool, 43.42431762);
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/Academy.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Academy.cs
@@ -10,7 +10,7 @@ public record Academy(
     string? PhaseOfEducation,
     int? NumberOfPupils,
     int? SchoolCapacity,
-    string? PercentageFreeSchoolMeals,
+    double? PercentageFreeSchoolMeals,
     AgeRange AgeRange,
     OfstedRating CurrentOfstedRating,
     OfstedRating PreviousOfstedRating,

--- a/DfE.FindInformationAcademiesTrusts.Data/Academy.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Academy.cs
@@ -13,7 +13,8 @@ public record Academy(
     string? PercentageFreeSchoolMeals,
     AgeRange AgeRange,
     OfstedRating CurrentOfstedRating,
-    OfstedRating PreviousOfstedRating)
+    OfstedRating PreviousOfstedRating,
+    int OldLaCode)
 {
     public float? PercentageFull
     {

--- a/DfE.FindInformationAcademiesTrusts.Data/IFreeSchoolMealsAverageProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/IFreeSchoolMealsAverageProvider.cs
@@ -1,0 +1,7 @@
+namespace DfE.FindInformationAcademiesTrusts.Data;
+
+public interface IFreeSchoolMealsAverageProvider
+{
+    public double GetLaAverage(Academy academy);
+    public double GetNationalAverage(Academy academy);
+}

--- a/DfE.FindInformationAcademiesTrusts.sln
+++ b/DfE.FindInformationAcademiesTrusts.sln
@@ -18,6 +18,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademie
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademiesTrusts.Data.Hardcoded", "DfE.FindInformationAcademiesTrusts.Data.Hardcoded\DfE.FindInformationAcademiesTrusts.Data.Hardcoded.csproj", "{01247163-9E65-48FB-9ACE-1A8BE995D1AC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests", "tests\DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests\DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests.csproj", "{1DF57DAB-F9BA-4810-BD35-BB59996FF7BB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,11 +58,16 @@ Global
 		{01247163-9E65-48FB-9ACE-1A8BE995D1AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01247163-9E65-48FB-9ACE-1A8BE995D1AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{01247163-9E65-48FB-9ACE-1A8BE995D1AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1DF57DAB-F9BA-4810-BD35-BB59996FF7BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1DF57DAB-F9BA-4810-BD35-BB59996FF7BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DF57DAB-F9BA-4810-BD35-BB59996FF7BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1DF57DAB-F9BA-4810-BD35-BB59996FF7BB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0A3416F9-33DB-4870-97EA-7CFF8D828031} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}
 		{E20D30CB-8EB1-453B-8C49-77CAFBF16A13} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}
 		{CE03C6BD-0160-4265-A287-3EC70103E4C9} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}
 		{90AA9D53-B5B0-489F-AEC1-23551EA04BC5} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}
+		{1DF57DAB-F9BA-4810-BD35-BB59996FF7BB} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}
 	EndGlobalSection
 EndGlobal

--- a/DfE.FindInformationAcademiesTrusts.sln
+++ b/DfE.FindInformationAcademiesTrusts.sln
@@ -16,6 +16,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademie
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademiesTrusts.Data.UnitTests", "tests\DfE.FindInformationAcademiesTrusts.Data.UnitTests\DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj", "{90AA9D53-B5B0-489F-AEC1-23551EA04BC5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DfE.FindInformationAcademiesTrusts.Data.Hardcoded", "DfE.FindInformationAcademiesTrusts.Data.Hardcoded\DfE.FindInformationAcademiesTrusts.Data.Hardcoded.csproj", "{01247163-9E65-48FB-9ACE-1A8BE995D1AC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{90AA9D53-B5B0-489F-AEC1-23551EA04BC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{90AA9D53-B5B0-489F-AEC1-23551EA04BC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{90AA9D53-B5B0-489F-AEC1-23551EA04BC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01247163-9E65-48FB-9ACE-1A8BE995D1AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01247163-9E65-48FB-9ACE-1A8BE995D1AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01247163-9E65-48FB-9ACE-1A8BE995D1AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01247163-9E65-48FB-9ACE-1A8BE995D1AC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0A3416F9-33DB-4870-97EA-7CFF8D828031} = {E22DC2DA-4EB5-41C6-A41D-349692BCCDBE}

--- a/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
+++ b/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
@@ -45,6 +45,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb\DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj"/>
+        <ProjectReference Include="..\DfE.FindInformationAcademiesTrusts.Data.Hardcoded\DfE.FindInformationAcademiesTrusts.Data.Hardcoded.csproj"/>
         <ProjectReference Include="..\DfE.FindInformationAcademiesTrusts.Data\DfE.FindInformationAcademiesTrusts.Data.csproj"/>
     </ItemGroup>
 </Project>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml
@@ -5,4 +5,41 @@
 @{
   Layout = "Academies/_AcademiesLayout";
 }
-<div>@Model.GetLaAverageFreeSchoolMeals()?.ToString("N0")</div>
+
+<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="free-school-meals-link">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">School name</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Pupils eligible for free school meals</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Local authority average 2022/23</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">National average 2022/23</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      @foreach (var academy in Model.Trust.Academies)
+      {
+        <tr class="govuk-table__row" data-testid="academy-row">
+          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@academy.EstablishmentName">
+            @academy.EstablishmentName<br/><span class="govuk-!-font-weight-regular">URN: @academy.Urn</span>
+          </th>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@academy.PercentageFreeSchoolMeals">
+            @if (academy.PercentageFreeSchoolMeals is not null)
+            {
+              @academy.PercentageFreeSchoolMeals<span>%</span>
+            }
+          </td>
+          @{ var academyTypeLaAverage = Model.GetLaAverageFreeSchoolMeals(academy); }
+          <td class="govuk-body govuk-table__cell" data-sort-value="@academyTypeLaAverage">
+            @academyTypeLaAverage.ToString("N1")%
+          </td>
+
+          @{ var academyTypeNationalAverage = Model.GetNationalAverageFreeSchoolMeals(academy); }
+          <td class="govuk-body govuk-table__cell" data-sort-value="@academyTypeNationalAverage">
+            @academyTypeNationalAverage.ToString("N1")%
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+</section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml
@@ -26,7 +26,7 @@
           <td class="govuk-body govuk-table__cell" data-sort-value="@academy.PercentageFreeSchoolMeals">
             @if (academy.PercentageFreeSchoolMeals is not null)
             {
-              @academy.PercentageFreeSchoolMeals<span>%</span>
+              @academy.PercentageFreeSchoolMeals?.ToString("N1")<span>%</span>
             }
           </td>
           @{ var academyTypeLaAverage = Model.GetLaAverageFreeSchoolMeals(academy); }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml
@@ -1,0 +1,8 @@
+@page "/trusts/academies/free-school-meals"
+@model FreeSchoolMealsModel
+
+
+@{
+  Layout = "Academies/_AcademiesLayout";
+}
+<div>@Model.GetLaAverageFreeSchoolMeals()?.ToString("N0")</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
@@ -1,0 +1,23 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
+
+public class FreeSchoolMealsModel : TrustsAreaModel, IAcademiesAreaModel
+{
+    private readonly IFreeSchoolMealsAverageProvider _freeSchoolMealsProvider;
+
+    public FreeSchoolMealsModel(ITrustProvider trustProvider,
+        IFreeSchoolMealsAverageProvider freeSchoolMealsAverageProvider) :
+        base(trustProvider, "Academies in this trust")
+    {
+        PageTitle = "Academies free school meals";
+        _freeSchoolMealsProvider = freeSchoolMealsAverageProvider;
+    }
+
+    public string TabName => "Free school meals";
+
+    public double? GetLaAverageFreeSchoolMeals()
+    {
+        return _freeSchoolMealsProvider.GetAverageByLaCodeAndPhaseType("334", "StateFundedApSchool");
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
@@ -16,8 +16,13 @@ public class FreeSchoolMealsModel : TrustsAreaModel, IAcademiesAreaModel
 
     public string TabName => "Free school meals";
 
-    public double? GetLaAverageFreeSchoolMeals()
+    public double GetLaAverageFreeSchoolMeals(Academy academy)
     {
-        return _freeSchoolMealsProvider.GetAverageByLaCodeAndPhaseType("334", "StateFundedApSchool");
+        return _freeSchoolMealsProvider.GetLaAverage(academy);
+    }
+
+    public double GetNationalAverageFreeSchoolMeals(Academy academy)
+    {
+        return _freeSchoolMealsProvider.GetNationalAverage(academy);
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_AcademiesLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_AcademiesLayout.cshtml
@@ -29,6 +29,10 @@
     <li class="moj-sub-navigation__item">
       <a id="academies-pupil-numbers-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Pupil numbers")" asp-page="./PupilNumbers" asp-route-uid="@Model.Trust.Uid"><span class="visually-hidden">Academies</span>Pupil numbers</a>
     </li>
+
+    <li class="moj-sub-navigation__item">
+      <a id="free-school-meals-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Free school meals")" asp-page="./FreeSchoolMeals" asp-route-uid="@Model.Trust.Uid"><span class="visually-hidden">Academies</span>Free school meals</a>
+    </li>
   </ul>
 
 </nav>

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -4,6 +4,7 @@ using DfE.FindInformationAcademiesTrusts.Authorization;
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
+using DfE.FindInformationAcademiesTrusts.Data.Hardcoded;
 using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Options;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -171,6 +172,7 @@ internal static class Program
         builder.Services.AddScoped<IPersonFactory, PersonFactory>();
         builder.Services.AddScoped<IAuthorizationHandler, HeaderRequirementHandler>();
         builder.Services.AddScoped<IOtherServicesLinkBuilder, OtherServicesLinkBuilder>();
+        builder.Services.AddScoped<IFreeSchoolMealsAverageProvider, FreeSchoolMealsAverageProvider>();
         builder.Services.AddHttpContextAccessor();
     }
 

--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ We are a tool for everyone in DfE to find information which is collated from mul
 ## Approach and decisions
 - [Architecture Decision Records (ADRs)](docs/adrs)
 - [Archive branches](docs/archive-branches.md)
+- [Hardcoded data](docs/hardcoded-data.md)
 - [Test Approach](docs/test-approach.md)

--- a/docs/adrs/0006-use-hardcoded-free-school-meals-statistics-data.md
+++ b/docs/adrs/0006-use-hardcoded-free-school-meals-statistics-data.md
@@ -1,0 +1,29 @@
+# 6. Use hardcoded data for free school meals averages
+
+Date: 2023-12-12
+
+## Status
+
+Accepted
+
+## Context
+
+For our MVP we have a user need to display the local and national percentages of students eligible for free school meals, alongside the figure for those eligible in a particular academy - so that the user can assess how well a trust is performing.
+
+The Academies database does not currently contain any accurate data on these figures, and that which is displayed to users in TRAMS is not correct.
+
+The figures are currently available via a csv download hosted on [Explore Education Statistics](https://explore-education-statistics.service.gov.uk/data-tables/permalink/25bc8d0b-c700-4000-1b8a-08dbb99e3fd8). However, there may be an api in development to make this data easier to access in the future.
+
+## Decision
+
+Rather than expend effort on creating a new table in the academies database—which is undergoing change—or creating a new application database for a data source which should be accessible via an open API in the not too distant future, we will hardcode the data into our application.
+
+In order to make it easy to change to a new data source in the future we have added the data in a C# static class, accessed via a provider layer.
+
+We will make it clear to the user that it is data that will not change, using the `Data source` component displayed at the bottom of each page. We will also display the years the data covers in the column headings, to make it clear to the user if it is out of date.
+
+## Consequences
+
+This approach gives us quick access to a small additional data source we need for MVP. However, adding data in this way will require manual updating. The hardcoded data should eventually be replaced with a database table, or direct access to the statistics data via API if one is developed in the future.
+
+This data is currently available publicly, so there is no risk in exposing senstive information by hardcoding it into our application.

--- a/docs/adrs/0006-use-hardcoded-free-school-meals-statistics-data.md
+++ b/docs/adrs/0006-use-hardcoded-free-school-meals-statistics-data.md
@@ -24,6 +24,6 @@ We will make it clear to the user that it is data that will not change, using th
 
 ## Consequences
 
-This approach gives us quick access to a small additional data source we need for MVP. However, adding data in this way will require manual updating. The hardcoded data should eventually be replaced with a database table, or direct access to the statistics data via API if one is developed in the future.
+This approach gives us quick access to a small additional data source we need for MVP. However, adding data in this way will [require updating](../hardcoded-data.md).
 
 This data is currently available publicly, so there is no risk in exposing senstive information by hardcoding it into our application.

--- a/docs/hardcoded-data.md
+++ b/docs/hardcoded-data.md
@@ -1,0 +1,29 @@
+# Hardcoded data
+
+## Free school meals averages
+
+### What is the data?
+
+The data is the percent of pupils eligible for free school meals (2022/23), by region and establishment type.
+It is taken from the Permanent data table
+['Pupil characteristics - number of pupils by fsm eligibility'](https://explore-education-statistics.service.gov.uk/data-tables/permalink/25bc8d0b-c700-4000-1b8a-08dbb99e3fd8) from 'Schools, pupils and their characteristics' on the Explore education statistics service.
+
+### Why is it hardcoded
+
+See [ADR 6 - Use hardcoded free school meals statistics data](adrs/0006-use-hardcoded-free-school-meals-statistics-data.md)
+
+### What needs updating in the future
+
+The data should either:
+
+- be removed, and accessed via an API request
+- be replaced with the latest annual figures when they are available
+
+### How to update it
+
+If updating the hardcoded data with new figures, you will need to:
+
+- Replace the contents of the method: `AddPercentagesByPhaseType()` on the static data class `FreeSchoolMealsData`
+- Update references to the year 2022/23 in the UI and in the code
+- **Note:** we have only added the four establishment types on the enum `ExploreEducationStatisticsPhaseType` as the other establishment types in the table are not currently relevant to our data
+- **Note:** the list of local authorities added in `PopulateLocalAuthorities` is from the same data table and could also become out of date

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Data.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Data.cs
@@ -256,4 +256,15 @@ public static class Data
         "Queen Elizabeth's",
         "Queensbridge"
     };
+
+    public static string[] GiasPhaseNames { get; } =
+    {
+        "Primary",
+        "Middle Deemed Primary",
+        "Secondary",
+        "Middle Deemed Secondary",
+        "16 Plus",
+        "Not applicable",
+        "All-through",
+    };
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Data.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Data.cs
@@ -121,23 +121,22 @@ public static class Data
         "South West"
     };
 
-    public static string[] LocalAuthorities { get; } =
+    public static Dictionary<int, string> LocalAuthorities { get; } = new()
     {
-        "Barnsley",
-        "Bradford",
-        "Calderdale",
-        "Doncaster",
-        "East Riding of Yorkshire",
-        "Kingston upon Hull, City of",
-        "Kirklees",
-        "Leeds",
-        "North East Lincolnshire",
-        "North Lincolnshire",
-        "North Yorkshire",
-        "Rotherham",
-        "Sheffield",
-        "Wakefield",
-        "York"
+        { 370, "Barnsley" },
+        { 371, "Doncaster" },
+        { 372, "Rotherham" },
+        { 373, "Sheffield" },
+        { 380, "Bradford" },
+        { 381, "Calderdale" },
+        { 382, "Kirklees" },
+        { 383, "Leeds" },
+        { 384, "Wakefield" },
+        { 390, "Gateshead" },
+        { 391, "Newcastle upon Tyne" },
+        { 392, "North Tyneside" },
+        { 393, "South Tyneside" },
+        { 394, "Sunderland" }
     };
 
     public static Dictionary<string, string[]> GovernorAppointingBodies { get; } = new()

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
@@ -8,7 +8,6 @@ public class AcademiesDbFaker
     private int _counter = 1233;
     private readonly Bogus.Faker _generalFaker = new();
 
-    private readonly string?[] _localAuthorities;
     private readonly GiasGroupLinkFaker _giasGroupLinkFaker;
     private readonly GiasEstablishmentFaker _giasEstablishmentFaker;
     private readonly GiasGroupFaker _giasGroupFaker;
@@ -19,18 +18,20 @@ public class AcademiesDbFaker
     private readonly CdmSystemuserFaker _cdmSystemuserFaker = new();
     private readonly MisEstablishmentFaker _misEstablishmentFaker;
     private AcademiesDbData _academiesDbData;
+    private readonly IEnumerable<int> _laCodes;
 
-    public AcademiesDbFaker(string?[] regions, string?[] localAuthorities, string[] fakeSchoolNames,
+    public AcademiesDbFaker(string?[] regions, Dictionary<int, string> localAuthorities, string[] fakeSchoolNames,
         Dictionary<string, string[]> governorAppointingBodies, string[] giasPhaseNames)
     {
         // Need a ref date for any use of `faker.Date` so the data generated doesn't change every day
         var refDate = new DateTime(2023, 11, 9);
 
-        _localAuthorities = localAuthorities;
+        _laCodes = localAuthorities.Select(la => la.Key);
         _giasGroupFaker = new GiasGroupFaker(refDate);
         _giasGovernanceFaker = new GiasGovernanceFaker(refDate, governorAppointingBodies);
         _giasEstablishmentFaker =
-            new GiasEstablishmentFaker(fakeSchoolNames, giasPhaseNames, new EstablishmentTypePicker());
+            new GiasEstablishmentFaker(fakeSchoolNames, giasPhaseNames, new EstablishmentTypePicker(),
+                localAuthorities);
         _giasGroupLinkFaker = new GiasGroupLinkFaker(refDate);
         _mstrTrustFaker = new MstrTrustFaker(regions);
         _mstrTrustGovernanceFaker = new MstrTrustGovernanceFaker();
@@ -92,7 +93,7 @@ public class AcademiesDbFaker
     private IEnumerable<GiasEstablishment> GenerateGiasEstablishments(TrustToGenerate trustToGenerate, string uid)
     {
         _giasEstablishmentFaker.SetUid(uid).SetLocalAuthoritiesSelection(
-            _generalFaker.PickRandom(_localAuthorities, _generalFaker.Random.Int(1, 4)).ToArray());
+            _generalFaker.PickRandom(_laCodes, _generalFaker.Random.Int(1, 4)).ToArray());
 
         if (trustToGenerate.HasNoAcademies)
         {

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/AcademiesDbFaker.cs
@@ -21,7 +21,7 @@ public class AcademiesDbFaker
     private AcademiesDbData _academiesDbData;
 
     public AcademiesDbFaker(string?[] regions, string?[] localAuthorities, string[] fakeSchoolNames,
-        Dictionary<string, string[]> governorAppointingBodies)
+        Dictionary<string, string[]> governorAppointingBodies, string[] giasPhaseNames)
     {
         // Need a ref date for any use of `faker.Date` so the data generated doesn't change every day
         var refDate = new DateTime(2023, 11, 9);
@@ -29,7 +29,8 @@ public class AcademiesDbFaker
         _localAuthorities = localAuthorities;
         _giasGroupFaker = new GiasGroupFaker(refDate);
         _giasGovernanceFaker = new GiasGovernanceFaker(refDate, governorAppointingBodies);
-        _giasEstablishmentFaker = new GiasEstablishmentFaker(fakeSchoolNames);
+        _giasEstablishmentFaker =
+            new GiasEstablishmentFaker(fakeSchoolNames, giasPhaseNames, new EstablishmentTypePicker());
         _giasGroupLinkFaker = new GiasGroupLinkFaker(refDate);
         _mstrTrustFaker = new MstrTrustFaker(regions);
         _mstrTrustGovernanceFaker = new MstrTrustGovernanceFaker();

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasEstablishmentFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasEstablishmentFaker.cs
@@ -6,21 +6,22 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Fakers;
 
 public class GiasEstablishmentFaker
 {
-    private IEnumerable<string?> _localAuthorities = Array.Empty<string>();
+    private IEnumerable<int> _laCodes = Array.Empty<int>();
     private readonly Faker<GiasEstablishment> _establishmentFaker;
     private readonly string[] _fakeSchoolNames;
     private string _uid = "";
     private readonly IEstablishmentTypePicker _giasEstablishmentTypePicker;
 
     public GiasEstablishmentFaker(string[] fakeSchoolNames, string[] giasPhaseNames,
-        IEstablishmentTypePicker giasEstablishmentTypePicker)
+        IEstablishmentTypePicker giasEstablishmentTypePicker, Dictionary<int, string> localAuthorities)
     {
         _giasEstablishmentTypePicker = giasEstablishmentTypePicker;
         _fakeSchoolNames = fakeSchoolNames;
         _establishmentFaker = new Faker<GiasEstablishment>("en_GB")
                 // will this Urn sometimes be a duplicate?
                 .RuleFor(a => a.Urn, f => int.Parse($"{_uid}{f.Random.Int(1000, 9999)}"))
-                .RuleFor(e => e.LaName, f => f.PickRandom(_localAuthorities))
+                .RuleFor(e => e.LaCode, f => f.PickRandom(_laCodes).ToString())
+                .RuleFor(e => e.LaName, (f, e) => localAuthorities[int.Parse(e.LaCode!)])
                 .RuleFor(e => e.UrbanRuralName, f => f.PickRandom(
                     "Urban city and town",
                     "Rural town and fringe",
@@ -95,9 +96,9 @@ public class GiasEstablishmentFaker
         return phaseOfEducationName == "Primary" ? "11" : faker.PickRandom("16", "18");
     }
 
-    public GiasEstablishmentFaker SetLocalAuthoritiesSelection(IEnumerable<string?> localAuthorities)
+    public GiasEstablishmentFaker SetLocalAuthoritiesSelection(IEnumerable<int> laCodes)
     {
-        _localAuthorities = localAuthorities;
+        _laCodes = laCodes;
         return this;
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasEstablishmentFaker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Fakers/GiasEstablishmentFaker.cs
@@ -1,4 +1,5 @@
 using Bogus;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Helpers;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Fakers;
@@ -9,16 +10,17 @@ public class GiasEstablishmentFaker
     private readonly Faker<GiasEstablishment> _establishmentFaker;
     private readonly string[] _fakeSchoolNames;
     private string _uid = "";
+    private readonly IEstablishmentTypePicker _giasEstablishmentTypePicker;
 
-    public GiasEstablishmentFaker(string[] fakeSchoolNames)
+    public GiasEstablishmentFaker(string[] fakeSchoolNames, string[] giasPhaseNames,
+        IEstablishmentTypePicker giasEstablishmentTypePicker)
     {
+        _giasEstablishmentTypePicker = giasEstablishmentTypePicker;
         _fakeSchoolNames = fakeSchoolNames;
         _establishmentFaker = new Faker<GiasEstablishment>("en_GB")
                 // will this Urn sometimes be a duplicate?
                 .RuleFor(a => a.Urn, f => int.Parse($"{_uid}{f.Random.Int(1000, 9999)}"))
                 .RuleFor(e => e.LaName, f => f.PickRandom(_localAuthorities))
-                .RuleFor(e => e.TypeOfEstablishmentName,
-                    f => f.PickRandom("Academy sponsor led", "Academy converter", "Free school"))
                 .RuleFor(e => e.UrbanRuralName, f => f.PickRandom(
                     "Urban city and town",
                     "Rural town and fringe",
@@ -35,7 +37,8 @@ public class GiasEstablishmentFaker
                 .RuleFor(e => e.PercentageFsm, f => f.Random.Int(1, 30).ToString())
                 .RuleSet("randomSchoolName", set =>
                 {
-                    set.RuleFor(e => e.PhaseOfEducationName, f => f.PickRandom("Primary", "Secondary"))
+                    set.RuleFor(e => e.PhaseOfEducationName, f => f.PickRandom(giasPhaseNames))
+                        .RuleFor(e => e.TypeOfEstablishmentName, RandomEstablishmentTypeOnPhase)
                         .RuleFor(e => e.EstablishmentName, GenerateSchoolName)
                         .RuleFor(e => e.StatutoryLowAge, (f, e) =>
                             GetMinAge(e.PhaseOfEducationName, f)
@@ -53,13 +56,19 @@ public class GiasEstablishmentFaker
                                     : e.EstablishmentName.Contains("Secondary",
                                         StringComparison.CurrentCultureIgnoreCase)
                                         ? "Secondary"
-                                        : f.PickRandom("Primary", "Secondary"))
+                                        : f.PickRandom(giasPhaseNames))
+                            .RuleFor(e => e.TypeOfEstablishmentName, RandomEstablishmentTypeOnPhase)
                             .RuleFor(e => e.StatutoryLowAge,
                                 (f, e) => GetMinAge(e.PhaseOfEducationName, f))
                             .RuleFor(e => e.StatutoryHighAge,
                                 (f, e) => GetMaxAge(e.PhaseOfEducationName, f));
                     })
             ;
+    }
+
+    private string RandomEstablishmentTypeOnPhase(Bogus.Faker f, GiasEstablishment e)
+    {
+        return f.PickRandom(_giasEstablishmentTypePicker.GetEstablishmentTypes(e));
     }
 
     private string GenerateSchoolName(Bogus.Faker faker, GiasEstablishment establishment)
@@ -69,7 +78,7 @@ public class GiasEstablishmentFaker
         if (name.StartsWith("st", StringComparison.InvariantCultureIgnoreCase) || faker.Random.Bool())
             name = $"{name} {faker.PickRandom("Church of England", "Cofe", "CE", "Catholic", "C of E", "R.C.")}";
 
-        if (faker.Random.Bool())
+        if (faker.Random.Bool() && !establishment.PhaseOfEducationName!.Contains("Not applicable"))
             name = $"{name} {establishment.PhaseOfEducationName}";
         name = $"{name} {faker.PickRandom("School", "Academy")}";
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Helpers/EstablishmentTypePicker.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Helpers/EstablishmentTypePicker.cs
@@ -1,0 +1,50 @@
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.Helpers;
+
+public interface IEstablishmentTypePicker
+{
+    public string[] GetEstablishmentTypes(GiasEstablishment establishment);
+}
+
+public class EstablishmentTypePicker : IEstablishmentTypePicker
+{
+    private readonly string[] _secondaryAllThroughPhaseNames =
+    {
+        "Secondary", "Middle Deemed Secondary", "16 Plus", "Not applicable", "All-through"
+    };
+
+    public string[] GetEstablishmentTypes(GiasEstablishment establishment)
+    {
+        if (establishment.PhaseOfEducationName == "Primary" ||
+            establishment.PhaseOfEducationName == "Middle Deemed Primary")
+        {
+            return new[]
+            {
+                "Community School", "Voluntary Aided School", "Foundation School",
+                "Voluntary Controlled School", "Academy Sponsor Led", "Academy Converter", "City Technology College",
+                "Free Schools", "University technical college", "Studio schools"
+            };
+        }
+
+        if (_secondaryAllThroughPhaseNames.Contains(establishment.PhaseOfEducationName))
+        {
+            return new[]
+            {
+                "Community School", "Voluntary Aided School", "Foundation School",
+                "Voluntary Controlled School", "Academy 16-19 Converter", "Academy Sponsor Led", "Academy Converter",
+                "City Technology College",
+                "Free Schools", "Free schools 16 to 19", "University technical college", "Studio schools",
+                "Academy 16 to 19 sponsor led"
+            };
+        }
+
+        return new[]
+        {
+            "Foundation Special School", "Community Special School", "Academy Special Converter",
+            "Academy Special Sponsor Led", "Free Schools Special",
+            "Pupil Referral Unit", "Academy Alternative Provision Sponsor Led",
+            "Free schools alternative provision", "Academy Alternative Provision Converter"
+        };
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Program.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/Program.cs
@@ -15,7 +15,7 @@ public static class Program
 
 
             var faker = new AcademiesDbFaker(Data.Regions, Data.LocalAuthorities, Data.Schools,
-                Data.GovernorAppointingBodies);
+                Data.GovernorAppointingBodies, Data.GiasPhaseNames);
             var academiesDbData = faker.Generate(Data.TrustsToGenerate);
 
             SqlScriptGenerator.GenerateAndSaveSqlScripts(academiesDbData, "data/createScript.sql",

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Extensions/StringExtensionsTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Extensions/StringExtensionsTests.cs
@@ -89,4 +89,19 @@ public class StringExtensionsTests
         var result = input.ParseAsNullableInt();
         result.Should().Be(expected);
     }
+
+    [Theory]
+    [InlineData("0", 0D)]
+    [InlineData("1", 1D)]
+    [InlineData("1.5", 1.5)]
+    [InlineData("1000", 1000D)]
+    [InlineData("99.99", 99.99)]
+    [InlineData("0.01", 0.01)]
+    [InlineData("", null)]
+    [InlineData("test", null)]
+    public void ParseAsNullableDouble_should_return_correctly_parsed_double(string? input, double? expected)
+    {
+        var result = input.ParseAsNullableDouble();
+        result.Should().BeApproximately(expected, 0.01);
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/AcademyFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/AcademyFactoryTests.cs
@@ -20,7 +20,8 @@ public class AcademyFactoryTests
         SchoolCapacity = "1000",
         PercentageFsm = "30.40",
         StatutoryLowAge = "5",
-        StatutoryHighAge = "11"
+        StatutoryHighAge = "11",
+        LaCode = "334"
     };
 
     private readonly GiasGroupLink _giasGroupLink = new() { JoinedDate = "16/11/2023" };
@@ -40,7 +41,8 @@ public class AcademyFactoryTests
             SchoolCapacity = "1000",
             PercentageFsm = "30.40",
             StatutoryLowAge = "5",
-            StatutoryHighAge = "11"
+            StatutoryHighAge = "11",
+            LaCode = "334"
         };
 
         var result = _sut.CreateFrom(_giasGroupLink, giasEstablishment);
@@ -56,6 +58,7 @@ public class AcademyFactoryTests
         result.SchoolCapacity.Should().Be(1000);
         result.PercentageFreeSchoolMeals.Should().Be("30.40");
         result.AgeRange.Should().Be(new AgeRange(5, 11));
+        result.OldLaCode.Should().Be(334);
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/AcademyFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/AcademyFactoryTests.cs
@@ -56,7 +56,7 @@ public class AcademyFactoryTests
         result.PhaseOfEducation.Should().Be("Primary");
         result.NumberOfPupils.Should().Be(999);
         result.SchoolCapacity.Should().Be(1000);
-        result.PercentageFreeSchoolMeals.Should().Be("30.40");
+        result.PercentageFreeSchoolMeals.Should().BeApproximately(30.40, 0.01);
         result.AgeRange.Should().Be(new AgeRange(5, 11));
         result.OldLaCode.Should().Be(334);
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.12.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Moq" Version="4.20.69"/>
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\DfE.FindInformationAcademiesTrusts.Data.Hardcoded\DfE.FindInformationAcademiesTrusts.Data.Hardcoded.csproj"/>
+        <ProjectReference Include="..\DfE.FindInformationAcademiesTrusts.Data.UnitTests\DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/FreeSchoolMealsAverageProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/FreeSchoolMealsAverageProviderTests.cs
@@ -1,0 +1,78 @@
+using static DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks.DummyAcademyFactory;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests;
+
+public class FreeSchoolMealsAverageProviderTests
+{
+    private readonly FreeSchoolMealsAverageProvider _sut = new();
+
+    [Theory]
+    [InlineData(334, "Secondary", "Pupil Referral Unit", 63.52941176F)]
+    [InlineData(372, "Primary", "Community School", 26.26287001F)]
+    [InlineData(929, "16 Plus", "Academy Converter", 20.62056176F)]
+    [InlineData(931, "All-through", "Free Schools Special", 38.25095057F)]
+    public void GetLaAverage_should_return_percentage_from_hardcoded_data(int laCode, string phaseOfEducation,
+        string establishmentType, double expected)
+    {
+        var dummyAcademy = GetDummyAcademy(111, laCode: laCode, phaseOfEducation: phaseOfEducation,
+            typeOfEstablishment: establishmentType);
+        var result = _sut.GetLaAverage(dummyAcademy);
+        result.Should().BeApproximately(expected, 0.01F);
+    }
+
+    [Theory]
+    [InlineData("Secondary", "Pupil Referral Unit", 57.78940186F)]
+    [InlineData("Primary", "Community School", 23.99569177F)]
+    [InlineData("16 Plus", "Academy Converter", 22.69174097F)]
+    [InlineData("All-through", "Free Schools Special", 45.98689461F)]
+    public void GetNationalAverage_should_return_national_percentage_from_hardcoded_data(string phaseOfEducation,
+        string establishmentType, double expected)
+    {
+        var dummyAcademy = GetDummyAcademy(111, phaseOfEducation: phaseOfEducation,
+            typeOfEstablishment: establishmentType);
+        var result = _sut.GetNationalAverage(dummyAcademy);
+        result.Should().BeApproximately(expected, 0.01F);
+    }
+
+    [Theory]
+    [InlineData("Secondary", "Pupil Referral Unit", ExploreEducationStatisticsPhaseType
+        .StateFundedApSchool)]
+    [InlineData("Middle Deemed Secondary", "Academy Alternative Provision Converter",
+        ExploreEducationStatisticsPhaseType
+            .StateFundedApSchool)]
+    [InlineData("Primary", "Community School", ExploreEducationStatisticsPhaseType
+        .StateFundedPrimary)]
+    [InlineData("16 Plus", "Academy Converter", ExploreEducationStatisticsPhaseType.StateFundedSecondary)]
+    [InlineData("Secondary", "Academy Converter", ExploreEducationStatisticsPhaseType.StateFundedSecondary)]
+    [InlineData("Middle Deemed Secondary", "Academy Converter",
+        ExploreEducationStatisticsPhaseType.StateFundedSecondary)]
+    [InlineData("Middle Deemed Secondary", "Voluntary Aided School",
+        ExploreEducationStatisticsPhaseType.StateFundedSecondary)]
+    [InlineData("Middle Deemed Secondary", "Foundation School",
+        ExploreEducationStatisticsPhaseType.StateFundedSecondary)]
+    [InlineData("All-through", "Free Schools Special", ExploreEducationStatisticsPhaseType
+        .StateFundedSpecialSchool)]
+    [InlineData("", "Academy Special Sponsor Led", ExploreEducationStatisticsPhaseType
+        .StateFundedSpecialSchool)]
+    [InlineData("Not applicable", "Foundation Special School", ExploreEducationStatisticsPhaseType
+        .StateFundedSpecialSchool)]
+    [InlineData("Primary", "Community Special School", ExploreEducationStatisticsPhaseType
+        .StateFundedSpecialSchool)]
+    public void GetKey_should_return_enum_value(string phaseOfEducation,
+        string establishmentType, ExploreEducationStatisticsPhaseType expected)
+    {
+        var dummyAcademy = GetDummyAcademy(111, phaseOfEducation: phaseOfEducation,
+            typeOfEstablishment: establishmentType);
+        var result = FreeSchoolMealsAverageProvider.GetPhaseTypeKey(dummyAcademy);
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetKey_should_through_exception_if_values_are_not_in_data()
+    {
+        var dummyAcademy = GetDummyAcademy(111);
+        var act = () => FreeSchoolMealsAverageProvider.GetPhaseTypeKey(dummyAcademy);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/FreeSchoolMealsAverageProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/FreeSchoolMealsAverageProviderTests.cs
@@ -68,11 +68,13 @@ public class FreeSchoolMealsAverageProviderTests
     }
 
     [Fact]
-    public void GetKey_should_through_exception_if_values_are_not_in_data()
+    public void GetKey_should_throw_exception_if_values_are_not_in_data()
     {
-        var dummyAcademy = GetDummyAcademy(111);
+        var dummyAcademy = GetDummyAcademy(111, phaseOfEducation: "Not a phase",
+            typeOfEstablishment: "not an establishment type");
         var act = () => FreeSchoolMealsAverageProvider.GetPhaseTypeKey(dummyAcademy);
 
-        act.Should().Throw<ArgumentOutOfRangeException>();
+        act.Should().Throw<ArgumentOutOfRangeException>().WithMessage(
+            "Can't get ExploreEducationStatisticsPhaseType for [PhaseOfEducation:Not a phase, TypeOfEstablishment:not an establishment type] (Parameter 'academy')");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/FreeSchoolMealsAverageTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/FreeSchoolMealsAverageTests.cs
@@ -1,0 +1,31 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests;
+
+public class FreeSchoolMealsAverageTests
+{
+    private readonly FreeSchoolMealsAverage _sut = new(1, "test", "test");
+
+    [Fact]
+    public void OldLaCode_should_be_initialised_with_constructor()
+    {
+        _sut.OldLaCode.Should().Be(1);
+    }
+
+    [Fact]
+    public void LaName_should_be_initialised_with_constructor()
+    {
+        _sut.LaName.Should().Be("test");
+    }
+
+    [Fact]
+    public void NewLaCode_should_be_initialised_with_constructor()
+    {
+        _sut.NewLaCode.Should().Be("test");
+    }
+
+    [Fact]
+    public void NewLaCode_is_not_required_constructor_parameter()
+    {
+        var sut = new FreeSchoolMealsAverage(2, "test");
+        sut.NewLaCode.Should().BeNull();
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/GlobalUsings.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using Xunit;
+global using FluentAssertions;
+global using Moq;

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyAcademyFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyAcademyFactory.cs
@@ -29,7 +29,7 @@ public class DummyAcademyFactory
         string phaseOfEducation = "test",
         int? numberOfPupils = 300,
         int? schoolCapacity = 400,
-        string? percentageFreeSchoolMeals = "test",
+        double? percentageFreeSchoolMeals = default,
         AgeRange? ageRange = null,
         int laCode = 334)
     {

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyAcademyFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyAcademyFactory.cs
@@ -30,7 +30,8 @@ public class DummyAcademyFactory
         int? numberOfPupils = 300,
         int? schoolCapacity = 400,
         string? percentageFreeSchoolMeals = "test",
-        AgeRange? ageRange = null)
+        AgeRange? ageRange = null,
+        int laCode = 334)
     {
         return new Academy(urn,
             new DateTime(2023, 11, 16),
@@ -44,6 +45,7 @@ public class DummyAcademyFactory
             percentageFreeSchoolMeals,
             ageRange ?? new AgeRange(1, 11),
             OfstedRating.None,
-            OfstedRating.None);
+            OfstedRating.None,
+            laCode);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
@@ -1,0 +1,34 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies;
+
+public class FreeSchoolMealsModelTests
+{
+    private readonly FreeSchoolMealsModel _sut;
+
+    public FreeSchoolMealsModelTests()
+    {
+        var mockTrustProvider = new Mock<ITrustProvider>();
+        var mockFreeSchoolMealsAverageProvider = new Mock<IFreeSchoolMealsAverageProvider>();
+        _sut = new FreeSchoolMealsModel(mockTrustProvider.Object, mockFreeSchoolMealsAverageProvider.Object);
+    }
+
+    [Fact]
+    public void PageTitle_should_be_AcademiesDetails()
+    {
+        _sut.PageTitle.Should().Be("Academies free school meals");
+    }
+
+    [Fact]
+    public void TabName_should_be_Details()
+    {
+        _sut.TabName.Should().Be("Free school meals");
+    }
+
+    [Fact]
+    public void PageName_should_be_AcademiesInThisTrust()
+    {
+        _sut.PageName.Should().Be("Academies in this trust");
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies;
@@ -6,12 +7,13 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies;
 public class FreeSchoolMealsModelTests
 {
     private readonly FreeSchoolMealsModel _sut;
+    private readonly Mock<IFreeSchoolMealsAverageProvider> _mockFreeSchoolMealsAverageProvider;
 
     public FreeSchoolMealsModelTests()
     {
         var mockTrustProvider = new Mock<ITrustProvider>();
-        var mockFreeSchoolMealsAverageProvider = new Mock<IFreeSchoolMealsAverageProvider>();
-        _sut = new FreeSchoolMealsModel(mockTrustProvider.Object, mockFreeSchoolMealsAverageProvider.Object);
+        _mockFreeSchoolMealsAverageProvider = new Mock<IFreeSchoolMealsAverageProvider>();
+        _sut = new FreeSchoolMealsModel(mockTrustProvider.Object, _mockFreeSchoolMealsAverageProvider.Object);
     }
 
     [Fact]
@@ -30,5 +32,27 @@ public class FreeSchoolMealsModelTests
     public void PageName_should_be_AcademiesInThisTrust()
     {
         _sut.PageName.Should().Be("Academies in this trust");
+    }
+
+    [Fact]
+    public void GetLaAverageFreeSchoolMeals_should_return_double_if_free_School_meals_provider_returns_value()
+    {
+        var dummyAcademy = DummyAcademyFactory.GetDummyAcademy(111);
+        var mockPercentage = 24.5;
+        _mockFreeSchoolMealsAverageProvider.Setup(p => p.GetLaAverage(dummyAcademy)).Returns(mockPercentage);
+
+        var result = _sut.GetLaAverageFreeSchoolMeals(dummyAcademy);
+        result.Should().Be(mockPercentage);
+    }
+
+    [Fact]
+    public void GetNationalAverageFreeSchoolMeals_should_return_double_if_free_School_meals_provider_returns_value()
+    {
+        var dummyAcademy = DummyAcademyFactory.GetDummyAcademy(111);
+        var mockPercentage = 24.5;
+        _mockFreeSchoolMealsAverageProvider.Setup(p => p.GetNationalAverage(dummyAcademy)).Returns(mockPercentage);
+
+        var result = _sut.GetNationalAverageFreeSchoolMeals(dummyAcademy);
+        result.Should().Be(mockPercentage);
     }
 }

--- a/tests/playwright/accessibility-tests/trusts/academies-pages.spec.ts
+++ b/tests/playwright/accessibility-tests/trusts/academies-pages.spec.ts
@@ -1,5 +1,6 @@
 import { FakeTestData } from '../../fake-data/fake-test-data'
 import { AcademiesDetailsPage } from '../../page-object-model/trust/academies/details-page'
+import { AcademiesFreeSchoolMealsPage } from '../../page-object-model/trust/academies/free-school-meals-page'
 import { AcademiesOfstedRatingsPage } from '../../page-object-model/trust/academies/ofsted-ratings-page'
 import { AcademiesPupilNumbersPage } from '../../page-object-model/trust/academies/pupil-numbers-page '
 import { test } from '../a11y-test'
@@ -10,6 +11,7 @@ test.describe('Academies pages', () => {
     const academiesDetailsPage = new AcademiesDetailsPage(page, fakeTestData)
     const academiesOfstedRatingsPage = new AcademiesOfstedRatingsPage(page, fakeTestData)
     const academiesPupilNumbersPage = new AcademiesPupilNumbersPage(page, fakeTestData)
+    const academiesFreeSchoolMealsPage = new AcademiesFreeSchoolMealsPage(page, fakeTestData)
 
     await academiesDetailsPage.goTo()
     await academiesDetailsPage.expect.toBeOnTheRightPage()
@@ -21,6 +23,10 @@ test.describe('Academies pages', () => {
 
     await academiesOfstedRatingsPage.subNavigation.clickOn('Pupil numbers')
     await academiesPupilNumbersPage.expect.toBeOnTheRightPage()
+    await expectNoAccessibilityViolations()
+
+    await academiesPupilNumbersPage.subNavigation.clickOn('Free school meals')
+    await academiesFreeSchoolMealsPage.expect.toBeOnTheRightPage()
     await expectNoAccessibilityViolations()
   })
 })

--- a/tests/playwright/fake-data/fake-test-data.ts
+++ b/tests/playwright/fake-data/fake-test-data.ts
@@ -31,6 +31,7 @@ export interface FakeAcademy {
     maximum: number
   }
   percentageFull: number
+  percentageFreeSchoolMeals: number
 }
 
 export interface FakePerson {

--- a/tests/playwright/fake-data/trusts.json
+++ b/tests/playwright/fake-data/trusts.json
@@ -20,7 +20,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 988,
         "schoolCapacity": 2406,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -46,7 +46,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 247,
         "schoolCapacity": 485,
-        "percentageFreeSchoolMeals": "4",
+        "percentageFreeSchoolMeals": 4,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -72,7 +72,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 983,
         "schoolCapacity": 1350,
-        "percentageFreeSchoolMeals": "25",
+        "percentageFreeSchoolMeals": 25,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -98,7 +98,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1201,
         "schoolCapacity": 1773,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -124,7 +124,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 772,
         "schoolCapacity": 1810,
-        "percentageFreeSchoolMeals": "20",
+        "percentageFreeSchoolMeals": 20,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -328,7 +328,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 398,
         "schoolCapacity": 380,
-        "percentageFreeSchoolMeals": "7",
+        "percentageFreeSchoolMeals": 7,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -354,7 +354,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 98,
         "schoolCapacity": 241,
-        "percentageFreeSchoolMeals": "10",
+        "percentageFreeSchoolMeals": 10,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -380,7 +380,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1998,
         "schoolCapacity": 2975,
-        "percentageFreeSchoolMeals": "28",
+        "percentageFreeSchoolMeals": 28,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -406,7 +406,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 2431,
         "schoolCapacity": 2901,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -432,7 +432,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 197,
         "schoolCapacity": 243,
-        "percentageFreeSchoolMeals": "29",
+        "percentageFreeSchoolMeals": 29,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -458,7 +458,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2796,
         "schoolCapacity": 2184,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -484,7 +484,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1377,
         "schoolCapacity": 1418,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -510,7 +510,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 910,
         "schoolCapacity": 2056,
-        "percentageFreeSchoolMeals": "10",
+        "percentageFreeSchoolMeals": 10,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -536,7 +536,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 386,
         "schoolCapacity": 807,
-        "percentageFreeSchoolMeals": "11",
+        "percentageFreeSchoolMeals": 11,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -562,7 +562,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 675,
         "schoolCapacity": 644,
-        "percentageFreeSchoolMeals": "25",
+        "percentageFreeSchoolMeals": 25,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -588,7 +588,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 374,
         "schoolCapacity": 438,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1013,7 +1013,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1525,
         "schoolCapacity": 2047,
-        "percentageFreeSchoolMeals": "8",
+        "percentageFreeSchoolMeals": 8,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1039,7 +1039,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 947,
         "schoolCapacity": 1570,
-        "percentageFreeSchoolMeals": "12",
+        "percentageFreeSchoolMeals": 12,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1065,7 +1065,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 3160,
         "schoolCapacity": 2859,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -1091,7 +1091,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 199,
         "schoolCapacity": 319,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1117,7 +1117,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 144,
         "schoolCapacity": 329,
-        "percentageFreeSchoolMeals": "10",
+        "percentageFreeSchoolMeals": 10,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1143,7 +1143,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 966,
         "schoolCapacity": 1936,
-        "percentageFreeSchoolMeals": "28",
+        "percentageFreeSchoolMeals": 28,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1169,7 +1169,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1255,
         "schoolCapacity": 1360,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -1195,7 +1195,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 685,
         "schoolCapacity": 1362,
-        "percentageFreeSchoolMeals": "26",
+        "percentageFreeSchoolMeals": 26,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1221,7 +1221,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1488,
         "schoolCapacity": 1602,
-        "percentageFreeSchoolMeals": "10",
+        "percentageFreeSchoolMeals": 10,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -1436,7 +1436,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1890,
         "schoolCapacity": 2929,
-        "percentageFreeSchoolMeals": "25",
+        "percentageFreeSchoolMeals": 25,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1462,7 +1462,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 114,
         "schoolCapacity": 281,
-        "percentageFreeSchoolMeals": "16",
+        "percentageFreeSchoolMeals": 16,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1600,7 +1600,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2090,
         "schoolCapacity": 2797,
-        "percentageFreeSchoolMeals": "28",
+        "percentageFreeSchoolMeals": 28,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -2066,7 +2066,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 3124,
         "schoolCapacity": 2673,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2092,7 +2092,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 717,
         "schoolCapacity": 1156,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -2118,7 +2118,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 814,
         "schoolCapacity": 703,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -2388,7 +2388,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2062,
         "schoolCapacity": 1903,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2493,7 +2493,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 2165,
         "schoolCapacity": 2546,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2519,7 +2519,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1892,
         "schoolCapacity": 2458,
-        "percentageFreeSchoolMeals": "28",
+        "percentageFreeSchoolMeals": 28,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2545,7 +2545,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1124,
         "schoolCapacity": 1398,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -2782,7 +2782,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1791,
         "schoolCapacity": 1526,
-        "percentageFreeSchoolMeals": "26",
+        "percentageFreeSchoolMeals": 26,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2808,7 +2808,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 931,
         "schoolCapacity": 758,
-        "percentageFreeSchoolMeals": "12",
+        "percentageFreeSchoolMeals": 12,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2834,7 +2834,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 656,
         "schoolCapacity": 851,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -2860,7 +2860,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1791,
         "schoolCapacity": 2036,
-        "percentageFreeSchoolMeals": "12",
+        "percentageFreeSchoolMeals": 12,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2886,7 +2886,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1469,
         "schoolCapacity": 1409,
-        "percentageFreeSchoolMeals": "3",
+        "percentageFreeSchoolMeals": 3,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -2912,7 +2912,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1831,
         "schoolCapacity": 1904,
-        "percentageFreeSchoolMeals": "11",
+        "percentageFreeSchoolMeals": 11,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2938,7 +2938,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 3078,
         "schoolCapacity": 2759,
-        "percentageFreeSchoolMeals": "25",
+        "percentageFreeSchoolMeals": 25,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3054,7 +3054,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 914,
         "schoolCapacity": 2263,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3080,7 +3080,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 514,
         "schoolCapacity": 547,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3106,7 +3106,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 705,
         "schoolCapacity": 1026,
-        "percentageFreeSchoolMeals": "25",
+        "percentageFreeSchoolMeals": 25,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -3132,7 +3132,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 347,
         "schoolCapacity": 577,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3158,7 +3158,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 832,
         "schoolCapacity": 698,
-        "percentageFreeSchoolMeals": "7",
+        "percentageFreeSchoolMeals": 7,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3184,7 +3184,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 614,
         "schoolCapacity": 1002,
-        "percentageFreeSchoolMeals": "11",
+        "percentageFreeSchoolMeals": 11,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -3210,7 +3210,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 2778,
         "schoolCapacity": 2431,
-        "percentageFreeSchoolMeals": "4",
+        "percentageFreeSchoolMeals": 4,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -3236,7 +3236,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 602,
         "schoolCapacity": 1039,
-        "percentageFreeSchoolMeals": "18",
+        "percentageFreeSchoolMeals": 18,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3262,7 +3262,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 114,
         "schoolCapacity": 119,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3543,7 +3543,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 798,
         "schoolCapacity": 1338,
-        "percentageFreeSchoolMeals": "26",
+        "percentageFreeSchoolMeals": 26,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -3569,7 +3569,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1217,
         "schoolCapacity": 2909,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -3595,7 +3595,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1634,
         "schoolCapacity": 1837,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3621,7 +3621,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2065,
         "schoolCapacity": 1612,
-        "percentageFreeSchoolMeals": "29",
+        "percentageFreeSchoolMeals": 29,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -3647,7 +3647,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2028,
         "schoolCapacity": 2982,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -3673,7 +3673,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 333,
         "schoolCapacity": 511,
-        "percentageFreeSchoolMeals": "9",
+        "percentageFreeSchoolMeals": 9,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3699,7 +3699,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2022,
         "schoolCapacity": 2052,
-        "percentageFreeSchoolMeals": "9",
+        "percentageFreeSchoolMeals": 9,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3725,7 +3725,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 314,
         "schoolCapacity": 370,
-        "percentageFreeSchoolMeals": "16",
+        "percentageFreeSchoolMeals": 16,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -3751,7 +3751,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 2067,
         "schoolCapacity": 2956,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3777,7 +3777,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1018,
         "schoolCapacity": 979,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -3803,7 +3803,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 681,
         "schoolCapacity": 1426,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3996,7 +3996,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1819,
         "schoolCapacity": 1601,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -4145,7 +4145,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1513,
         "schoolCapacity": 2379,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -4171,7 +4171,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 600,
         "schoolCapacity": 966,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -4197,7 +4197,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1737,
         "schoolCapacity": 1900,
-        "percentageFreeSchoolMeals": "4",
+        "percentageFreeSchoolMeals": 4,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -4223,7 +4223,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1951,
         "schoolCapacity": 2054,
-        "percentageFreeSchoolMeals": "8",
+        "percentageFreeSchoolMeals": 8,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -4249,7 +4249,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 916,
         "schoolCapacity": 1953,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -4894,7 +4894,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1031,
         "schoolCapacity": 1035,
-        "percentageFreeSchoolMeals": "20",
+        "percentageFreeSchoolMeals": 20,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -4920,7 +4920,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2577,
         "schoolCapacity": 2853,
-        "percentageFreeSchoolMeals": "4",
+        "percentageFreeSchoolMeals": 4,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -4946,7 +4946,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2240,
         "schoolCapacity": 1858,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -4972,7 +4972,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 731,
         "schoolCapacity": 1045,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -4998,7 +4998,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 201,
         "schoolCapacity": 349,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5024,7 +5024,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 177,
         "schoolCapacity": 192,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -5050,7 +5050,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1531,
         "schoolCapacity": 1814,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5199,7 +5199,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1312,
         "schoolCapacity": 1862,
-        "percentageFreeSchoolMeals": "12",
+        "percentageFreeSchoolMeals": 12,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -5225,7 +5225,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 977,
         "schoolCapacity": 1458,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5251,7 +5251,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1025,
         "schoolCapacity": 804,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5277,7 +5277,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1274,
         "schoolCapacity": 1525,
-        "percentageFreeSchoolMeals": "16",
+        "percentageFreeSchoolMeals": 16,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -5303,7 +5303,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2659,
         "schoolCapacity": 2302,
-        "percentageFreeSchoolMeals": "25",
+        "percentageFreeSchoolMeals": 25,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5329,7 +5329,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 298,
         "schoolCapacity": 356,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -5355,7 +5355,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 925,
         "schoolCapacity": 727,
-        "percentageFreeSchoolMeals": "10",
+        "percentageFreeSchoolMeals": 10,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5381,7 +5381,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1034,
         "schoolCapacity": 1515,
-        "percentageFreeSchoolMeals": "18",
+        "percentageFreeSchoolMeals": 18,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5407,7 +5407,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 338,
         "schoolCapacity": 348,
-        "percentageFreeSchoolMeals": "10",
+        "percentageFreeSchoolMeals": 10,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5633,7 +5633,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 248,
         "schoolCapacity": 273,
-        "percentageFreeSchoolMeals": "10",
+        "percentageFreeSchoolMeals": 10,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -5659,7 +5659,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 951,
         "schoolCapacity": 1109,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -5685,7 +5685,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 252,
         "schoolCapacity": 459,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5711,7 +5711,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 310,
         "schoolCapacity": 754,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5737,7 +5737,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 282,
         "schoolCapacity": 592,
-        "percentageFreeSchoolMeals": "26",
+        "percentageFreeSchoolMeals": 26,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -5763,7 +5763,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1885,
         "schoolCapacity": 2282,
-        "percentageFreeSchoolMeals": "1",
+        "percentageFreeSchoolMeals": 1,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -6044,7 +6044,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 306,
         "schoolCapacity": 555,
-        "percentageFreeSchoolMeals": "21",
+        "percentageFreeSchoolMeals": 21,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -6070,7 +6070,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 134,
         "schoolCapacity": 127,
-        "percentageFreeSchoolMeals": "18",
+        "percentageFreeSchoolMeals": 18,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -6096,7 +6096,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 380,
         "schoolCapacity": 301,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -6122,7 +6122,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1273,
         "schoolCapacity": 1960,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -6148,7 +6148,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1694,
         "schoolCapacity": 1606,
-        "percentageFreeSchoolMeals": "11",
+        "percentageFreeSchoolMeals": 11,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -6617,7 +6617,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 943,
         "schoolCapacity": 730,
-        "percentageFreeSchoolMeals": "17",
+        "percentageFreeSchoolMeals": 17,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -6643,7 +6643,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1550,
         "schoolCapacity": 1434,
-        "percentageFreeSchoolMeals": "26",
+        "percentageFreeSchoolMeals": 26,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -6669,7 +6669,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1160,
         "schoolCapacity": 2127,
-        "percentageFreeSchoolMeals": "16",
+        "percentageFreeSchoolMeals": 16,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -6695,7 +6695,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 879,
         "schoolCapacity": 1291,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -6721,7 +6721,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1386,
         "schoolCapacity": 1572,
-        "percentageFreeSchoolMeals": "9",
+        "percentageFreeSchoolMeals": 9,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -7131,7 +7131,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 511,
         "schoolCapacity": 649,
-        "percentageFreeSchoolMeals": "8",
+        "percentageFreeSchoolMeals": 8,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -7157,7 +7157,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1607,
         "schoolCapacity": 1352,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -7183,7 +7183,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 806,
         "schoolCapacity": 934,
-        "percentageFreeSchoolMeals": "15",
+        "percentageFreeSchoolMeals": 15,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -7464,7 +7464,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 3221,
         "schoolCapacity": 2918,
-        "percentageFreeSchoolMeals": "4",
+        "percentageFreeSchoolMeals": 4,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -7490,7 +7490,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1435,
         "schoolCapacity": 1218,
-        "percentageFreeSchoolMeals": "3",
+        "percentageFreeSchoolMeals": 3,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -7516,7 +7516,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 3612,
         "schoolCapacity": 2804,
-        "percentageFreeSchoolMeals": "28",
+        "percentageFreeSchoolMeals": 28,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -7542,7 +7542,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1005,
         "schoolCapacity": 2286,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -7568,7 +7568,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 976,
         "schoolCapacity": 988,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -7594,7 +7594,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1448,
         "schoolCapacity": 1976,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -7620,7 +7620,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 470,
         "schoolCapacity": 765,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -7646,7 +7646,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1593,
         "schoolCapacity": 1842,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -7672,7 +7672,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1493,
         "schoolCapacity": 2861,
-        "percentageFreeSchoolMeals": "18",
+        "percentageFreeSchoolMeals": 18,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -7887,7 +7887,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1111,
         "schoolCapacity": 1283,
-        "percentageFreeSchoolMeals": "26",
+        "percentageFreeSchoolMeals": 26,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -8323,7 +8323,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1759,
         "schoolCapacity": 1903,
-        "percentageFreeSchoolMeals": "29",
+        "percentageFreeSchoolMeals": 29,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -8349,7 +8349,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1376,
         "schoolCapacity": 1067,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -8375,7 +8375,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 900,
         "schoolCapacity": 1526,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -8401,7 +8401,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1429,
         "schoolCapacity": 2897,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -8427,7 +8427,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 465,
         "schoolCapacity": 608,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -8453,7 +8453,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2896,
         "schoolCapacity": 2696,
-        "percentageFreeSchoolMeals": "3",
+        "percentageFreeSchoolMeals": 3,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -8479,7 +8479,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1050,
         "schoolCapacity": 1184,
-        "percentageFreeSchoolMeals": "29",
+        "percentageFreeSchoolMeals": 29,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -8760,7 +8760,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1827,
         "schoolCapacity": 1717,
-        "percentageFreeSchoolMeals": "12",
+        "percentageFreeSchoolMeals": 12,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -8786,7 +8786,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 486,
         "schoolCapacity": 579,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -8812,7 +8812,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1215,
         "schoolCapacity": 1428,
-        "percentageFreeSchoolMeals": "3",
+        "percentageFreeSchoolMeals": 3,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -8838,7 +8838,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 590,
         "schoolCapacity": 785,
-        "percentageFreeSchoolMeals": "7",
+        "percentageFreeSchoolMeals": 7,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -9039,7 +9039,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1451,
         "schoolCapacity": 1315,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -9065,7 +9065,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1059,
         "schoolCapacity": 2141,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -9091,7 +9091,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1333,
         "schoolCapacity": 2355,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -9117,7 +9117,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1840,
         "schoolCapacity": 1611,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -9143,7 +9143,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 844,
         "schoolCapacity": 695,
-        "percentageFreeSchoolMeals": "11",
+        "percentageFreeSchoolMeals": 11,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -9169,7 +9169,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1113,
         "schoolCapacity": 1522,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -9195,7 +9195,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1157,
         "schoolCapacity": 1429,
-        "percentageFreeSchoolMeals": "7",
+        "percentageFreeSchoolMeals": 7,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -9221,7 +9221,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 508,
         "schoolCapacity": 610,
-        "percentageFreeSchoolMeals": "21",
+        "percentageFreeSchoolMeals": 21,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -9247,7 +9247,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 499,
         "schoolCapacity": 490,
-        "percentageFreeSchoolMeals": "25",
+        "percentageFreeSchoolMeals": 25,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -9580,7 +9580,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 652,
         "schoolCapacity": 672,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -9935,7 +9935,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 2573,
         "schoolCapacity": 2023,
-        "percentageFreeSchoolMeals": "3",
+        "percentageFreeSchoolMeals": 3,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -9961,7 +9961,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 867,
         "schoolCapacity": 1008,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -9987,7 +9987,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1998,
         "schoolCapacity": 2033,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -10013,7 +10013,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 996,
         "schoolCapacity": 1200,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -10039,7 +10039,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 284,
         "schoolCapacity": 271,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -10065,7 +10065,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 793,
         "schoolCapacity": 1400,
-        "percentageFreeSchoolMeals": "21",
+        "percentageFreeSchoolMeals": 21,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -10413,7 +10413,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1630,
         "schoolCapacity": 1841,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -10439,7 +10439,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 3205,
         "schoolCapacity": 2699,
-        "percentageFreeSchoolMeals": "4",
+        "percentageFreeSchoolMeals": 4,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -10465,7 +10465,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2403,
         "schoolCapacity": 2395,
-        "percentageFreeSchoolMeals": "20",
+        "percentageFreeSchoolMeals": 20,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -10491,7 +10491,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1317,
         "schoolCapacity": 1441,
-        "percentageFreeSchoolMeals": "21",
+        "percentageFreeSchoolMeals": 21,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -10517,7 +10517,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 3033,
         "schoolCapacity": 2990,
-        "percentageFreeSchoolMeals": "17",
+        "percentageFreeSchoolMeals": 17,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -10721,7 +10721,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 883,
         "schoolCapacity": 736,
-        "percentageFreeSchoolMeals": "28",
+        "percentageFreeSchoolMeals": 28,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -10747,7 +10747,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1636,
         "schoolCapacity": 2167,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -10773,7 +10773,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1378,
         "schoolCapacity": 2153,
-        "percentageFreeSchoolMeals": "18",
+        "percentageFreeSchoolMeals": 18,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -10799,7 +10799,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 910,
         "schoolCapacity": 826,
-        "percentageFreeSchoolMeals": "8",
+        "percentageFreeSchoolMeals": 8,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -10825,7 +10825,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 877,
         "schoolCapacity": 735,
-        "percentageFreeSchoolMeals": "7",
+        "percentageFreeSchoolMeals": 7,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -10851,7 +10851,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 529,
         "schoolCapacity": 677,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -10877,7 +10877,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 955,
         "schoolCapacity": 1569,
-        "percentageFreeSchoolMeals": "16",
+        "percentageFreeSchoolMeals": 16,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -11222,7 +11222,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 959,
         "schoolCapacity": 1171,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -11382,7 +11382,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 3514,
         "schoolCapacity": 2914,
-        "percentageFreeSchoolMeals": "11",
+        "percentageFreeSchoolMeals": 11,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -11649,7 +11649,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1043,
         "schoolCapacity": 1230,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -11675,7 +11675,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1945,
         "schoolCapacity": 1906,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -11923,7 +11923,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 741,
         "schoolCapacity": 653,
-        "percentageFreeSchoolMeals": "25",
+        "percentageFreeSchoolMeals": 25,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -11949,7 +11949,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 82,
         "schoolCapacity": 173,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -11975,7 +11975,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1287,
         "schoolCapacity": 1530,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -12001,7 +12001,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 345,
         "schoolCapacity": 270,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -12027,7 +12027,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 823,
         "schoolCapacity": 1145,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -12360,7 +12360,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 811,
         "schoolCapacity": 1486,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -12386,7 +12386,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 2890,
         "schoolCapacity": 2552,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -12412,7 +12412,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 912,
         "schoolCapacity": 1284,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -12438,7 +12438,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 961,
         "schoolCapacity": 1254,
-        "percentageFreeSchoolMeals": "9",
+        "percentageFreeSchoolMeals": 9,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -12464,7 +12464,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1540,
         "schoolCapacity": 1837,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -12490,7 +12490,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1026,
         "schoolCapacity": 909,
-        "percentageFreeSchoolMeals": "8",
+        "percentageFreeSchoolMeals": 8,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -12516,7 +12516,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1647,
         "schoolCapacity": 2912,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -12542,7 +12542,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2121,
         "schoolCapacity": 2013,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -12568,7 +12568,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 2824,
         "schoolCapacity": 2682,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -12594,7 +12594,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2856,
         "schoolCapacity": 2825,
-        "percentageFreeSchoolMeals": "29",
+        "percentageFreeSchoolMeals": 29,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -12710,7 +12710,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 539,
         "schoolCapacity": 924,
-        "percentageFreeSchoolMeals": "15",
+        "percentageFreeSchoolMeals": 15,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -12999,7 +12999,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 2324,
         "schoolCapacity": 2578,
-        "percentageFreeSchoolMeals": "29",
+        "percentageFreeSchoolMeals": 29,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -13025,7 +13025,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1307,
         "schoolCapacity": 1948,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -13051,7 +13051,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1080,
         "schoolCapacity": 1325,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -13077,7 +13077,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 385,
         "schoolCapacity": 937,
-        "percentageFreeSchoolMeals": "16",
+        "percentageFreeSchoolMeals": 16,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -13103,7 +13103,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1424,
         "schoolCapacity": 1389,
-        "percentageFreeSchoolMeals": "11",
+        "percentageFreeSchoolMeals": 11,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -13129,7 +13129,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2501,
         "schoolCapacity": 2335,
-        "percentageFreeSchoolMeals": "28",
+        "percentageFreeSchoolMeals": 28,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -13155,7 +13155,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 511,
         "schoolCapacity": 674,
-        "percentageFreeSchoolMeals": "16",
+        "percentageFreeSchoolMeals": 16,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -13181,7 +13181,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1896,
         "schoolCapacity": 1864,
-        "percentageFreeSchoolMeals": "10",
+        "percentageFreeSchoolMeals": 10,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -13207,7 +13207,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1245,
         "schoolCapacity": 1499,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -13477,7 +13477,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 684,
         "schoolCapacity": 693,
-        "percentageFreeSchoolMeals": "10",
+        "percentageFreeSchoolMeals": 10,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -13503,7 +13503,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 907,
         "schoolCapacity": 1026,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -13529,7 +13529,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2841,
         "schoolCapacity": 2543,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -13555,7 +13555,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 333,
         "schoolCapacity": 788,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -13581,7 +13581,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1178,
         "schoolCapacity": 2364,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -13607,7 +13607,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 745,
         "schoolCapacity": 1690,
-        "percentageFreeSchoolMeals": "29",
+        "percentageFreeSchoolMeals": 29,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -13633,7 +13633,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 203,
         "schoolCapacity": 343,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -13659,7 +13659,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 2074,
         "schoolCapacity": 1704,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -13685,7 +13685,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1102,
         "schoolCapacity": 1206,
-        "percentageFreeSchoolMeals": "7",
+        "percentageFreeSchoolMeals": 7,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -13711,7 +13711,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1156,
         "schoolCapacity": 1827,
-        "percentageFreeSchoolMeals": "12",
+        "percentageFreeSchoolMeals": 12,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -13737,7 +13737,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 921,
         "schoolCapacity": 877,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -14007,7 +14007,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1915,
         "schoolCapacity": 2702,
-        "percentageFreeSchoolMeals": "18",
+        "percentageFreeSchoolMeals": 18,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -14033,7 +14033,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1474,
         "schoolCapacity": 2254,
-        "percentageFreeSchoolMeals": "16",
+        "percentageFreeSchoolMeals": 16,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -14059,7 +14059,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 65,
         "schoolCapacity": 126,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -14085,7 +14085,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1399,
         "schoolCapacity": 1107,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -14111,7 +14111,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2534,
         "schoolCapacity": 2265,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -14137,7 +14137,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 2656,
         "schoolCapacity": 2938,
-        "percentageFreeSchoolMeals": "9",
+        "percentageFreeSchoolMeals": 9,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -14163,7 +14163,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1083,
         "schoolCapacity": 1457,
-        "percentageFreeSchoolMeals": "12",
+        "percentageFreeSchoolMeals": 12,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -14189,7 +14189,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 787,
         "schoolCapacity": 1634,
-        "percentageFreeSchoolMeals": "1",
+        "percentageFreeSchoolMeals": 1,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -14812,7 +14812,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 3052,
         "schoolCapacity": 2511,
-        "percentageFreeSchoolMeals": "20",
+        "percentageFreeSchoolMeals": 20,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -14972,7 +14972,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2490,
         "schoolCapacity": 2572,
-        "percentageFreeSchoolMeals": "15",
+        "percentageFreeSchoolMeals": 15,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -15165,7 +15165,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1202,
         "schoolCapacity": 1700,
-        "percentageFreeSchoolMeals": "16",
+        "percentageFreeSchoolMeals": 16,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -15303,7 +15303,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1943,
         "schoolCapacity": 1722,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -15430,7 +15430,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 460,
         "schoolCapacity": 491,
-        "percentageFreeSchoolMeals": "1",
+        "percentageFreeSchoolMeals": 1,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -15744,7 +15744,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 899,
         "schoolCapacity": 1168,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -15970,7 +15970,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 3050,
         "schoolCapacity": 2380,
-        "percentageFreeSchoolMeals": "21",
+        "percentageFreeSchoolMeals": 21,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -16284,7 +16284,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1349,
         "schoolCapacity": 1285,
-        "percentageFreeSchoolMeals": "9",
+        "percentageFreeSchoolMeals": 9,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -16573,7 +16573,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 615,
         "schoolCapacity": 1484,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -16599,7 +16599,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 621,
         "schoolCapacity": 698,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -16625,7 +16625,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1312,
         "schoolCapacity": 1017,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -16651,7 +16651,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1279,
         "schoolCapacity": 1489,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -16677,7 +16677,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 131,
         "schoolCapacity": 178,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -16703,7 +16703,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1522,
         "schoolCapacity": 1274,
-        "percentageFreeSchoolMeals": "18",
+        "percentageFreeSchoolMeals": 18,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -16729,7 +16729,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 188,
         "schoolCapacity": 356,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -16755,7 +16755,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1581,
         "schoolCapacity": 1427,
-        "percentageFreeSchoolMeals": "28",
+        "percentageFreeSchoolMeals": 28,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -16781,7 +16781,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1667,
         "schoolCapacity": 2347,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -17095,7 +17095,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 740,
         "schoolCapacity": 721,
-        "percentageFreeSchoolMeals": "16",
+        "percentageFreeSchoolMeals": 16,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -17310,7 +17310,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 753,
         "schoolCapacity": 1006,
-        "percentageFreeSchoolMeals": "8",
+        "percentageFreeSchoolMeals": 8,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -17635,7 +17635,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 206,
         "schoolCapacity": 397,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -17806,7 +17806,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2866,
         "schoolCapacity": 2559,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -18153,7 +18153,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1855,
         "schoolCapacity": 1885,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -18346,7 +18346,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 3010,
         "schoolCapacity": 2321,
-        "percentageFreeSchoolMeals": "17",
+        "percentageFreeSchoolMeals": 17,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -18583,7 +18583,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2133,
         "schoolCapacity": 2240,
-        "percentageFreeSchoolMeals": "7",
+        "percentageFreeSchoolMeals": 7,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -18853,7 +18853,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 80,
         "schoolCapacity": 127,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -19134,7 +19134,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 328,
         "schoolCapacity": 433,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -19160,7 +19160,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1680,
         "schoolCapacity": 1425,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -19186,7 +19186,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 151,
         "schoolCapacity": 168,
-        "percentageFreeSchoolMeals": "28",
+        "percentageFreeSchoolMeals": 28,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19212,7 +19212,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1403,
         "schoolCapacity": 1491,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19238,7 +19238,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1116,
         "schoolCapacity": 896,
-        "percentageFreeSchoolMeals": "10",
+        "percentageFreeSchoolMeals": 10,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19264,7 +19264,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 295,
         "schoolCapacity": 399,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -19290,7 +19290,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 347,
         "schoolCapacity": 720,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -19316,7 +19316,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 207,
         "schoolCapacity": 300,
-        "percentageFreeSchoolMeals": "26",
+        "percentageFreeSchoolMeals": 26,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19342,7 +19342,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 3286,
         "schoolCapacity": 2641,
-        "percentageFreeSchoolMeals": "7",
+        "percentageFreeSchoolMeals": 7,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19368,7 +19368,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 900,
         "schoolCapacity": 1286,
-        "percentageFreeSchoolMeals": "7",
+        "percentageFreeSchoolMeals": 7,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19394,7 +19394,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 2328,
         "schoolCapacity": 2137,
-        "percentageFreeSchoolMeals": "26",
+        "percentageFreeSchoolMeals": 26,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19686,7 +19686,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1910,
         "schoolCapacity": 2682,
-        "percentageFreeSchoolMeals": "28",
+        "percentageFreeSchoolMeals": 28,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -19712,7 +19712,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2724,
         "schoolCapacity": 2417,
-        "percentageFreeSchoolMeals": "8",
+        "percentageFreeSchoolMeals": 8,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19982,7 +19982,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 473,
         "schoolCapacity": 397,
-        "percentageFreeSchoolMeals": "9",
+        "percentageFreeSchoolMeals": 9,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20008,7 +20008,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1471,
         "schoolCapacity": 2971,
-        "percentageFreeSchoolMeals": "10",
+        "percentageFreeSchoolMeals": 10,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20034,7 +20034,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1651,
         "schoolCapacity": 1692,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20060,7 +20060,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 822,
         "schoolCapacity": 1976,
-        "percentageFreeSchoolMeals": "15",
+        "percentageFreeSchoolMeals": 15,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20086,7 +20086,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 714,
         "schoolCapacity": 666,
-        "percentageFreeSchoolMeals": "26",
+        "percentageFreeSchoolMeals": 26,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20112,7 +20112,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1623,
         "schoolCapacity": 2600,
-        "percentageFreeSchoolMeals": "3",
+        "percentageFreeSchoolMeals": 3,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20138,7 +20138,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 658,
         "schoolCapacity": 666,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -20331,7 +20331,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1087,
         "schoolCapacity": 1742,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20357,7 +20357,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1163,
         "schoolCapacity": 2242,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20383,7 +20383,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1908,
         "schoolCapacity": 1718,
-        "percentageFreeSchoolMeals": "3",
+        "percentageFreeSchoolMeals": 3,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20409,7 +20409,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1104,
         "schoolCapacity": 1855,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20435,7 +20435,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 2514,
         "schoolCapacity": 2594,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20461,7 +20461,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1955,
         "schoolCapacity": 2261,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20487,7 +20487,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1012,
         "schoolCapacity": 1288,
-        "percentageFreeSchoolMeals": "10",
+        "percentageFreeSchoolMeals": 10,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20513,7 +20513,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 831,
         "schoolCapacity": 1373,
-        "percentageFreeSchoolMeals": "18",
+        "percentageFreeSchoolMeals": 18,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20640,7 +20640,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 998,
         "schoolCapacity": 1248,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20899,7 +20899,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1075,
         "schoolCapacity": 1221,
-        "percentageFreeSchoolMeals": "18",
+        "percentageFreeSchoolMeals": 18,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20925,7 +20925,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 3537,
         "schoolCapacity": 2795,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20951,7 +20951,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 899,
         "schoolCapacity": 1350,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20977,7 +20977,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 604,
         "schoolCapacity": 1445,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21003,7 +21003,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 838,
         "schoolCapacity": 654,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -21029,7 +21029,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1590,
         "schoolCapacity": 2783,
-        "percentageFreeSchoolMeals": "28",
+        "percentageFreeSchoolMeals": 28,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21055,7 +21055,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2102,
         "schoolCapacity": 1809,
-        "percentageFreeSchoolMeals": "11",
+        "percentageFreeSchoolMeals": 11,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -21081,7 +21081,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 696,
         "schoolCapacity": 622,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21107,7 +21107,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2173,
         "schoolCapacity": 2086,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -21133,7 +21133,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 2732,
         "schoolCapacity": 2533,
-        "percentageFreeSchoolMeals": "14",
+        "percentageFreeSchoolMeals": 14,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -21159,7 +21159,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 308,
         "schoolCapacity": 262,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -21316,7 +21316,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 2288,
         "schoolCapacity": 1995,
-        "percentageFreeSchoolMeals": "15",
+        "percentageFreeSchoolMeals": 15,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -21342,7 +21342,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1323,
         "schoolCapacity": 2261,
-        "percentageFreeSchoolMeals": "11",
+        "percentageFreeSchoolMeals": 11,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -21368,7 +21368,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1697,
         "schoolCapacity": 2319,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -21394,7 +21394,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1047,
         "schoolCapacity": 2383,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21420,7 +21420,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 882,
         "schoolCapacity": 700,
-        "percentageFreeSchoolMeals": "15",
+        "percentageFreeSchoolMeals": 15,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21446,7 +21446,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 908,
         "schoolCapacity": 1372,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -21472,7 +21472,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 581,
         "schoolCapacity": 1285,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21498,7 +21498,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 482,
         "schoolCapacity": 1084,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21524,7 +21524,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2678,
         "schoolCapacity": 2978,
-        "percentageFreeSchoolMeals": "15",
+        "percentageFreeSchoolMeals": 15,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21550,7 +21550,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1530,
         "schoolCapacity": 1534,
-        "percentageFreeSchoolMeals": "15",
+        "percentageFreeSchoolMeals": 15,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21576,7 +21576,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 826,
         "schoolCapacity": 1626,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21780,7 +21780,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 494,
         "schoolCapacity": 488,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -21806,7 +21806,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 370,
         "schoolCapacity": 430,
-        "percentageFreeSchoolMeals": "1",
+        "percentageFreeSchoolMeals": 1,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21832,7 +21832,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 165,
         "schoolCapacity": 213,
-        "percentageFreeSchoolMeals": "8",
+        "percentageFreeSchoolMeals": 8,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -21858,7 +21858,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1769,
         "schoolCapacity": 2425,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21884,7 +21884,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1129,
         "schoolCapacity": 1779,
-        "percentageFreeSchoolMeals": "3",
+        "percentageFreeSchoolMeals": 3,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -21910,7 +21910,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1255,
         "schoolCapacity": 1377,
-        "percentageFreeSchoolMeals": "30",
+        "percentageFreeSchoolMeals": 30,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -22235,7 +22235,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1053,
         "schoolCapacity": 2328,
-        "percentageFreeSchoolMeals": "8",
+        "percentageFreeSchoolMeals": 8,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -22261,7 +22261,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1643,
         "schoolCapacity": 1435,
-        "percentageFreeSchoolMeals": "9",
+        "percentageFreeSchoolMeals": 9,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -22287,7 +22287,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1290,
         "schoolCapacity": 1950,
-        "percentageFreeSchoolMeals": "15",
+        "percentageFreeSchoolMeals": 15,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -22313,7 +22313,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 354,
         "schoolCapacity": 533,
-        "percentageFreeSchoolMeals": "29",
+        "percentageFreeSchoolMeals": 29,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -22671,7 +22671,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1662,
         "schoolCapacity": 2132,
-        "percentageFreeSchoolMeals": "28",
+        "percentageFreeSchoolMeals": 28,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -22697,7 +22697,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 955,
         "schoolCapacity": 2013,
-        "percentageFreeSchoolMeals": "4",
+        "percentageFreeSchoolMeals": 4,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -22723,7 +22723,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1006,
         "schoolCapacity": 1244,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -22749,7 +22749,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1368,
         "schoolCapacity": 1160,
-        "percentageFreeSchoolMeals": "18",
+        "percentageFreeSchoolMeals": 18,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -23130,7 +23130,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1171,
         "schoolCapacity": 942,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -23156,7 +23156,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1312,
         "schoolCapacity": 1251,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -23182,7 +23182,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1600,
         "schoolCapacity": 1723,
-        "percentageFreeSchoolMeals": "23",
+        "percentageFreeSchoolMeals": 23,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -23208,7 +23208,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1592,
         "schoolCapacity": 2485,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -23234,7 +23234,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1085,
         "schoolCapacity": 1157,
-        "percentageFreeSchoolMeals": "19",
+        "percentageFreeSchoolMeals": 19,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -23260,7 +23260,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2410,
         "schoolCapacity": 2385,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -23286,7 +23286,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 557,
         "schoolCapacity": 1164,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -23435,7 +23435,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 279,
         "schoolCapacity": 391,
-        "percentageFreeSchoolMeals": "20",
+        "percentageFreeSchoolMeals": 20,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -23461,7 +23461,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 2271,
         "schoolCapacity": 2251,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -23487,7 +23487,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 256,
         "schoolCapacity": 334,
-        "percentageFreeSchoolMeals": "29",
+        "percentageFreeSchoolMeals": 29,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -23812,7 +23812,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 456,
         "schoolCapacity": 622,
-        "percentageFreeSchoolMeals": "15",
+        "percentageFreeSchoolMeals": 15,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -23838,7 +23838,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 2890,
         "schoolCapacity": 2980,
-        "percentageFreeSchoolMeals": "12",
+        "percentageFreeSchoolMeals": 12,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -23864,7 +23864,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 87,
         "schoolCapacity": 136,
-        "percentageFreeSchoolMeals": "17",
+        "percentageFreeSchoolMeals": 17,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -23890,7 +23890,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 857,
         "schoolCapacity": 1066,
-        "percentageFreeSchoolMeals": "17",
+        "percentageFreeSchoolMeals": 17,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -23916,7 +23916,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 2885,
         "schoolCapacity": 2314,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -23942,7 +23942,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2870,
         "schoolCapacity": 2297,
-        "percentageFreeSchoolMeals": "21",
+        "percentageFreeSchoolMeals": 21,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -23968,7 +23968,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1320,
         "schoolCapacity": 2274,
-        "percentageFreeSchoolMeals": "20",
+        "percentageFreeSchoolMeals": 20,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -24304,7 +24304,7 @@
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1098,
         "schoolCapacity": 866,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -24330,7 +24330,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 796,
         "schoolCapacity": 1750,
-        "percentageFreeSchoolMeals": "22",
+        "percentageFreeSchoolMeals": 22,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -24356,7 +24356,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1045,
         "schoolCapacity": 1557,
-        "percentageFreeSchoolMeals": "8",
+        "percentageFreeSchoolMeals": 8,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -24382,7 +24382,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 2121,
         "schoolCapacity": 1902,
-        "percentageFreeSchoolMeals": "3",
+        "percentageFreeSchoolMeals": 3,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -24408,7 +24408,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 827,
         "schoolCapacity": 655,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -24434,7 +24434,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1053,
         "schoolCapacity": 1530,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -24460,7 +24460,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 350,
         "schoolCapacity": 298,
-        "percentageFreeSchoolMeals": "16",
+        "percentageFreeSchoolMeals": 16,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -24653,7 +24653,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1347,
         "schoolCapacity": 1468,
-        "percentageFreeSchoolMeals": "1",
+        "percentageFreeSchoolMeals": 1,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -24679,7 +24679,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 155,
         "schoolCapacity": 173,
-        "percentageFreeSchoolMeals": "6",
+        "percentageFreeSchoolMeals": 6,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -24705,7 +24705,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 985,
         "schoolCapacity": 1991,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -24731,7 +24731,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 3399,
         "schoolCapacity": 2667,
-        "percentageFreeSchoolMeals": "8",
+        "percentageFreeSchoolMeals": 8,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -24757,7 +24757,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 370,
         "schoolCapacity": 315,
-        "percentageFreeSchoolMeals": "17",
+        "percentageFreeSchoolMeals": 17,
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -24783,7 +24783,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 434,
         "schoolCapacity": 945,
-        "percentageFreeSchoolMeals": "27",
+        "percentageFreeSchoolMeals": 27,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -24809,7 +24809,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 264,
         "schoolCapacity": 653,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -24835,7 +24835,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1268,
         "schoolCapacity": 2712,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -24861,7 +24861,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2083,
         "schoolCapacity": 2996,
-        "percentageFreeSchoolMeals": "12",
+        "percentageFreeSchoolMeals": 12,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -25054,7 +25054,7 @@
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 546,
         "schoolCapacity": 508,
-        "percentageFreeSchoolMeals": "13",
+        "percentageFreeSchoolMeals": 13,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -25080,7 +25080,7 @@
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2042,
         "schoolCapacity": 1768,
-        "percentageFreeSchoolMeals": "4",
+        "percentageFreeSchoolMeals": 4,
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -25106,7 +25106,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 625,
         "schoolCapacity": 644,
-        "percentageFreeSchoolMeals": "11",
+        "percentageFreeSchoolMeals": 11,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -25132,7 +25132,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1878,
         "schoolCapacity": 1792,
-        "percentageFreeSchoolMeals": "5",
+        "percentageFreeSchoolMeals": 5,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -25158,7 +25158,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 585,
         "schoolCapacity": 1454,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -25184,7 +25184,7 @@
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 388,
         "schoolCapacity": 606,
-        "percentageFreeSchoolMeals": "2",
+        "percentageFreeSchoolMeals": 2,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -25210,7 +25210,7 @@
         "phaseOfEducation": "All-through",
         "numberOfPupils": 528,
         "schoolCapacity": 1066,
-        "percentageFreeSchoolMeals": "8",
+        "percentageFreeSchoolMeals": 8,
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -25236,7 +25236,7 @@
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 167,
         "schoolCapacity": 256,
-        "percentageFreeSchoolMeals": "24",
+        "percentageFreeSchoolMeals": 24,
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -25262,7 +25262,7 @@
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 3148,
         "schoolCapacity": 2703,
-        "percentageFreeSchoolMeals": "17",
+        "percentageFreeSchoolMeals": 17,
         "ageRange": {
           "minimum": 11,
           "maximum": 16

--- a/tests/playwright/fake-data/trusts.json
+++ b/tests/playwright/fake-data/trusts.json
@@ -15,7 +15,7 @@
         "dateAcademyJoinedTrust": "2019-04-06T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s CE Middle Deemed Secondary School",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 988,
@@ -33,6 +33,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2021-03-16T00:00:00"
         },
+        "oldLaCode": 384,
         "percentageFull": 41
       },
       {
@@ -40,7 +41,7 @@
         "dateAcademyJoinedTrust": "2018-08-11T00:00:00",
         "establishmentName": "St. Mary\u0027s C of E School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 247,
@@ -58,6 +59,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-07-06T00:00:00"
         },
+        "oldLaCode": 371,
         "percentageFull": 51
       },
       {
@@ -65,7 +67,7 @@
         "dateAcademyJoinedTrust": "2021-11-10T00:00:00",
         "establishmentName": "Horizon CE Middle Deemed Primary School",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 983,
@@ -83,6 +85,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 392,
         "percentageFull": 73
       },
       {
@@ -90,7 +93,7 @@
         "dateAcademyJoinedTrust": "2021-10-07T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 CE Academy",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1201,
@@ -108,6 +111,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-06-28T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 68
       },
       {
@@ -115,7 +119,7 @@
         "dateAcademyJoinedTrust": "2022-05-17T00:00:00",
         "establishmentName": "St. James\u0027 Catholic All-through School",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 772,
@@ -133,6 +137,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2019-04-16T00:00:00"
         },
+        "oldLaCode": 384,
         "percentageFull": 43
       }
     ],
@@ -318,7 +323,7 @@
         "dateAcademyJoinedTrust": "2023-04-20T00:00:00",
         "establishmentName": "St. Paul\u0027s Catholic All-through Academy",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 398,
@@ -336,6 +341,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-12-31T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 105
       },
       {
@@ -343,7 +349,7 @@
         "dateAcademyJoinedTrust": "2020-10-28T00:00:00",
         "establishmentName": "St. John\u0027s Catholic Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 98,
@@ -361,6 +367,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-10-06T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 41
       },
       {
@@ -368,7 +375,7 @@
         "dateAcademyJoinedTrust": "2022-07-16T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 Academy",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1998,
@@ -386,6 +393,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2013-05-24T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 67
       },
       {
@@ -393,7 +401,7 @@
         "dateAcademyJoinedTrust": "2021-10-22T00:00:00",
         "establishmentName": "St. Marys R.C. Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 2431,
@@ -411,6 +419,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 381,
         "percentageFull": 84
       },
       {
@@ -418,7 +427,7 @@
         "dateAcademyJoinedTrust": "2022-08-16T00:00:00",
         "establishmentName": "Horizon Cofe All-through Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 197,
@@ -436,6 +445,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2020-11-03T00:00:00"
         },
+        "oldLaCode": 394,
         "percentageFull": 81
       },
       {
@@ -443,7 +453,7 @@
         "dateAcademyJoinedTrust": "2023-05-29T00:00:00",
         "establishmentName": "Mulberry Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2796,
@@ -461,6 +471,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-03-10T00:00:00"
         },
+        "oldLaCode": 394,
         "percentageFull": 128
       },
       {
@@ -468,7 +479,7 @@
         "dateAcademyJoinedTrust": "2021-02-11T00:00:00",
         "establishmentName": "Harris Cofe Secondary Academy",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1377,
@@ -486,6 +497,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 390,
         "percentageFull": 97
       },
       {
@@ -493,7 +505,7 @@
         "dateAcademyJoinedTrust": "2023-04-02T00:00:00",
         "establishmentName": "Longhill School",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 910,
@@ -511,6 +523,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-02-04T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 44
       },
       {
@@ -518,7 +531,7 @@
         "dateAcademyJoinedTrust": "2021-04-30T00:00:00",
         "establishmentName": "Meridian School",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 386,
@@ -536,6 +549,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-03-24T00:00:00"
         },
+        "oldLaCode": 371,
         "percentageFull": 48
       },
       {
@@ -543,7 +557,7 @@
         "dateAcademyJoinedTrust": "2023-09-10T00:00:00",
         "establishmentName": "Momentum Community School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 675,
@@ -561,6 +575,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-01-01T00:00:00"
         },
+        "oldLaCode": 371,
         "percentageFull": 105
       },
       {
@@ -568,7 +583,7 @@
         "dateAcademyJoinedTrust": "2023-09-17T00:00:00",
         "establishmentName": "Harris Church of England Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 374,
@@ -586,6 +601,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2016-02-29T00:00:00"
         },
+        "oldLaCode": 371,
         "percentageFull": 85
       }
     ],
@@ -992,7 +1008,7 @@
         "dateAcademyJoinedTrust": "2023-09-14T00:00:00",
         "establishmentName": "Mulberry CE 16 Plus Academy",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1525,
@@ -1010,6 +1026,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-03-25T00:00:00"
         },
+        "oldLaCode": 394,
         "percentageFull": 74
       },
       {
@@ -1017,7 +1034,7 @@
         "dateAcademyJoinedTrust": "2021-07-30T00:00:00",
         "establishmentName": "Northwood Church of England Academy",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 947,
@@ -1035,6 +1052,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2021-06-29T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 60
       },
       {
@@ -1042,7 +1060,7 @@
         "dateAcademyJoinedTrust": "2018-06-30T00:00:00",
         "establishmentName": "St. James\u0027s R.C. Academy",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "North Yorkshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 3160,
@@ -1060,6 +1078,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2021-10-18T00:00:00"
         },
+        "oldLaCode": 390,
         "percentageFull": 111
       },
       {
@@ -1067,7 +1086,7 @@
         "dateAcademyJoinedTrust": "2023-02-09T00:00:00",
         "establishmentName": "St. Peter\u0027s Church of England School",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "North Yorkshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 199,
@@ -1085,6 +1104,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-07-04T00:00:00"
         },
+        "oldLaCode": 390,
         "percentageFull": 62
       },
       {
@@ -1092,7 +1112,7 @@
         "dateAcademyJoinedTrust": "2022-12-20T00:00:00",
         "establishmentName": "St. Catherine\u0027s Catholic Secondary School",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "North Yorkshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 144,
@@ -1110,6 +1130,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 390,
         "percentageFull": 44
       },
       {
@@ -1117,7 +1138,7 @@
         "dateAcademyJoinedTrust": "2021-01-11T00:00:00",
         "establishmentName": "Beacon Catholic Academy",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 966,
@@ -1135,6 +1156,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 394,
         "percentageFull": 50
       },
       {
@@ -1142,7 +1164,7 @@
         "dateAcademyJoinedTrust": "2020-08-04T00:00:00",
         "establishmentName": "George Abbey CE All-through School",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "North Yorkshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1255,
@@ -1160,6 +1182,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2011-02-24T00:00:00"
         },
+        "oldLaCode": 390,
         "percentageFull": 92
       },
       {
@@ -1185,6 +1208,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2015-01-30T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 50
       },
       {
@@ -1192,7 +1216,7 @@
         "dateAcademyJoinedTrust": "2022-01-08T00:00:00",
         "establishmentName": "Greensward Academy",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1488,
@@ -1210,6 +1234,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 392,
         "percentageFull": 93
       }
     ],
@@ -1406,7 +1431,7 @@
         "dateAcademyJoinedTrust": "2020-06-21T00:00:00",
         "establishmentName": "St. Marys Catholic School",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1890,
@@ -1424,6 +1449,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-11-07T00:00:00"
         },
+        "oldLaCode": 394,
         "percentageFull": 65
       },
       {
@@ -1431,7 +1457,7 @@
         "dateAcademyJoinedTrust": "2022-05-23T00:00:00",
         "establishmentName": "Greensward C of E Academy",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 114,
@@ -1449,6 +1475,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-01-20T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 41
       }
     ],
@@ -1568,7 +1595,7 @@
         "dateAcademyJoinedTrust": "2022-07-21T00:00:00",
         "establishmentName": "St. Catherine\u0027s R.C. Academy",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Sheffield",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2090,
@@ -1586,6 +1613,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2018-08-08T00:00:00"
         },
+        "oldLaCode": 373,
         "percentageFull": 75
       }
     ],
@@ -2033,7 +2061,7 @@
         "dateAcademyJoinedTrust": "2023-03-13T00:00:00",
         "establishmentName": "Beacon Church of England All-through School",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 3124,
@@ -2051,6 +2079,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-07-19T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 117
       },
       {
@@ -2058,7 +2087,7 @@
         "dateAcademyJoinedTrust": "2022-03-25T00:00:00",
         "establishmentName": "St. Peter\u0027s C of E Middle Deemed Secondary School",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 717,
@@ -2076,6 +2105,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-02-01T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 62
       },
       {
@@ -2083,7 +2113,7 @@
         "dateAcademyJoinedTrust": "2021-08-20T00:00:00",
         "establishmentName": "St. Joseph\u0027s Catholic All-through Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Bradford",
+        "localAuthority": "Barnsley",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 814,
@@ -2101,6 +2131,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 116
       }
     ],
@@ -2352,7 +2383,7 @@
         "dateAcademyJoinedTrust": "2016-03-14T00:00:00",
         "establishmentName": "Greensward Secondary Academy",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2062,
@@ -2370,6 +2401,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 371,
         "percentageFull": 108
       }
     ],
@@ -2456,7 +2488,7 @@
         "dateAcademyJoinedTrust": "2019-10-21T00:00:00",
         "establishmentName": "Peacehaven Community Cofe School",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 2165,
@@ -2474,6 +2506,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2021-03-06T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 85
       },
       {
@@ -2481,7 +2514,7 @@
         "dateAcademyJoinedTrust": "2019-09-01T00:00:00",
         "establishmentName": "Co-op C of E Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Barnsley",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1892,
@@ -2499,6 +2532,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2018-12-29T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 77
       },
       {
@@ -2524,6 +2558,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2020-09-13T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 80
       }
     ],
@@ -2740,9 +2775,9 @@
       {
         "urn": 12645485,
         "dateAcademyJoinedTrust": "2020-10-05T00:00:00",
-        "establishmentName": "Rotherham R.C. All-through Academy",
+        "establishmentName": "Newcastle upon Tyne R.C. All-through Academy",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1791,
@@ -2760,6 +2795,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 391,
         "percentageFull": 117
       },
       {
@@ -2767,7 +2803,7 @@
         "dateAcademyJoinedTrust": "2022-09-23T00:00:00",
         "establishmentName": "St. John\u0027s CE School",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 931,
@@ -2785,6 +2821,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2018-07-10T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 123
       },
       {
@@ -2792,7 +2829,7 @@
         "dateAcademyJoinedTrust": "2017-09-01T00:00:00",
         "establishmentName": "St. Mary\u0027s R.C. Secondary School",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 656,
@@ -2810,6 +2847,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2011-05-19T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 77
       },
       {
@@ -2817,7 +2855,7 @@
         "dateAcademyJoinedTrust": "2018-10-10T00:00:00",
         "establishmentName": "Halewood C of E Academy",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1791,
@@ -2835,6 +2873,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-06-24T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 88
       },
       {
@@ -2842,7 +2881,7 @@
         "dateAcademyJoinedTrust": "2020-11-23T00:00:00",
         "establishmentName": "Beacon Academy",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1469,
@@ -2860,6 +2899,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 391,
         "percentageFull": 104
       },
       {
@@ -2867,7 +2907,7 @@
         "dateAcademyJoinedTrust": "2021-04-03T00:00:00",
         "establishmentName": "St. Anne\u0027s C of E Secondary School",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1831,
@@ -2885,6 +2925,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2013-12-29T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 96
       },
       {
@@ -2892,7 +2933,7 @@
         "dateAcademyJoinedTrust": "2020-02-29T00:00:00",
         "establishmentName": "St. Paul\u0027s Catholic Secondary Academy",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 3078,
@@ -2910,6 +2951,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-01-28T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 112
       }
     ],
@@ -3007,7 +3049,7 @@
         "dateAcademyJoinedTrust": "2022-06-09T00:00:00",
         "establishmentName": "St. Marys R.C. All-through Academy",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 914,
@@ -3025,6 +3067,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2016-12-24T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 40
       },
       {
@@ -3032,7 +3075,7 @@
         "dateAcademyJoinedTrust": "2022-10-02T00:00:00",
         "establishmentName": "St. Peter\u0027s Church of England Middle Deemed Primary Academy",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 514,
@@ -3050,6 +3093,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-06-15T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 94
       },
       {
@@ -3057,7 +3101,7 @@
         "dateAcademyJoinedTrust": "2023-08-20T00:00:00",
         "establishmentName": "St. Joseph\u0027s Cofe School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 705,
@@ -3075,6 +3119,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 69
       },
       {
@@ -3082,7 +3127,7 @@
         "dateAcademyJoinedTrust": "2022-08-20T00:00:00",
         "establishmentName": "St. Paul\u0027s Cofe Academy",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 347,
@@ -3100,6 +3145,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2019-02-27T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 60
       },
       {
@@ -3107,7 +3153,7 @@
         "dateAcademyJoinedTrust": "2021-05-05T00:00:00",
         "establishmentName": "Barr and Community All-through Academy",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 832,
@@ -3125,6 +3171,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-05-11T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 119
       },
       {
@@ -3132,7 +3179,7 @@
         "dateAcademyJoinedTrust": "2022-08-06T00:00:00",
         "establishmentName": "St. Peter\u0027s Catholic Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 614,
@@ -3150,6 +3197,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2021-05-24T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 61
       },
       {
@@ -3157,7 +3205,7 @@
         "dateAcademyJoinedTrust": "2021-03-02T00:00:00",
         "establishmentName": "St. Peter\u0027s Catholic School",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 2778,
@@ -3175,6 +3223,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-12-04T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 114
       },
       {
@@ -3182,7 +3231,7 @@
         "dateAcademyJoinedTrust": "2023-10-31T00:00:00",
         "establishmentName": "Glyn Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 602,
@@ -3200,6 +3249,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-12-11T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 58
       },
       {
@@ -3207,7 +3257,7 @@
         "dateAcademyJoinedTrust": "2022-05-05T00:00:00",
         "establishmentName": "Co-op R.C. Middle Deemed Secondary Academy",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 114,
@@ -3225,6 +3275,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 96
       }
     ],
@@ -3505,6 +3556,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 382,
         "percentageFull": 60
       },
       {
@@ -3512,7 +3564,7 @@
         "dateAcademyJoinedTrust": "2022-01-02T00:00:00",
         "establishmentName": "Pollich Ferry CE Academy",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "North Yorkshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1217,
@@ -3530,6 +3582,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 390,
         "percentageFull": 42
       },
       {
@@ -3537,7 +3590,7 @@
         "dateAcademyJoinedTrust": "2017-05-26T00:00:00",
         "establishmentName": "Greensward Academy",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1634,
@@ -3555,6 +3608,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 384,
         "percentageFull": 89
       },
       {
@@ -3562,7 +3616,7 @@
         "dateAcademyJoinedTrust": "2021-03-03T00:00:00",
         "establishmentName": "Queensbridge Catholic Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2065,
@@ -3580,6 +3634,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-06-06T00:00:00"
         },
+        "oldLaCode": 384,
         "percentageFull": 128
       },
       {
@@ -3605,6 +3660,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-11-20T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 68
       },
       {
@@ -3630,6 +3686,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-12-09T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 65
       },
       {
@@ -3637,7 +3694,7 @@
         "dateAcademyJoinedTrust": "2022-01-31T00:00:00",
         "establishmentName": "Beacon School",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "North Yorkshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2022,
@@ -3655,6 +3712,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 390,
         "percentageFull": 99
       },
       {
@@ -3680,6 +3738,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2012-12-25T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 85
       },
       {
@@ -3705,6 +3764,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2013-08-07T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 70
       },
       {
@@ -3712,7 +3772,7 @@
         "dateAcademyJoinedTrust": "2016-02-13T00:00:00",
         "establishmentName": "Limehurst C of E 16 Plus School",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1018,
@@ -3730,6 +3790,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-12-29T00:00:00"
         },
+        "oldLaCode": 384,
         "percentageFull": 104
       },
       {
@@ -3755,6 +3816,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 382,
         "percentageFull": 48
       }
     ],
@@ -3947,6 +4009,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2022-12-19T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 114
       }
     ],
@@ -4095,6 +4158,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2017-04-14T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 64
       },
       {
@@ -4102,7 +4166,7 @@
         "dateAcademyJoinedTrust": "2023-01-20T00:00:00",
         "establishmentName": "Longhill Cofe 16 Plus Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 600,
@@ -4120,6 +4184,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 392,
         "percentageFull": 62
       },
       {
@@ -4145,6 +4210,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 382,
         "percentageFull": 91
       },
       {
@@ -4170,6 +4236,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 382,
         "percentageFull": 95
       },
       {
@@ -4177,7 +4244,7 @@
         "dateAcademyJoinedTrust": "2022-03-30T00:00:00",
         "establishmentName": "George Abbey Primary School",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "North Yorkshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 916,
@@ -4195,6 +4262,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 390,
         "percentageFull": 47
       }
     ],
@@ -4821,7 +4889,7 @@
         "dateAcademyJoinedTrust": "2022-07-01T00:00:00",
         "establishmentName": "St. Peter\u0027s CE Academy",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1031,
@@ -4839,6 +4907,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 381,
         "percentageFull": 100
       },
       {
@@ -4846,7 +4915,7 @@
         "dateAcademyJoinedTrust": "2019-10-31T00:00:00",
         "establishmentName": "Barr and Community School",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2577,
@@ -4864,6 +4933,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 381,
         "percentageFull": 90
       },
       {
@@ -4871,7 +4941,7 @@
         "dateAcademyJoinedTrust": "2022-01-11T00:00:00",
         "establishmentName": "Lampton School",
         "typeOfEstablishment": "Academy 16-19 Converter",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2240,
@@ -4889,6 +4959,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 381,
         "percentageFull": 121
       },
       {
@@ -4896,7 +4967,7 @@
         "dateAcademyJoinedTrust": "2021-10-04T00:00:00",
         "establishmentName": "Halewood School",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 731,
@@ -4914,6 +4985,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-07-23T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 70
       },
       {
@@ -4921,7 +4993,7 @@
         "dateAcademyJoinedTrust": "2020-07-08T00:00:00",
         "establishmentName": "Co-op School",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 201,
@@ -4939,6 +5011,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2014-09-24T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 58
       },
       {
@@ -4946,7 +5019,7 @@
         "dateAcademyJoinedTrust": "2019-12-30T00:00:00",
         "establishmentName": "Queensbridge Primary Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 177,
@@ -4964,6 +5037,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2018-10-08T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 92
       },
       {
@@ -4971,7 +5045,7 @@
         "dateAcademyJoinedTrust": "2023-04-26T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s Academy",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1531,
@@ -4989,6 +5063,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 381,
         "percentageFull": 84
       }
     ],
@@ -5119,7 +5194,7 @@
         "dateAcademyJoinedTrust": "2021-12-11T00:00:00",
         "establishmentName": "St. Mary\u0027s R.C. Secondary School",
         "typeOfEstablishment": "Academy 16-19 Converter",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1312,
@@ -5137,6 +5212,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-03-31T00:00:00"
         },
+        "oldLaCode": 394,
         "percentageFull": 70
       },
       {
@@ -5144,7 +5220,7 @@
         "dateAcademyJoinedTrust": "2023-06-08T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s R.C. Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 977,
@@ -5162,6 +5238,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2012-10-29T00:00:00"
         },
+        "oldLaCode": 394,
         "percentageFull": 67
       },
       {
@@ -5169,7 +5246,7 @@
         "dateAcademyJoinedTrust": "2022-05-30T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 C of E School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1025,
@@ -5187,6 +5264,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 394,
         "percentageFull": 127
       },
       {
@@ -5194,7 +5272,7 @@
         "dateAcademyJoinedTrust": "2020-07-12T00:00:00",
         "establishmentName": "Greensward Catholic Primary School",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1274,
@@ -5212,6 +5290,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2015-03-04T00:00:00"
         },
+        "oldLaCode": 394,
         "percentageFull": 84
       },
       {
@@ -5219,7 +5298,7 @@
         "dateAcademyJoinedTrust": "2019-08-09T00:00:00",
         "establishmentName": "St. Marys R.C. School",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2659,
@@ -5237,6 +5316,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 394,
         "percentageFull": 116
       },
       {
@@ -5244,7 +5324,7 @@
         "dateAcademyJoinedTrust": "2017-10-24T00:00:00",
         "establishmentName": "Longhill R.C. Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 298,
@@ -5262,6 +5342,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2013-03-28T00:00:00"
         },
+        "oldLaCode": 394,
         "percentageFull": 84
       },
       {
@@ -5269,7 +5350,7 @@
         "dateAcademyJoinedTrust": "2019-10-16T00:00:00",
         "establishmentName": "Beacon Secondary Academy",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 925,
@@ -5287,6 +5368,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 394,
         "percentageFull": 127
       },
       {
@@ -5294,7 +5376,7 @@
         "dateAcademyJoinedTrust": "2021-06-05T00:00:00",
         "establishmentName": "Peacehaven Community Church of England Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1034,
@@ -5312,6 +5394,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 394,
         "percentageFull": 68
       },
       {
@@ -5319,7 +5402,7 @@
         "dateAcademyJoinedTrust": "2021-08-12T00:00:00",
         "establishmentName": "St. Joseph\u0027s R.C. Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 338,
@@ -5337,6 +5420,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 394,
         "percentageFull": 97
       }
     ],
@@ -5544,7 +5628,7 @@
         "dateAcademyJoinedTrust": "2019-10-08T00:00:00",
         "establishmentName": "Greensward School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 248,
@@ -5562,6 +5646,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 392,
         "percentageFull": 91
       },
       {
@@ -5569,7 +5654,7 @@
         "dateAcademyJoinedTrust": "2022-09-09T00:00:00",
         "establishmentName": "Lampton Church of England 16 Plus Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 951,
@@ -5587,6 +5672,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-07-19T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 86
       },
       {
@@ -5594,7 +5680,7 @@
         "dateAcademyJoinedTrust": "2020-06-04T00:00:00",
         "establishmentName": "Peacehaven Community Cofe Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 252,
@@ -5612,6 +5698,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2015-04-19T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 55
       },
       {
@@ -5619,7 +5706,7 @@
         "dateAcademyJoinedTrust": "2020-12-18T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s 16 Plus Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 310,
@@ -5637,6 +5724,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2020-08-09T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 41
       },
       {
@@ -5644,7 +5732,7 @@
         "dateAcademyJoinedTrust": "2020-10-11T00:00:00",
         "establishmentName": "Horizon Secondary Academy",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 282,
@@ -5662,6 +5750,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2022-09-09T00:00:00"
         },
+        "oldLaCode": 384,
         "percentageFull": 48
       },
       {
@@ -5669,7 +5758,7 @@
         "dateAcademyJoinedTrust": "2022-08-03T00:00:00",
         "establishmentName": "Glyn Secondary Academy",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1885,
@@ -5687,6 +5776,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 392,
         "percentageFull": 83
       }
     ],
@@ -5947,9 +6037,9 @@
       {
         "urn": 12717311,
         "dateAcademyJoinedTrust": "2023-06-25T00:00:00",
-        "establishmentName": "North East Lincolnshire R.C. All-through School",
+        "establishmentName": "Wakefield R.C. All-through School",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 306,
@@ -5967,6 +6057,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 384,
         "percentageFull": 55
       },
       {
@@ -5992,6 +6083,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-03-22T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 106
       },
       {
@@ -6017,6 +6109,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2015-04-11T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 126
       },
       {
@@ -6024,7 +6117,7 @@
         "dateAcademyJoinedTrust": "2023-08-06T00:00:00",
         "establishmentName": "Co-op Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1273,
@@ -6042,6 +6135,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2018-02-28T00:00:00"
         },
+        "oldLaCode": 384,
         "percentageFull": 65
       },
       {
@@ -6049,7 +6143,7 @@
         "dateAcademyJoinedTrust": "2023-10-22T00:00:00",
         "establishmentName": "Evalyn Oval Middle Deemed Primary School",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1694,
@@ -6067,6 +6161,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 371,
         "percentageFull": 105
       }
     ],
@@ -6535,6 +6630,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-05-15T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 129
       },
       {
@@ -6542,7 +6638,7 @@
         "dateAcademyJoinedTrust": "2018-06-29T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s 16 Plus Academy",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "North Yorkshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1550,
@@ -6560,6 +6656,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 390,
         "percentageFull": 108
       },
       {
@@ -6567,7 +6664,7 @@
         "dateAcademyJoinedTrust": "2021-05-01T00:00:00",
         "establishmentName": "Malbank School",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1160,
@@ -6585,6 +6682,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2013-02-23T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 55
       },
       {
@@ -6592,7 +6690,7 @@
         "dateAcademyJoinedTrust": "2015-08-25T00:00:00",
         "establishmentName": "Glyn Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Leeds",
+        "localAuthority": "Kirklees",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 879,
@@ -6610,6 +6708,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2015-10-15T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 68
       },
       {
@@ -6617,7 +6716,7 @@
         "dateAcademyJoinedTrust": "2015-06-22T00:00:00",
         "establishmentName": "St. Joseph\u0027s Cofe School",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "Leeds",
+        "localAuthority": "Kirklees",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1386,
@@ -6635,6 +6734,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-09-20T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 88
       }
     ],
@@ -7026,7 +7126,7 @@
         "dateAcademyJoinedTrust": "2023-04-10T00:00:00",
         "establishmentName": "Harris Catholic Middle Deemed Primary Academy",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 511,
@@ -7044,6 +7144,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-04-13T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 79
       },
       {
@@ -7051,7 +7152,7 @@
         "dateAcademyJoinedTrust": "2023-05-07T00:00:00",
         "establishmentName": "St. Peter\u0027s CE All-through Academy",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1607,
@@ -7069,6 +7170,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2012-05-18T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 119
       },
       {
@@ -7076,7 +7178,7 @@
         "dateAcademyJoinedTrust": "2023-03-18T00:00:00",
         "establishmentName": "Harris School",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 806,
@@ -7094,6 +7196,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 381,
         "percentageFull": 86
       }
     ],
@@ -7356,7 +7459,7 @@
         "dateAcademyJoinedTrust": "2022-06-20T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s Catholic Academy",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 3221,
@@ -7374,6 +7477,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2013-11-30T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 110
       },
       {
@@ -7381,7 +7485,7 @@
         "dateAcademyJoinedTrust": "2023-05-03T00:00:00",
         "establishmentName": "Mulberry School",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1435,
@@ -7399,6 +7503,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 383,
         "percentageFull": 118
       },
       {
@@ -7406,7 +7511,7 @@
         "dateAcademyJoinedTrust": "2022-04-01T00:00:00",
         "establishmentName": "Meridian Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 3612,
@@ -7424,6 +7529,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 129
       },
       {
@@ -7431,7 +7537,7 @@
         "dateAcademyJoinedTrust": "2020-10-23T00:00:00",
         "establishmentName": "Meridian CE School",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1005,
@@ -7449,6 +7555,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 44
       },
       {
@@ -7456,7 +7563,7 @@
         "dateAcademyJoinedTrust": "2023-02-04T00:00:00",
         "establishmentName": "Longhill Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 976,
@@ -7474,6 +7581,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2018-03-31T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 99
       },
       {
@@ -7481,7 +7589,7 @@
         "dateAcademyJoinedTrust": "2021-02-15T00:00:00",
         "establishmentName": "Longhill Middle Deemed Secondary Academy",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1448,
@@ -7499,6 +7607,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 73
       },
       {
@@ -7506,7 +7615,7 @@
         "dateAcademyJoinedTrust": "2021-04-04T00:00:00",
         "establishmentName": "Beacon School",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 470,
@@ -7524,6 +7633,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 61
       },
       {
@@ -7531,7 +7641,7 @@
         "dateAcademyJoinedTrust": "2023-05-25T00:00:00",
         "establishmentName": "Horizon Middle Deemed Secondary School",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1593,
@@ -7549,6 +7659,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2020-02-24T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 86
       },
       {
@@ -7556,7 +7667,7 @@
         "dateAcademyJoinedTrust": "2023-07-06T00:00:00",
         "establishmentName": "Momentum Community Secondary Academy",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1493,
@@ -7574,6 +7685,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-02-15T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 52
       }
     ],
@@ -7770,7 +7882,7 @@
         "dateAcademyJoinedTrust": "2022-11-30T00:00:00",
         "establishmentName": "Co-op Catholic Primary Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1111,
@@ -7788,6 +7900,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-09-04T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 87
       }
     ],
@@ -8205,7 +8318,7 @@
         "dateAcademyJoinedTrust": "2020-10-11T00:00:00",
         "establishmentName": "St. Anne\u0027s Cofe Academy",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1759,
@@ -8223,6 +8336,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-10-08T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 92
       },
       {
@@ -8230,7 +8344,7 @@
         "dateAcademyJoinedTrust": "2016-12-22T00:00:00",
         "establishmentName": "Harris Primary Academy",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1376,
@@ -8248,6 +8362,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2019-05-28T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 129
       },
       {
@@ -8255,7 +8370,7 @@
         "dateAcademyJoinedTrust": "2020-06-12T00:00:00",
         "establishmentName": "Oasis Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 900,
@@ -8273,6 +8388,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2017-12-14T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 59
       },
       {
@@ -8280,7 +8396,7 @@
         "dateAcademyJoinedTrust": "2017-04-12T00:00:00",
         "establishmentName": "Limehurst 16 Plus School",
         "typeOfEstablishment": "Academy 16-19 Converter",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1429,
@@ -8298,6 +8414,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2020-06-24T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 49
       },
       {
@@ -8305,7 +8422,7 @@
         "dateAcademyJoinedTrust": "2022-03-27T00:00:00",
         "establishmentName": "Halewood Cofe All-through Academy",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 465,
@@ -8323,6 +8440,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2016-07-09T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 76
       },
       {
@@ -8330,7 +8448,7 @@
         "dateAcademyJoinedTrust": "2020-04-04T00:00:00",
         "establishmentName": "Barr and Community School",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2896,
@@ -8348,6 +8466,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-03-17T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 107
       },
       {
@@ -8355,7 +8474,7 @@
         "dateAcademyJoinedTrust": "2019-01-25T00:00:00",
         "establishmentName": "St. Marys Church of England Middle Deemed Secondary School",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1050,
@@ -8373,6 +8492,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 89
       }
     ],
@@ -8635,7 +8755,7 @@
         "dateAcademyJoinedTrust": "2023-08-28T00:00:00",
         "establishmentName": "Horizon Church of England School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Rotherham",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1827,
@@ -8653,6 +8773,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-03-30T00:00:00"
         },
+        "oldLaCode": 372,
         "percentageFull": 106
       },
       {
@@ -8660,7 +8781,7 @@
         "dateAcademyJoinedTrust": "2023-07-28T00:00:00",
         "establishmentName": "St. Peter\u0027s Catholic Middle Deemed Secondary School",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 486,
@@ -8678,6 +8799,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 84
       },
       {
@@ -8685,7 +8807,7 @@
         "dateAcademyJoinedTrust": "2023-05-07T00:00:00",
         "establishmentName": "St. Catherine\u0027s R.C. Primary Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Rotherham",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1215,
@@ -8703,6 +8825,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-07-16T00:00:00"
         },
+        "oldLaCode": 372,
         "percentageFull": 85
       },
       {
@@ -8710,7 +8833,7 @@
         "dateAcademyJoinedTrust": "2023-07-24T00:00:00",
         "establishmentName": "St. Joseph\u0027s C of E School",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Rotherham",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 590,
@@ -8728,6 +8851,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2012-08-08T00:00:00"
         },
+        "oldLaCode": 372,
         "percentageFull": 75
       }
     ],
@@ -8910,7 +9034,7 @@
         "dateAcademyJoinedTrust": "2018-07-20T00:00:00",
         "establishmentName": "George Abbey Academy",
         "typeOfEstablishment": "Academy 16-19 Converter",
-        "localAuthority": "Kirklees",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1451,
@@ -8928,6 +9052,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-05-16T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 110
       },
       {
@@ -8935,7 +9060,7 @@
         "dateAcademyJoinedTrust": "2018-09-18T00:00:00",
         "establishmentName": "Longhill School",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "Kirklees",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1059,
@@ -8953,6 +9078,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-03-01T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 49
       },
       {
@@ -8960,7 +9086,7 @@
         "dateAcademyJoinedTrust": "2020-03-13T00:00:00",
         "establishmentName": "Ray Wall Secondary Academy",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "Kirklees",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1333,
@@ -8978,6 +9104,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2021-11-23T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 57
       },
       {
@@ -8985,7 +9112,7 @@
         "dateAcademyJoinedTrust": "2018-08-01T00:00:00",
         "establishmentName": "Mulberry Church of England School",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Kirklees",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1840,
@@ -9003,6 +9130,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 381,
         "percentageFull": 114
       },
       {
@@ -9010,7 +9138,7 @@
         "dateAcademyJoinedTrust": "2023-11-03T00:00:00",
         "establishmentName": "Northwood R.C. School",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Kirklees",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 844,
@@ -9028,6 +9156,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-01-28T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 121
       },
       {
@@ -9035,7 +9164,7 @@
         "dateAcademyJoinedTrust": "2019-10-10T00:00:00",
         "establishmentName": "Lampton Church of England 16 Plus Academy",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "Kirklees",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1113,
@@ -9053,6 +9182,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 381,
         "percentageFull": 73
       },
       {
@@ -9060,7 +9190,7 @@
         "dateAcademyJoinedTrust": "2021-09-23T00:00:00",
         "establishmentName": "Greensward Academy",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "Kirklees",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1157,
@@ -9078,14 +9208,15 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2021-10-28T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 81
       },
       {
         "urn": 12612628,
         "dateAcademyJoinedTrust": "2020-11-17T00:00:00",
-        "establishmentName": "Kirklees Catholic All-through Academy",
+        "establishmentName": "Calderdale Catholic All-through Academy",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "Kirklees",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 508,
@@ -9103,6 +9234,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2015-12-13T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 83
       },
       {
@@ -9110,7 +9242,7 @@
         "dateAcademyJoinedTrust": "2021-07-22T00:00:00",
         "establishmentName": "St. Anne\u0027s R.C. Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Kirklees",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 499,
@@ -9128,6 +9260,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2021-10-08T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 102
       }
     ],
@@ -9442,7 +9575,7 @@
         "dateAcademyJoinedTrust": "2022-09-14T00:00:00",
         "establishmentName": "St. James\u0027 R.C. Middle Deemed Primary Academy",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 652,
@@ -9460,6 +9593,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2015-11-16T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 97
       }
     ],
@@ -9796,7 +9930,7 @@
         "dateAcademyJoinedTrust": "2022-12-03T00:00:00",
         "establishmentName": "St. John\u0027s Church of England All-through School",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 2573,
@@ -9814,6 +9948,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2013-03-21T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 127
       },
       {
@@ -9821,7 +9956,7 @@
         "dateAcademyJoinedTrust": "2022-05-16T00:00:00",
         "establishmentName": "St. Paul\u0027s Cofe All-through School",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 867,
@@ -9839,6 +9974,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 392,
         "percentageFull": 86
       },
       {
@@ -9846,7 +9982,7 @@
         "dateAcademyJoinedTrust": "2017-04-19T00:00:00",
         "establishmentName": "Horizon CE School",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1998,
@@ -9864,6 +10000,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 392,
         "percentageFull": 98
       },
       {
@@ -9871,7 +10008,7 @@
         "dateAcademyJoinedTrust": "2018-01-06T00:00:00",
         "establishmentName": "St. Mary\u0027s C of E School",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 996,
@@ -9889,6 +10026,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-12-15T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 83
       },
       {
@@ -9896,7 +10034,7 @@
         "dateAcademyJoinedTrust": "2018-07-12T00:00:00",
         "establishmentName": "Queensbridge Cofe School",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 284,
@@ -9914,6 +10052,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-11-30T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 105
       },
       {
@@ -9921,7 +10060,7 @@
         "dateAcademyJoinedTrust": "2019-02-14T00:00:00",
         "establishmentName": "Co-op Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 793,
@@ -9939,6 +10078,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-01-01T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 57
       }
     ],
@@ -10268,7 +10408,7 @@
         "dateAcademyJoinedTrust": "2021-03-14T00:00:00",
         "establishmentName": "Harris Primary Academy",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1630,
@@ -10286,6 +10426,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2016-03-02T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 89
       },
       {
@@ -10293,7 +10434,7 @@
         "dateAcademyJoinedTrust": "2022-06-11T00:00:00",
         "establishmentName": "Northwood CE Middle Deemed Primary School",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 3205,
@@ -10311,6 +10452,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 381,
         "percentageFull": 119
       },
       {
@@ -10318,7 +10460,7 @@
         "dateAcademyJoinedTrust": "2022-05-19T00:00:00",
         "establishmentName": "Horizon Catholic Academy",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2403,
@@ -10336,6 +10478,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2013-10-16T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 100
       },
       {
@@ -10343,7 +10486,7 @@
         "dateAcademyJoinedTrust": "2022-12-29T00:00:00",
         "establishmentName": "Momentum Community Middle Deemed Primary Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1317,
@@ -10361,6 +10504,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 381,
         "percentageFull": 91
       },
       {
@@ -10368,7 +10512,7 @@
         "dateAcademyJoinedTrust": "2023-06-10T00:00:00",
         "establishmentName": "Queensbridge Church of England School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 3033,
@@ -10386,6 +10530,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-08-02T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 101
       }
     ],
@@ -10571,7 +10716,7 @@
         "dateAcademyJoinedTrust": "2023-10-09T00:00:00",
         "establishmentName": "St. Anne\u0027s C of E School",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 883,
@@ -10589,6 +10734,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-06-20T00:00:00"
         },
+        "oldLaCode": 393,
         "percentageFull": 120
       },
       {
@@ -10614,6 +10760,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2021-06-24T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 75
       },
       {
@@ -10639,6 +10786,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-12-16T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 64
       },
       {
@@ -10664,6 +10812,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2019-08-13T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 110
       },
       {
@@ -10689,6 +10838,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-12-17T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 119
       },
       {
@@ -10714,6 +10864,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2013-05-12T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 78
       },
       {
@@ -10721,7 +10872,7 @@
         "dateAcademyJoinedTrust": "2022-06-17T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 Catholic Academy",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 955,
@@ -10739,6 +10890,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2020-06-03T00:00:00"
         },
+        "oldLaCode": 393,
         "percentageFull": 61
       }
     ],
@@ -11083,6 +11235,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2013-08-31T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 82
       }
     ],
@@ -11222,9 +11375,9 @@
       {
         "urn": 12739115,
         "dateAcademyJoinedTrust": "2021-09-01T00:00:00",
-        "establishmentName": "Bradford Catholic School",
+        "establishmentName": "Doncaster Catholic School",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 3514,
@@ -11242,6 +11395,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2018-11-13T00:00:00"
         },
+        "oldLaCode": 371,
         "percentageFull": 121
       }
     ],
@@ -11490,7 +11644,7 @@
         "dateAcademyJoinedTrust": "2023-01-28T00:00:00",
         "establishmentName": "Northwood R.C. Academy",
         "typeOfEstablishment": "Academy 16-19 Converter",
-        "localAuthority": "Leeds",
+        "localAuthority": "Barnsley",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1043,
@@ -11508,6 +11662,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2020-08-06T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 85
       },
       {
@@ -11515,7 +11670,7 @@
         "dateAcademyJoinedTrust": "2016-10-14T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 School",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "Leeds",
+        "localAuthority": "Barnsley",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1945,
@@ -11533,6 +11688,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2021-03-14T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 102
       }
     ],
@@ -11762,7 +11918,7 @@
         "dateAcademyJoinedTrust": "2022-04-05T00:00:00",
         "establishmentName": "Meridian CE 16 Plus Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 741,
@@ -11780,6 +11936,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2023-04-03T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 113
       },
       {
@@ -11787,7 +11944,7 @@
         "dateAcademyJoinedTrust": "2022-04-02T00:00:00",
         "establishmentName": "St. James\u0027 CE Academy",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 82,
@@ -11805,6 +11962,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 47
       },
       {
@@ -11812,7 +11970,7 @@
         "dateAcademyJoinedTrust": "2020-02-16T00:00:00",
         "establishmentName": "St. Catherine\u0027s Church of England Academy",
         "typeOfEstablishment": "Academy 16-19 Converter",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1287,
@@ -11830,6 +11988,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 84
       },
       {
@@ -11837,7 +11996,7 @@
         "dateAcademyJoinedTrust": "2019-10-18T00:00:00",
         "establishmentName": "Longhill CE Academy",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 345,
@@ -11855,6 +12014,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-04-14T00:00:00"
         },
+        "oldLaCode": 384,
         "percentageFull": 128
       },
       {
@@ -11862,7 +12022,7 @@
         "dateAcademyJoinedTrust": "2022-03-09T00:00:00",
         "establishmentName": "Northwood Academy",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 823,
@@ -11880,6 +12040,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-03-24T00:00:00"
         },
+        "oldLaCode": 384,
         "percentageFull": 72
       }
     ],
@@ -12194,7 +12355,7 @@
         "dateAcademyJoinedTrust": "2020-09-07T00:00:00",
         "establishmentName": "Horizon Academy",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Rotherham",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 811,
@@ -12212,6 +12373,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-06-21T00:00:00"
         },
+        "oldLaCode": 372,
         "percentageFull": 55
       },
       {
@@ -12219,7 +12381,7 @@
         "dateAcademyJoinedTrust": "2021-02-01T00:00:00",
         "establishmentName": "Glyn All-through Academy",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Rotherham",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 2890,
@@ -12237,6 +12399,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-10-04T00:00:00"
         },
+        "oldLaCode": 372,
         "percentageFull": 113
       },
       {
@@ -12244,7 +12407,7 @@
         "dateAcademyJoinedTrust": "2015-12-13T00:00:00",
         "establishmentName": "Barr and Community Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 912,
@@ -12262,6 +12425,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-01-17T00:00:00"
         },
+        "oldLaCode": 394,
         "percentageFull": 71
       },
       {
@@ -12269,7 +12433,7 @@
         "dateAcademyJoinedTrust": "2015-11-26T00:00:00",
         "establishmentName": "Mulberry School",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Rotherham",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 961,
@@ -12287,6 +12451,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-10-27T00:00:00"
         },
+        "oldLaCode": 372,
         "percentageFull": 77
       },
       {
@@ -12294,7 +12459,7 @@
         "dateAcademyJoinedTrust": "2021-11-16T00:00:00",
         "establishmentName": "Co-op School",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Sheffield",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1540,
@@ -12312,6 +12477,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2016-03-09T00:00:00"
         },
+        "oldLaCode": 373,
         "percentageFull": 84
       },
       {
@@ -12319,7 +12485,7 @@
         "dateAcademyJoinedTrust": "2022-03-16T00:00:00",
         "establishmentName": "Momentum Community CE Academy",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Rotherham",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1026,
@@ -12337,6 +12503,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-10-06T00:00:00"
         },
+        "oldLaCode": 372,
         "percentageFull": 113
       },
       {
@@ -12344,7 +12511,7 @@
         "dateAcademyJoinedTrust": "2017-01-31T00:00:00",
         "establishmentName": "Longhill Academy",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Sheffield",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1647,
@@ -12362,6 +12529,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-08-04T00:00:00"
         },
+        "oldLaCode": 373,
         "percentageFull": 57
       },
       {
@@ -12369,7 +12537,7 @@
         "dateAcademyJoinedTrust": "2015-04-28T00:00:00",
         "establishmentName": "Harris R.C. Secondary Academy",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2121,
@@ -12387,6 +12555,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 394,
         "percentageFull": 105
       },
       {
@@ -12394,7 +12563,7 @@
         "dateAcademyJoinedTrust": "2019-12-25T00:00:00",
         "establishmentName": "Horizon CE Academy",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 2824,
@@ -12412,6 +12581,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 394,
         "percentageFull": 105
       },
       {
@@ -12419,7 +12589,7 @@
         "dateAcademyJoinedTrust": "2020-10-27T00:00:00",
         "establishmentName": "Greensward Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2856,
@@ -12437,6 +12607,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 394,
         "percentageFull": 101
       }
     ],
@@ -12534,7 +12705,7 @@
         "dateAcademyJoinedTrust": "2022-11-30T00:00:00",
         "establishmentName": "St. James\u0027 R.C. Primary School",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 539,
@@ -12552,6 +12723,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 381,
         "percentageFull": 58
       }
     ],
@@ -12822,7 +12994,7 @@
         "dateAcademyJoinedTrust": "2019-07-24T00:00:00",
         "establishmentName": "Lampton School",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 2324,
@@ -12840,6 +13012,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2021-12-14T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 90
       },
       {
@@ -12847,7 +13020,7 @@
         "dateAcademyJoinedTrust": "2021-05-17T00:00:00",
         "establishmentName": "St. Catherine\u0027s Catholic School",
         "typeOfEstablishment": "Academy 16-19 Converter",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1307,
@@ -12865,6 +13038,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2021-08-12T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 67
       },
       {
@@ -12872,7 +13046,7 @@
         "dateAcademyJoinedTrust": "2019-10-07T00:00:00",
         "establishmentName": "Co-op R.C. Middle Deemed Primary Academy",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1080,
@@ -12890,6 +13064,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2013-09-14T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 82
       },
       {
@@ -12897,7 +13072,7 @@
         "dateAcademyJoinedTrust": "2021-08-24T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic School",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 385,
@@ -12915,6 +13090,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-10-08T00:00:00"
         },
+        "oldLaCode": 393,
         "percentageFull": 41
       },
       {
@@ -12922,7 +13098,7 @@
         "dateAcademyJoinedTrust": "2022-07-08T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 Church of England Academy",
         "typeOfEstablishment": "Academy 16-19 Converter",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1424,
@@ -12940,6 +13116,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2014-11-15T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 103
       },
       {
@@ -12947,7 +13124,7 @@
         "dateAcademyJoinedTrust": "2023-01-31T00:00:00",
         "establishmentName": "Beacon Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2501,
@@ -12965,6 +13142,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2013-04-01T00:00:00"
         },
+        "oldLaCode": 393,
         "percentageFull": 107
       },
       {
@@ -12972,7 +13150,7 @@
         "dateAcademyJoinedTrust": "2018-08-18T00:00:00",
         "establishmentName": "Mulberry CE All-through School",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 511,
@@ -12990,6 +13168,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 393,
         "percentageFull": 76
       },
       {
@@ -12997,7 +13176,7 @@
         "dateAcademyJoinedTrust": "2020-03-17T00:00:00",
         "establishmentName": "Barr and Community School",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1896,
@@ -13015,6 +13194,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-06-09T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 102
       },
       {
@@ -13022,7 +13202,7 @@
         "dateAcademyJoinedTrust": "2019-12-18T00:00:00",
         "establishmentName": "Obie Square CE 16 Plus School",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1245,
@@ -13040,6 +13220,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2018-05-27T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 83
       }
     ],
@@ -13291,7 +13472,7 @@
         "dateAcademyJoinedTrust": "2022-04-11T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s CE Academy",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 684,
@@ -13309,6 +13490,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2013-06-07T00:00:00"
         },
+        "oldLaCode": 393,
         "percentageFull": 99
       },
       {
@@ -13334,6 +13516,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 88
       },
       {
@@ -13359,6 +13542,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-11-28T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 112
       },
       {
@@ -13366,7 +13550,7 @@
         "dateAcademyJoinedTrust": "2022-12-16T00:00:00",
         "establishmentName": "Lampton Primary School",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Rotherham",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 333,
@@ -13384,6 +13568,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2019-11-06T00:00:00"
         },
+        "oldLaCode": 372,
         "percentageFull": 42
       },
       {
@@ -13391,7 +13576,7 @@
         "dateAcademyJoinedTrust": "2020-12-22T00:00:00",
         "establishmentName": "St. Joseph\u0027s Church of England All-through Academy",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1178,
@@ -13409,6 +13594,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 393,
         "percentageFull": 50
       },
       {
@@ -13416,7 +13602,7 @@
         "dateAcademyJoinedTrust": "2022-01-14T00:00:00",
         "establishmentName": "Queensbridge Middle Deemed Primary Academy",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Rotherham",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 745,
@@ -13434,6 +13620,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 372,
         "percentageFull": 44
       },
       {
@@ -13441,7 +13628,7 @@
         "dateAcademyJoinedTrust": "2023-09-18T00:00:00",
         "establishmentName": "Halewood R.C. School",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 203,
@@ -13459,6 +13646,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 393,
         "percentageFull": 59
       },
       {
@@ -13484,6 +13672,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2022-05-08T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 122
       },
       {
@@ -13491,7 +13680,7 @@
         "dateAcademyJoinedTrust": "2023-05-24T00:00:00",
         "establishmentName": "St. Catherine\u0027s C of E Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Rotherham",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1102,
@@ -13509,6 +13698,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-02-09T00:00:00"
         },
+        "oldLaCode": 372,
         "percentageFull": 91
       },
       {
@@ -13534,6 +13724,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-12-11T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 63
       },
       {
@@ -13541,7 +13732,7 @@
         "dateAcademyJoinedTrust": "2022-04-09T00:00:00",
         "establishmentName": "St. James\u0027 R.C. Academy",
         "typeOfEstablishment": "Academy 16-19 Converter",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Rotherham",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 921,
@@ -13559,6 +13750,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2011-04-26T00:00:00"
         },
+        "oldLaCode": 372,
         "percentageFull": 105
       }
     ],
@@ -13810,7 +14002,7 @@
         "dateAcademyJoinedTrust": "2022-12-22T00:00:00",
         "establishmentName": "Glyn Catholic Academy",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1915,
@@ -13828,6 +14020,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-12-10T00:00:00"
         },
+        "oldLaCode": 371,
         "percentageFull": 71
       },
       {
@@ -13835,7 +14028,7 @@
         "dateAcademyJoinedTrust": "2021-02-12T00:00:00",
         "establishmentName": "Horizon Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Sheffield",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1474,
@@ -13853,6 +14046,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2022-03-03T00:00:00"
         },
+        "oldLaCode": 373,
         "percentageFull": 65
       },
       {
@@ -13860,7 +14054,7 @@
         "dateAcademyJoinedTrust": "2022-10-02T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s Catholic Primary School",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 65,
@@ -13878,6 +14072,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-02-14T00:00:00"
         },
+        "oldLaCode": 371,
         "percentageFull": 52
       },
       {
@@ -13885,7 +14080,7 @@
         "dateAcademyJoinedTrust": "2020-06-11T00:00:00",
         "establishmentName": "Longhill Catholic School",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1399,
@@ -13903,6 +14098,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 126
       },
       {
@@ -13910,7 +14106,7 @@
         "dateAcademyJoinedTrust": "2023-11-03T00:00:00",
         "establishmentName": "Vicente Harbors School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Sheffield",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2534,
@@ -13928,6 +14124,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2015-10-19T00:00:00"
         },
+        "oldLaCode": 373,
         "percentageFull": 112
       },
       {
@@ -13935,7 +14132,7 @@
         "dateAcademyJoinedTrust": "2021-11-18T00:00:00",
         "establishmentName": "Lampton Cofe Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Sheffield",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 2656,
@@ -13953,6 +14150,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-12-17T00:00:00"
         },
+        "oldLaCode": 373,
         "percentageFull": 90
       },
       {
@@ -13960,7 +14158,7 @@
         "dateAcademyJoinedTrust": "2022-11-10T00:00:00",
         "establishmentName": "St. James\u0027 C of E Academy",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1083,
@@ -13978,6 +14176,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 74
       },
       {
@@ -13985,7 +14184,7 @@
         "dateAcademyJoinedTrust": "2021-04-17T00:00:00",
         "establishmentName": "Halewood Academy",
         "typeOfEstablishment": "Academy 16-19 Converter",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Sheffield",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 787,
@@ -14003,6 +14202,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2021-03-02T00:00:00"
         },
+        "oldLaCode": 373,
         "percentageFull": 48
       }
     ],
@@ -14625,6 +14825,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-06-09T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 122
       }
     ],
@@ -14766,7 +14967,7 @@
         "dateAcademyJoinedTrust": "2021-09-23T00:00:00",
         "establishmentName": "St. Mary\u0027s Anglican Academy",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2490,
@@ -14784,6 +14985,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 391,
         "percentageFull": 97
       }
     ],
@@ -14958,7 +15160,7 @@
         "dateAcademyJoinedTrust": "2021-05-25T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic High School Academy",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Sheffield",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1202,
@@ -14976,6 +15178,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 373,
         "percentageFull": 71
       }
     ],
@@ -15113,6 +15316,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2014-05-04T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 113
       }
     ],
@@ -15221,7 +15425,7 @@
         "dateAcademyJoinedTrust": "2015-03-25T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "Kingston upon Hull, City of",
+        "localAuthority": "Calderdale",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 460,
@@ -15239,6 +15443,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2023-03-07T00:00:00"
         },
+        "oldLaCode": 381,
         "percentageFull": 94
       }
     ],
@@ -15534,7 +15739,7 @@
         "dateAcademyJoinedTrust": "2023-05-08T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 899,
@@ -15552,6 +15757,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 390,
         "percentageFull": 77
       }
     ],
@@ -15777,6 +15983,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2020-10-05T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 128
       }
     ],
@@ -16072,7 +16279,7 @@
         "dateAcademyJoinedTrust": "2019-04-25T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1349,
@@ -16090,6 +16297,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 371,
         "percentageFull": 105
       }
     ],
@@ -16360,7 +16568,7 @@
         "dateAcademyJoinedTrust": "2019-12-03T00:00:00",
         "establishmentName": "St Mary\u0027s Catholic Primary School",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 615,
@@ -16378,6 +16586,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2020-02-02T00:00:00"
         },
+        "oldLaCode": 371,
         "percentageFull": 41
       },
       {
@@ -16385,7 +16594,7 @@
         "dateAcademyJoinedTrust": "2019-11-17T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 621,
@@ -16403,6 +16612,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 371,
         "percentageFull": 89
       },
       {
@@ -16410,7 +16620,7 @@
         "dateAcademyJoinedTrust": "2023-04-12T00:00:00",
         "establishmentName": "St. Marys Catholic Primary School",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1312,
@@ -16428,6 +16638,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2013-12-07T00:00:00"
         },
+        "oldLaCode": 371,
         "percentageFull": 129
       },
       {
@@ -16435,7 +16646,7 @@
         "dateAcademyJoinedTrust": "2022-12-21T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Bradford",
+        "localAuthority": "Doncaster",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1279,
@@ -16453,6 +16664,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2012-11-01T00:00:00"
         },
+        "oldLaCode": 371,
         "percentageFull": 86
       },
       {
@@ -16460,7 +16672,7 @@
         "dateAcademyJoinedTrust": "2021-12-29T00:00:00",
         "establishmentName": "St Marys Catholic Primary School",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 131,
@@ -16478,6 +16690,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-05-08T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 74
       },
       {
@@ -16485,7 +16698,7 @@
         "dateAcademyJoinedTrust": "2019-09-05T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1522,
@@ -16503,6 +16716,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 384,
         "percentageFull": 119
       },
       {
@@ -16510,7 +16724,7 @@
         "dateAcademyJoinedTrust": "2023-10-15T00:00:00",
         "establishmentName": "St. Mary\u0027s RC Primary School",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 188,
@@ -16528,6 +16742,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 384,
         "percentageFull": 53
       },
       {
@@ -16535,7 +16750,7 @@
         "dateAcademyJoinedTrust": "2023-04-05T00:00:00",
         "establishmentName": "St. Mary\u0027s Primary School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1581,
@@ -16553,6 +16768,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 392,
         "percentageFull": 111
       },
       {
@@ -16560,7 +16776,7 @@
         "dateAcademyJoinedTrust": "2021-05-13T00:00:00",
         "establishmentName": "St. Mary\u0027s Primary School",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1667,
@@ -16578,6 +16794,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 384,
         "percentageFull": 71
       }
     ],
@@ -16873,7 +17090,7 @@
         "dateAcademyJoinedTrust": "2022-09-16T00:00:00",
         "establishmentName": "St Mary\u0027s CE Academy",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 740,
@@ -16891,6 +17108,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2012-05-18T00:00:00"
         },
+        "oldLaCode": 390,
         "percentageFull": 103
       }
     ],
@@ -17087,7 +17305,7 @@
         "dateAcademyJoinedTrust": "2022-10-12T00:00:00",
         "establishmentName": "St Mary\u0027s Church of England Academy",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 753,
@@ -17105,6 +17323,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-02-04T00:00:00"
         },
+        "oldLaCode": 390,
         "percentageFull": 75
       }
     ],
@@ -17411,7 +17630,7 @@
         "dateAcademyJoinedTrust": "2021-11-23T00:00:00",
         "establishmentName": "St Mary\u0027s Cofe Academy",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 206,
@@ -17429,6 +17648,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-09-19T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 52
       }
     ],
@@ -17581,7 +17801,7 @@
         "dateAcademyJoinedTrust": "2022-04-22T00:00:00",
         "establishmentName": "St Mary\u0027s C.E. Academy",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2866,
@@ -17599,6 +17819,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 393,
         "percentageFull": 112
       }
     ],
@@ -17927,7 +18148,7 @@
         "dateAcademyJoinedTrust": "2018-08-05T00:00:00",
         "establishmentName": "St Mary\u0027s C/E Academy",
         "typeOfEstablishment": "Academy 16-19 Converter",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1855,
@@ -17945,6 +18166,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 393,
         "percentageFull": 98
       }
     ],
@@ -18119,7 +18341,7 @@
         "dateAcademyJoinedTrust": "2022-05-24T00:00:00",
         "establishmentName": "St Mary\u0027s C of E Academy",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "North Yorkshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 3010,
@@ -18137,6 +18359,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-05-30T00:00:00"
         },
+        "oldLaCode": 390,
         "percentageFull": 130
       }
     ],
@@ -18355,7 +18578,7 @@
         "dateAcademyJoinedTrust": "2017-05-14T00:00:00",
         "establishmentName": "St Mary\u0027s Church of England VA Primary Academy",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2133,
@@ -18373,6 +18596,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2016-04-01T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 95
       }
     ],
@@ -18624,7 +18848,7 @@
         "dateAcademyJoinedTrust": "2022-09-14T00:00:00",
         "establishmentName": "St Mary\u0027s Primary School, A Catholic Voluntary Academy",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Gateshead",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 80,
@@ -18642,6 +18866,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2016-12-01T00:00:00"
         },
+        "oldLaCode": 390,
         "percentageFull": 63
       }
     ],
@@ -18922,6 +19147,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 76
       },
       {
@@ -18947,6 +19173,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 118
       },
       {
@@ -18972,6 +19199,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2020-07-12T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 90
       },
       {
@@ -18997,6 +19225,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 94
       },
       {
@@ -19022,6 +19251,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2012-06-21T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 125
       },
       {
@@ -19047,6 +19277,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-12-24T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 74
       },
       {
@@ -19072,6 +19303,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-02-12T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 48
       },
       {
@@ -19097,6 +19329,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2011-10-14T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 69
       },
       {
@@ -19122,6 +19355,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2016-08-08T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 124
       },
       {
@@ -19147,6 +19381,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 70
       },
       {
@@ -19172,6 +19407,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 109
       }
     ],
@@ -19445,7 +19681,7 @@
         "dateAcademyJoinedTrust": "2013-12-30T00:00:00",
         "establishmentName": "Meridian Cofe 16 Plus School",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1910,
@@ -19463,6 +19699,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 380,
         "percentageFull": 71
       },
       {
@@ -19470,7 +19707,7 @@
         "dateAcademyJoinedTrust": "2020-03-10T00:00:00",
         "establishmentName": "St. James\u0027 R.C. 16 Plus School",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2724,
@@ -19488,6 +19725,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2021-03-26T00:00:00"
         },
+        "oldLaCode": 393,
         "percentageFull": 113
       }
     ],
@@ -19757,6 +19995,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-10-06T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 119
       },
       {
@@ -19782,6 +20021,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 50
       },
       {
@@ -19807,6 +20047,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2019-08-06T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 98
       },
       {
@@ -19832,6 +20073,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 42
       },
       {
@@ -19857,6 +20099,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2020-10-04T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 107
       },
       {
@@ -19882,6 +20125,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-08-16T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 62
       },
       {
@@ -19907,6 +20151,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 99
       }
     ],
@@ -20099,6 +20344,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 62
       },
       {
@@ -20124,6 +20370,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2021-07-17T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 52
       },
       {
@@ -20149,6 +20396,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 111
       },
       {
@@ -20174,6 +20422,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 60
       },
       {
@@ -20181,7 +20430,7 @@
         "dateAcademyJoinedTrust": "2018-07-03T00:00:00",
         "establishmentName": "Limehurst Catholic Middle Deemed Primary School",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 2514,
@@ -20199,6 +20448,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2012-11-29T00:00:00"
         },
+        "oldLaCode": 393,
         "percentageFull": 97
       },
       {
@@ -20206,7 +20456,7 @@
         "dateAcademyJoinedTrust": "2018-08-19T00:00:00",
         "establishmentName": "Meridian Cofe 16 Plus Academy",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1955,
@@ -20224,14 +20474,15 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 393,
         "percentageFull": 86
       },
       {
         "urn": 13025908,
         "dateAcademyJoinedTrust": "2021-02-04T00:00:00",
-        "establishmentName": "Wakefield Cofe School",
+        "establishmentName": "South Tyneside Cofe School",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 1012,
@@ -20249,6 +20500,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 393,
         "percentageFull": 79
       },
       {
@@ -20256,7 +20508,7 @@
         "dateAcademyJoinedTrust": "2020-11-20T00:00:00",
         "establishmentName": "Limehurst Middle Deemed Secondary Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 831,
@@ -20274,6 +20526,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2018-12-29T00:00:00"
         },
+        "oldLaCode": 393,
         "percentageFull": 61
       }
     ],
@@ -20400,6 +20653,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-01-24T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 80
       }
     ],
@@ -20640,7 +20894,7 @@
         "dateAcademyJoinedTrust": "2015-02-09T00:00:00",
         "establishmentName": "Meridian School",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1075,
@@ -20658,6 +20912,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-04-29T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 88
       },
       {
@@ -20665,7 +20920,7 @@
         "dateAcademyJoinedTrust": "2015-12-08T00:00:00",
         "establishmentName": "Malbank Church of England School",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 3537,
@@ -20683,6 +20938,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2022-10-12T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 127
       },
       {
@@ -20690,7 +20946,7 @@
         "dateAcademyJoinedTrust": "2020-07-12T00:00:00",
         "establishmentName": "Longhill R.C. Academy",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 899,
@@ -20708,6 +20964,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 392,
         "percentageFull": 67
       },
       {
@@ -20715,7 +20972,7 @@
         "dateAcademyJoinedTrust": "2015-07-08T00:00:00",
         "establishmentName": "St. Joseph\u0027s Church of England Academy",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 604,
@@ -20733,6 +20990,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2014-10-18T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 42
       },
       {
@@ -20740,7 +20998,7 @@
         "dateAcademyJoinedTrust": "2022-05-13T00:00:00",
         "establishmentName": "St. Peter\u0027s R.C. School",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 838,
@@ -20758,6 +21016,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2020-05-30T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 128
       },
       {
@@ -20783,6 +21042,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 382,
         "percentageFull": 57
       },
       {
@@ -20790,7 +21050,7 @@
         "dateAcademyJoinedTrust": "2021-01-28T00:00:00",
         "establishmentName": "St. Marys Cofe 16 Plus Academy",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2102,
@@ -20808,6 +21068,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 392,
         "percentageFull": 116
       },
       {
@@ -20815,7 +21076,7 @@
         "dateAcademyJoinedTrust": "2015-03-01T00:00:00",
         "establishmentName": "Margie Mountains Middle Deemed Primary Academy",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 696,
@@ -20833,6 +21094,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2011-01-20T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 112
       },
       {
@@ -20858,6 +21120,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2012-05-14T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 104
       },
       {
@@ -20883,6 +21146,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-10-07T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 108
       },
       {
@@ -20890,7 +21154,7 @@
         "dateAcademyJoinedTrust": "2018-01-18T00:00:00",
         "establishmentName": "George Abbey Academy",
         "typeOfEstablishment": "Academy 16 to 19 sponsor led",
-        "localAuthority": "Rotherham",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 308,
@@ -20908,6 +21172,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2017-06-26T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 118
       }
     ],
@@ -21046,7 +21311,7 @@
         "dateAcademyJoinedTrust": "2019-07-20T00:00:00",
         "establishmentName": "St. James\u0027s R.C. Academy",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 2288,
@@ -21064,6 +21329,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 384,
         "percentageFull": 115
       },
       {
@@ -21089,6 +21355,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2020-05-28T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 59
       },
       {
@@ -21096,7 +21363,7 @@
         "dateAcademyJoinedTrust": "2016-09-03T00:00:00",
         "establishmentName": "Greensward Catholic Primary School",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1697,
@@ -21114,6 +21381,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-08-06T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 73
       },
       {
@@ -21121,7 +21389,7 @@
         "dateAcademyJoinedTrust": "2017-03-26T00:00:00",
         "establishmentName": "Mulberry Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1047,
@@ -21139,6 +21407,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-02-21T00:00:00"
         },
+        "oldLaCode": 384,
         "percentageFull": 44
       },
       {
@@ -21164,6 +21433,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-03-30T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 126
       },
       {
@@ -21171,7 +21441,7 @@
         "dateAcademyJoinedTrust": "2015-01-21T00:00:00",
         "establishmentName": "Glyn School",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 908,
@@ -21189,6 +21459,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-07-26T00:00:00"
         },
+        "oldLaCode": 384,
         "percentageFull": 66
       },
       {
@@ -21196,7 +21467,7 @@
         "dateAcademyJoinedTrust": "2015-12-19T00:00:00",
         "establishmentName": "St. Mary\u0027s Cofe School",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 581,
@@ -21214,6 +21485,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2016-01-06T00:00:00"
         },
+        "oldLaCode": 384,
         "percentageFull": 45
       },
       {
@@ -21221,7 +21493,7 @@
         "dateAcademyJoinedTrust": "2017-11-13T00:00:00",
         "establishmentName": "Malbank School",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 482,
@@ -21239,6 +21511,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 392,
         "percentageFull": 44
       },
       {
@@ -21264,6 +21537,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-11-29T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 90
       },
       {
@@ -21289,6 +21563,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2021-10-20T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 100
       },
       {
@@ -21296,7 +21571,7 @@
         "dateAcademyJoinedTrust": "2020-02-15T00:00:00",
         "establishmentName": "Glyn R.C. School",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Sheffield",
+        "localAuthority": "North Tyneside",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 826,
@@ -21314,6 +21589,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2022-06-18T00:00:00"
         },
+        "oldLaCode": 392,
         "percentageFull": 51
       }
     ],
@@ -21499,7 +21775,7 @@
         "dateAcademyJoinedTrust": "2020-10-08T00:00:00",
         "establishmentName": "Momentum Community R.C. School",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 494,
@@ -21517,6 +21793,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2022-01-20T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 101
       },
       {
@@ -21524,7 +21801,7 @@
         "dateAcademyJoinedTrust": "2017-02-23T00:00:00",
         "establishmentName": "St. James\u0027 C of E School",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Kirklees",
+        "localAuthority": "Barnsley",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 370,
@@ -21542,6 +21819,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-09-23T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 86
       },
       {
@@ -21549,7 +21827,7 @@
         "dateAcademyJoinedTrust": "2023-01-10T00:00:00",
         "establishmentName": "St. James\u0027 CE Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Leeds",
+        "localAuthority": "Kirklees",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 165,
@@ -21567,6 +21845,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 382,
         "percentageFull": 77
       },
       {
@@ -21574,7 +21853,7 @@
         "dateAcademyJoinedTrust": "2017-02-26T00:00:00",
         "establishmentName": "Peacehaven Community Church of England School",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "Leeds",
+        "localAuthority": "Kirklees",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1769,
@@ -21592,6 +21871,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2011-11-27T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 73
       },
       {
@@ -21599,7 +21879,7 @@
         "dateAcademyJoinedTrust": "2021-03-19T00:00:00",
         "establishmentName": "St. Catherine\u0027s Catholic Academy",
         "typeOfEstablishment": "Academy 16-19 Converter",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1129,
@@ -21617,6 +21897,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-04-04T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 63
       },
       {
@@ -21624,7 +21905,7 @@
         "dateAcademyJoinedTrust": "2021-05-12T00:00:00",
         "establishmentName": "St. John\u0027s Catholic Middle Deemed Secondary Academy",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Kirklees",
+        "localAuthority": "Barnsley",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1255,
@@ -21642,6 +21923,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2015-01-30T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 91
       }
     ],
@@ -21966,6 +22248,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2020-05-24T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 45
       },
       {
@@ -21973,7 +22256,7 @@
         "dateAcademyJoinedTrust": "2021-10-13T00:00:00",
         "establishmentName": "St. Catherine\u0027s Cofe School",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "East Riding of Yorkshire",
+        "localAuthority": "Bradford",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1643,
@@ -21991,6 +22274,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-05-10T00:00:00"
         },
+        "oldLaCode": 380,
         "percentageFull": 114
       },
       {
@@ -22016,6 +22300,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-05-06T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 66
       },
       {
@@ -22041,6 +22326,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2017-04-21T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 66
       }
     ],
@@ -22380,7 +22666,7 @@
         "dateAcademyJoinedTrust": "2015-01-10T00:00:00",
         "establishmentName": "St. James\u0027 R.C. Academy",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Sheffield",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 1662,
@@ -22398,6 +22684,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-03-12T00:00:00"
         },
+        "oldLaCode": 373,
         "percentageFull": 78
       },
       {
@@ -22405,7 +22692,7 @@
         "dateAcademyJoinedTrust": "2014-10-19T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 School",
         "typeOfEstablishment": "Free schools 16 to 19",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Sheffield",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 955,
@@ -22423,6 +22710,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 373,
         "percentageFull": 47
       },
       {
@@ -22430,7 +22718,7 @@
         "dateAcademyJoinedTrust": "2021-03-08T00:00:00",
         "establishmentName": "St. Joseph\u0027s Cofe Middle Deemed Primary School",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Sheffield",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1006,
@@ -22448,6 +22736,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 373,
         "percentageFull": 81
       },
       {
@@ -22455,7 +22744,7 @@
         "dateAcademyJoinedTrust": "2021-05-03T00:00:00",
         "establishmentName": "St. James\u0027 Church of England School",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Sheffield",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1368,
@@ -22473,6 +22762,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2014-12-14T00:00:00"
         },
+        "oldLaCode": 373,
         "percentageFull": 118
       }
     ],
@@ -22835,7 +23125,7 @@
         "dateAcademyJoinedTrust": "2021-11-20T00:00:00",
         "establishmentName": "St. John\u0027s R.C. School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Rotherham",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 1171,
@@ -22853,6 +23143,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 372,
         "percentageFull": 124
       },
       {
@@ -22860,7 +23151,7 @@
         "dateAcademyJoinedTrust": "2015-03-15T00:00:00",
         "establishmentName": "Greensward C of E Academy",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "North Yorkshire",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1312,
@@ -22878,6 +23169,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2015-08-12T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 105
       },
       {
@@ -22885,7 +23177,7 @@
         "dateAcademyJoinedTrust": "2016-08-31T00:00:00",
         "establishmentName": "Beacon School",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Rotherham",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1600,
@@ -22903,6 +23195,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 372,
         "percentageFull": 93
       },
       {
@@ -22910,7 +23203,7 @@
         "dateAcademyJoinedTrust": "2021-08-13T00:00:00",
         "establishmentName": "St. Marys Catholic Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1592,
@@ -22928,6 +23221,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 384,
         "percentageFull": 64
       },
       {
@@ -22935,7 +23229,7 @@
         "dateAcademyJoinedTrust": "2015-03-09T00:00:00",
         "establishmentName": "Longhill Academy",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "Doncaster",
+        "localAuthority": "Rotherham",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1085,
@@ -22953,6 +23247,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 372,
         "percentageFull": 94
       },
       {
@@ -22960,7 +23255,7 @@
         "dateAcademyJoinedTrust": "2020-01-03T00:00:00",
         "establishmentName": "Limehurst C of E School",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "North Lincolnshire",
+        "localAuthority": "Wakefield",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2410,
@@ -22978,6 +23273,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 384,
         "percentageFull": 101
       },
       {
@@ -23003,6 +23299,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-10-22T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 48
       }
     ],
@@ -23133,7 +23430,7 @@
         "dateAcademyJoinedTrust": "2021-05-06T00:00:00",
         "establishmentName": "Harris R.C. Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Bradford",
+        "localAuthority": "Barnsley",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 279,
@@ -23151,6 +23448,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2016-01-04T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 71
       },
       {
@@ -23158,7 +23456,7 @@
         "dateAcademyJoinedTrust": "2017-01-20T00:00:00",
         "establishmentName": "St. Marys CE School",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Bradford",
+        "localAuthority": "Barnsley",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 2271,
@@ -23176,6 +23474,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2013-12-06T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 101
       },
       {
@@ -23183,7 +23482,7 @@
         "dateAcademyJoinedTrust": "2017-07-15T00:00:00",
         "establishmentName": "Co-op Secondary School",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Bradford",
+        "localAuthority": "Barnsley",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 256,
@@ -23201,6 +23500,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2012-09-07T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 77
       }
     ],
@@ -23507,7 +23807,7 @@
         "dateAcademyJoinedTrust": "2022-10-28T00:00:00",
         "establishmentName": "St. James\u0027s Church of England School",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 456,
@@ -23525,6 +23825,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2012-08-22T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 73
       },
       {
@@ -23532,7 +23833,7 @@
         "dateAcademyJoinedTrust": "2022-12-21T00:00:00",
         "establishmentName": "St. Mary\u0027s R.C. Middle Deemed Secondary School",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 2890,
@@ -23550,6 +23851,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 383,
         "percentageFull": 97
       },
       {
@@ -23557,7 +23859,7 @@
         "dateAcademyJoinedTrust": "2023-05-27T00:00:00",
         "establishmentName": "Lucile Ferry Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 87,
@@ -23575,6 +23877,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-11-24T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 64
       },
       {
@@ -23582,7 +23885,7 @@
         "dateAcademyJoinedTrust": "2023-05-23T00:00:00",
         "establishmentName": "Glyn School",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 857,
@@ -23600,6 +23903,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 383,
         "percentageFull": 80
       },
       {
@@ -23607,7 +23911,7 @@
         "dateAcademyJoinedTrust": "2023-05-11T00:00:00",
         "establishmentName": "Wiza Springs Catholic Middle Deemed Secondary School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 2885,
@@ -23625,6 +23929,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-07-20T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 125
       },
       {
@@ -23632,7 +23937,7 @@
         "dateAcademyJoinedTrust": "2023-04-30T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 R.C. School",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 2870,
@@ -23650,6 +23955,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 383,
         "percentageFull": 125
       },
       {
@@ -23657,7 +23963,7 @@
         "dateAcademyJoinedTrust": "2022-08-05T00:00:00",
         "establishmentName": "Krajcik Spur Cofe All-through School",
         "typeOfEstablishment": "Academy Sponsor Led",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1320,
@@ -23675,6 +23981,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 383,
         "percentageFull": 58
       }
     ],
@@ -23992,7 +24299,7 @@
         "dateAcademyJoinedTrust": "2021-03-02T00:00:00",
         "establishmentName": "Halewood C of E Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Barnsley",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Middle Deemed Secondary",
         "numberOfPupils": 1098,
@@ -24010,6 +24317,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2013-12-20T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 127
       },
       {
@@ -24017,7 +24325,7 @@
         "dateAcademyJoinedTrust": "2023-07-03T00:00:00",
         "establishmentName": "Zula Skyway Secondary School",
         "typeOfEstablishment": "City Technology College",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Barnsley",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 796,
@@ -24035,6 +24343,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2020-02-27T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 45
       },
       {
@@ -24042,7 +24351,7 @@
         "dateAcademyJoinedTrust": "2020-09-15T00:00:00",
         "establishmentName": "St. Marys Church of England Middle Deemed Primary Academy",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Leeds",
+        "localAuthority": "Kirklees",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Middle Deemed Primary",
         "numberOfPupils": 1045,
@@ -24060,6 +24369,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2014-03-11T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 67
       },
       {
@@ -24067,7 +24377,7 @@
         "dateAcademyJoinedTrust": "2022-01-17T00:00:00",
         "establishmentName": "St. James\u0027 C of E Academy",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "Leeds",
+        "localAuthority": "Kirklees",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 2121,
@@ -24085,14 +24395,15 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-10-03T00:00:00"
         },
+        "oldLaCode": 382,
         "percentageFull": 112
       },
       {
         "urn": 12377014,
         "dateAcademyJoinedTrust": "2022-12-20T00:00:00",
-        "establishmentName": "Calderdale Academy",
+        "establishmentName": "Barnsley Academy",
         "typeOfEstablishment": "University technical college",
-        "localAuthority": "Calderdale",
+        "localAuthority": "Barnsley",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 827,
@@ -24110,6 +24421,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 126
       },
       {
@@ -24117,7 +24429,7 @@
         "dateAcademyJoinedTrust": "2021-11-13T00:00:00",
         "establishmentName": "Lampton School",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1053,
@@ -24135,6 +24447,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 383,
         "percentageFull": 69
       },
       {
@@ -24142,7 +24455,7 @@
         "dateAcademyJoinedTrust": "2021-09-15T00:00:00",
         "establishmentName": "St. Marys R.C. Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "North East Lincolnshire",
+        "localAuthority": "Leeds",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 350,
@@ -24160,6 +24473,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 383,
         "percentageFull": 117
       }
     ],
@@ -24334,7 +24648,7 @@
         "dateAcademyJoinedTrust": "2022-10-07T00:00:00",
         "establishmentName": "Glyn Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "All-through",
         "numberOfPupils": 1347,
@@ -24352,6 +24666,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-10-03T00:00:00"
         },
+        "oldLaCode": 393,
         "percentageFull": 92
       },
       {
@@ -24359,7 +24674,7 @@
         "dateAcademyJoinedTrust": "2023-05-12T00:00:00",
         "establishmentName": "Longhill School",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 155,
@@ -24377,6 +24692,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-05-20T00:00:00"
         },
+        "oldLaCode": 394,
         "percentageFull": 90
       },
       {
@@ -24384,7 +24700,7 @@
         "dateAcademyJoinedTrust": "2022-06-30T00:00:00",
         "establishmentName": "Beacon R.C. Academy",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 985,
@@ -24402,6 +24718,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-07-13T00:00:00"
         },
+        "oldLaCode": 394,
         "percentageFull": 49
       },
       {
@@ -24409,7 +24726,7 @@
         "dateAcademyJoinedTrust": "2023-08-19T00:00:00",
         "establishmentName": "Northwood C of E School",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 3399,
@@ -24427,6 +24744,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 394,
         "percentageFull": 127
       },
       {
@@ -24434,7 +24752,7 @@
         "dateAcademyJoinedTrust": "2023-07-18T00:00:00",
         "establishmentName": "Beacon Primary School",
         "typeOfEstablishment": "Studio schools",
-        "localAuthority": "Wakefield",
+        "localAuthority": "South Tyneside",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 370,
@@ -24452,6 +24770,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-05-07T00:00:00"
         },
+        "oldLaCode": 393,
         "percentageFull": 117
       },
       {
@@ -24459,7 +24778,7 @@
         "dateAcademyJoinedTrust": "2022-10-09T00:00:00",
         "establishmentName": "Glyn Cofe School",
         "typeOfEstablishment": "Foundation School",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 434,
@@ -24477,14 +24796,15 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 394,
         "percentageFull": 46
       },
       {
         "urn": 12411249,
         "dateAcademyJoinedTrust": "2022-10-15T00:00:00",
-        "establishmentName": "Rotherham Academy",
+        "establishmentName": "Newcastle upon Tyne Academy",
         "typeOfEstablishment": "Community School",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
         "numberOfPupils": 264,
@@ -24502,6 +24822,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2012-05-24T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 40
       },
       {
@@ -24509,7 +24830,7 @@
         "dateAcademyJoinedTrust": "2022-11-07T00:00:00",
         "establishmentName": "Greensward School",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "York",
+        "localAuthority": "Sunderland",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 1268,
@@ -24527,6 +24848,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2015-09-20T00:00:00"
         },
+        "oldLaCode": 394,
         "percentageFull": 47
       },
       {
@@ -24534,7 +24856,7 @@
         "dateAcademyJoinedTrust": "2022-05-31T00:00:00",
         "establishmentName": "Beacon Cofe 16 Plus Academy",
         "typeOfEstablishment": "Voluntary Aided School",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "16 Plus",
         "numberOfPupils": 2083,
@@ -24552,6 +24874,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-11-25T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 70
       }
     ],
@@ -24744,6 +25067,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 383,
         "percentageFull": 107
       },
       {
@@ -24751,7 +25075,7 @@
         "dateAcademyJoinedTrust": "2023-07-29T00:00:00",
         "establishmentName": "St. Anne\u0027s Catholic Primary Academy",
         "typeOfEstablishment": "Voluntary Controlled School",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
         "numberOfPupils": 2042,
@@ -24769,6 +25093,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-02-22T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 115
       },
       {
@@ -24776,7 +25101,7 @@
         "dateAcademyJoinedTrust": "2023-07-08T00:00:00",
         "establishmentName": "St. Mary\u0027s Cofe Academy",
         "typeOfEstablishment": "Free Schools",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 625,
@@ -24794,6 +25119,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2021-03-26T00:00:00"
         },
+        "oldLaCode": 391,
         "percentageFull": 97
       },
       {
@@ -24819,6 +25145,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 383,
         "percentageFull": 105
       },
       {
@@ -24844,6 +25171,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 40
       },
       {
@@ -24869,6 +25197,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2018-06-04T00:00:00"
         },
+        "oldLaCode": 383,
         "percentageFull": 64
       },
       {
@@ -24894,6 +25223,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 370,
         "percentageFull": 50
       },
       {
@@ -24901,7 +25231,7 @@
         "dateAcademyJoinedTrust": "2023-07-26T00:00:00",
         "establishmentName": "St. Joseph\u0027s CE Academy",
         "typeOfEstablishment": "Academy Converter",
-        "localAuthority": "Rotherham",
+        "localAuthority": "Newcastle upon Tyne",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Not applicable",
         "numberOfPupils": 167,
@@ -24919,6 +25249,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
+        "oldLaCode": 391,
         "percentageFull": 65
       },
       {
@@ -24944,6 +25275,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-01-23T00:00:00"
         },
+        "oldLaCode": 370,
         "percentageFull": 116
       }
     ],

--- a/tests/playwright/fake-data/trusts.json
+++ b/tests/playwright/fake-data/trusts.json
@@ -13,17 +13,17 @@
       {
         "urn": 12337613,
         "dateAcademyJoinedTrust": "2019-04-06T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s CE Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Queen Elizabeth\u0027s CE Middle Deemed Secondary School",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "North East Lincolnshire",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 170,
-        "schoolCapacity": 134,
-        "percentageFreeSchoolMeals": "14",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 988,
+        "schoolCapacity": 2406,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -33,22 +33,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2021-03-16T00:00:00"
         },
-        "percentageFull": 127
+        "percentageFull": 41
       },
       {
         "urn": 12335382,
         "dateAcademyJoinedTrust": "2018-08-11T00:00:00",
         "establishmentName": "St. Mary\u0027s C of E School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 224,
-        "schoolCapacity": 455,
-        "percentageFreeSchoolMeals": "2",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 247,
+        "schoolCapacity": 485,
+        "percentageFreeSchoolMeals": "4",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -58,22 +58,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-07-06T00:00:00"
         },
-        "percentageFull": 49
+        "percentageFull": 51
       },
       {
         "urn": 12333702,
         "dateAcademyJoinedTrust": "2021-11-10T00:00:00",
-        "establishmentName": "Horizon CE Primary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Horizon CE Middle Deemed Primary School",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Sheffield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1320,
-        "schoolCapacity": 1158,
-        "percentageFreeSchoolMeals": "8",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 983,
+        "schoolCapacity": 1350,
+        "percentageFreeSchoolMeals": "25",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -83,19 +83,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 114
+        "percentageFull": 73
       },
       {
         "urn": 12337501,
         "dateAcademyJoinedTrust": "2021-10-07T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 CE Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 945,
-        "schoolCapacity": 993,
-        "percentageFreeSchoolMeals": "25",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1201,
+        "schoolCapacity": 1773,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -108,19 +108,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-06-28T00:00:00"
         },
-        "percentageFull": 95
+        "percentageFull": 68
       },
       {
         "urn": 12339659,
         "dateAcademyJoinedTrust": "2022-05-17T00:00:00",
-        "establishmentName": "St. James\u0027 Catholic Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. James\u0027 Catholic All-through School",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "North East Lincolnshire",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 186,
-        "schoolCapacity": 186,
-        "percentageFreeSchoolMeals": "28",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 772,
+        "schoolCapacity": 1810,
+        "percentageFreeSchoolMeals": "20",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -133,7 +133,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2019-04-16T00:00:00"
         },
-        "percentageFull": 100
+        "percentageFull": 43
       }
     ],
     "governors": [
@@ -316,17 +316,17 @@
       {
         "urn": 12509686,
         "dateAcademyJoinedTrust": "2023-04-20T00:00:00",
-        "establishmentName": "St. Paul\u0027s Catholic Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "St. Paul\u0027s Catholic All-through Academy",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1278,
-        "schoolCapacity": 2183,
-        "percentageFreeSchoolMeals": "30",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 398,
+        "schoolCapacity": 380,
+        "percentageFreeSchoolMeals": "7",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -336,22 +336,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-12-31T00:00:00"
         },
-        "percentageFull": 59
+        "percentageFull": 105
       },
       {
         "urn": 12504701,
         "dateAcademyJoinedTrust": "2020-10-28T00:00:00",
-        "establishmentName": "St. John\u0027s Catholic Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. John\u0027s Catholic Academy",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 85,
-        "schoolCapacity": 123,
-        "percentageFreeSchoolMeals": "25",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 98,
+        "schoolCapacity": 241,
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -361,19 +361,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-10-06T00:00:00"
         },
-        "percentageFull": 69
+        "percentageFull": 41
       },
       {
         "urn": 12503201,
         "dateAcademyJoinedTrust": "2022-07-16T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Holly Lodge Girls\u0027 Academy",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Kingston upon Hull, City of",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1194,
-        "schoolCapacity": 975,
-        "percentageFreeSchoolMeals": "26",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1998,
+        "schoolCapacity": 2975,
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -386,19 +386,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2013-05-24T00:00:00"
         },
-        "percentageFull": 122
+        "percentageFull": 67
       },
       {
         "urn": 12503506,
         "dateAcademyJoinedTrust": "2021-10-22T00:00:00",
         "establishmentName": "St. Marys R.C. Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1819,
-        "schoolCapacity": 1511,
-        "percentageFreeSchoolMeals": "29",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 2431,
+        "schoolCapacity": 2901,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -411,22 +411,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 120
+        "percentageFull": 84
       },
       {
         "urn": 12503550,
         "dateAcademyJoinedTrust": "2022-08-16T00:00:00",
-        "establishmentName": "Horizon Cofe Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Horizon Cofe All-through Academy",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "York",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1789,
-        "schoolCapacity": 1427,
-        "percentageFreeSchoolMeals": "30",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 197,
+        "schoolCapacity": 243,
+        "percentageFreeSchoolMeals": "29",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -436,19 +436,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2020-11-03T00:00:00"
         },
-        "percentageFull": 125
+        "percentageFull": 81
       },
       {
         "urn": 12504045,
         "dateAcademyJoinedTrust": "2023-05-29T00:00:00",
         "establishmentName": "Mulberry Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1624,
-        "schoolCapacity": 2937,
-        "percentageFreeSchoolMeals": "11",
+        "numberOfPupils": 2796,
+        "schoolCapacity": 2184,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -461,19 +461,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-03-10T00:00:00"
         },
-        "percentageFull": 55
+        "percentageFull": 128
       },
       {
         "urn": 12502788,
         "dateAcademyJoinedTrust": "2021-02-11T00:00:00",
         "establishmentName": "Harris Cofe Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1576,
-        "schoolCapacity": 1941,
-        "percentageFreeSchoolMeals": "10",
+        "numberOfPupils": 1377,
+        "schoolCapacity": 1418,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -486,19 +486,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 81
+        "percentageFull": 97
       },
       {
         "urn": 12501431,
         "dateAcademyJoinedTrust": "2023-04-02T00:00:00",
         "establishmentName": "Longhill School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 160,
-        "schoolCapacity": 237,
-        "percentageFreeSchoolMeals": "23",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 910,
+        "schoolCapacity": 2056,
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -511,22 +511,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-02-04T00:00:00"
         },
-        "percentageFull": 68
+        "percentageFull": 44
       },
       {
         "urn": 12504209,
         "dateAcademyJoinedTrust": "2021-04-30T00:00:00",
         "establishmentName": "Meridian School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 254,
-        "schoolCapacity": 352,
-        "percentageFreeSchoolMeals": "27",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 386,
+        "schoolCapacity": 807,
+        "percentageFreeSchoolMeals": "11",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -536,19 +536,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-03-24T00:00:00"
         },
-        "percentageFull": 72
+        "percentageFull": 48
       },
       {
         "urn": 12506854,
         "dateAcademyJoinedTrust": "2023-09-10T00:00:00",
         "establishmentName": "Momentum Community School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2474,
-        "schoolCapacity": 2189,
-        "percentageFreeSchoolMeals": "5",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 675,
+        "schoolCapacity": 644,
+        "percentageFreeSchoolMeals": "25",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -561,19 +561,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-01-01T00:00:00"
         },
-        "percentageFull": 113
+        "percentageFull": 105
       },
       {
         "urn": 12502736,
         "dateAcademyJoinedTrust": "2023-09-17T00:00:00",
         "establishmentName": "Harris Church of England Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1234,
-        "schoolCapacity": 1566,
-        "percentageFreeSchoolMeals": "17",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 374,
+        "schoolCapacity": 438,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -586,7 +586,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2016-02-29T00:00:00"
         },
-        "percentageFull": 79
+        "percentageFull": 85
       }
     ],
     "governors": [
@@ -990,14 +990,14 @@
       {
         "urn": 12776766,
         "dateAcademyJoinedTrust": "2023-09-14T00:00:00",
-        "establishmentName": "Mulberry CE Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Mulberry CE 16 Plus Academy",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "York",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 752,
-        "schoolCapacity": 1211,
-        "percentageFreeSchoolMeals": "20",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1525,
+        "schoolCapacity": 2047,
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1010,22 +1010,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-03-25T00:00:00"
         },
-        "percentageFull": 62
+        "percentageFull": 74
       },
       {
         "urn": 12772425,
         "dateAcademyJoinedTrust": "2021-07-30T00:00:00",
-        "establishmentName": "Northwood Church of England Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Northwood Church of England Academy",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Sheffield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 552,
-        "schoolCapacity": 755,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 947,
+        "schoolCapacity": 1570,
+        "percentageFreeSchoolMeals": "12",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -1035,19 +1035,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2021-06-29T00:00:00"
         },
-        "percentageFull": 73
+        "percentageFull": 60
       },
       {
         "urn": 12775819,
         "dateAcademyJoinedTrust": "2018-06-30T00:00:00",
-        "establishmentName": "St. James\u0027s R.C. Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. James\u0027s R.C. Academy",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "North Yorkshire",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1048,
-        "schoolCapacity": 2373,
-        "percentageFreeSchoolMeals": "22",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 3160,
+        "schoolCapacity": 2859,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -1060,18 +1060,18 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2021-10-18T00:00:00"
         },
-        "percentageFull": 44
+        "percentageFull": 111
       },
       {
         "urn": 12773241,
         "dateAcademyJoinedTrust": "2023-02-09T00:00:00",
         "establishmentName": "St. Peter\u0027s Church of England School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "North Yorkshire",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 633,
-        "schoolCapacity": 818,
+        "numberOfPupils": 199,
+        "schoolCapacity": 319,
         "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 11,
@@ -1085,19 +1085,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-07-04T00:00:00"
         },
-        "percentageFull": 77
+        "percentageFull": 62
       },
       {
         "urn": 12777917,
         "dateAcademyJoinedTrust": "2022-12-20T00:00:00",
         "establishmentName": "St. Catherine\u0027s Catholic Secondary School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 146,
-        "schoolCapacity": 217,
-        "percentageFreeSchoolMeals": "12",
+        "numberOfPupils": 144,
+        "schoolCapacity": 329,
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1110,22 +1110,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 67
+        "percentageFull": 44
       },
       {
         "urn": 12779058,
         "dateAcademyJoinedTrust": "2021-01-11T00:00:00",
-        "establishmentName": "Beacon Catholic Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Beacon Catholic Academy",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 512,
-        "schoolCapacity": 418,
-        "percentageFreeSchoolMeals": "23",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 966,
+        "schoolCapacity": 1936,
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -1135,22 +1135,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 122
+        "percentageFull": 50
       },
       {
         "urn": 12778940,
         "dateAcademyJoinedTrust": "2020-08-04T00:00:00",
-        "establishmentName": "George Abbey CE Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "George Abbey CE All-through School",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "North Yorkshire",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1975,
-        "schoolCapacity": 1784,
-        "percentageFreeSchoolMeals": "29",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1255,
+        "schoolCapacity": 1360,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -1160,19 +1160,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2011-02-24T00:00:00"
         },
-        "percentageFull": 111
+        "percentageFull": 92
       },
       {
         "urn": 12772848,
         "dateAcademyJoinedTrust": "2023-08-03T00:00:00",
         "establishmentName": "St. Mary\u0027s CE Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Leeds",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 504,
-        "schoolCapacity": 432,
-        "percentageFreeSchoolMeals": "19",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 685,
+        "schoolCapacity": 1362,
+        "percentageFreeSchoolMeals": "26",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1185,19 +1185,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2015-01-30T00:00:00"
         },
-        "percentageFull": 117
+        "percentageFull": 50
       },
       {
         "urn": 12773091,
         "dateAcademyJoinedTrust": "2022-01-08T00:00:00",
         "establishmentName": "Greensward Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Sheffield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1233,
-        "schoolCapacity": 1805,
-        "percentageFreeSchoolMeals": "6",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1488,
+        "schoolCapacity": 1602,
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -1210,7 +1210,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 68
+        "percentageFull": 93
       }
     ],
     "governors": [
@@ -1405,13 +1405,13 @@
         "urn": 12445266,
         "dateAcademyJoinedTrust": "2020-06-21T00:00:00",
         "establishmentName": "St. Marys Catholic School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1001,
-        "schoolCapacity": 890,
-        "percentageFreeSchoolMeals": "8",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1890,
+        "schoolCapacity": 2929,
+        "percentageFreeSchoolMeals": "25",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1424,19 +1424,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-11-07T00:00:00"
         },
-        "percentageFull": 112
+        "percentageFull": 65
       },
       {
         "urn": 12443026,
         "dateAcademyJoinedTrust": "2022-05-23T00:00:00",
         "establishmentName": "Greensward C of E Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 102,
-        "schoolCapacity": 118,
-        "percentageFreeSchoolMeals": "10",
+        "numberOfPupils": 114,
+        "schoolCapacity": 281,
+        "percentageFreeSchoolMeals": "16",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -1449,7 +1449,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-01-20T00:00:00"
         },
-        "percentageFull": 86
+        "percentageFull": 41
       }
     ],
     "governors": [
@@ -1567,16 +1567,16 @@
         "urn": 12638598,
         "dateAcademyJoinedTrust": "2022-07-21T00:00:00",
         "establishmentName": "St. Catherine\u0027s R.C. Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Doncaster",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1494,
-        "schoolCapacity": 1218,
-        "percentageFreeSchoolMeals": "2",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 2090,
+        "schoolCapacity": 2797,
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -1586,7 +1586,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2018-08-08T00:00:00"
         },
-        "percentageFull": 123
+        "percentageFull": 75
       }
     ],
     "governors": [
@@ -2031,14 +2031,14 @@
       {
         "urn": 12828575,
         "dateAcademyJoinedTrust": "2023-03-13T00:00:00",
-        "establishmentName": "Beacon Church of England Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Beacon Church of England All-through School",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2434,
-        "schoolCapacity": 2577,
-        "percentageFreeSchoolMeals": "27",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 3124,
+        "schoolCapacity": 2673,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2051,19 +2051,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-07-19T00:00:00"
         },
-        "percentageFull": 94
+        "percentageFull": 117
       },
       {
         "urn": 12829272,
         "dateAcademyJoinedTrust": "2022-03-25T00:00:00",
-        "establishmentName": "St. Peter\u0027s C of E Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. Peter\u0027s C of E Middle Deemed Secondary School",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 651,
-        "schoolCapacity": 808,
-        "percentageFreeSchoolMeals": "15",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 717,
+        "schoolCapacity": 1156,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -2076,19 +2076,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-02-01T00:00:00"
         },
-        "percentageFull": 81
+        "percentageFull": 62
       },
       {
         "urn": 12823909,
         "dateAcademyJoinedTrust": "2021-08-20T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Catholic Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. Joseph\u0027s Catholic All-through Academy",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2001,
-        "schoolCapacity": 2543,
-        "percentageFreeSchoolMeals": "29",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 814,
+        "schoolCapacity": 703,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -2101,7 +2101,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 79
+        "percentageFull": 116
       }
     ],
     "governors": [
@@ -2351,13 +2351,13 @@
         "urn": 12541144,
         "dateAcademyJoinedTrust": "2016-03-14T00:00:00",
         "establishmentName": "Greensward Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Bradford",
-        "urbanRural": "Urban major conurbation",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1286,
-        "schoolCapacity": 2303,
-        "percentageFreeSchoolMeals": "13",
+        "numberOfPupils": 2062,
+        "schoolCapacity": 1903,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2370,7 +2370,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 56
+        "percentageFull": 108
       }
     ],
     "governors": [
@@ -2455,16 +2455,16 @@
         "urn": 12608497,
         "dateAcademyJoinedTrust": "2019-10-21T00:00:00",
         "establishmentName": "Peacehaven Community Cofe School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Sheffield",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1713,
-        "schoolCapacity": 1551,
-        "percentageFreeSchoolMeals": "28",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 2165,
+        "schoolCapacity": 2546,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -2474,19 +2474,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2021-03-06T00:00:00"
         },
-        "percentageFull": 110
+        "percentageFull": 85
       },
       {
         "urn": 12602606,
         "dateAcademyJoinedTrust": "2019-09-01T00:00:00",
         "establishmentName": "Co-op C of E Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1579,
-        "schoolCapacity": 1291,
-        "percentageFreeSchoolMeals": "24",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1892,
+        "schoolCapacity": 2458,
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2499,19 +2499,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2018-12-29T00:00:00"
         },
-        "percentageFull": 122
+        "percentageFull": 77
       },
       {
         "urn": 12608821,
         "dateAcademyJoinedTrust": "2021-11-09T00:00:00",
         "establishmentName": "Peacehaven Community Catholic School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Leeds",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1144,
-        "schoolCapacity": 1401,
-        "percentageFreeSchoolMeals": "13",
+        "numberOfPupils": 1124,
+        "schoolCapacity": 1398,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -2524,7 +2524,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2020-09-13T00:00:00"
         },
-        "percentageFull": 82
+        "percentageFull": 80
       }
     ],
     "governors": [
@@ -2740,14 +2740,14 @@
       {
         "urn": 12645485,
         "dateAcademyJoinedTrust": "2020-10-05T00:00:00",
-        "establishmentName": "Rotherham R.C. Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Rotherham R.C. All-through Academy",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 3027,
-        "schoolCapacity": 2593,
-        "percentageFreeSchoolMeals": "27",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1791,
+        "schoolCapacity": 1526,
+        "percentageFreeSchoolMeals": "26",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2766,13 +2766,13 @@
         "urn": 12648455,
         "dateAcademyJoinedTrust": "2022-09-23T00:00:00",
         "establishmentName": "St. John\u0027s CE School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Rotherham",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2050,
-        "schoolCapacity": 2771,
-        "percentageFreeSchoolMeals": "25",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 931,
+        "schoolCapacity": 758,
+        "percentageFreeSchoolMeals": "12",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -2785,19 +2785,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2018-07-10T00:00:00"
         },
-        "percentageFull": 74
+        "percentageFull": 123
       },
       {
         "urn": 12647065,
         "dateAcademyJoinedTrust": "2017-09-01T00:00:00",
         "establishmentName": "St. Mary\u0027s R.C. Secondary School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1347,
-        "schoolCapacity": 1293,
-        "percentageFreeSchoolMeals": "10",
+        "numberOfPupils": 656,
+        "schoolCapacity": 851,
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -2810,22 +2810,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2011-05-19T00:00:00"
         },
-        "percentageFull": 104
+        "percentageFull": 77
       },
       {
         "urn": 12642219,
         "dateAcademyJoinedTrust": "2018-10-10T00:00:00",
         "establishmentName": "Halewood C of E Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Rotherham",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1231,
-        "schoolCapacity": 1645,
-        "percentageFreeSchoolMeals": "18",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1791,
+        "schoolCapacity": 2036,
+        "percentageFreeSchoolMeals": "12",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -2835,19 +2835,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-06-24T00:00:00"
         },
-        "percentageFull": 75
+        "percentageFull": 88
       },
       {
         "urn": 12641654,
         "dateAcademyJoinedTrust": "2020-11-23T00:00:00",
         "establishmentName": "Beacon Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 1042,
-        "schoolCapacity": 2170,
-        "percentageFreeSchoolMeals": "4",
+        "numberOfPupils": 1469,
+        "schoolCapacity": 1409,
+        "percentageFreeSchoolMeals": "3",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -2860,22 +2860,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 48
+        "percentageFull": 104
       },
       {
         "urn": 12642852,
         "dateAcademyJoinedTrust": "2021-04-03T00:00:00",
-        "establishmentName": "St. Anne\u0027s C of E Primary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. Anne\u0027s C of E Secondary School",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Rotherham",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1377,
-        "schoolCapacity": 1910,
-        "percentageFreeSchoolMeals": "9",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 1831,
+        "schoolCapacity": 1904,
+        "percentageFreeSchoolMeals": "11",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -2885,19 +2885,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2013-12-29T00:00:00"
         },
-        "percentageFull": 72
+        "percentageFull": 96
       },
       {
         "urn": 12642082,
         "dateAcademyJoinedTrust": "2020-02-29T00:00:00",
         "establishmentName": "St. Paul\u0027s Catholic Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Rotherham",
         "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2756,
-        "schoolCapacity": 2406,
-        "percentageFreeSchoolMeals": "13",
+        "numberOfPupils": 3078,
+        "schoolCapacity": 2759,
+        "percentageFreeSchoolMeals": "25",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -2910,7 +2910,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-01-28T00:00:00"
         },
-        "percentageFull": 115
+        "percentageFull": 112
       }
     ],
     "governors": [
@@ -3005,14 +3005,14 @@
       {
         "urn": 12431284,
         "dateAcademyJoinedTrust": "2022-06-09T00:00:00",
-        "establishmentName": "St. Marys R.C. Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "St. Marys R.C. All-through Academy",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 134,
-        "schoolCapacity": 113,
-        "percentageFreeSchoolMeals": "28",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 914,
+        "schoolCapacity": 2263,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3025,19 +3025,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2016-12-24T00:00:00"
         },
-        "percentageFull": 119
+        "percentageFull": 40
       },
       {
         "urn": 12439670,
         "dateAcademyJoinedTrust": "2022-10-02T00:00:00",
-        "establishmentName": "St. Peter\u0027s Church of England Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. Peter\u0027s Church of England Middle Deemed Primary Academy",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2388,
-        "schoolCapacity": 1838,
-        "percentageFreeSchoolMeals": "8",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 514,
+        "schoolCapacity": 547,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -3050,17 +3050,17 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-06-15T00:00:00"
         },
-        "percentageFull": 130
+        "percentageFull": 94
       },
       {
         "urn": 12437733,
         "dateAcademyJoinedTrust": "2023-08-20T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Cofe Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. Joseph\u0027s Cofe School",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1172,
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 705,
         "schoolCapacity": 1026,
         "percentageFreeSchoolMeals": "25",
         "ageRange": {
@@ -3075,22 +3075,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 114
+        "percentageFull": 69
       },
       {
         "urn": 12435212,
         "dateAcademyJoinedTrust": "2022-08-20T00:00:00",
         "establishmentName": "St. Paul\u0027s Cofe Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 400,
-        "schoolCapacity": 750,
-        "percentageFreeSchoolMeals": "6",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 347,
+        "schoolCapacity": 577,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -3100,22 +3100,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2019-02-27T00:00:00"
         },
-        "percentageFull": 53
+        "percentageFull": 60
       },
       {
         "urn": 12436854,
         "dateAcademyJoinedTrust": "2021-05-05T00:00:00",
-        "establishmentName": "Barr and Community Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Barr and Community All-through Academy",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1562,
-        "schoolCapacity": 2651,
-        "percentageFreeSchoolMeals": "29",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 832,
+        "schoolCapacity": 698,
+        "percentageFreeSchoolMeals": "7",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -3125,22 +3125,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-05-11T00:00:00"
         },
-        "percentageFull": 59
+        "percentageFull": 119
       },
       {
         "urn": 12435698,
         "dateAcademyJoinedTrust": "2022-08-06T00:00:00",
         "establishmentName": "St. Peter\u0027s Catholic Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 555,
-        "schoolCapacity": 786,
-        "percentageFreeSchoolMeals": "1",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 614,
+        "schoolCapacity": 1002,
+        "percentageFreeSchoolMeals": "11",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -3150,22 +3150,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2021-05-24T00:00:00"
         },
-        "percentageFull": 71
+        "percentageFull": 61
       },
       {
         "urn": 12434103,
         "dateAcademyJoinedTrust": "2021-03-02T00:00:00",
         "establishmentName": "St. Peter\u0027s Catholic School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1285,
-        "schoolCapacity": 2494,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 2778,
+        "schoolCapacity": 2431,
+        "percentageFreeSchoolMeals": "4",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -3175,22 +3175,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-12-04T00:00:00"
         },
-        "percentageFull": 52
+        "percentageFull": 114
       },
       {
         "urn": 12434818,
         "dateAcademyJoinedTrust": "2023-10-31T00:00:00",
         "establishmentName": "Glyn Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 634,
-        "schoolCapacity": 677,
-        "percentageFreeSchoolMeals": "5",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 602,
+        "schoolCapacity": 1039,
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -3200,22 +3200,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-12-11T00:00:00"
         },
-        "percentageFull": 94
+        "percentageFull": 58
       },
       {
         "urn": 12435354,
         "dateAcademyJoinedTrust": "2022-05-05T00:00:00",
-        "establishmentName": "Co-op R.C. Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Co-op R.C. Middle Deemed Secondary Academy",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2438,
-        "schoolCapacity": 1897,
-        "percentageFreeSchoolMeals": "16",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 114,
+        "schoolCapacity": 119,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -3225,7 +3225,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 129
+        "percentageFull": 96
       }
     ],
     "governors": [
@@ -3485,17 +3485,17 @@
       {
         "urn": 12349602,
         "dateAcademyJoinedTrust": "2016-11-14T00:00:00",
-        "establishmentName": "Momentum Community R.C. Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Momentum Community R.C. Middle Deemed Primary Academy",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 845,
-        "schoolCapacity": 732,
-        "percentageFreeSchoolMeals": "5",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 798,
+        "schoolCapacity": 1338,
+        "percentageFreeSchoolMeals": "26",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -3505,19 +3505,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 115
+        "percentageFull": 60
       },
       {
         "urn": 12346213,
         "dateAcademyJoinedTrust": "2022-01-02T00:00:00",
         "establishmentName": "Pollich Ferry CE Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban minor conurbation",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 129,
-        "schoolCapacity": 159,
-        "percentageFreeSchoolMeals": "4",
+        "numberOfPupils": 1217,
+        "schoolCapacity": 2909,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -3530,18 +3530,218 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 81
+        "percentageFull": 42
       },
       {
         "urn": 12343678,
         "dateAcademyJoinedTrust": "2017-05-26T00:00:00",
-        "establishmentName": "Greensward Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Greensward Academy",
+        "typeOfEstablishment": "Free schools 16 to 19",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1634,
+        "schoolCapacity": 1837,
+        "percentageFreeSchoolMeals": "27",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": {
+          "ofstedRatingScore": -1,
+          "inspectionEndDate": null
+        },
+        "previousOfstedRating": {
+          "ofstedRatingScore": -1,
+          "inspectionEndDate": null
+        },
+        "percentageFull": 89
+      },
+      {
+        "urn": 12347464,
+        "dateAcademyJoinedTrust": "2021-03-03T00:00:00",
+        "establishmentName": "Queensbridge Catholic Academy",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "North Lincolnshire",
         "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 2065,
+        "schoolCapacity": 1612,
+        "percentageFreeSchoolMeals": "29",
+        "ageRange": {
+          "minimum": 5,
+          "maximum": 11
+        },
+        "currentOfstedRating": {
+          "ofstedRatingScore": 2,
+          "inspectionEndDate": "2022-04-26T00:00:00"
+        },
+        "previousOfstedRating": {
+          "ofstedRatingScore": 2,
+          "inspectionEndDate": "2018-06-06T00:00:00"
+        },
+        "percentageFull": 128
+      },
+      {
+        "urn": 12349353,
+        "dateAcademyJoinedTrust": "2018-12-13T00:00:00",
+        "establishmentName": "Queensbridge Primary School",
+        "typeOfEstablishment": "Voluntary Controlled School",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 2028,
+        "schoolCapacity": 2982,
+        "percentageFreeSchoolMeals": "2",
+        "ageRange": {
+          "minimum": 4,
+          "maximum": 11
+        },
+        "currentOfstedRating": {
+          "ofstedRatingScore": 1,
+          "inspectionEndDate": "2021-12-21T00:00:00"
+        },
+        "previousOfstedRating": {
+          "ofstedRatingScore": 4,
+          "inspectionEndDate": "2019-11-20T00:00:00"
+        },
+        "percentageFull": 68
+      },
+      {
+        "urn": 12347369,
+        "dateAcademyJoinedTrust": "2020-02-13T00:00:00",
+        "establishmentName": "Mulberry Secondary Academy",
+        "typeOfEstablishment": "Voluntary Aided School",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2027,
-        "schoolCapacity": 1678,
+        "numberOfPupils": 333,
+        "schoolCapacity": 511,
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": {
+          "ofstedRatingScore": 1,
+          "inspectionEndDate": "2022-12-29T00:00:00"
+        },
+        "previousOfstedRating": {
+          "ofstedRatingScore": 1,
+          "inspectionEndDate": "2016-12-09T00:00:00"
+        },
+        "percentageFull": 65
+      },
+      {
+        "urn": 12345808,
+        "dateAcademyJoinedTrust": "2022-01-31T00:00:00",
+        "establishmentName": "Beacon School",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
+        "localAuthority": "North Yorkshire",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 2022,
+        "schoolCapacity": 2052,
+        "percentageFreeSchoolMeals": "9",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": {
+          "ofstedRatingScore": 2,
+          "inspectionEndDate": "2021-07-06T00:00:00"
+        },
+        "previousOfstedRating": {
+          "ofstedRatingScore": -1,
+          "inspectionEndDate": null
+        },
+        "percentageFull": 99
+      },
+      {
+        "urn": 12347264,
+        "dateAcademyJoinedTrust": "2022-03-26T00:00:00",
+        "establishmentName": "Meridian Middle Deemed Primary Academy",
+        "typeOfEstablishment": "City Technology College",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 314,
+        "schoolCapacity": 370,
+        "percentageFreeSchoolMeals": "16",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": {
+          "ofstedRatingScore": 3,
+          "inspectionEndDate": "2021-05-29T00:00:00"
+        },
+        "previousOfstedRating": {
+          "ofstedRatingScore": 4,
+          "inspectionEndDate": "2012-12-25T00:00:00"
+        },
+        "percentageFull": 85
+      },
+      {
+        "urn": 12347769,
+        "dateAcademyJoinedTrust": "2015-10-03T00:00:00",
+        "establishmentName": "St. Peter\u0027s CE Academy",
+        "typeOfEstablishment": "Academy Sponsor Led",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 2067,
+        "schoolCapacity": 2956,
+        "percentageFreeSchoolMeals": "24",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 16
+        },
+        "currentOfstedRating": {
+          "ofstedRatingScore": 3,
+          "inspectionEndDate": "2020-07-23T00:00:00"
+        },
+        "previousOfstedRating": {
+          "ofstedRatingScore": 1,
+          "inspectionEndDate": "2013-08-07T00:00:00"
+        },
+        "percentageFull": 70
+      },
+      {
+        "urn": 12345659,
+        "dateAcademyJoinedTrust": "2016-02-13T00:00:00",
+        "establishmentName": "Limehurst C of E 16 Plus School",
+        "typeOfEstablishment": "Community School",
+        "localAuthority": "North Lincolnshire",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1018,
+        "schoolCapacity": 979,
+        "percentageFreeSchoolMeals": "22",
+        "ageRange": {
+          "minimum": 11,
+          "maximum": 18
+        },
+        "currentOfstedRating": {
+          "ofstedRatingScore": 1,
+          "inspectionEndDate": "2021-04-20T00:00:00"
+        },
+        "previousOfstedRating": {
+          "ofstedRatingScore": 2,
+          "inspectionEndDate": "2019-12-29T00:00:00"
+        },
+        "percentageFull": 104
+      },
+      {
+        "urn": 12349596,
+        "dateAcademyJoinedTrust": "2021-03-08T00:00:00",
+        "establishmentName": "Northwood Cofe All-through School",
+        "typeOfEstablishment": "Free schools 16 to 19",
+        "localAuthority": "Kirklees",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 681,
+        "schoolCapacity": 1426,
         "percentageFreeSchoolMeals": "23",
         "ageRange": {
           "minimum": 11,
@@ -3555,207 +3755,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 121
-      },
-      {
-        "urn": 12347464,
-        "dateAcademyJoinedTrust": "2021-03-03T00:00:00",
-        "establishmentName": "Queensbridge Catholic Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 3650,
-        "schoolCapacity": 2939,
-        "percentageFreeSchoolMeals": "1",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": {
-          "ofstedRatingScore": 2,
-          "inspectionEndDate": "2022-04-26T00:00:00"
-        },
-        "previousOfstedRating": {
-          "ofstedRatingScore": 2,
-          "inspectionEndDate": "2018-06-06T00:00:00"
-        },
-        "percentageFull": 124
-      },
-      {
-        "urn": 12349353,
-        "dateAcademyJoinedTrust": "2018-12-13T00:00:00",
-        "establishmentName": "Queensbridge Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 433,
-        "schoolCapacity": 1002,
-        "percentageFreeSchoolMeals": "3",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": {
-          "ofstedRatingScore": 1,
-          "inspectionEndDate": "2021-12-21T00:00:00"
-        },
-        "previousOfstedRating": {
-          "ofstedRatingScore": 4,
-          "inspectionEndDate": "2019-11-20T00:00:00"
-        },
-        "percentageFull": 43
-      },
-      {
-        "urn": 12347369,
-        "dateAcademyJoinedTrust": "2020-02-13T00:00:00",
-        "establishmentName": "Mulberry Primary Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 584,
-        "schoolCapacity": 913,
-        "percentageFreeSchoolMeals": "11",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": {
-          "ofstedRatingScore": 1,
-          "inspectionEndDate": "2022-12-29T00:00:00"
-        },
-        "previousOfstedRating": {
-          "ofstedRatingScore": 1,
-          "inspectionEndDate": "2016-12-09T00:00:00"
-        },
-        "percentageFull": 64
-      },
-      {
-        "urn": 12345808,
-        "dateAcademyJoinedTrust": "2022-01-31T00:00:00",
-        "establishmentName": "Beacon School",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1284,
-        "schoolCapacity": 1986,
-        "percentageFreeSchoolMeals": "13",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": {
-          "ofstedRatingScore": 2,
-          "inspectionEndDate": "2021-07-06T00:00:00"
-        },
-        "previousOfstedRating": {
-          "ofstedRatingScore": -1,
-          "inspectionEndDate": null
-        },
-        "percentageFull": 65
-      },
-      {
-        "urn": 12347264,
-        "dateAcademyJoinedTrust": "2022-03-26T00:00:00",
-        "establishmentName": "Meridian Secondary Academy",
-        "typeOfEstablishment": "Free school",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1358,
-        "schoolCapacity": 1548,
-        "percentageFreeSchoolMeals": "8",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 18
-        },
-        "currentOfstedRating": {
-          "ofstedRatingScore": 3,
-          "inspectionEndDate": "2021-05-29T00:00:00"
-        },
-        "previousOfstedRating": {
-          "ofstedRatingScore": 4,
-          "inspectionEndDate": "2012-12-25T00:00:00"
-        },
-        "percentageFull": 88
-      },
-      {
-        "urn": 12347769,
-        "dateAcademyJoinedTrust": "2015-10-03T00:00:00",
-        "establishmentName": "St. Peter\u0027s CE Academy",
-        "typeOfEstablishment": "Academy converter",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1170,
-        "schoolCapacity": 1064,
-        "percentageFreeSchoolMeals": "24",
-        "ageRange": {
-          "minimum": 4,
-          "maximum": 11
-        },
-        "currentOfstedRating": {
-          "ofstedRatingScore": 3,
-          "inspectionEndDate": "2020-07-23T00:00:00"
-        },
-        "previousOfstedRating": {
-          "ofstedRatingScore": 1,
-          "inspectionEndDate": "2013-08-07T00:00:00"
-        },
-        "percentageFull": 110
-      },
-      {
-        "urn": 12345659,
-        "dateAcademyJoinedTrust": "2016-02-13T00:00:00",
-        "establishmentName": "Limehurst C of E Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2274,
-        "schoolCapacity": 2161,
-        "percentageFreeSchoolMeals": "18",
-        "ageRange": {
-          "minimum": 5,
-          "maximum": 11
-        },
-        "currentOfstedRating": {
-          "ofstedRatingScore": 1,
-          "inspectionEndDate": "2021-04-20T00:00:00"
-        },
-        "previousOfstedRating": {
-          "ofstedRatingScore": 2,
-          "inspectionEndDate": "2019-12-29T00:00:00"
-        },
-        "percentageFull": 105
-      },
-      {
-        "urn": 12349596,
-        "dateAcademyJoinedTrust": "2021-03-08T00:00:00",
-        "establishmentName": "Northwood Cofe Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
-        "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 375,
-        "schoolCapacity": 348,
-        "percentageFreeSchoolMeals": "28",
-        "ageRange": {
-          "minimum": 11,
-          "maximum": 16
-        },
-        "currentOfstedRating": {
-          "ofstedRatingScore": -1,
-          "inspectionEndDate": null
-        },
-        "previousOfstedRating": {
-          "ofstedRatingScore": -1,
-          "inspectionEndDate": null
-        },
-        "percentageFull": 108
+        "percentageFull": 48
       }
     ],
     "governors": [
@@ -3928,13 +3928,13 @@
         "urn": 12402803,
         "dateAcademyJoinedTrust": "2019-10-14T00:00:00",
         "establishmentName": "Horizon C of E School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2712,
-        "schoolCapacity": 2473,
-        "percentageFreeSchoolMeals": "23",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1819,
+        "schoolCapacity": 1601,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -3947,7 +3947,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2022-12-19T00:00:00"
         },
-        "percentageFull": 110
+        "percentageFull": 114
       }
     ],
     "governors": [
@@ -4076,13 +4076,13 @@
         "urn": 12532975,
         "dateAcademyJoinedTrust": "2023-10-01T00:00:00",
         "establishmentName": "St. Peter\u0027s Church of England Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1101,
-        "schoolCapacity": 860,
-        "percentageFreeSchoolMeals": "6",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1513,
+        "schoolCapacity": 2379,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -4095,22 +4095,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2017-04-14T00:00:00"
         },
-        "percentageFull": 128
+        "percentageFull": 64
       },
       {
         "urn": 12534242,
         "dateAcademyJoinedTrust": "2023-01-20T00:00:00",
-        "establishmentName": "Longhill Cofe Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Longhill Cofe 16 Plus Academy",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 659,
-        "schoolCapacity": 813,
-        "percentageFreeSchoolMeals": "21",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 600,
+        "schoolCapacity": 966,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -4120,22 +4120,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 81
+        "percentageFull": 62
       },
       {
         "urn": 12536195,
         "dateAcademyJoinedTrust": "2023-11-08T00:00:00",
         "establishmentName": "Beacon School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 906,
-        "schoolCapacity": 1757,
-        "percentageFreeSchoolMeals": "25",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1737,
+        "schoolCapacity": 1900,
+        "percentageFreeSchoolMeals": "4",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -4145,19 +4145,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 52
+        "percentageFull": 91
       },
       {
         "urn": 12532916,
         "dateAcademyJoinedTrust": "2022-04-20T00:00:00",
-        "establishmentName": "Momentum Community Cofe Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Momentum Community Cofe School",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1141,
-        "schoolCapacity": 1871,
-        "percentageFreeSchoolMeals": "23",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1951,
+        "schoolCapacity": 2054,
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -4170,19 +4170,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 61
+        "percentageFull": 95
       },
       {
         "urn": 12539657,
         "dateAcademyJoinedTrust": "2022-03-30T00:00:00",
         "establishmentName": "George Abbey Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 359,
-        "schoolCapacity": 323,
-        "percentageFreeSchoolMeals": "2",
+        "numberOfPupils": 916,
+        "schoolCapacity": 1953,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -4195,7 +4195,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 111
+        "percentageFull": 47
       }
     ],
     "governors": [
@@ -4820,13 +4820,13 @@
         "urn": 12426461,
         "dateAcademyJoinedTrust": "2022-07-01T00:00:00",
         "establishmentName": "St. Peter\u0027s CE Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural town and fringe",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1961,
-        "schoolCapacity": 2021,
-        "percentageFreeSchoolMeals": "10",
+        "numberOfPupils": 1031,
+        "schoolCapacity": 1035,
+        "percentageFreeSchoolMeals": "20",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -4839,18 +4839,18 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 97
+        "percentageFull": 100
       },
       {
         "urn": 12424197,
         "dateAcademyJoinedTrust": "2019-10-31T00:00:00",
         "establishmentName": "Barr and Community School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban minor conurbation",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 854,
-        "schoolCapacity": 1721,
+        "numberOfPupils": 2577,
+        "schoolCapacity": 2853,
         "percentageFreeSchoolMeals": "4",
         "ageRange": {
           "minimum": 4,
@@ -4864,22 +4864,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 50
+        "percentageFull": 90
       },
       {
         "urn": 12429810,
         "dateAcademyJoinedTrust": "2022-01-11T00:00:00",
         "establishmentName": "Lampton School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Kingston upon Hull, City of",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2057,
-        "schoolCapacity": 2697,
-        "percentageFreeSchoolMeals": "18",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 2240,
+        "schoolCapacity": 1858,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -4889,19 +4889,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 76
+        "percentageFull": 121
       },
       {
         "urn": 12427550,
         "dateAcademyJoinedTrust": "2021-10-04T00:00:00",
         "establishmentName": "Halewood School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural town and fringe",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 836,
-        "schoolCapacity": 1065,
-        "percentageFreeSchoolMeals": "3",
+        "numberOfPupils": 731,
+        "schoolCapacity": 1045,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -4914,19 +4914,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-07-23T00:00:00"
         },
-        "percentageFull": 78
+        "percentageFull": 70
       },
       {
         "urn": 12426767,
         "dateAcademyJoinedTrust": "2020-07-08T00:00:00",
         "establishmentName": "Co-op School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "Kingston upon Hull, City of",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 861,
-        "schoolCapacity": 671,
-        "percentageFreeSchoolMeals": "27",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 201,
+        "schoolCapacity": 349,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -4939,22 +4939,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2014-09-24T00:00:00"
         },
-        "percentageFull": 128
+        "percentageFull": 58
       },
       {
         "urn": 12421877,
         "dateAcademyJoinedTrust": "2019-12-30T00:00:00",
-        "establishmentName": "Queensbridge Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Queensbridge Primary Academy",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2115,
-        "schoolCapacity": 1774,
-        "percentageFreeSchoolMeals": "2",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 177,
+        "schoolCapacity": 192,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -4964,19 +4964,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2018-10-08T00:00:00"
         },
-        "percentageFull": 119
+        "percentageFull": 92
       },
       {
         "urn": 12421197,
         "dateAcademyJoinedTrust": "2023-04-26T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1945,
-        "schoolCapacity": 1530,
-        "percentageFreeSchoolMeals": "19",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1531,
+        "schoolCapacity": 1814,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -4989,7 +4989,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 127
+        "percentageFull": 84
       }
     ],
     "governors": [
@@ -5117,17 +5117,17 @@
       {
         "urn": 12477387,
         "dateAcademyJoinedTrust": "2021-12-11T00:00:00",
-        "establishmentName": "St. Mary\u0027s R.C. Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "St. Mary\u0027s R.C. Secondary School",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 796,
-        "schoolCapacity": 1081,
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 1312,
+        "schoolCapacity": 1862,
         "percentageFreeSchoolMeals": "12",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -5137,19 +5137,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-03-31T00:00:00"
         },
-        "percentageFull": 74
+        "percentageFull": 70
       },
       {
         "urn": 12478300,
         "dateAcademyJoinedTrust": "2023-06-08T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s R.C. Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "York",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 548,
-        "schoolCapacity": 971,
-        "percentageFreeSchoolMeals": "18",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 977,
+        "schoolCapacity": 1458,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5162,19 +5162,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2012-10-29T00:00:00"
         },
-        "percentageFull": 56
+        "percentageFull": 67
       },
       {
         "urn": 12475812,
         "dateAcademyJoinedTrust": "2022-05-30T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 C of E School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "York",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 3119,
-        "schoolCapacity": 2920,
-        "percentageFreeSchoolMeals": "29",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1025,
+        "schoolCapacity": 804,
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5187,22 +5187,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 107
+        "percentageFull": 127
       },
       {
         "urn": 12472342,
         "dateAcademyJoinedTrust": "2020-07-12T00:00:00",
-        "establishmentName": "Greensward Catholic Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Greensward Catholic Primary School",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "York",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1314,
-        "schoolCapacity": 1502,
-        "percentageFreeSchoolMeals": "1",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 1274,
+        "schoolCapacity": 1525,
+        "percentageFreeSchoolMeals": "16",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -5212,19 +5212,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2015-03-04T00:00:00"
         },
-        "percentageFull": 87
+        "percentageFull": 84
       },
       {
         "urn": 12474923,
         "dateAcademyJoinedTrust": "2019-08-09T00:00:00",
         "establishmentName": "St. Marys R.C. School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2876,
-        "schoolCapacity": 2533,
-        "percentageFreeSchoolMeals": "21",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 2659,
+        "schoolCapacity": 2302,
+        "percentageFreeSchoolMeals": "25",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5237,22 +5237,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 114
+        "percentageFull": 116
       },
       {
         "urn": 12473541,
         "dateAcademyJoinedTrust": "2017-10-24T00:00:00",
         "establishmentName": "Longhill R.C. Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "York",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 672,
-        "schoolCapacity": 1506,
-        "percentageFreeSchoolMeals": "29",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 298,
+        "schoolCapacity": 356,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -5262,18 +5262,18 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2013-03-28T00:00:00"
         },
-        "percentageFull": 45
+        "percentageFull": 84
       },
       {
         "urn": 12475028,
         "dateAcademyJoinedTrust": "2019-10-16T00:00:00",
         "establishmentName": "Beacon Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "York",
         "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1977,
-        "schoolCapacity": 2911,
+        "numberOfPupils": 925,
+        "schoolCapacity": 727,
         "percentageFreeSchoolMeals": "10",
         "ageRange": {
           "minimum": 11,
@@ -5287,19 +5287,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 68
+        "percentageFull": 127
       },
       {
         "urn": 12476693,
         "dateAcademyJoinedTrust": "2021-06-05T00:00:00",
         "establishmentName": "Peacehaven Community Church of England Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "York",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 919,
-        "schoolCapacity": 1009,
-        "percentageFreeSchoolMeals": "12",
+        "numberOfPupils": 1034,
+        "schoolCapacity": 1515,
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5312,22 +5312,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 91
+        "percentageFull": 68
       },
       {
         "urn": 12478921,
         "dateAcademyJoinedTrust": "2021-08-12T00:00:00",
         "establishmentName": "St. Joseph\u0027s R.C. Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "York",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1323,
-        "schoolCapacity": 1940,
-        "percentageFreeSchoolMeals": "14",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 338,
+        "schoolCapacity": 348,
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -5337,7 +5337,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 68
+        "percentageFull": 97
       }
     ],
     "governors": [
@@ -5543,13 +5543,13 @@
         "urn": 12684722,
         "dateAcademyJoinedTrust": "2019-10-08T00:00:00",
         "establishmentName": "Greensward School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1192,
-        "schoolCapacity": 1735,
-        "percentageFreeSchoolMeals": "16",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 248,
+        "schoolCapacity": 273,
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -5562,19 +5562,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 69
+        "percentageFull": 91
       },
       {
         "urn": 12681121,
         "dateAcademyJoinedTrust": "2022-09-09T00:00:00",
-        "establishmentName": "Lampton Church of England Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Lampton Church of England 16 Plus Academy",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1740,
-        "schoolCapacity": 1573,
-        "percentageFreeSchoolMeals": "21",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 951,
+        "schoolCapacity": 1109,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -5587,22 +5587,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-07-19T00:00:00"
         },
-        "percentageFull": 111
+        "percentageFull": 86
       },
       {
         "urn": 12684273,
         "dateAcademyJoinedTrust": "2020-06-04T00:00:00",
         "establishmentName": "Peacehaven Community Cofe Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Rotherham",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 694,
-        "schoolCapacity": 579,
-        "percentageFreeSchoolMeals": "30",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 252,
+        "schoolCapacity": 459,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -5612,22 +5612,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2015-04-19T00:00:00"
         },
-        "percentageFull": 120
+        "percentageFull": 55
       },
       {
         "urn": 12684038,
         "dateAcademyJoinedTrust": "2020-12-18T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Queen Elizabeth\u0027s 16 Plus Academy",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Rotherham",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 130,
-        "schoolCapacity": 135,
-        "percentageFreeSchoolMeals": "20",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 310,
+        "schoolCapacity": 754,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -5637,19 +5637,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2020-08-09T00:00:00"
         },
-        "percentageFull": 96
+        "percentageFull": 41
       },
       {
         "urn": 12683012,
         "dateAcademyJoinedTrust": "2020-10-11T00:00:00",
         "establishmentName": "Horizon Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 400,
-        "schoolCapacity": 344,
-        "percentageFreeSchoolMeals": "10",
+        "numberOfPupils": 282,
+        "schoolCapacity": 592,
+        "percentageFreeSchoolMeals": "26",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -5662,19 +5662,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2022-09-09T00:00:00"
         },
-        "percentageFull": 116
+        "percentageFull": 48
       },
       {
         "urn": 12688636,
         "dateAcademyJoinedTrust": "2022-08-03T00:00:00",
         "establishmentName": "Glyn Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Rotherham",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 622,
-        "schoolCapacity": 1473,
-        "percentageFreeSchoolMeals": "11",
+        "numberOfPupils": 1885,
+        "schoolCapacity": 2282,
+        "percentageFreeSchoolMeals": "1",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5687,7 +5687,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 42
+        "percentageFull": 83
       }
     ],
     "governors": [
@@ -5947,14 +5947,14 @@
       {
         "urn": 12717311,
         "dateAcademyJoinedTrust": "2023-06-25T00:00:00",
-        "establishmentName": "North East Lincolnshire R.C. Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "North East Lincolnshire R.C. All-through School",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 596,
-        "schoolCapacity": 588,
-        "percentageFreeSchoolMeals": "27",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 306,
+        "schoolCapacity": 555,
+        "percentageFreeSchoolMeals": "21",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -5967,19 +5967,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 101
+        "percentageFull": 55
       },
       {
         "urn": 12712128,
         "dateAcademyJoinedTrust": "2023-06-15T00:00:00",
-        "establishmentName": "Horizon Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Horizon Middle Deemed Primary Academy",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2066,
-        "schoolCapacity": 2202,
-        "percentageFreeSchoolMeals": "9",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 134,
+        "schoolCapacity": 127,
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -5992,19 +5992,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-03-22T00:00:00"
         },
-        "percentageFull": 94
+        "percentageFull": 106
       },
       {
         "urn": 12711109,
         "dateAcademyJoinedTrust": "2023-02-19T00:00:00",
         "establishmentName": "Oasis Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 3409,
-        "schoolCapacity": 2881,
-        "percentageFreeSchoolMeals": "14",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 380,
+        "schoolCapacity": 301,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -6017,22 +6017,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2015-04-11T00:00:00"
         },
-        "percentageFull": 118
+        "percentageFull": 126
       },
       {
         "urn": 12714185,
         "dateAcademyJoinedTrust": "2023-08-06T00:00:00",
         "establishmentName": "Co-op Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 707,
-        "schoolCapacity": 903,
-        "percentageFreeSchoolMeals": "30",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1273,
+        "schoolCapacity": 1960,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -6042,22 +6042,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2018-02-28T00:00:00"
         },
-        "percentageFull": 78
+        "percentageFull": 65
       },
       {
         "urn": 12713338,
         "dateAcademyJoinedTrust": "2023-10-22T00:00:00",
-        "establishmentName": "Evalyn Oval Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Evalyn Oval Middle Deemed Primary School",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1579,
-        "schoolCapacity": 2211,
-        "percentageFreeSchoolMeals": "8",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1694,
+        "schoolCapacity": 1606,
+        "percentageFreeSchoolMeals": "11",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -6067,7 +6067,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 71
+        "percentageFull": 105
       }
     ],
     "governors": [
@@ -6515,14 +6515,14 @@
       {
         "urn": 12795741,
         "dateAcademyJoinedTrust": "2017-07-27T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Cofe Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. Joseph\u0027s Cofe Middle Deemed Secondary Academy",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2626,
-        "schoolCapacity": 2974,
-        "percentageFreeSchoolMeals": "15",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 943,
+        "schoolCapacity": 730,
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -6535,22 +6535,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-05-15T00:00:00"
         },
-        "percentageFull": 88
+        "percentageFull": 129
       },
       {
         "urn": 12792091,
         "dateAcademyJoinedTrust": "2018-06-29T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Queen Elizabeth\u0027s 16 Plus Academy",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2678,
-        "schoolCapacity": 2294,
-        "percentageFreeSchoolMeals": "18",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1550,
+        "schoolCapacity": 1434,
+        "percentageFreeSchoolMeals": "26",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -6560,22 +6560,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 117
+        "percentageFull": 108
       },
       {
         "urn": 12791927,
         "dateAcademyJoinedTrust": "2021-05-01T00:00:00",
         "establishmentName": "Malbank School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Kingston upon Hull, City of",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 489,
-        "schoolCapacity": 568,
-        "percentageFreeSchoolMeals": "2",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 1160,
+        "schoolCapacity": 2127,
+        "percentageFreeSchoolMeals": "16",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -6585,18 +6585,18 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2013-02-23T00:00:00"
         },
-        "percentageFull": 86
+        "percentageFull": 55
       },
       {
         "urn": 12799828,
         "dateAcademyJoinedTrust": "2015-08-25T00:00:00",
         "establishmentName": "Glyn Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Leeds",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1043,
-        "schoolCapacity": 1004,
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 879,
+        "schoolCapacity": 1291,
         "percentageFreeSchoolMeals": "22",
         "ageRange": {
           "minimum": 11,
@@ -6610,19 +6610,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2015-10-15T00:00:00"
         },
-        "percentageFull": 104
+        "percentageFull": 68
       },
       {
         "urn": 12799337,
         "dateAcademyJoinedTrust": "2015-06-22T00:00:00",
         "establishmentName": "St. Joseph\u0027s Cofe School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Leeds",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1107,
-        "schoolCapacity": 1653,
-        "percentageFreeSchoolMeals": "12",
+        "numberOfPupils": 1386,
+        "schoolCapacity": 1572,
+        "percentageFreeSchoolMeals": "9",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -6635,7 +6635,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-09-20T00:00:00"
         },
-        "percentageFull": 67
+        "percentageFull": 88
       }
     ],
     "governors": [
@@ -7024,17 +7024,17 @@
       {
         "urn": 12594864,
         "dateAcademyJoinedTrust": "2023-04-10T00:00:00",
-        "establishmentName": "Harris Catholic Primary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Harris Catholic Middle Deemed Primary Academy",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 841,
-        "schoolCapacity": 1350,
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 511,
+        "schoolCapacity": 649,
         "percentageFreeSchoolMeals": "8",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -7044,22 +7044,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-04-13T00:00:00"
         },
-        "percentageFull": 62
+        "percentageFull": 79
       },
       {
         "urn": 12597560,
         "dateAcademyJoinedTrust": "2023-05-07T00:00:00",
-        "establishmentName": "St. Peter\u0027s CE Primary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. Peter\u0027s CE All-through Academy",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Kingston upon Hull, City of",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2117,
-        "schoolCapacity": 2641,
-        "percentageFreeSchoolMeals": "28",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1607,
+        "schoolCapacity": 1352,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -7069,22 +7069,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2012-05-18T00:00:00"
         },
-        "percentageFull": 80
+        "percentageFull": 119
       },
       {
         "urn": 12599757,
         "dateAcademyJoinedTrust": "2023-03-18T00:00:00",
         "establishmentName": "Harris School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1340,
-        "schoolCapacity": 1591,
-        "percentageFreeSchoolMeals": "11",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 806,
+        "schoolCapacity": 934,
+        "percentageFreeSchoolMeals": "15",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -7094,7 +7094,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 84
+        "percentageFull": 86
       }
     ],
     "governors": [
@@ -7355,13 +7355,13 @@
         "urn": 12397279,
         "dateAcademyJoinedTrust": "2022-06-20T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s Catholic Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Sheffield",
-        "urbanRural": "Urban minor conurbation",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 1218,
-        "schoolCapacity": 2368,
-        "percentageFreeSchoolMeals": "2",
+        "numberOfPupils": 3221,
+        "schoolCapacity": 2918,
+        "percentageFreeSchoolMeals": "4",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -7374,19 +7374,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2013-11-30T00:00:00"
         },
-        "percentageFull": 51
+        "percentageFull": 110
       },
       {
         "urn": 12396709,
         "dateAcademyJoinedTrust": "2023-05-03T00:00:00",
         "establishmentName": "Mulberry School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1217,
-        "schoolCapacity": 2607,
-        "percentageFreeSchoolMeals": "17",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1435,
+        "schoolCapacity": 1218,
+        "percentageFreeSchoolMeals": "3",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -7399,19 +7399,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 47
+        "percentageFull": 118
       },
       {
         "urn": 12398921,
         "dateAcademyJoinedTrust": "2022-04-01T00:00:00",
         "establishmentName": "Meridian Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban minor conurbation",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 3604,
-        "schoolCapacity": 2963,
-        "percentageFreeSchoolMeals": "11",
+        "numberOfPupils": 3612,
+        "schoolCapacity": 2804,
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -7424,19 +7424,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 122
+        "percentageFull": 129
       },
       {
         "urn": 12399680,
         "dateAcademyJoinedTrust": "2020-10-23T00:00:00",
-        "establishmentName": "Meridian CE Secondary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Meridian CE School",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 183,
-        "schoolCapacity": 228,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1005,
+        "schoolCapacity": 2286,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -7449,19 +7449,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 80
+        "percentageFull": 44
       },
       {
         "urn": 12396893,
         "dateAcademyJoinedTrust": "2023-02-04T00:00:00",
-        "establishmentName": "Longhill Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Longhill Academy",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2214,
-        "schoolCapacity": 1994,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 976,
+        "schoolCapacity": 988,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -7474,22 +7474,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2018-03-31T00:00:00"
         },
-        "percentageFull": 111
+        "percentageFull": 99
       },
       {
         "urn": 12398268,
         "dateAcademyJoinedTrust": "2021-02-15T00:00:00",
-        "establishmentName": "Longhill Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Longhill Middle Deemed Secondary Academy",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 668,
-        "schoolCapacity": 1172,
-        "percentageFreeSchoolMeals": "14",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1448,
+        "schoolCapacity": 1976,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -7499,22 +7499,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 57
+        "percentageFull": 73
       },
       {
         "urn": 12393624,
         "dateAcademyJoinedTrust": "2021-04-04T00:00:00",
         "establishmentName": "Beacon School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 835,
-        "schoolCapacity": 793,
-        "percentageFreeSchoolMeals": "10",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 470,
+        "schoolCapacity": 765,
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -7524,22 +7524,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 105
+        "percentageFull": 61
       },
       {
         "urn": 12395025,
         "dateAcademyJoinedTrust": "2023-05-25T00:00:00",
-        "establishmentName": "Horizon Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Horizon Middle Deemed Secondary School",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1300,
-        "schoolCapacity": 1598,
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1593,
+        "schoolCapacity": 1842,
         "percentageFreeSchoolMeals": "14",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -7549,22 +7549,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2020-02-24T00:00:00"
         },
-        "percentageFull": 81
+        "percentageFull": 86
       },
       {
         "urn": 12392700,
         "dateAcademyJoinedTrust": "2023-07-06T00:00:00",
-        "establishmentName": "Momentum Community Primary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Momentum Community Secondary Academy",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 448,
-        "schoolCapacity": 492,
-        "percentageFreeSchoolMeals": "10",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 1493,
+        "schoolCapacity": 2861,
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -7574,7 +7574,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-02-15T00:00:00"
         },
-        "percentageFull": 91
+        "percentageFull": 52
       }
     ],
     "governors": [
@@ -7768,17 +7768,17 @@
       {
         "urn": 12661504,
         "dateAcademyJoinedTrust": "2022-11-30T00:00:00",
-        "establishmentName": "Co-op Catholic Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Co-op Catholic Primary Academy",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1870,
-        "schoolCapacity": 1601,
-        "percentageFreeSchoolMeals": "3",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 1111,
+        "schoolCapacity": 1283,
+        "percentageFreeSchoolMeals": "26",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -7788,7 +7788,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-09-04T00:00:00"
         },
-        "percentageFull": 117
+        "percentageFull": 87
       }
     ],
     "governors": [
@@ -8204,13 +8204,13 @@
         "urn": 12785749,
         "dateAcademyJoinedTrust": "2020-10-11T00:00:00",
         "establishmentName": "St. Anne\u0027s Cofe Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2251,
-        "schoolCapacity": 1789,
-        "percentageFreeSchoolMeals": "24",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1759,
+        "schoolCapacity": 1903,
+        "percentageFreeSchoolMeals": "29",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -8223,22 +8223,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-10-08T00:00:00"
         },
-        "percentageFull": 126
+        "percentageFull": 92
       },
       {
         "urn": 12782851,
         "dateAcademyJoinedTrust": "2016-12-22T00:00:00",
-        "establishmentName": "Harris Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Harris Primary Academy",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1703,
-        "schoolCapacity": 2968,
-        "percentageFreeSchoolMeals": "4",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 1376,
+        "schoolCapacity": 1067,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -8248,22 +8248,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2019-05-28T00:00:00"
         },
-        "percentageFull": 57
+        "percentageFull": 129
       },
       {
         "urn": 12786559,
         "dateAcademyJoinedTrust": "2020-06-12T00:00:00",
         "establishmentName": "Oasis Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 570,
-        "schoolCapacity": 712,
-        "percentageFreeSchoolMeals": "18",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 900,
+        "schoolCapacity": 1526,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -8273,22 +8273,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2017-12-14T00:00:00"
         },
-        "percentageFull": 80
+        "percentageFull": 59
       },
       {
         "urn": 12789186,
         "dateAcademyJoinedTrust": "2017-04-12T00:00:00",
-        "establishmentName": "Limehurst Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Limehurst 16 Plus School",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 518,
-        "schoolCapacity": 400,
-        "percentageFreeSchoolMeals": "19",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1429,
+        "schoolCapacity": 2897,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -8298,19 +8298,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2020-06-24T00:00:00"
         },
-        "percentageFull": 130
+        "percentageFull": 49
       },
       {
         "urn": 12789531,
         "dateAcademyJoinedTrust": "2022-03-27T00:00:00",
-        "establishmentName": "Halewood Cofe Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Halewood Cofe All-through Academy",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1043,
-        "schoolCapacity": 1276,
-        "percentageFreeSchoolMeals": "27",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 465,
+        "schoolCapacity": 608,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -8323,22 +8323,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2016-07-09T00:00:00"
         },
-        "percentageFull": 82
+        "percentageFull": 76
       },
       {
         "urn": 12788904,
         "dateAcademyJoinedTrust": "2020-04-04T00:00:00",
         "establishmentName": "Barr and Community School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1046,
-        "schoolCapacity": 2273,
-        "percentageFreeSchoolMeals": "19",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 2896,
+        "schoolCapacity": 2696,
+        "percentageFreeSchoolMeals": "3",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -8348,22 +8348,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-03-17T00:00:00"
         },
-        "percentageFull": 46
+        "percentageFull": 107
       },
       {
         "urn": 12785003,
         "dateAcademyJoinedTrust": "2019-01-25T00:00:00",
-        "establishmentName": "St. Marys Church of England Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. Marys Church of England Middle Deemed Secondary School",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2118,
-        "schoolCapacity": 1669,
-        "percentageFreeSchoolMeals": "14",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1050,
+        "schoolCapacity": 1184,
+        "percentageFreeSchoolMeals": "29",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -8373,7 +8373,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 127
+        "percentageFull": 89
       }
     ],
     "governors": [
@@ -8634,16 +8634,16 @@
         "urn": 12354169,
         "dateAcademyJoinedTrust": "2023-08-28T00:00:00",
         "establishmentName": "Horizon Church of England School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Calderdale",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1677,
-        "schoolCapacity": 2239,
-        "percentageFreeSchoolMeals": "1",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 1827,
+        "schoolCapacity": 1717,
+        "percentageFreeSchoolMeals": "12",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -8653,22 +8653,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-03-30T00:00:00"
         },
-        "percentageFull": 75
+        "percentageFull": 106
       },
       {
         "urn": 12355911,
         "dateAcademyJoinedTrust": "2023-07-28T00:00:00",
-        "establishmentName": "St. Peter\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. Peter\u0027s Catholic Middle Deemed Secondary School",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1696,
-        "schoolCapacity": 1518,
-        "percentageFreeSchoolMeals": "14",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 486,
+        "schoolCapacity": 579,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -8678,22 +8678,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 112
+        "percentageFull": 84
       },
       {
         "urn": 12351340,
         "dateAcademyJoinedTrust": "2023-05-07T00:00:00",
-        "establishmentName": "St. Catherine\u0027s R.C. Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. Catherine\u0027s R.C. Primary Academy",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Calderdale",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 716,
-        "schoolCapacity": 1553,
-        "percentageFreeSchoolMeals": "4",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 1215,
+        "schoolCapacity": 1428,
+        "percentageFreeSchoolMeals": "3",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -8703,19 +8703,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-07-16T00:00:00"
         },
-        "percentageFull": 46
+        "percentageFull": 85
       },
       {
         "urn": 12356740,
         "dateAcademyJoinedTrust": "2023-07-24T00:00:00",
         "establishmentName": "St. Joseph\u0027s C of E School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Calderdale",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 748,
-        "schoolCapacity": 1231,
-        "percentageFreeSchoolMeals": "26",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 590,
+        "schoolCapacity": 785,
+        "percentageFreeSchoolMeals": "7",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -8728,7 +8728,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2012-08-08T00:00:00"
         },
-        "percentageFull": 61
+        "percentageFull": 75
       }
     ],
     "governors": [
@@ -8909,16 +8909,16 @@
         "urn": 12611221,
         "dateAcademyJoinedTrust": "2018-07-20T00:00:00",
         "establishmentName": "George Abbey Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1235,
-        "schoolCapacity": 2368,
-        "percentageFreeSchoolMeals": "25",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1451,
+        "schoolCapacity": 1315,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -8928,19 +8928,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-05-16T00:00:00"
         },
-        "percentageFull": 52
+        "percentageFull": 110
       },
       {
         "urn": 12613611,
         "dateAcademyJoinedTrust": "2018-09-18T00:00:00",
         "establishmentName": "Longhill School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 439,
-        "schoolCapacity": 404,
-        "percentageFreeSchoolMeals": "4",
+        "numberOfPupils": 1059,
+        "schoolCapacity": 2141,
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -8953,19 +8953,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-03-01T00:00:00"
         },
-        "percentageFull": 109
+        "percentageFull": 49
       },
       {
         "urn": 12616455,
         "dateAcademyJoinedTrust": "2020-03-13T00:00:00",
         "establishmentName": "Ray Wall Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Kirklees",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 507,
-        "schoolCapacity": 635,
-        "percentageFreeSchoolMeals": "11",
+        "numberOfPupils": 1333,
+        "schoolCapacity": 2355,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -8978,22 +8978,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2021-11-23T00:00:00"
         },
-        "percentageFull": 80
+        "percentageFull": 57
       },
       {
         "urn": 12614243,
         "dateAcademyJoinedTrust": "2018-08-01T00:00:00",
-        "establishmentName": "Mulberry Church of England Primary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Mulberry Church of England School",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2617,
-        "schoolCapacity": 2491,
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1840,
+        "schoolCapacity": 1611,
         "percentageFreeSchoolMeals": "22",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -9003,19 +9003,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 105
+        "percentageFull": 114
       },
       {
         "urn": 12611397,
         "dateAcademyJoinedTrust": "2023-11-03T00:00:00",
         "establishmentName": "Northwood R.C. School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Kirklees",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1965,
-        "schoolCapacity": 2725,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 844,
+        "schoolCapacity": 695,
+        "percentageFreeSchoolMeals": "11",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -9028,22 +9028,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-01-28T00:00:00"
         },
-        "percentageFull": 72
+        "percentageFull": 121
       },
       {
         "urn": 12613597,
         "dateAcademyJoinedTrust": "2019-10-10T00:00:00",
-        "establishmentName": "Lampton Church of England Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Lampton Church of England 16 Plus Academy",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1394,
-        "schoolCapacity": 1167,
-        "percentageFreeSchoolMeals": "21",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1113,
+        "schoolCapacity": 1522,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -9053,19 +9053,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 119
+        "percentageFull": 73
       },
       {
         "urn": 12615622,
         "dateAcademyJoinedTrust": "2021-09-23T00:00:00",
         "establishmentName": "Greensward Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 829,
-        "schoolCapacity": 1420,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1157,
+        "schoolCapacity": 1429,
+        "percentageFreeSchoolMeals": "7",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -9078,19 +9078,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2021-10-28T00:00:00"
         },
-        "percentageFull": 58
+        "percentageFull": 81
       },
       {
         "urn": 12612628,
         "dateAcademyJoinedTrust": "2020-11-17T00:00:00",
-        "establishmentName": "Kirklees Catholic Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Kirklees Catholic All-through Academy",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Kirklees",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1510,
-        "schoolCapacity": 1497,
-        "percentageFreeSchoolMeals": "29",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 508,
+        "schoolCapacity": 610,
+        "percentageFreeSchoolMeals": "21",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -9103,19 +9103,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2015-12-13T00:00:00"
         },
-        "percentageFull": 101
+        "percentageFull": 83
       },
       {
         "urn": 12612096,
         "dateAcademyJoinedTrust": "2021-07-22T00:00:00",
         "establishmentName": "St. Anne\u0027s R.C. Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 2405,
-        "schoolCapacity": 2091,
-        "percentageFreeSchoolMeals": "4",
+        "numberOfPupils": 499,
+        "schoolCapacity": 490,
+        "percentageFreeSchoolMeals": "25",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -9128,7 +9128,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2021-10-08T00:00:00"
         },
-        "percentageFull": 115
+        "percentageFull": 102
       }
     ],
     "governors": [
@@ -9440,17 +9440,17 @@
       {
         "urn": 12551391,
         "dateAcademyJoinedTrust": "2022-09-14T00:00:00",
-        "establishmentName": "St. James\u0027 R.C. Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. James\u0027 R.C. Middle Deemed Primary Academy",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1011,
-        "schoolCapacity": 1935,
-        "percentageFreeSchoolMeals": "6",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 652,
+        "schoolCapacity": 672,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -9460,7 +9460,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2015-11-16T00:00:00"
         },
-        "percentageFull": 52
+        "percentageFull": 97
       }
     ],
     "governors": [
@@ -9794,17 +9794,17 @@
       {
         "urn": 12495790,
         "dateAcademyJoinedTrust": "2022-12-03T00:00:00",
-        "establishmentName": "St. John\u0027s Church of England Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "St. John\u0027s Church of England All-through School",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Rotherham",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1382,
-        "schoolCapacity": 2909,
-        "percentageFreeSchoolMeals": "28",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 2573,
+        "schoolCapacity": 2023,
+        "percentageFreeSchoolMeals": "3",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -9814,22 +9814,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2013-03-21T00:00:00"
         },
-        "percentageFull": 48
+        "percentageFull": 127
       },
       {
         "urn": 12498250,
         "dateAcademyJoinedTrust": "2022-05-16T00:00:00",
-        "establishmentName": "St. Paul\u0027s Cofe Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. Paul\u0027s Cofe All-through School",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Sheffield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1501,
-        "schoolCapacity": 1582,
-        "percentageFreeSchoolMeals": "29",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 867,
+        "schoolCapacity": 1008,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -9839,19 +9839,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 95
+        "percentageFull": 86
       },
       {
         "urn": 12492421,
         "dateAcademyJoinedTrust": "2017-04-19T00:00:00",
-        "establishmentName": "Horizon CE Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Horizon CE School",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "Sheffield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1055,
-        "schoolCapacity": 1978,
-        "percentageFreeSchoolMeals": "25",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1998,
+        "schoolCapacity": 2033,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -9864,22 +9864,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 53
+        "percentageFull": 98
       },
       {
         "urn": 12497747,
         "dateAcademyJoinedTrust": "2018-01-06T00:00:00",
         "establishmentName": "St. Mary\u0027s C of E School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 655,
-        "schoolCapacity": 1485,
-        "percentageFreeSchoolMeals": "28",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 996,
+        "schoolCapacity": 1200,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -9889,19 +9889,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-12-15T00:00:00"
         },
-        "percentageFull": 44
+        "percentageFull": 83
       },
       {
         "urn": 12494025,
         "dateAcademyJoinedTrust": "2018-07-12T00:00:00",
         "establishmentName": "Queensbridge Cofe School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Sheffield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2820,
-        "schoolCapacity": 2191,
-        "percentageFreeSchoolMeals": "20",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 284,
+        "schoolCapacity": 271,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -9914,22 +9914,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-11-30T00:00:00"
         },
-        "percentageFull": 129
+        "percentageFull": 105
       },
       {
         "urn": 12497312,
         "dateAcademyJoinedTrust": "2019-02-14T00:00:00",
-        "establishmentName": "Co-op Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Co-op Academy",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Sheffield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 644,
-        "schoolCapacity": 636,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 793,
+        "schoolCapacity": 1400,
+        "percentageFreeSchoolMeals": "21",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -9939,7 +9939,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-01-01T00:00:00"
         },
-        "percentageFull": 101
+        "percentageFull": 57
       }
     ],
     "governors": [
@@ -10266,17 +10266,17 @@
       {
         "urn": 12588170,
         "dateAcademyJoinedTrust": "2021-03-14T00:00:00",
-        "establishmentName": "Harris Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Harris Primary Academy",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1858,
-        "schoolCapacity": 1663,
-        "percentageFreeSchoolMeals": "2",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 1630,
+        "schoolCapacity": 1841,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -10286,22 +10286,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2016-03-02T00:00:00"
         },
-        "percentageFull": 112
+        "percentageFull": 89
       },
       {
         "urn": 12582987,
         "dateAcademyJoinedTrust": "2022-06-11T00:00:00",
-        "establishmentName": "Northwood CE Primary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Northwood CE Middle Deemed Primary School",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Kingston upon Hull, City of",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1359,
-        "schoolCapacity": 2637,
-        "percentageFreeSchoolMeals": "9",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 3205,
+        "schoolCapacity": 2699,
+        "percentageFreeSchoolMeals": "4",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -10311,19 +10311,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 52
+        "percentageFull": 119
       },
       {
         "urn": 12582552,
         "dateAcademyJoinedTrust": "2022-05-19T00:00:00",
         "establishmentName": "Horizon Catholic Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Kingston upon Hull, City of",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 2007,
-        "schoolCapacity": 2045,
-        "percentageFreeSchoolMeals": "3",
+        "numberOfPupils": 2403,
+        "schoolCapacity": 2395,
+        "percentageFreeSchoolMeals": "20",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -10336,19 +10336,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2013-10-16T00:00:00"
         },
-        "percentageFull": 98
+        "percentageFull": 100
       },
       {
         "urn": 12585873,
         "dateAcademyJoinedTrust": "2022-12-29T00:00:00",
-        "establishmentName": "Momentum Community Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Momentum Community Middle Deemed Primary Academy",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1759,
-        "schoolCapacity": 1756,
-        "percentageFreeSchoolMeals": "8",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1317,
+        "schoolCapacity": 1441,
+        "percentageFreeSchoolMeals": "21",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -10361,19 +10361,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 100
+        "percentageFull": 91
       },
       {
         "urn": 12587850,
         "dateAcademyJoinedTrust": "2023-06-10T00:00:00",
         "establishmentName": "Queensbridge Church of England School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Kingston upon Hull, City of",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1862,
-        "schoolCapacity": 2080,
-        "percentageFreeSchoolMeals": "30",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 3033,
+        "schoolCapacity": 2990,
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -10386,7 +10386,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-08-02T00:00:00"
         },
-        "percentageFull": 90
+        "percentageFull": 101
       }
     ],
     "governors": [
@@ -10570,16 +10570,16 @@
         "urn": 12364812,
         "dateAcademyJoinedTrust": "2023-10-09T00:00:00",
         "establishmentName": "St. Anne\u0027s C of E School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 3285,
-        "schoolCapacity": 2677,
-        "percentageFreeSchoolMeals": "9",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 883,
+        "schoolCapacity": 736,
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -10589,22 +10589,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-06-20T00:00:00"
         },
-        "percentageFull": 123
+        "percentageFull": 120
       },
       {
         "urn": 12365409,
         "dateAcademyJoinedTrust": "2022-12-19T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s R.C. Primary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Queen Elizabeth\u0027s R.C. Secondary Academy",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Leeds",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1588,
-        "schoolCapacity": 1244,
-        "percentageFreeSchoolMeals": "10",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 1636,
+        "schoolCapacity": 2167,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -10614,19 +10614,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2021-06-24T00:00:00"
         },
-        "percentageFull": 128
+        "percentageFull": 75
       },
       {
         "urn": 12362276,
         "dateAcademyJoinedTrust": "2022-12-10T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Church of England Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "St. Catherine\u0027s Church of England School",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Leeds",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 798,
-        "schoolCapacity": 873,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1378,
+        "schoolCapacity": 2153,
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -10639,19 +10639,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-12-16T00:00:00"
         },
-        "percentageFull": 91
+        "percentageFull": 64
       },
       {
         "urn": 12364634,
         "dateAcademyJoinedTrust": "2022-05-05T00:00:00",
         "establishmentName": "Harris C of E Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "Leeds",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1448,
-        "schoolCapacity": 2360,
-        "percentageFreeSchoolMeals": "14",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 910,
+        "schoolCapacity": 826,
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -10664,22 +10664,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2019-08-13T00:00:00"
         },
-        "percentageFull": 61
+        "percentageFull": 110
       },
       {
         "urn": 12366369,
         "dateAcademyJoinedTrust": "2023-07-13T00:00:00",
         "establishmentName": "Peacehaven Community School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Leeds",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1596,
-        "schoolCapacity": 2656,
-        "percentageFreeSchoolMeals": "2",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 877,
+        "schoolCapacity": 735,
+        "percentageFreeSchoolMeals": "7",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -10689,22 +10689,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-12-17T00:00:00"
         },
-        "percentageFull": 60
+        "percentageFull": 119
       },
       {
         "urn": 12364893,
         "dateAcademyJoinedTrust": "2022-08-13T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Church of England Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Queen Elizabeth\u0027s Church of England All-through School",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Leeds",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1567,
-        "schoolCapacity": 1327,
-        "percentageFreeSchoolMeals": "28",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 529,
+        "schoolCapacity": 677,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -10714,19 +10714,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2013-05-12T00:00:00"
         },
-        "percentageFull": 118
+        "percentageFull": 78
       },
       {
         "urn": 12366789,
         "dateAcademyJoinedTrust": "2022-06-17T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 Catholic Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Wakefield",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 672,
-        "schoolCapacity": 772,
-        "percentageFreeSchoolMeals": "15",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 955,
+        "schoolCapacity": 1569,
+        "percentageFreeSchoolMeals": "16",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -10739,7 +10739,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2020-06-03T00:00:00"
         },
-        "percentageFull": 87
+        "percentageFull": 61
       }
     ],
     "governors": [
@@ -11064,16 +11064,16 @@
         "urn": 12455616,
         "dateAcademyJoinedTrust": "2016-07-14T00:00:00",
         "establishmentName": "Harris School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Leeds",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1540,
-        "schoolCapacity": 1451,
-        "percentageFreeSchoolMeals": "28",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 959,
+        "schoolCapacity": 1171,
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -11083,7 +11083,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2013-08-31T00:00:00"
         },
-        "percentageFull": 106
+        "percentageFull": 82
       }
     ],
     "governors": [
@@ -11223,13 +11223,13 @@
         "urn": 12739115,
         "dateAcademyJoinedTrust": "2021-09-01T00:00:00",
         "establishmentName": "Bradford Catholic School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Bradford",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1934,
-        "schoolCapacity": 2697,
-        "percentageFreeSchoolMeals": "28",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 3514,
+        "schoolCapacity": 2914,
+        "percentageFreeSchoolMeals": "11",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -11242,7 +11242,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2018-11-13T00:00:00"
         },
-        "percentageFull": 72
+        "percentageFull": 121
       }
     ],
     "governors": [
@@ -11489,16 +11489,16 @@
         "urn": 12482522,
         "dateAcademyJoinedTrust": "2023-01-28T00:00:00",
         "establishmentName": "Northwood R.C. Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Leeds",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1192,
-        "schoolCapacity": 1544,
-        "percentageFreeSchoolMeals": "14",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1043,
+        "schoolCapacity": 1230,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -11508,22 +11508,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2020-08-06T00:00:00"
         },
-        "percentageFull": 77
+        "percentageFull": 85
       },
       {
         "urn": 12481889,
         "dateAcademyJoinedTrust": "2016-10-14T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Holly Lodge Girls\u0027 School",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Leeds",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2278,
-        "schoolCapacity": 2100,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1945,
+        "schoolCapacity": 1906,
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -11533,7 +11533,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2021-03-14T00:00:00"
         },
-        "percentageFull": 108
+        "percentageFull": 102
       }
     ],
     "governors": [
@@ -11760,14 +11760,14 @@
       {
         "urn": 12515395,
         "dateAcademyJoinedTrust": "2022-04-05T00:00:00",
-        "establishmentName": "Meridian CE Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Meridian CE 16 Plus Academy",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2775,
-        "schoolCapacity": 2470,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 741,
+        "schoolCapacity": 653,
+        "percentageFreeSchoolMeals": "25",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -11780,19 +11780,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2023-04-03T00:00:00"
         },
-        "percentageFull": 112
+        "percentageFull": 113
       },
       {
         "urn": 12518913,
         "dateAcademyJoinedTrust": "2022-04-02T00:00:00",
         "establishmentName": "St. James\u0027 CE Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 413,
-        "schoolCapacity": 347,
-        "percentageFreeSchoolMeals": "6",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 82,
+        "schoolCapacity": 173,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -11805,22 +11805,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 119
+        "percentageFull": 47
       },
       {
         "urn": 12515398,
         "dateAcademyJoinedTrust": "2020-02-16T00:00:00",
         "establishmentName": "St. Catherine\u0027s Church of England Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 696,
-        "schoolCapacity": 1521,
-        "percentageFreeSchoolMeals": "25",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1287,
+        "schoolCapacity": 1530,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -11830,18 +11830,18 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 46
+        "percentageFull": 84
       },
       {
         "urn": 12513742,
         "dateAcademyJoinedTrust": "2019-10-18T00:00:00",
         "establishmentName": "Longhill CE Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2317,
-        "schoolCapacity": 2933,
+        "numberOfPupils": 345,
+        "schoolCapacity": 270,
         "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 11,
@@ -11855,22 +11855,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-04-14T00:00:00"
         },
-        "percentageFull": 79
+        "percentageFull": 128
       },
       {
         "urn": 12511868,
         "dateAcademyJoinedTrust": "2022-03-09T00:00:00",
         "establishmentName": "Northwood Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "North East Lincolnshire",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1206,
-        "schoolCapacity": 1128,
-        "percentageFreeSchoolMeals": "25",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 823,
+        "schoolCapacity": 1145,
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -11880,7 +11880,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-03-24T00:00:00"
         },
-        "percentageFull": 107
+        "percentageFull": 72
       }
     ],
     "governors": [
@@ -12193,16 +12193,16 @@
         "urn": 12656635,
         "dateAcademyJoinedTrust": "2020-09-07T00:00:00",
         "establishmentName": "Horizon Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Calderdale",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 628,
-        "schoolCapacity": 570,
-        "percentageFreeSchoolMeals": "3",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 811,
+        "schoolCapacity": 1486,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -12212,22 +12212,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-06-21T00:00:00"
         },
-        "percentageFull": 110
+        "percentageFull": 55
       },
       {
         "urn": 12652436,
         "dateAcademyJoinedTrust": "2021-02-01T00:00:00",
-        "establishmentName": "Glyn Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Glyn All-through Academy",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Calderdale",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2909,
-        "schoolCapacity": 2461,
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 2890,
+        "schoolCapacity": 2552,
         "percentageFreeSchoolMeals": "27",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -12237,22 +12237,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-10-04T00:00:00"
         },
-        "percentageFull": 118
+        "percentageFull": 113
       },
       {
         "urn": 12652236,
         "dateAcademyJoinedTrust": "2015-12-13T00:00:00",
         "establishmentName": "Barr and Community Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "York",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 628,
-        "schoolCapacity": 1100,
-        "percentageFreeSchoolMeals": "3",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 912,
+        "schoolCapacity": 1284,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -12262,22 +12262,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-01-17T00:00:00"
         },
-        "percentageFull": 57
+        "percentageFull": 71
       },
       {
         "urn": 12655317,
         "dateAcademyJoinedTrust": "2015-11-26T00:00:00",
         "establishmentName": "Mulberry School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Calderdale",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 829,
-        "schoolCapacity": 1281,
-        "percentageFreeSchoolMeals": "2",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 961,
+        "schoolCapacity": 1254,
+        "percentageFreeSchoolMeals": "9",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -12287,19 +12287,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-10-27T00:00:00"
         },
-        "percentageFull": 65
+        "percentageFull": 77
       },
       {
         "urn": 12656580,
         "dateAcademyJoinedTrust": "2021-11-16T00:00:00",
         "establishmentName": "Co-op School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "Doncaster",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1219,
-        "schoolCapacity": 1513,
-        "percentageFreeSchoolMeals": "15",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1540,
+        "schoolCapacity": 1837,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -12312,22 +12312,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2016-03-09T00:00:00"
         },
-        "percentageFull": 81
+        "percentageFull": 84
       },
       {
         "urn": 12656721,
         "dateAcademyJoinedTrust": "2022-03-16T00:00:00",
         "establishmentName": "Momentum Community CE Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Calderdale",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1539,
-        "schoolCapacity": 2450,
-        "percentageFreeSchoolMeals": "2",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 1026,
+        "schoolCapacity": 909,
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -12337,22 +12337,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-10-06T00:00:00"
         },
-        "percentageFull": 63
+        "percentageFull": 113
       },
       {
         "urn": 12656117,
         "dateAcademyJoinedTrust": "2017-01-31T00:00:00",
         "establishmentName": "Longhill Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Doncaster",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 699,
-        "schoolCapacity": 634,
-        "percentageFreeSchoolMeals": "1",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 1647,
+        "schoolCapacity": 2912,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -12362,19 +12362,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-08-04T00:00:00"
         },
-        "percentageFull": 110
+        "percentageFull": 57
       },
       {
         "urn": 12654631,
         "dateAcademyJoinedTrust": "2015-04-28T00:00:00",
         "establishmentName": "Harris R.C. Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2078,
-        "schoolCapacity": 2206,
-        "percentageFreeSchoolMeals": "12",
+        "numberOfPupils": 2121,
+        "schoolCapacity": 2013,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -12387,19 +12387,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 94
+        "percentageFull": 105
       },
       {
         "urn": 12659989,
         "dateAcademyJoinedTrust": "2019-12-25T00:00:00",
         "establishmentName": "Horizon CE Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "York",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1777,
-        "schoolCapacity": 2204,
-        "percentageFreeSchoolMeals": "23",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 2824,
+        "schoolCapacity": 2682,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -12412,22 +12412,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 81
+        "percentageFull": 105
       },
       {
         "urn": 12657189,
         "dateAcademyJoinedTrust": "2020-10-27T00:00:00",
         "establishmentName": "Greensward Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2627,
-        "schoolCapacity": 2069,
-        "percentageFreeSchoolMeals": "11",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 2856,
+        "schoolCapacity": 2825,
+        "percentageFreeSchoolMeals": "29",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -12437,7 +12437,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 127
+        "percentageFull": 101
       }
     ],
     "governors": [
@@ -12533,13 +12533,13 @@
         "urn": 12386376,
         "dateAcademyJoinedTrust": "2022-11-30T00:00:00",
         "establishmentName": "St. James\u0027 R.C. Primary School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural town and fringe",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 583,
-        "schoolCapacity": 689,
-        "percentageFreeSchoolMeals": "3",
+        "numberOfPupils": 539,
+        "schoolCapacity": 924,
+        "percentageFreeSchoolMeals": "15",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -12552,7 +12552,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 85
+        "percentageFull": 58
       }
     ],
     "governors": [
@@ -12821,16 +12821,16 @@
         "urn": 12568198,
         "dateAcademyJoinedTrust": "2019-07-24T00:00:00",
         "establishmentName": "Lampton School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2152,
-        "schoolCapacity": 1716,
-        "percentageFreeSchoolMeals": "28",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 2324,
+        "schoolCapacity": 2578,
+        "percentageFreeSchoolMeals": "29",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -12840,22 +12840,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2021-12-14T00:00:00"
         },
-        "percentageFull": 125
+        "percentageFull": 90
       },
       {
         "urn": 12565983,
         "dateAcademyJoinedTrust": "2021-05-17T00:00:00",
         "establishmentName": "St. Catherine\u0027s Catholic School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 440,
-        "schoolCapacity": 973,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1307,
+        "schoolCapacity": 1948,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -12865,19 +12865,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2021-08-12T00:00:00"
         },
-        "percentageFull": 45
+        "percentageFull": 67
       },
       {
         "urn": 12569319,
         "dateAcademyJoinedTrust": "2019-10-07T00:00:00",
-        "establishmentName": "Co-op R.C. Secondary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Co-op R.C. Middle Deemed Primary Academy",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1381,
-        "schoolCapacity": 1437,
-        "percentageFreeSchoolMeals": "5",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1080,
+        "schoolCapacity": 1325,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -12890,19 +12890,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2013-09-14T00:00:00"
         },
-        "percentageFull": 96
+        "percentageFull": 82
       },
       {
         "urn": 12563479,
         "dateAcademyJoinedTrust": "2021-08-24T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Wakefield",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 118,
-        "schoolCapacity": 135,
-        "percentageFreeSchoolMeals": "23",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 385,
+        "schoolCapacity": 937,
+        "percentageFreeSchoolMeals": "16",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -12915,22 +12915,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-10-08T00:00:00"
         },
-        "percentageFull": 87
+        "percentageFull": 41
       },
       {
         "urn": 12561439,
         "dateAcademyJoinedTrust": "2022-07-08T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 Church of England Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1489,
-        "schoolCapacity": 2114,
-        "percentageFreeSchoolMeals": "28",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1424,
+        "schoolCapacity": 1389,
+        "percentageFreeSchoolMeals": "11",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -12940,22 +12940,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2014-11-15T00:00:00"
         },
-        "percentageFull": 70
+        "percentageFull": 103
       },
       {
         "urn": 12561840,
         "dateAcademyJoinedTrust": "2023-01-31T00:00:00",
         "establishmentName": "Beacon Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Wakefield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2763,
-        "schoolCapacity": 2263,
-        "percentageFreeSchoolMeals": "3",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 2501,
+        "schoolCapacity": 2335,
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -12965,22 +12965,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2013-04-01T00:00:00"
         },
-        "percentageFull": 122
+        "percentageFull": 107
       },
       {
         "urn": 12569592,
         "dateAcademyJoinedTrust": "2018-08-18T00:00:00",
-        "establishmentName": "Mulberry CE Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Mulberry CE All-through School",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Wakefield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1071,
-        "schoolCapacity": 1254,
-        "percentageFreeSchoolMeals": "29",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 511,
+        "schoolCapacity": 674,
+        "percentageFreeSchoolMeals": "16",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -12990,19 +12990,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 85
+        "percentageFull": 76
       },
       {
         "urn": 12569162,
         "dateAcademyJoinedTrust": "2020-03-17T00:00:00",
         "establishmentName": "Barr and Community School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1405,
-        "schoolCapacity": 2088,
-        "percentageFreeSchoolMeals": "23",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1896,
+        "schoolCapacity": 1864,
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -13015,22 +13015,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-06-09T00:00:00"
         },
-        "percentageFull": 67
+        "percentageFull": 102
       },
       {
         "urn": 12563651,
         "dateAcademyJoinedTrust": "2019-12-18T00:00:00",
-        "establishmentName": "Obie Square CE Primary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Obie Square CE 16 Plus School",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1534,
-        "schoolCapacity": 1487,
-        "percentageFreeSchoolMeals": "18",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1245,
+        "schoolCapacity": 1499,
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -13040,7 +13040,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2018-05-27T00:00:00"
         },
-        "percentageFull": 103
+        "percentageFull": 83
       }
     ],
     "governors": [
@@ -13290,16 +13290,16 @@
         "urn": 12727040,
         "dateAcademyJoinedTrust": "2022-04-11T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s CE Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Wakefield",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1363,
-        "schoolCapacity": 1991,
-        "percentageFreeSchoolMeals": "24",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 684,
+        "schoolCapacity": 693,
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -13309,22 +13309,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2013-06-07T00:00:00"
         },
-        "percentageFull": 68
+        "percentageFull": 99
       },
       {
         "urn": 12721493,
         "dateAcademyJoinedTrust": "2021-04-19T00:00:00",
-        "establishmentName": "Barnsley Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Barnsley School",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1768,
-        "schoolCapacity": 1660,
-        "percentageFreeSchoolMeals": "25",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 907,
+        "schoolCapacity": 1026,
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -13334,22 +13334,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 107
+        "percentageFull": 88
       },
       {
         "urn": 12727156,
         "dateAcademyJoinedTrust": "2023-05-11T00:00:00",
         "establishmentName": "Oasis Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 3121,
-        "schoolCapacity": 2411,
-        "percentageFreeSchoolMeals": "4",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 2841,
+        "schoolCapacity": 2543,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -13359,22 +13359,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-11-28T00:00:00"
         },
-        "percentageFull": 129
+        "percentageFull": 112
       },
       {
         "urn": 12724156,
         "dateAcademyJoinedTrust": "2022-12-16T00:00:00",
-        "establishmentName": "Lampton Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Lampton Primary School",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Calderdale",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 165,
-        "schoolCapacity": 172,
-        "percentageFreeSchoolMeals": "4",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 333,
+        "schoolCapacity": 788,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -13384,22 +13384,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2019-11-06T00:00:00"
         },
-        "percentageFull": 96
+        "percentageFull": 42
       },
       {
         "urn": 12722779,
         "dateAcademyJoinedTrust": "2020-12-22T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Church of England Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. Joseph\u0027s Church of England All-through Academy",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Wakefield",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 223,
-        "schoolCapacity": 417,
-        "percentageFreeSchoolMeals": "27",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1178,
+        "schoolCapacity": 2364,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -13409,22 +13409,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 53
+        "percentageFull": 50
       },
       {
         "urn": 12727489,
         "dateAcademyJoinedTrust": "2022-01-14T00:00:00",
-        "establishmentName": "Queensbridge Primary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Queensbridge Middle Deemed Primary Academy",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Calderdale",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 288,
-        "schoolCapacity": 231,
-        "percentageFreeSchoolMeals": "8",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 745,
+        "schoolCapacity": 1690,
+        "percentageFreeSchoolMeals": "29",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -13434,22 +13434,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 125
+        "percentageFull": 44
       },
       {
         "urn": 12729531,
         "dateAcademyJoinedTrust": "2023-09-18T00:00:00",
         "establishmentName": "Halewood R.C. School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Wakefield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 418,
-        "schoolCapacity": 722,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 203,
+        "schoolCapacity": 343,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -13459,22 +13459,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 58
+        "percentageFull": 59
       },
       {
         "urn": 12729225,
         "dateAcademyJoinedTrust": "2022-04-12T00:00:00",
-        "establishmentName": "George Abbey Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "George Abbey Middle Deemed Primary School",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Barnsley",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1470,
-        "schoolCapacity": 2733,
-        "percentageFreeSchoolMeals": "8",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 2074,
+        "schoolCapacity": 1704,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -13484,22 +13484,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2022-05-08T00:00:00"
         },
-        "percentageFull": 54
+        "percentageFull": 122
       },
       {
         "urn": 12723363,
         "dateAcademyJoinedTrust": "2023-05-24T00:00:00",
         "establishmentName": "St. Catherine\u0027s C of E Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Calderdale",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1027,
-        "schoolCapacity": 1756,
-        "percentageFreeSchoolMeals": "16",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1102,
+        "schoolCapacity": 1206,
+        "percentageFreeSchoolMeals": "7",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -13509,19 +13509,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-02-09T00:00:00"
         },
-        "percentageFull": 58
+        "percentageFull": 91
       },
       {
         "urn": 12726667,
         "dateAcademyJoinedTrust": "2022-04-02T00:00:00",
         "establishmentName": "Myra Pike C of E Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 643,
-        "schoolCapacity": 850,
-        "percentageFreeSchoolMeals": "2",
+        "numberOfPupils": 1156,
+        "schoolCapacity": 1827,
+        "percentageFreeSchoolMeals": "12",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -13534,22 +13534,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-12-11T00:00:00"
         },
-        "percentageFull": 76
+        "percentageFull": 63
       },
       {
         "urn": 12728837,
         "dateAcademyJoinedTrust": "2022-04-09T00:00:00",
         "establishmentName": "St. James\u0027 R.C. Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Calderdale",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2126,
-        "schoolCapacity": 2196,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 921,
+        "schoolCapacity": 877,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -13559,7 +13559,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2011-04-26T00:00:00"
         },
-        "percentageFull": 97
+        "percentageFull": 105
       }
     ],
     "governors": [
@@ -13809,16 +13809,16 @@
         "urn": 12672444,
         "dateAcademyJoinedTrust": "2022-12-22T00:00:00",
         "establishmentName": "Glyn Catholic Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Bradford",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1010,
-        "schoolCapacity": 1094,
-        "percentageFreeSchoolMeals": "8",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1915,
+        "schoolCapacity": 2702,
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -13828,22 +13828,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-12-10T00:00:00"
         },
-        "percentageFull": 92
+        "percentageFull": 71
       },
       {
         "urn": 12676378,
         "dateAcademyJoinedTrust": "2021-02-12T00:00:00",
         "establishmentName": "Horizon Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Doncaster",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 804,
-        "schoolCapacity": 919,
-        "percentageFreeSchoolMeals": "27",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1474,
+        "schoolCapacity": 2254,
+        "percentageFreeSchoolMeals": "16",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -13853,22 +13853,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2022-03-03T00:00:00"
         },
-        "percentageFull": 87
+        "percentageFull": 65
       },
       {
         "urn": 12673132,
         "dateAcademyJoinedTrust": "2022-10-02T00:00:00",
-        "establishmentName": "Queen Elizabeth\u0027s Catholic Secondary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Queen Elizabeth\u0027s Catholic Primary School",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 573,
-        "schoolCapacity": 475,
-        "percentageFreeSchoolMeals": "4",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 65,
+        "schoolCapacity": 126,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -13878,19 +13878,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-02-14T00:00:00"
         },
-        "percentageFull": 121
+        "percentageFull": 52
       },
       {
         "urn": 12672721,
         "dateAcademyJoinedTrust": "2020-06-11T00:00:00",
         "establishmentName": "Longhill Catholic School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 3432,
-        "schoolCapacity": 2883,
-        "percentageFreeSchoolMeals": "16",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1399,
+        "schoolCapacity": 1107,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -13903,19 +13903,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 119
+        "percentageFull": 126
       },
       {
         "urn": 12678926,
         "dateAcademyJoinedTrust": "2023-11-03T00:00:00",
         "establishmentName": "Vicente Harbors School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Doncaster",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2494,
-        "schoolCapacity": 2416,
-        "percentageFreeSchoolMeals": "13",
+        "numberOfPupils": 2534,
+        "schoolCapacity": 2265,
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -13928,22 +13928,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2015-10-19T00:00:00"
         },
-        "percentageFull": 103
+        "percentageFull": 112
       },
       {
         "urn": 12677491,
         "dateAcademyJoinedTrust": "2021-11-18T00:00:00",
         "establishmentName": "Lampton Cofe Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Doncaster",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1120,
-        "schoolCapacity": 1724,
-        "percentageFreeSchoolMeals": "5",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 2656,
+        "schoolCapacity": 2938,
+        "percentageFreeSchoolMeals": "9",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -13953,22 +13953,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-12-17T00:00:00"
         },
-        "percentageFull": 65
+        "percentageFull": 90
       },
       {
         "urn": 12677550,
         "dateAcademyJoinedTrust": "2022-11-10T00:00:00",
         "establishmentName": "St. James\u0027 C of E Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "East Riding of Yorkshire",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 908,
-        "schoolCapacity": 1205,
-        "percentageFreeSchoolMeals": "5",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1083,
+        "schoolCapacity": 1457,
+        "percentageFreeSchoolMeals": "12",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -13978,22 +13978,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 75
+        "percentageFull": 74
       },
       {
         "urn": 12673750,
         "dateAcademyJoinedTrust": "2021-04-17T00:00:00",
         "establishmentName": "Halewood Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Doncaster",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 146,
-        "schoolCapacity": 363,
-        "percentageFreeSchoolMeals": "19",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 787,
+        "schoolCapacity": 1634,
+        "percentageFreeSchoolMeals": "1",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -14003,7 +14003,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2021-03-02T00:00:00"
         },
-        "percentageFull": 40
+        "percentageFull": 48
       }
     ],
     "governors": [
@@ -14606,16 +14606,16 @@
         "urn": 12836225,
         "dateAcademyJoinedTrust": "2020-04-18T00:00:00",
         "establishmentName": "St. Mary\u0027s Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Barnsley",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2693,
-        "schoolCapacity": 2728,
-        "percentageFreeSchoolMeals": "26",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 3052,
+        "schoolCapacity": 2511,
+        "percentageFreeSchoolMeals": "20",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -14625,7 +14625,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2018-06-09T00:00:00"
         },
-        "percentageFull": 99
+        "percentageFull": 122
       }
     ],
     "governors": [
@@ -14765,13 +14765,13 @@
         "urn": 12846737,
         "dateAcademyJoinedTrust": "2021-09-23T00:00:00",
         "establishmentName": "St. Mary\u0027s Anglican Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Rotherham",
-        "urbanRural": "Urban minor conurbation",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1593,
-        "schoolCapacity": 1931,
-        "percentageFreeSchoolMeals": "11",
+        "numberOfPupils": 2490,
+        "schoolCapacity": 2572,
+        "percentageFreeSchoolMeals": "15",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -14784,7 +14784,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 82
+        "percentageFull": 97
       }
     ],
     "governors": [
@@ -14957,13 +14957,13 @@
         "urn": 12858643,
         "dateAcademyJoinedTrust": "2021-05-25T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic High School Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Doncaster",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 958,
-        "schoolCapacity": 1089,
-        "percentageFreeSchoolMeals": "18",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1202,
+        "schoolCapacity": 1700,
+        "percentageFreeSchoolMeals": "16",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -14976,7 +14976,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 88
+        "percentageFull": 71
       }
     ],
     "governors": [
@@ -15094,13 +15094,13 @@
         "urn": 12863655,
         "dateAcademyJoinedTrust": "2023-01-25T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Kirklees",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 1296,
-        "schoolCapacity": 2448,
-        "percentageFreeSchoolMeals": "24",
+        "numberOfPupils": 1943,
+        "schoolCapacity": 1722,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -15113,7 +15113,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2014-05-04T00:00:00"
         },
-        "percentageFull": 53
+        "percentageFull": 113
       }
     ],
     "governors": [
@@ -15220,13 +15220,13 @@
         "urn": 12872954,
         "dateAcademyJoinedTrust": "2015-03-25T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Kingston upon Hull, City of",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 767,
-        "schoolCapacity": 1828,
-        "percentageFreeSchoolMeals": "6",
+        "numberOfPupils": 460,
+        "schoolCapacity": 491,
+        "percentageFreeSchoolMeals": "1",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -15239,7 +15239,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2023-03-07T00:00:00"
         },
-        "percentageFull": 42
+        "percentageFull": 94
       }
     ],
     "governors": [
@@ -15533,13 +15533,13 @@
         "urn": 12887881,
         "dateAcademyJoinedTrust": "2023-05-08T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural town and fringe",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 1055,
-        "schoolCapacity": 1291,
-        "percentageFreeSchoolMeals": "25",
+        "numberOfPupils": 899,
+        "schoolCapacity": 1168,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -15552,7 +15552,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 82
+        "percentageFull": 77
       }
     ],
     "governors": [
@@ -15758,13 +15758,13 @@
         "urn": 12891990,
         "dateAcademyJoinedTrust": "2015-10-03T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban major conurbation",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 3011,
-        "schoolCapacity": 2941,
-        "percentageFreeSchoolMeals": "4",
+        "numberOfPupils": 3050,
+        "schoolCapacity": 2380,
+        "percentageFreeSchoolMeals": "21",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -15777,7 +15777,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2020-10-05T00:00:00"
         },
-        "percentageFull": 102
+        "percentageFull": 128
       }
     ],
     "governors": [
@@ -16071,13 +16071,13 @@
         "urn": 12908977,
         "dateAcademyJoinedTrust": "2019-04-25T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 1410,
-        "schoolCapacity": 2194,
-        "percentageFreeSchoolMeals": "26",
+        "numberOfPupils": 1349,
+        "schoolCapacity": 1285,
+        "percentageFreeSchoolMeals": "9",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -16090,7 +16090,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 64
+        "percentageFull": 105
       }
     ],
     "governors": [
@@ -16359,13 +16359,13 @@
         "urn": 12912837,
         "dateAcademyJoinedTrust": "2019-12-03T00:00:00",
         "establishmentName": "St Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 78,
-        "schoolCapacity": 146,
-        "percentageFreeSchoolMeals": "13",
+        "numberOfPupils": 615,
+        "schoolCapacity": 1484,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -16378,19 +16378,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2020-02-02T00:00:00"
         },
-        "percentageFull": 53
+        "percentageFull": 41
       },
       {
         "urn": 12917539,
         "dateAcademyJoinedTrust": "2019-11-17T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 1793,
-        "schoolCapacity": 1679,
-        "percentageFreeSchoolMeals": "24",
+        "numberOfPupils": 621,
+        "schoolCapacity": 698,
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -16403,19 +16403,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 107
+        "percentageFull": 89
       },
       {
         "urn": 12915993,
         "dateAcademyJoinedTrust": "2023-04-12T00:00:00",
         "establishmentName": "St. Marys Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Bradford",
-        "urbanRural": "Rural town and fringe",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 3213,
-        "schoolCapacity": 2968,
-        "percentageFreeSchoolMeals": "12",
+        "numberOfPupils": 1312,
+        "schoolCapacity": 1017,
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -16428,19 +16428,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2013-12-07T00:00:00"
         },
-        "percentageFull": 108
+        "percentageFull": 129
       },
       {
         "urn": 12916796,
         "dateAcademyJoinedTrust": "2022-12-21T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Bradford",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 681,
-        "schoolCapacity": 1580,
-        "percentageFreeSchoolMeals": "29",
+        "numberOfPupils": 1279,
+        "schoolCapacity": 1489,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -16453,19 +16453,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2012-11-01T00:00:00"
         },
-        "percentageFull": 43
+        "percentageFull": 86
       },
       {
         "urn": 12913458,
         "dateAcademyJoinedTrust": "2021-12-29T00:00:00",
         "establishmentName": "St Marys Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Sheffield",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 1145,
-        "schoolCapacity": 1190,
-        "percentageFreeSchoolMeals": "18",
+        "numberOfPupils": 131,
+        "schoolCapacity": 178,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -16478,19 +16478,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-05-08T00:00:00"
         },
-        "percentageFull": 96
+        "percentageFull": 74
       },
       {
         "urn": 12916212,
         "dateAcademyJoinedTrust": "2019-09-05T00:00:00",
         "establishmentName": "St. Mary\u0027s Catholic Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 2455,
-        "schoolCapacity": 2660,
-        "percentageFreeSchoolMeals": "4",
+        "numberOfPupils": 1522,
+        "schoolCapacity": 1274,
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -16503,19 +16503,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 92
+        "percentageFull": 119
       },
       {
         "urn": 12911526,
         "dateAcademyJoinedTrust": "2023-10-15T00:00:00",
         "establishmentName": "St. Mary\u0027s RC Primary School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 557,
-        "schoolCapacity": 517,
-        "percentageFreeSchoolMeals": "26",
+        "numberOfPupils": 188,
+        "schoolCapacity": 356,
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -16528,19 +16528,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 108
+        "percentageFull": 53
       },
       {
         "urn": 12912724,
         "dateAcademyJoinedTrust": "2023-04-05T00:00:00",
         "establishmentName": "St. Mary\u0027s Primary School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Sheffield",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 2933,
-        "schoolCapacity": 2382,
-        "percentageFreeSchoolMeals": "29",
+        "numberOfPupils": 1581,
+        "schoolCapacity": 1427,
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -16553,19 +16553,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 123
+        "percentageFull": 111
       },
       {
         "urn": 12915249,
         "dateAcademyJoinedTrust": "2021-05-13T00:00:00",
         "establishmentName": "St. Mary\u0027s Primary School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban major conurbation",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 1189,
-        "schoolCapacity": 1099,
-        "percentageFreeSchoolMeals": "15",
+        "numberOfPupils": 1667,
+        "schoolCapacity": 2347,
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -16578,7 +16578,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 108
+        "percentageFull": 71
       }
     ],
     "governors": [
@@ -16872,13 +16872,13 @@
         "urn": 12929707,
         "dateAcademyJoinedTrust": "2022-09-16T00:00:00",
         "establishmentName": "St Mary\u0027s CE Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "North Lincolnshire",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1853,
-        "schoolCapacity": 2121,
-        "percentageFreeSchoolMeals": "29",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 740,
+        "schoolCapacity": 721,
+        "percentageFreeSchoolMeals": "16",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -16891,7 +16891,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2012-05-18T00:00:00"
         },
-        "percentageFull": 87
+        "percentageFull": 103
       }
     ],
     "governors": [
@@ -17086,13 +17086,13 @@
         "urn": 12939530,
         "dateAcademyJoinedTrust": "2022-10-12T00:00:00",
         "establishmentName": "St Mary\u0027s Church of England Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "North Lincolnshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 766,
-        "schoolCapacity": 1224,
-        "percentageFreeSchoolMeals": "30",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 753,
+        "schoolCapacity": 1006,
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -17105,7 +17105,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-02-04T00:00:00"
         },
-        "percentageFull": 63
+        "percentageFull": 75
       }
     ],
     "governors": [
@@ -17410,16 +17410,16 @@
         "urn": 12948275,
         "dateAcademyJoinedTrust": "2021-11-23T00:00:00",
         "establishmentName": "St Mary\u0027s Cofe Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Sheffield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 465,
-        "schoolCapacity": 487,
-        "percentageFreeSchoolMeals": "6",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 206,
+        "schoolCapacity": 397,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -17429,7 +17429,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-09-19T00:00:00"
         },
-        "percentageFull": 95
+        "percentageFull": 52
       }
     ],
     "governors": [
@@ -17580,13 +17580,13 @@
         "urn": 12957755,
         "dateAcademyJoinedTrust": "2022-04-22T00:00:00",
         "establishmentName": "St Mary\u0027s C.E. Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "Wakefield",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2301,
-        "schoolCapacity": 2420,
-        "percentageFreeSchoolMeals": "21",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 2866,
+        "schoolCapacity": 2559,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -17599,7 +17599,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 95
+        "percentageFull": 112
       }
     ],
     "governors": [
@@ -17926,16 +17926,16 @@
         "urn": 12969163,
         "dateAcademyJoinedTrust": "2018-08-05T00:00:00",
         "establishmentName": "St Mary\u0027s C/E Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Wakefield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2098,
-        "schoolCapacity": 1982,
-        "percentageFreeSchoolMeals": "15",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1855,
+        "schoolCapacity": 1885,
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -17945,7 +17945,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 106
+        "percentageFull": 98
       }
     ],
     "governors": [
@@ -18118,13 +18118,13 @@
         "urn": 12973023,
         "dateAcademyJoinedTrust": "2022-05-24T00:00:00",
         "establishmentName": "St Mary\u0027s C of E Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "North Yorkshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2637,
-        "schoolCapacity": 2991,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 3010,
+        "schoolCapacity": 2321,
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -18137,7 +18137,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-05-30T00:00:00"
         },
-        "percentageFull": 88
+        "percentageFull": 130
       }
     ],
     "governors": [
@@ -18354,13 +18354,13 @@
         "urn": 12982361,
         "dateAcademyJoinedTrust": "2017-05-14T00:00:00",
         "establishmentName": "St Mary\u0027s Church of England VA Primary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban major conurbation",
+        "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 1094,
-        "schoolCapacity": 1879,
-        "percentageFreeSchoolMeals": "6",
+        "numberOfPupils": 2133,
+        "schoolCapacity": 2240,
+        "percentageFreeSchoolMeals": "7",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -18373,7 +18373,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2016-04-01T00:00:00"
         },
-        "percentageFull": 58
+        "percentageFull": 95
       }
     ],
     "governors": [
@@ -18623,13 +18623,13 @@
         "urn": 12992262,
         "dateAcademyJoinedTrust": "2022-09-14T00:00:00",
         "establishmentName": "St Mary\u0027s Primary School, A Catholic Voluntary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "North Lincolnshire",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 469,
-        "schoolCapacity": 849,
-        "percentageFreeSchoolMeals": "21",
+        "numberOfPupils": 80,
+        "schoolCapacity": 127,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -18642,7 +18642,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2016-12-01T00:00:00"
         },
-        "percentageFull": 55
+        "percentageFull": 63
       }
     ],
     "governors": [
@@ -18903,13 +18903,13 @@
         "urn": 12623662,
         "dateAcademyJoinedTrust": "2022-02-26T00:00:00",
         "establishmentName": "St. James\u0027 Cofe Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Barnsley",
         "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 558,
-        "schoolCapacity": 1255,
-        "percentageFreeSchoolMeals": "1",
+        "numberOfPupils": 328,
+        "schoolCapacity": 433,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -18922,22 +18922,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 44
+        "percentageFull": 76
       },
       {
         "urn": 12623497,
         "dateAcademyJoinedTrust": "2022-02-16T00:00:00",
         "establishmentName": "Beacon School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1192,
-        "schoolCapacity": 2611,
-        "percentageFreeSchoolMeals": "6",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1680,
+        "schoolCapacity": 1425,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -18947,22 +18947,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 46
+        "percentageFull": 118
       },
       {
         "urn": 12625501,
         "dateAcademyJoinedTrust": "2020-05-23T00:00:00",
         "establishmentName": "Barnsley CE School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2124,
-        "schoolCapacity": 1717,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 151,
+        "schoolCapacity": 168,
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -18972,22 +18972,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2020-07-12T00:00:00"
         },
-        "percentageFull": 124
+        "percentageFull": 90
       },
       {
         "urn": 12625233,
         "dateAcademyJoinedTrust": "2021-03-27T00:00:00",
         "establishmentName": "St. Joseph\u0027s Catholic Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 831,
-        "schoolCapacity": 1843,
-        "percentageFreeSchoolMeals": "7",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1403,
+        "schoolCapacity": 1491,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -18997,22 +18997,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 45
+        "percentageFull": 94
       },
       {
         "urn": 12623069,
         "dateAcademyJoinedTrust": "2022-04-30T00:00:00",
         "establishmentName": "Oasis Church of England School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Barnsley",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1902,
-        "schoolCapacity": 2823,
-        "percentageFreeSchoolMeals": "11",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 1116,
+        "schoolCapacity": 896,
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -19022,22 +19022,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2012-06-21T00:00:00"
         },
-        "percentageFull": 67
+        "percentageFull": 125
       },
       {
         "urn": 12623953,
         "dateAcademyJoinedTrust": "2022-05-27T00:00:00",
         "establishmentName": "Halewood C of E School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1443,
-        "schoolCapacity": 1193,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 295,
+        "schoolCapacity": 399,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -19047,19 +19047,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-12-24T00:00:00"
         },
-        "percentageFull": 121
+        "percentageFull": 74
       },
       {
         "urn": 12628378,
         "dateAcademyJoinedTrust": "2021-06-04T00:00:00",
         "establishmentName": "George Abbey Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 200,
-        "schoolCapacity": 364,
-        "percentageFreeSchoolMeals": "14",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 347,
+        "schoolCapacity": 720,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -19072,19 +19072,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-02-12T00:00:00"
         },
-        "percentageFull": 55
+        "percentageFull": 48
       },
       {
         "urn": 12627171,
         "dateAcademyJoinedTrust": "2023-01-19T00:00:00",
         "establishmentName": "Lampton School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1208,
-        "schoolCapacity": 1034,
-        "percentageFreeSchoolMeals": "25",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 207,
+        "schoolCapacity": 300,
+        "percentageFreeSchoolMeals": "26",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19097,19 +19097,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2011-10-14T00:00:00"
         },
-        "percentageFull": 117
+        "percentageFull": 69
       },
       {
         "urn": 12624706,
         "dateAcademyJoinedTrust": "2021-05-10T00:00:00",
         "establishmentName": "Co-op Church of England Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1695,
-        "schoolCapacity": 2820,
-        "percentageFreeSchoolMeals": "8",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 3286,
+        "schoolCapacity": 2641,
+        "percentageFreeSchoolMeals": "7",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19122,19 +19122,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2016-08-08T00:00:00"
         },
-        "percentageFull": 60
+        "percentageFull": 124
       },
       {
         "urn": 12627410,
         "dateAcademyJoinedTrust": "2021-01-28T00:00:00",
-        "establishmentName": "George Abbey Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "George Abbey All-through School",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 621,
-        "schoolCapacity": 1067,
-        "percentageFreeSchoolMeals": "30",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 900,
+        "schoolCapacity": 1286,
+        "percentageFreeSchoolMeals": "7",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19147,22 +19147,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 58
+        "percentageFull": 70
       },
       {
         "urn": 12624506,
         "dateAcademyJoinedTrust": "2022-02-05T00:00:00",
         "establishmentName": "Co-op CE School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2731,
-        "schoolCapacity": 2322,
-        "percentageFreeSchoolMeals": "14",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 2328,
+        "schoolCapacity": 2137,
+        "percentageFreeSchoolMeals": "26",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -19172,7 +19172,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 118
+        "percentageFull": 109
       }
     ],
     "governors": [
@@ -19443,17 +19443,17 @@
       {
         "urn": 13008533,
         "dateAcademyJoinedTrust": "2013-12-30T00:00:00",
-        "establishmentName": "Meridian Cofe Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Meridian Cofe 16 Plus School",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1358,
-        "schoolCapacity": 1105,
-        "percentageFreeSchoolMeals": "20",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1910,
+        "schoolCapacity": 2682,
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -19463,19 +19463,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 123
+        "percentageFull": 71
       },
       {
         "urn": 13002589,
         "dateAcademyJoinedTrust": "2020-03-10T00:00:00",
-        "establishmentName": "St. James\u0027 R.C. Secondary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. James\u0027 R.C. 16 Plus School",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Wakefield",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1508,
-        "schoolCapacity": 2443,
-        "percentageFreeSchoolMeals": "21",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 2724,
+        "schoolCapacity": 2417,
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19488,7 +19488,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2021-03-26T00:00:00"
         },
-        "percentageFull": 62
+        "percentageFull": 113
       }
     ],
     "governors": [
@@ -19737,17 +19737,17 @@
       {
         "urn": 13012709,
         "dateAcademyJoinedTrust": "2022-11-14T00:00:00",
-        "establishmentName": "Predovic Coves Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Predovic Coves Secondary Academy",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Barnsley",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1695,
-        "schoolCapacity": 2648,
-        "percentageFreeSchoolMeals": "11",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 473,
+        "schoolCapacity": 397,
+        "percentageFreeSchoolMeals": "9",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -19757,22 +19757,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-10-06T00:00:00"
         },
-        "percentageFull": 64
+        "percentageFull": 119
       },
       {
         "urn": 13016240,
         "dateAcademyJoinedTrust": "2023-08-19T00:00:00",
         "establishmentName": "St. John\u0027s R.C. Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 279,
-        "schoolCapacity": 406,
-        "percentageFreeSchoolMeals": "15",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1471,
+        "schoolCapacity": 2971,
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -19782,19 +19782,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 69
+        "percentageFull": 50
       },
       {
         "urn": 13011919,
         "dateAcademyJoinedTrust": "2022-10-31T00:00:00",
         "establishmentName": "Lampton Catholic School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2058,
-        "schoolCapacity": 1956,
-        "percentageFreeSchoolMeals": "10",
+        "numberOfPupils": 1651,
+        "schoolCapacity": 1692,
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19807,19 +19807,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2019-08-06T00:00:00"
         },
-        "percentageFull": 105
+        "percentageFull": 98
       },
       {
         "urn": 13018272,
         "dateAcademyJoinedTrust": "2023-04-12T00:00:00",
-        "establishmentName": "Holly Lodge Girls\u0027 CE Secondary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Holly Lodge Girls\u0027 CE All-through School",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Barnsley",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 126,
-        "schoolCapacity": 150,
-        "percentageFreeSchoolMeals": "27",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 822,
+        "schoolCapacity": 1976,
+        "percentageFreeSchoolMeals": "15",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19832,19 +19832,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 84
+        "percentageFull": 42
       },
       {
         "urn": 13018978,
         "dateAcademyJoinedTrust": "2023-10-08T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2654,
-        "schoolCapacity": 2265,
-        "percentageFreeSchoolMeals": "17",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 714,
+        "schoolCapacity": 666,
+        "percentageFreeSchoolMeals": "26",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -19857,19 +19857,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2020-10-04T00:00:00"
         },
-        "percentageFull": 117
+        "percentageFull": 107
       },
       {
         "urn": 13019070,
         "dateAcademyJoinedTrust": "2023-01-21T00:00:00",
         "establishmentName": "St. Anne\u0027s Cofe Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Barnsley",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 392,
-        "schoolCapacity": 823,
-        "percentageFreeSchoolMeals": "22",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1623,
+        "schoolCapacity": 2600,
+        "percentageFreeSchoolMeals": "3",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -19882,19 +19882,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2019-08-16T00:00:00"
         },
-        "percentageFull": 48
+        "percentageFull": 62
       },
       {
         "urn": 13014962,
         "dateAcademyJoinedTrust": "2023-01-04T00:00:00",
         "establishmentName": "Halewood Catholic Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 2567,
-        "schoolCapacity": 1996,
-        "percentageFreeSchoolMeals": "2",
+        "numberOfPupils": 658,
+        "schoolCapacity": 666,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -19907,7 +19907,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 129
+        "percentageFull": 99
       }
     ],
     "governors": [
@@ -20080,16 +20080,16 @@
         "urn": 13023510,
         "dateAcademyJoinedTrust": "2020-08-05T00:00:00",
         "establishmentName": "St. Joseph\u0027s Catholic Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 450,
-        "schoolCapacity": 822,
-        "percentageFreeSchoolMeals": "8",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1087,
+        "schoolCapacity": 1742,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -20099,22 +20099,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 55
+        "percentageFull": 62
       },
       {
         "urn": 13024938,
         "dateAcademyJoinedTrust": "2022-01-29T00:00:00",
-        "establishmentName": "Oasis Primary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Oasis All-through School",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Barnsley",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 616,
-        "schoolCapacity": 483,
-        "percentageFreeSchoolMeals": "28",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1163,
+        "schoolCapacity": 2242,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -20124,19 +20124,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2021-07-17T00:00:00"
         },
-        "percentageFull": 128
+        "percentageFull": 52
       },
       {
         "urn": 13028956,
         "dateAcademyJoinedTrust": "2019-12-27T00:00:00",
-        "establishmentName": "St. Catherine\u0027s Catholic Secondary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. Catherine\u0027s Catholic Middle Deemed Secondary School",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1171,
-        "schoolCapacity": 2391,
-        "percentageFreeSchoolMeals": "17",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1908,
+        "schoolCapacity": 1718,
+        "percentageFreeSchoolMeals": "3",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20149,22 +20149,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 49
+        "percentageFull": 111
       },
       {
         "urn": 13027588,
         "dateAcademyJoinedTrust": "2023-09-12T00:00:00",
-        "establishmentName": "Co-op Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Co-op 16 Plus Academy",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 406,
-        "schoolCapacity": 728,
-        "percentageFreeSchoolMeals": "18",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1104,
+        "schoolCapacity": 1855,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -20174,22 +20174,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 56
+        "percentageFull": 60
       },
       {
         "urn": 13027701,
         "dateAcademyJoinedTrust": "2018-07-03T00:00:00",
-        "establishmentName": "Limehurst Catholic Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Limehurst Catholic Middle Deemed Primary School",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Wakefield",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1517,
-        "schoolCapacity": 1935,
-        "percentageFreeSchoolMeals": "7",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 2514,
+        "schoolCapacity": 2594,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -20199,22 +20199,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2012-11-29T00:00:00"
         },
-        "percentageFull": 78
+        "percentageFull": 97
       },
       {
         "urn": 13025025,
         "dateAcademyJoinedTrust": "2018-08-19T00:00:00",
-        "establishmentName": "Meridian Cofe Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Meridian Cofe 16 Plus Academy",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Wakefield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1707,
-        "schoolCapacity": 1598,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1955,
+        "schoolCapacity": 2261,
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -20224,19 +20224,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 107
+        "percentageFull": 86
       },
       {
         "urn": 13025908,
         "dateAcademyJoinedTrust": "2021-02-04T00:00:00",
         "establishmentName": "Wakefield Cofe School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "Wakefield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 906,
-        "schoolCapacity": 1343,
-        "percentageFreeSchoolMeals": "19",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 1012,
+        "schoolCapacity": 1288,
+        "percentageFreeSchoolMeals": "10",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20249,19 +20249,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 67
+        "percentageFull": 79
       },
       {
         "urn": 13022876,
         "dateAcademyJoinedTrust": "2020-11-20T00:00:00",
-        "establishmentName": "Limehurst Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Limehurst Middle Deemed Secondary Academy",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Wakefield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 715,
-        "schoolCapacity": 761,
-        "percentageFreeSchoolMeals": "17",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 831,
+        "schoolCapacity": 1373,
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20274,7 +20274,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2018-12-29T00:00:00"
         },
-        "percentageFull": 94
+        "percentageFull": 61
       }
     ],
     "governors": [
@@ -20381,13 +20381,13 @@
         "urn": 13039066,
         "dateAcademyJoinedTrust": "2022-11-27T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s C of E School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Barnsley",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1079,
-        "schoolCapacity": 1388,
-        "percentageFreeSchoolMeals": "14",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 998,
+        "schoolCapacity": 1248,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20400,7 +20400,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-01-24T00:00:00"
         },
-        "percentageFull": 78
+        "percentageFull": 80
       }
     ],
     "governors": [
@@ -20639,13 +20639,13 @@
         "urn": 13049660,
         "dateAcademyJoinedTrust": "2015-02-09T00:00:00",
         "establishmentName": "Meridian School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1509,
-        "schoolCapacity": 1649,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1075,
+        "schoolCapacity": 1221,
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20658,19 +20658,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-04-29T00:00:00"
         },
-        "percentageFull": 92
+        "percentageFull": 88
       },
       {
         "urn": 13047416,
         "dateAcademyJoinedTrust": "2015-12-08T00:00:00",
-        "establishmentName": "Malbank Church of England Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Malbank Church of England School",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Rotherham",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 3230,
-        "schoolCapacity": 2890,
-        "percentageFreeSchoolMeals": "23",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 3537,
+        "schoolCapacity": 2795,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20683,19 +20683,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2022-10-12T00:00:00"
         },
-        "percentageFull": 112
+        "percentageFull": 127
       },
       {
         "urn": 13043350,
         "dateAcademyJoinedTrust": "2020-07-12T00:00:00",
-        "establishmentName": "Longhill R.C. Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Longhill R.C. Academy",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 752,
-        "schoolCapacity": 956,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 899,
+        "schoolCapacity": 1350,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20708,22 +20708,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 79
+        "percentageFull": 67
       },
       {
         "urn": 13043060,
         "dateAcademyJoinedTrust": "2015-07-08T00:00:00",
         "establishmentName": "St. Joseph\u0027s Church of England Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 87,
-        "schoolCapacity": 158,
-        "percentageFreeSchoolMeals": "10",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 604,
+        "schoolCapacity": 1445,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -20733,19 +20733,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2014-10-18T00:00:00"
         },
-        "percentageFull": 55
+        "percentageFull": 42
       },
       {
         "urn": 13043996,
         "dateAcademyJoinedTrust": "2022-05-13T00:00:00",
         "establishmentName": "St. Peter\u0027s R.C. School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2281,
-        "schoolCapacity": 2940,
-        "percentageFreeSchoolMeals": "23",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 838,
+        "schoolCapacity": 654,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20758,19 +20758,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2020-05-30T00:00:00"
         },
-        "percentageFull": 78
+        "percentageFull": 128
       },
       {
         "urn": 13042477,
         "dateAcademyJoinedTrust": "2020-10-21T00:00:00",
         "establishmentName": "Momentum Community Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Kirklees",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 803,
-        "schoolCapacity": 652,
-        "percentageFreeSchoolMeals": "8",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1590,
+        "schoolCapacity": 2783,
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -20783,19 +20783,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 123
+        "percentageFull": 57
       },
       {
         "urn": 13049468,
         "dateAcademyJoinedTrust": "2021-01-28T00:00:00",
-        "establishmentName": "St. Marys Cofe Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. Marys Cofe 16 Plus Academy",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1802,
-        "schoolCapacity": 2555,
-        "percentageFreeSchoolMeals": "18",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 2102,
+        "schoolCapacity": 1809,
+        "percentageFreeSchoolMeals": "11",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20808,22 +20808,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 71
+        "percentageFull": 116
       },
       {
         "urn": 13046616,
         "dateAcademyJoinedTrust": "2015-03-01T00:00:00",
-        "establishmentName": "Margie Mountains Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Margie Mountains Middle Deemed Primary Academy",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2684,
-        "schoolCapacity": 2417,
-        "percentageFreeSchoolMeals": "9",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 696,
+        "schoolCapacity": 622,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -20833,22 +20833,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2011-01-20T00:00:00"
         },
-        "percentageFull": 111
+        "percentageFull": 112
       },
       {
         "urn": 13041370,
         "dateAcademyJoinedTrust": "2016-02-01T00:00:00",
         "establishmentName": "Longhill Cofe School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2620,
-        "schoolCapacity": 2168,
-        "percentageFreeSchoolMeals": "5",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 2173,
+        "schoolCapacity": 2086,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -20858,19 +20858,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2012-05-14T00:00:00"
         },
-        "percentageFull": 121
+        "percentageFull": 104
       },
       {
         "urn": 13049087,
         "dateAcademyJoinedTrust": "2014-02-18T00:00:00",
-        "establishmentName": "Oasis Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Oasis Middle Deemed Primary School",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Kirklees",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1874,
-        "schoolCapacity": 2287,
-        "percentageFreeSchoolMeals": "5",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 2732,
+        "schoolCapacity": 2533,
+        "percentageFreeSchoolMeals": "14",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20883,19 +20883,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-10-07T00:00:00"
         },
-        "percentageFull": 82
+        "percentageFull": 108
       },
       {
         "urn": 13044183,
         "dateAcademyJoinedTrust": "2018-01-18T00:00:00",
         "establishmentName": "George Abbey Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy 16 to 19 sponsor led",
         "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1443,
-        "schoolCapacity": 2603,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 308,
+        "schoolCapacity": 262,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -20908,7 +20908,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2017-06-26T00:00:00"
         },
-        "percentageFull": 55
+        "percentageFull": 118
       }
     ],
     "governors": [
@@ -21044,14 +21044,14 @@
       {
         "urn": 13052358,
         "dateAcademyJoinedTrust": "2019-07-20T00:00:00",
-        "establishmentName": "St. James\u0027s R.C. Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. James\u0027s R.C. Academy",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2060,
-        "schoolCapacity": 2508,
-        "percentageFreeSchoolMeals": "24",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 2288,
+        "schoolCapacity": 1995,
+        "percentageFreeSchoolMeals": "15",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -21064,22 +21064,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 82
+        "percentageFull": 115
       },
       {
         "urn": 13053575,
         "dateAcademyJoinedTrust": "2019-06-15T00:00:00",
         "establishmentName": "St. John\u0027s Catholic School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Barnsley",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 501,
-        "schoolCapacity": 696,
-        "percentageFreeSchoolMeals": "27",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1323,
+        "schoolCapacity": 2261,
+        "percentageFreeSchoolMeals": "11",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -21089,22 +21089,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2020-05-28T00:00:00"
         },
-        "percentageFull": 72
+        "percentageFull": 59
       },
       {
         "urn": 13051518,
         "dateAcademyJoinedTrust": "2016-09-03T00:00:00",
-        "establishmentName": "Greensward Catholic Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Greensward Catholic Primary School",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Sheffield",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1116,
-        "schoolCapacity": 1169,
-        "percentageFreeSchoolMeals": "4",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 1697,
+        "schoolCapacity": 2319,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -21114,19 +21114,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-08-06T00:00:00"
         },
-        "percentageFull": 95
+        "percentageFull": 73
       },
       {
         "urn": 13055708,
         "dateAcademyJoinedTrust": "2017-03-26T00:00:00",
-        "establishmentName": "Mulberry Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Mulberry Academy",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "North East Lincolnshire",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 247,
-        "schoolCapacity": 227,
-        "percentageFreeSchoolMeals": "24",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1047,
+        "schoolCapacity": 2383,
+        "percentageFreeSchoolMeals": "23",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21139,22 +21139,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-02-21T00:00:00"
         },
-        "percentageFull": 109
+        "percentageFull": 44
       },
       {
         "urn": 13053607,
         "dateAcademyJoinedTrust": "2016-03-07T00:00:00",
-        "establishmentName": "St. Mary\u0027s CE Primary Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "St. Mary\u0027s CE 16 Plus Academy",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2367,
-        "schoolCapacity": 2873,
-        "percentageFreeSchoolMeals": "21",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 882,
+        "schoolCapacity": 700,
+        "percentageFreeSchoolMeals": "15",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -21164,19 +21164,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-03-30T00:00:00"
         },
-        "percentageFull": 82
+        "percentageFull": 126
       },
       {
         "urn": 13055078,
         "dateAcademyJoinedTrust": "2015-01-21T00:00:00",
         "establishmentName": "Glyn School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 1214,
-        "schoolCapacity": 943,
-        "percentageFreeSchoolMeals": "1",
+        "numberOfPupils": 908,
+        "schoolCapacity": 1372,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -21189,22 +21189,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-07-26T00:00:00"
         },
-        "percentageFull": 129
+        "percentageFull": 66
       },
       {
         "urn": 13057609,
         "dateAcademyJoinedTrust": "2015-12-19T00:00:00",
         "establishmentName": "St. Mary\u0027s Cofe School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 121,
-        "schoolCapacity": 268,
-        "percentageFreeSchoolMeals": "23",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 581,
+        "schoolCapacity": 1285,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -21219,17 +21219,17 @@
       {
         "urn": 13053313,
         "dateAcademyJoinedTrust": "2017-11-13T00:00:00",
-        "establishmentName": "Malbank Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Malbank School",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Sheffield",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 136,
-        "schoolCapacity": 242,
-        "percentageFreeSchoolMeals": "24",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 482,
+        "schoolCapacity": 1084,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -21239,22 +21239,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 56
+        "percentageFull": 44
       },
       {
         "urn": 13051212,
         "dateAcademyJoinedTrust": "2017-08-11T00:00:00",
         "establishmentName": "Malbank R.C. School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1448,
-        "schoolCapacity": 1709,
-        "percentageFreeSchoolMeals": "10",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 2678,
+        "schoolCapacity": 2978,
+        "percentageFreeSchoolMeals": "15",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -21264,19 +21264,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-11-29T00:00:00"
         },
-        "percentageFull": 85
+        "percentageFull": 90
       },
       {
         "urn": 13054707,
         "dateAcademyJoinedTrust": "2019-04-18T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Church of England Secondary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. Joseph\u0027s Church of England Middle Deemed Secondary School",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1695,
-        "schoolCapacity": 2026,
-        "percentageFreeSchoolMeals": "17",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1530,
+        "schoolCapacity": 1534,
+        "percentageFreeSchoolMeals": "15",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21289,19 +21289,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2021-10-20T00:00:00"
         },
-        "percentageFull": 84
+        "percentageFull": 100
       },
       {
         "urn": 13052076,
         "dateAcademyJoinedTrust": "2020-02-15T00:00:00",
-        "establishmentName": "Glyn R.C. Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Glyn R.C. School",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Sheffield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 498,
-        "schoolCapacity": 448,
-        "percentageFreeSchoolMeals": "23",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 826,
+        "schoolCapacity": 1626,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21314,7 +21314,7 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2022-06-18T00:00:00"
         },
-        "percentageFull": 111
+        "percentageFull": 51
       }
     ],
     "governors": [
@@ -21498,16 +21498,16 @@
         "urn": 13069871,
         "dateAcademyJoinedTrust": "2020-10-08T00:00:00",
         "establishmentName": "Momentum Community R.C. School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "North East Lincolnshire",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1088,
-        "schoolCapacity": 2073,
-        "percentageFreeSchoolMeals": "13",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 494,
+        "schoolCapacity": 488,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -21517,22 +21517,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2022-01-20T00:00:00"
         },
-        "percentageFull": 52
+        "percentageFull": 101
       },
       {
         "urn": 13061994,
         "dateAcademyJoinedTrust": "2017-02-23T00:00:00",
         "establishmentName": "St. James\u0027 C of E School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Kirklees",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 670,
-        "schoolCapacity": 1587,
-        "percentageFreeSchoolMeals": "22",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 370,
+        "schoolCapacity": 430,
+        "percentageFreeSchoolMeals": "1",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -21542,19 +21542,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-09-23T00:00:00"
         },
-        "percentageFull": 42
+        "percentageFull": 86
       },
       {
         "urn": 13069800,
         "dateAcademyJoinedTrust": "2023-01-10T00:00:00",
         "establishmentName": "St. James\u0027 CE Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Leeds",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Rural town and fringe",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 827,
-        "schoolCapacity": 1308,
-        "percentageFreeSchoolMeals": "12",
+        "numberOfPupils": 165,
+        "schoolCapacity": 213,
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -21567,19 +21567,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 63
+        "percentageFull": 77
       },
       {
         "urn": 13063498,
         "dateAcademyJoinedTrust": "2017-02-26T00:00:00",
         "establishmentName": "Peacehaven Community Church of England School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Leeds",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 891,
-        "schoolCapacity": 1162,
-        "percentageFreeSchoolMeals": "15",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1769,
+        "schoolCapacity": 2425,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -21592,22 +21592,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2011-11-27T00:00:00"
         },
-        "percentageFull": 77
+        "percentageFull": 73
       },
       {
         "urn": 13069734,
         "dateAcademyJoinedTrust": "2021-03-19T00:00:00",
         "establishmentName": "St. Catherine\u0027s Catholic Academy",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 412,
-        "schoolCapacity": 856,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1129,
+        "schoolCapacity": 1779,
+        "percentageFreeSchoolMeals": "3",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -21617,19 +21617,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-04-04T00:00:00"
         },
-        "percentageFull": 48
+        "percentageFull": 63
       },
       {
         "urn": 13062036,
         "dateAcademyJoinedTrust": "2021-05-12T00:00:00",
-        "establishmentName": "St. John\u0027s Catholic Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. John\u0027s Catholic Middle Deemed Secondary Academy",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Kirklees",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2243,
-        "schoolCapacity": 1749,
-        "percentageFreeSchoolMeals": "18",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1255,
+        "schoolCapacity": 1377,
+        "percentageFreeSchoolMeals": "30",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -21642,7 +21642,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2015-01-30T00:00:00"
         },
-        "percentageFull": 128
+        "percentageFull": 91
       }
     ],
     "governors": [
@@ -21947,16 +21947,16 @@
         "urn": 13078133,
         "dateAcademyJoinedTrust": "2023-06-18T00:00:00",
         "establishmentName": "Co-op Catholic School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 170,
-        "schoolCapacity": 268,
-        "percentageFreeSchoolMeals": "30",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1053,
+        "schoolCapacity": 2328,
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -21966,22 +21966,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2020-05-24T00:00:00"
         },
-        "percentageFull": 63
+        "percentageFull": 45
       },
       {
         "urn": 13072522,
         "dateAcademyJoinedTrust": "2021-10-13T00:00:00",
         "establishmentName": "St. Catherine\u0027s Cofe School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "East Riding of Yorkshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1628,
-        "schoolCapacity": 2500,
-        "percentageFreeSchoolMeals": "29",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1643,
+        "schoolCapacity": 1435,
+        "percentageFreeSchoolMeals": "9",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -21991,22 +21991,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2015-05-10T00:00:00"
         },
-        "percentageFull": 65
+        "percentageFull": 114
       },
       {
         "urn": 13075728,
         "dateAcademyJoinedTrust": "2020-09-03T00:00:00",
-        "establishmentName": "George Abbey Primary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "George Abbey Middle Deemed Primary Academy",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Kirklees",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 792,
-        "schoolCapacity": 942,
-        "percentageFreeSchoolMeals": "8",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1290,
+        "schoolCapacity": 1950,
+        "percentageFreeSchoolMeals": "15",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -22016,18 +22016,18 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-05-06T00:00:00"
         },
-        "percentageFull": 84
+        "percentageFull": 66
       },
       {
         "urn": 13073544,
         "dateAcademyJoinedTrust": "2023-07-10T00:00:00",
         "establishmentName": "Melissa Port Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Kirklees",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1193,
-        "schoolCapacity": 953,
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 354,
+        "schoolCapacity": 533,
         "percentageFreeSchoolMeals": "29",
         "ageRange": {
           "minimum": 11,
@@ -22041,7 +22041,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2017-04-21T00:00:00"
         },
-        "percentageFull": 125
+        "percentageFull": 66
       }
     ],
     "governors": [
@@ -22379,13 +22379,13 @@
         "urn": 13087290,
         "dateAcademyJoinedTrust": "2015-01-10T00:00:00",
         "establishmentName": "St. James\u0027 R.C. Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Doncaster",
         "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1618,
-        "schoolCapacity": 1323,
-        "percentageFreeSchoolMeals": "12",
+        "numberOfPupils": 1662,
+        "schoolCapacity": 2132,
+        "percentageFreeSchoolMeals": "28",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -22398,19 +22398,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-03-12T00:00:00"
         },
-        "percentageFull": 122
+        "percentageFull": 78
       },
       {
         "urn": 13082848,
         "dateAcademyJoinedTrust": "2014-10-19T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Free schools 16 to 19",
         "localAuthority": "Doncaster",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 176,
-        "schoolCapacity": 340,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 955,
+        "schoolCapacity": 2013,
+        "percentageFreeSchoolMeals": "4",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -22423,22 +22423,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 52
+        "percentageFull": 47
       },
       {
         "urn": 13085540,
         "dateAcademyJoinedTrust": "2021-03-08T00:00:00",
-        "establishmentName": "St. Joseph\u0027s Cofe Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. Joseph\u0027s Cofe Middle Deemed Primary School",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 803,
-        "schoolCapacity": 1418,
-        "percentageFreeSchoolMeals": "9",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1006,
+        "schoolCapacity": 1244,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -22448,19 +22448,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 57
+        "percentageFull": 81
       },
       {
         "urn": 13083178,
         "dateAcademyJoinedTrust": "2021-05-03T00:00:00",
         "establishmentName": "St. James\u0027 Church of England School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2428,
-        "schoolCapacity": 2613,
-        "percentageFreeSchoolMeals": "8",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1368,
+        "schoolCapacity": 1160,
+        "percentageFreeSchoolMeals": "18",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -22473,7 +22473,7 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2014-12-14T00:00:00"
         },
-        "percentageFull": 93
+        "percentageFull": 118
       }
     ],
     "governors": [
@@ -22834,16 +22834,16 @@
         "urn": 12529588,
         "dateAcademyJoinedTrust": "2021-11-20T00:00:00",
         "establishmentName": "St. John\u0027s R.C. School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2944,
-        "schoolCapacity": 2817,
-        "percentageFreeSchoolMeals": "3",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 1171,
+        "schoolCapacity": 942,
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 16
+          "minimum": 4,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -22853,22 +22853,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 105
+        "percentageFull": 124
       },
       {
         "urn": 12526059,
         "dateAcademyJoinedTrust": "2015-03-15T00:00:00",
         "establishmentName": "Greensward C of E Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "North Yorkshire",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1206,
-        "schoolCapacity": 2191,
-        "percentageFreeSchoolMeals": "24",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1312,
+        "schoolCapacity": 1251,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -22878,22 +22878,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2015-08-12T00:00:00"
         },
-        "percentageFull": 55
+        "percentageFull": 105
       },
       {
         "urn": 12521256,
         "dateAcademyJoinedTrust": "2016-08-31T00:00:00",
-        "establishmentName": "Beacon Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Beacon School",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Doncaster",
         "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1918,
-        "schoolCapacity": 1804,
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1600,
+        "schoolCapacity": 1723,
         "percentageFreeSchoolMeals": "23",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -22903,22 +22903,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 106
+        "percentageFull": 93
       },
       {
         "urn": 12526906,
         "dateAcademyJoinedTrust": "2021-08-13T00:00:00",
         "establishmentName": "St. Marys Catholic Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1043,
-        "schoolCapacity": 875,
-        "percentageFreeSchoolMeals": "24",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1592,
+        "schoolCapacity": 2485,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -22928,22 +22928,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 119
+        "percentageFull": 64
       },
       {
         "urn": 12528307,
         "dateAcademyJoinedTrust": "2015-03-09T00:00:00",
         "establishmentName": "Longhill Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Doncaster",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1751,
-        "schoolCapacity": 1833,
-        "percentageFreeSchoolMeals": "30",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1085,
+        "schoolCapacity": 1157,
+        "percentageFreeSchoolMeals": "19",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -22953,22 +22953,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 96
+        "percentageFull": 94
       },
       {
         "urn": 12523085,
         "dateAcademyJoinedTrust": "2020-01-03T00:00:00",
         "establishmentName": "Limehurst C of E School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "North Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2164,
-        "schoolCapacity": 2067,
-        "percentageFreeSchoolMeals": "11",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 2410,
+        "schoolCapacity": 2385,
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -22978,19 +22978,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 105
+        "percentageFull": 101
       },
       {
         "urn": 12525393,
         "dateAcademyJoinedTrust": "2016-07-12T00:00:00",
         "establishmentName": "Harris R.C. School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 418,
-        "schoolCapacity": 351,
-        "percentageFreeSchoolMeals": "2",
+        "numberOfPupils": 557,
+        "schoolCapacity": 1164,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
           "minimum": 5,
           "maximum": 11
@@ -23003,7 +23003,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-10-22T00:00:00"
         },
-        "percentageFull": 119
+        "percentageFull": 48
       }
     ],
     "governors": [
@@ -23132,13 +23132,13 @@
         "urn": 12765474,
         "dateAcademyJoinedTrust": "2021-05-06T00:00:00",
         "establishmentName": "Harris R.C. Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Bradford",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1097,
-        "schoolCapacity": 1110,
-        "percentageFreeSchoolMeals": "5",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 279,
+        "schoolCapacity": 391,
+        "percentageFreeSchoolMeals": "20",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -23151,19 +23151,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2016-01-04T00:00:00"
         },
-        "percentageFull": 99
+        "percentageFull": 71
       },
       {
         "urn": 12768824,
         "dateAcademyJoinedTrust": "2017-01-20T00:00:00",
-        "establishmentName": "St. Marys CE Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. Marys CE School",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Bradford",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2146,
-        "schoolCapacity": 2062,
-        "percentageFreeSchoolMeals": "23",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 2271,
+        "schoolCapacity": 2251,
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -23176,19 +23176,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2013-12-06T00:00:00"
         },
-        "percentageFull": 104
+        "percentageFull": 101
       },
       {
         "urn": 12764006,
         "dateAcademyJoinedTrust": "2017-07-15T00:00:00",
         "establishmentName": "Co-op Secondary School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Bradford",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1593,
-        "schoolCapacity": 1276,
-        "percentageFreeSchoolMeals": "10",
+        "numberOfPupils": 256,
+        "schoolCapacity": 334,
+        "percentageFreeSchoolMeals": "29",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -23201,7 +23201,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2012-09-07T00:00:00"
         },
-        "percentageFull": 125
+        "percentageFull": 77
       }
     ],
     "governors": [
@@ -23506,16 +23506,16 @@
         "urn": 12698396,
         "dateAcademyJoinedTrust": "2022-10-28T00:00:00",
         "establishmentName": "St. James\u0027s Church of England School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 969,
-        "schoolCapacity": 1174,
-        "percentageFreeSchoolMeals": "21",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 456,
+        "schoolCapacity": 622,
+        "percentageFreeSchoolMeals": "15",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 3,
@@ -23525,19 +23525,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2012-08-22T00:00:00"
         },
-        "percentageFull": 83
+        "percentageFull": 73
       },
       {
         "urn": 12695108,
         "dateAcademyJoinedTrust": "2022-12-21T00:00:00",
-        "establishmentName": "St. Mary\u0027s R.C. Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. Mary\u0027s R.C. Middle Deemed Secondary School",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1427,
-        "schoolCapacity": 1936,
-        "percentageFreeSchoolMeals": "16",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 2890,
+        "schoolCapacity": 2980,
+        "percentageFreeSchoolMeals": "12",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -23550,19 +23550,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 74
+        "percentageFull": 97
       },
       {
         "urn": 12699676,
         "dateAcademyJoinedTrust": "2023-05-27T00:00:00",
         "establishmentName": "Lucile Ferry Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 776,
-        "schoolCapacity": 867,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 87,
+        "schoolCapacity": 136,
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -23575,22 +23575,22 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2017-11-24T00:00:00"
         },
-        "percentageFull": 90
+        "percentageFull": 64
       },
       {
         "urn": 12691615,
         "dateAcademyJoinedTrust": "2023-05-23T00:00:00",
         "establishmentName": "Glyn School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "North East Lincolnshire",
         "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1261,
-        "schoolCapacity": 1401,
-        "percentageFreeSchoolMeals": "29",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 857,
+        "schoolCapacity": 1066,
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -23600,19 +23600,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 90
+        "percentageFull": 80
       },
       {
         "urn": 12692285,
         "dateAcademyJoinedTrust": "2023-05-11T00:00:00",
-        "establishmentName": "Wiza Springs Catholic Secondary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Wiza Springs Catholic Middle Deemed Secondary School",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2204,
-        "schoolCapacity": 2829,
-        "percentageFreeSchoolMeals": "16",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 2885,
+        "schoolCapacity": 2314,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -23625,22 +23625,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-07-20T00:00:00"
         },
-        "percentageFull": 78
+        "percentageFull": 125
       },
       {
         "urn": 12695771,
         "dateAcademyJoinedTrust": "2023-04-30T00:00:00",
         "establishmentName": "Holly Lodge Girls\u0027 R.C. School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2911,
-        "schoolCapacity": 2838,
-        "percentageFreeSchoolMeals": "13",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 2870,
+        "schoolCapacity": 2297,
+        "percentageFreeSchoolMeals": "21",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -23650,22 +23650,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 103
+        "percentageFull": 125
       },
       {
         "urn": 12698646,
         "dateAcademyJoinedTrust": "2022-08-05T00:00:00",
-        "establishmentName": "Krajcik Spur Cofe Primary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Krajcik Spur Cofe All-through School",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 670,
-        "schoolCapacity": 682,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1320,
+        "schoolCapacity": 2274,
+        "percentageFreeSchoolMeals": "20",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -23675,7 +23675,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 98
+        "percentageFull": 58
       }
     ],
     "governors": [
@@ -23991,16 +23991,16 @@
         "urn": 12371191,
         "dateAcademyJoinedTrust": "2021-03-02T00:00:00",
         "establishmentName": "Halewood C of E Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Calderdale",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1618,
-        "schoolCapacity": 2896,
-        "percentageFreeSchoolMeals": "16",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Middle Deemed Secondary",
+        "numberOfPupils": 1098,
+        "schoolCapacity": 866,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -24010,19 +24010,19 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2013-12-20T00:00:00"
         },
-        "percentageFull": 56
+        "percentageFull": 127
       },
       {
         "urn": 12371169,
         "dateAcademyJoinedTrust": "2023-07-03T00:00:00",
         "establishmentName": "Zula Skyway Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "typeOfEstablishment": "City Technology College",
         "localAuthority": "Calderdale",
         "urbanRural": "Rural village in a sparse setting",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 287,
-        "schoolCapacity": 276,
-        "percentageFreeSchoolMeals": "13",
+        "numberOfPupils": 796,
+        "schoolCapacity": 1750,
+        "percentageFreeSchoolMeals": "22",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -24035,19 +24035,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2020-02-27T00:00:00"
         },
-        "percentageFull": 104
+        "percentageFull": 45
       },
       {
         "urn": 12377899,
         "dateAcademyJoinedTrust": "2020-09-15T00:00:00",
-        "establishmentName": "St. Marys Church of England Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. Marys Church of England Middle Deemed Primary Academy",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Leeds",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 597,
-        "schoolCapacity": 974,
-        "percentageFreeSchoolMeals": "7",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 1045,
+        "schoolCapacity": 1557,
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -24060,22 +24060,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2014-03-11T00:00:00"
         },
-        "percentageFull": 61
+        "percentageFull": 67
       },
       {
         "urn": 12374275,
         "dateAcademyJoinedTrust": "2022-01-17T00:00:00",
         "establishmentName": "St. James\u0027 C of E Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Leeds",
         "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1124,
-        "schoolCapacity": 2405,
-        "percentageFreeSchoolMeals": "29",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 2121,
+        "schoolCapacity": 1902,
+        "percentageFreeSchoolMeals": "3",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -24085,19 +24085,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-10-03T00:00:00"
         },
-        "percentageFull": 47
+        "percentageFull": 112
       },
       {
         "urn": 12377014,
         "dateAcademyJoinedTrust": "2022-12-20T00:00:00",
-        "establishmentName": "Calderdale Secondary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Calderdale Academy",
+        "typeOfEstablishment": "University technical college",
         "localAuthority": "Calderdale",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1315,
-        "schoolCapacity": 2879,
-        "percentageFreeSchoolMeals": "23",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 827,
+        "schoolCapacity": 655,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -24110,19 +24110,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 46
+        "percentageFull": 126
       },
       {
         "urn": 12373767,
         "dateAcademyJoinedTrust": "2021-11-13T00:00:00",
-        "establishmentName": "Lampton Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Lampton School",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1128,
-        "schoolCapacity": 1029,
-        "percentageFreeSchoolMeals": "23",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1053,
+        "schoolCapacity": 1530,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -24135,22 +24135,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 110
+        "percentageFull": 69
       },
       {
         "urn": 12374093,
         "dateAcademyJoinedTrust": "2021-09-15T00:00:00",
-        "establishmentName": "St. Marys R.C. Primary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. Marys R.C. Academy",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "North East Lincolnshire",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2212,
-        "schoolCapacity": 2599,
-        "percentageFreeSchoolMeals": "24",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 350,
+        "schoolCapacity": 298,
+        "percentageFreeSchoolMeals": "16",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -24160,7 +24160,7 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 85
+        "percentageFull": 117
       }
     ],
     "governors": [
@@ -24333,16 +24333,16 @@
         "urn": 12413760,
         "dateAcademyJoinedTrust": "2022-10-07T00:00:00",
         "establishmentName": "Glyn Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Wakefield",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 738,
-        "schoolCapacity": 1767,
-        "percentageFreeSchoolMeals": "29",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1347,
+        "schoolCapacity": 1468,
+        "percentageFreeSchoolMeals": "1",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -24352,22 +24352,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2014-10-03T00:00:00"
         },
-        "percentageFull": 42
+        "percentageFull": 92
       },
       {
         "urn": 12417462,
         "dateAcademyJoinedTrust": "2023-05-12T00:00:00",
         "establishmentName": "Longhill School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "York",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 982,
-        "schoolCapacity": 1695,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 155,
+        "schoolCapacity": 173,
+        "percentageFreeSchoolMeals": "6",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -24377,19 +24377,19 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2018-05-20T00:00:00"
         },
-        "percentageFull": 58
+        "percentageFull": 90
       },
       {
         "urn": 12418651,
         "dateAcademyJoinedTrust": "2022-06-30T00:00:00",
         "establishmentName": "Beacon R.C. Academy",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "York",
-        "urbanRural": "Urban major conurbation",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 217,
-        "schoolCapacity": 405,
-        "percentageFreeSchoolMeals": "26",
+        "urbanRural": "Rural town and fringe",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 985,
+        "schoolCapacity": 1991,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -24402,19 +24402,19 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2017-07-13T00:00:00"
         },
-        "percentageFull": 54
+        "percentageFull": 49
       },
       {
         "urn": 12416875,
         "dateAcademyJoinedTrust": "2023-08-19T00:00:00",
         "establishmentName": "Northwood C of E School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "York",
-        "urbanRural": "Urban minor conurbation",
+        "urbanRural": "Urban city and town",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 1863,
-        "schoolCapacity": 2918,
-        "percentageFreeSchoolMeals": "4",
+        "numberOfPupils": 3399,
+        "schoolCapacity": 2667,
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -24427,22 +24427,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 64
+        "percentageFull": 127
       },
       {
         "urn": 12416433,
         "dateAcademyJoinedTrust": "2023-07-18T00:00:00",
-        "establishmentName": "Beacon Secondary School",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "Beacon Primary School",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Wakefield",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 2363,
-        "schoolCapacity": 2598,
-        "percentageFreeSchoolMeals": "1",
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Primary",
+        "numberOfPupils": 370,
+        "schoolCapacity": 315,
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
-          "minimum": 11,
-          "maximum": 18
+          "minimum": 5,
+          "maximum": 11
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -24452,22 +24452,22 @@
           "ofstedRatingScore": 2,
           "inspectionEndDate": "2019-05-07T00:00:00"
         },
-        "percentageFull": 91
+        "percentageFull": 117
       },
       {
         "urn": 12416251,
         "dateAcademyJoinedTrust": "2022-10-09T00:00:00",
         "establishmentName": "Glyn Cofe School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "York",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 347,
-        "schoolCapacity": 291,
-        "percentageFreeSchoolMeals": "19",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 434,
+        "schoolCapacity": 945,
+        "percentageFreeSchoolMeals": "27",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -24477,22 +24477,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 119
+        "percentageFull": 46
       },
       {
         "urn": 12411249,
         "dateAcademyJoinedTrust": "2022-10-15T00:00:00",
         "establishmentName": "Rotherham Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 128,
-        "schoolCapacity": 115,
-        "percentageFreeSchoolMeals": "10",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 264,
+        "schoolCapacity": 653,
+        "percentageFreeSchoolMeals": "24",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -24502,22 +24502,22 @@
           "ofstedRatingScore": 3,
           "inspectionEndDate": "2012-05-24T00:00:00"
         },
-        "percentageFull": 111
+        "percentageFull": 40
       },
       {
         "urn": 12412972,
         "dateAcademyJoinedTrust": "2022-11-07T00:00:00",
         "establishmentName": "Greensward School",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "York",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 144,
-        "schoolCapacity": 317,
-        "percentageFreeSchoolMeals": "22",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 1268,
+        "schoolCapacity": 2712,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -24527,22 +24527,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2015-09-20T00:00:00"
         },
-        "percentageFull": 45
+        "percentageFull": 47
       },
       {
         "urn": 12419399,
         "dateAcademyJoinedTrust": "2022-05-31T00:00:00",
-        "establishmentName": "Beacon Cofe Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "Beacon Cofe 16 Plus Academy",
+        "typeOfEstablishment": "Voluntary Aided School",
         "localAuthority": "Rotherham",
         "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 783,
-        "schoolCapacity": 1051,
-        "percentageFreeSchoolMeals": "18",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 2083,
+        "schoolCapacity": 2996,
+        "percentageFreeSchoolMeals": "12",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 1,
@@ -24552,7 +24552,7 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2016-11-25T00:00:00"
         },
-        "percentageFull": 75
+        "percentageFull": 70
       }
     ],
     "governors": [
@@ -24725,16 +24725,16 @@
         "urn": 12745522,
         "dateAcademyJoinedTrust": "2023-09-25T00:00:00",
         "establishmentName": "Leeds School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Community School",
         "localAuthority": "Leeds",
         "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1799,
-        "schoolCapacity": 2278,
-        "percentageFreeSchoolMeals": "5",
+        "phaseOfEducation": "Middle Deemed Primary",
+        "numberOfPupils": 546,
+        "schoolCapacity": 508,
+        "percentageFreeSchoolMeals": "13",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -24744,19 +24744,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 79
+        "percentageFull": 107
       },
       {
         "urn": 12746125,
         "dateAcademyJoinedTrust": "2023-07-29T00:00:00",
         "establishmentName": "St. Anne\u0027s Catholic Primary Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Voluntary Controlled School",
         "localAuthority": "Rotherham",
-        "urbanRural": "Rural village in a sparse setting",
+        "urbanRural": "Urban major conurbation",
         "phaseOfEducation": "Primary",
-        "numberOfPupils": 1242,
-        "schoolCapacity": 2533,
-        "percentageFreeSchoolMeals": "3",
+        "numberOfPupils": 2042,
+        "schoolCapacity": 1768,
+        "percentageFreeSchoolMeals": "4",
         "ageRange": {
           "minimum": 4,
           "maximum": 11
@@ -24769,19 +24769,19 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2016-02-22T00:00:00"
         },
-        "percentageFull": 49
+        "percentageFull": 115
       },
       {
         "urn": 12741442,
         "dateAcademyJoinedTrust": "2023-07-08T00:00:00",
-        "establishmentName": "St. Mary\u0027s Cofe Secondary Academy",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. Mary\u0027s Cofe Academy",
+        "typeOfEstablishment": "Free Schools",
         "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Secondary",
-        "numberOfPupils": 1414,
-        "schoolCapacity": 1941,
-        "percentageFreeSchoolMeals": "22",
+        "urbanRural": "Urban major conurbation",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 625,
+        "schoolCapacity": 644,
+        "percentageFreeSchoolMeals": "11",
         "ageRange": {
           "minimum": 11,
           "maximum": 18
@@ -24794,22 +24794,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2021-03-26T00:00:00"
         },
-        "percentageFull": 73
+        "percentageFull": 97
       },
       {
         "urn": 12744538,
         "dateAcademyJoinedTrust": "2023-08-06T00:00:00",
         "establishmentName": "St. Paul\u0027s R.C. School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "typeOfEstablishment": "Academy Sponsor Led",
         "localAuthority": "Leeds",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 1185,
-        "schoolCapacity": 2189,
-        "percentageFreeSchoolMeals": "30",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 1878,
+        "schoolCapacity": 1792,
+        "percentageFreeSchoolMeals": "5",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -24819,22 +24819,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 54
+        "percentageFull": 105
       },
       {
         "urn": 12748658,
         "dateAcademyJoinedTrust": "2023-07-15T00:00:00",
-        "establishmentName": "St. John\u0027s Church of England Primary School",
-        "typeOfEstablishment": "Free school",
+        "establishmentName": "St. John\u0027s Church of England Secondary School",
+        "typeOfEstablishment": "Foundation School",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural village in a sparse setting",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 46,
-        "schoolCapacity": 106,
-        "percentageFreeSchoolMeals": "10",
+        "urbanRural": "Urban minor conurbation",
+        "phaseOfEducation": "Secondary",
+        "numberOfPupils": 585,
+        "schoolCapacity": 1454,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 2,
@@ -24844,19 +24844,19 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 43
+        "percentageFull": 40
       },
       {
         "urn": 12748681,
         "dateAcademyJoinedTrust": "2023-09-10T00:00:00",
         "establishmentName": "Queen Elizabeth\u0027s Academy",
-        "typeOfEstablishment": "Free school",
+        "typeOfEstablishment": "Studio schools",
         "localAuthority": "Leeds",
-        "urbanRural": "Urban city and town",
+        "urbanRural": "Urban minor conurbation",
         "phaseOfEducation": "Secondary",
-        "numberOfPupils": 395,
-        "schoolCapacity": 874,
-        "percentageFreeSchoolMeals": "11",
+        "numberOfPupils": 388,
+        "schoolCapacity": 606,
+        "percentageFreeSchoolMeals": "2",
         "ageRange": {
           "minimum": 11,
           "maximum": 16
@@ -24869,22 +24869,22 @@
           "ofstedRatingScore": 4,
           "inspectionEndDate": "2018-06-04T00:00:00"
         },
-        "percentageFull": 45
+        "percentageFull": 64
       },
       {
         "urn": 12743713,
         "dateAcademyJoinedTrust": "2023-09-19T00:00:00",
-        "establishmentName": "Limehurst R.C. Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Limehurst R.C. All-through School",
+        "typeOfEstablishment": "Academy 16-19 Converter",
         "localAuthority": "Barnsley",
-        "urbanRural": "Rural town and fringe",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 257,
-        "schoolCapacity": 407,
-        "percentageFreeSchoolMeals": "30",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "All-through",
+        "numberOfPupils": 528,
+        "schoolCapacity": 1066,
+        "percentageFreeSchoolMeals": "8",
         "ageRange": {
-          "minimum": 5,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 18
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -24894,22 +24894,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 63
+        "percentageFull": 50
       },
       {
         "urn": 12748301,
         "dateAcademyJoinedTrust": "2023-07-26T00:00:00",
-        "establishmentName": "St. Joseph\u0027s CE Primary Academy",
-        "typeOfEstablishment": "Academy converter",
+        "establishmentName": "St. Joseph\u0027s CE Academy",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Rotherham",
-        "urbanRural": "Urban city and town",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 999,
-        "schoolCapacity": 914,
+        "urbanRural": "Rural village in a sparse setting",
+        "phaseOfEducation": "Not applicable",
+        "numberOfPupils": 167,
+        "schoolCapacity": 256,
         "percentageFreeSchoolMeals": "24",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": -1,
@@ -24919,22 +24919,22 @@
           "ofstedRatingScore": -1,
           "inspectionEndDate": null
         },
-        "percentageFull": 109
+        "percentageFull": 65
       },
       {
         "urn": 12746981,
         "dateAcademyJoinedTrust": "2023-10-02T00:00:00",
-        "establishmentName": "Barnsley Primary School",
-        "typeOfEstablishment": "Academy sponsor led",
+        "establishmentName": "Barnsley 16 Plus School",
+        "typeOfEstablishment": "Academy Converter",
         "localAuthority": "Barnsley",
-        "urbanRural": "Urban minor conurbation",
-        "phaseOfEducation": "Primary",
-        "numberOfPupils": 2287,
-        "schoolCapacity": 2564,
-        "percentageFreeSchoolMeals": "18",
+        "urbanRural": "Urban city and town",
+        "phaseOfEducation": "16 Plus",
+        "numberOfPupils": 3148,
+        "schoolCapacity": 2703,
+        "percentageFreeSchoolMeals": "17",
         "ageRange": {
-          "minimum": 4,
-          "maximum": 11
+          "minimum": 11,
+          "maximum": 16
         },
         "currentOfstedRating": {
           "ofstedRatingScore": 4,
@@ -24944,7 +24944,7 @@
           "ofstedRatingScore": 1,
           "inspectionEndDate": "2015-01-23T00:00:00"
         },
-        "percentageFull": 89
+        "percentageFull": 116
       }
     ],
     "governors": [

--- a/tests/playwright/page-object-model/trust/academies/free-school-meals-page.ts
+++ b/tests/playwright/page-object-model/trust/academies/free-school-meals-page.ts
@@ -1,0 +1,48 @@
+import { Page, expect } from '@playwright/test'
+import { FakeAcademy, FakeTestData } from '../../../fake-data/fake-test-data'
+import { BaseAcademiesPage, BaseAcademiesPageAssertions } from './base-academies-page'
+import { RowComponent } from '../../shared/table-component'
+
+enum ColumnHeading {
+  PupilsEligableForFreeSchoolMeals,
+  LocalAuthorityAverage,
+  NationalAverage
+}
+
+const percentageFormatToOneDecimalPlace = /\d+\.\d%/
+
+export class AcademiesFreeSchoolMealsPage extends BaseAcademiesPage {
+  readonly expect: FreeSchoolMealsPageAssertions
+  constructor (readonly page: Page, fakeTestData: FakeTestData) {
+    super(page, fakeTestData, '/trusts/academies/free-school-meals')
+    this.expect = new FreeSchoolMealsPageAssertions(this)
+  }
+}
+
+class FreeSchoolMealsPageAssertions extends BaseAcademiesPageAssertions {
+  constructor (readonly page: AcademiesFreeSchoolMealsPage) {
+    super(page)
+  }
+
+  async toBeOnTheRightPage (): Promise<void> {
+    await this.toBeOnAcademiesInTrustPages()
+    await expect(this.page.page).toHaveTitle(/free school meals/)
+  }
+
+  async toDisplayCorrectInformationAboutAcademiesInThatTrust (): Promise<void> {
+    const rowCount = await this.page.academiesTable.getRowCount()
+    let rowComponent: RowComponent
+    let expectedFakeAcademy: FakeAcademy
+    // start at 1 (rather than 0) because the first row will be the header
+    for (let i = 1; i < rowCount; i++) {
+      rowComponent = this.page.academiesTable.getRowComponentAt(i)
+      expectedFakeAcademy = await this.page.getExpectedAcademyMatching(rowComponent.rowHeaderLocator)
+
+      await expect(rowComponent.rowHeaderLocator).toContainText(expectedFakeAcademy.establishmentName)
+      await expect(rowComponent.rowHeaderLocator).toContainText(`URN: ${expectedFakeAcademy.urn}`)
+      await expect(rowComponent.cellLocator(ColumnHeading.PupilsEligableForFreeSchoolMeals)).toContainText(`${expectedFakeAcademy.percentageFreeSchoolMeals.toFixed(1)}%`)
+      await expect(rowComponent.cellLocator(ColumnHeading.LocalAuthorityAverage)).toContainText(percentageFormatToOneDecimalPlace)
+      await expect(rowComponent.cellLocator(ColumnHeading.NationalAverage)).toContainText(percentageFormatToOneDecimalPlace)
+    }
+  }
+}

--- a/tests/playwright/ui-tests/navigation.spec.ts
+++ b/tests/playwright/ui-tests/navigation.spec.ts
@@ -11,6 +11,7 @@ import { CookiesPage } from '../page-object-model/cookies-page'
 import { AcademiesDetailsPage } from '../page-object-model/trust/academies/details-page'
 import { AcademiesOfstedRatingsPage } from '../page-object-model/trust/academies/ofsted-ratings-page'
 import { AcademiesPupilNumbersPage } from '../page-object-model/trust/academies/pupil-numbers-page '
+import { AcademiesFreeSchoolMealsPage } from '../page-object-model/trust/academies/free-school-meals-page'
 
 test.describe('Navigation', () => {
   let homePage: HomePage
@@ -24,6 +25,7 @@ test.describe('Navigation', () => {
   let academiesDetailsPage: AcademiesDetailsPage
   let academiesOfstedRatingsPage: AcademiesOfstedRatingsPage
   let academiesPupilNumbersPage: AcademiesPupilNumbersPage
+  let academiesFreeSchoolMealsPage: AcademiesFreeSchoolMealsPage
 
   test.beforeEach(async ({ page }) => {
     const fakeTestData = new FakeTestData()
@@ -35,6 +37,7 @@ test.describe('Navigation', () => {
     academiesDetailsPage = new AcademiesDetailsPage(page, fakeTestData)
     academiesOfstedRatingsPage = new AcademiesOfstedRatingsPage(page, fakeTestData)
     academiesPupilNumbersPage = new AcademiesPupilNumbersPage(page, fakeTestData)
+    academiesFreeSchoolMealsPage = new AcademiesFreeSchoolMealsPage(page, fakeTestData)
     privacyPage = new PrivacyPage(page)
     accessibilityPage = new AccessibilityPage(page)
     cookiesPage = new CookiesPage(page)
@@ -88,6 +91,18 @@ test.describe('Navigation', () => {
     await academiesOfstedRatingsPage.subNavigation.clickOn('Pupil numbers')
     await academiesPupilNumbersPage.expect.toBeOnTheRightPage()
     await academiesPupilNumbersPage.subNavigation.clickOn('Details')
+    await academiesDetailsPage.expect.toBeOnTheRightPage()
+    await academiesDetailsPage.subNavigation.clickOn('Free school meals')
+    await academiesFreeSchoolMealsPage.expect.toBeOnTheRightPage()
+    await academiesFreeSchoolMealsPage.subNavigation.clickOn('Ofsted ratings')
+    await academiesOfstedRatingsPage.expect.toBeOnTheRightPage()
+    await academiesOfstedRatingsPage.subNavigation.clickOn('Free school meals')
+    await academiesFreeSchoolMealsPage.expect.toBeOnTheRightPage()
+    await academiesFreeSchoolMealsPage.subNavigation.clickOn('Pupil numbers')
+    await academiesPupilNumbersPage.expect.toBeOnTheRightPage()
+    await academiesPupilNumbersPage.subNavigation.clickOn('Free school meals')
+    await academiesFreeSchoolMealsPage.expect.toBeOnTheRightPage()
+    await academiesFreeSchoolMealsPage.subNavigation.clickOn('Details')
     await academiesDetailsPage.expect.toBeOnTheRightPage()
   })
 

--- a/tests/playwright/ui-tests/trusts/academies/free-school-meals-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/academies/free-school-meals-page.spec.ts
@@ -1,0 +1,14 @@
+import { test } from '@playwright/test'
+import { FakeTestData } from '../../../fake-data/fake-test-data'
+import { AcademiesFreeSchoolMealsPage } from '../../../page-object-model/trust/academies/free-school-meals-page'
+
+test.describe('Academies in trust details page', () => {
+  test('user should see the right information about a trust', async ({ page }) => {
+    const freeSchoolMealsPage = new AcademiesFreeSchoolMealsPage(page, new FakeTestData())
+
+    await freeSchoolMealsPage.goTo()
+    await freeSchoolMealsPage.expect.toBeOnTheRightPage()
+    await freeSchoolMealsPage.expect.toDisplayInformationForAllAcademiesInThatTrust()
+    await freeSchoolMealsPage.expect.toDisplayCorrectInformationAboutAcademiesInThatTrust()
+  })
+})


### PR DESCRIPTION
On this page, a user will be able to see information about the % of pupils in each academy/school are eligible for free school meals and how these figures compare with the averages for the local authority and national picture.

Local authority and national percentages of students eligible for free school meals are broken down by establishment type, so each academy in a trust may have a different local and national average to compare to depending on the phase of education and establishment type. 

Related to [User Story 134797](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/134797?McasTsid=26110&McasCtx=4): Build: Academies in Trust Page - free school meals

**Adding a hardcoded data source**
Our current source for this data is a csv file hosted on [Explore Education Statistics](https://explore-education-statistics.service.gov.uk/data-tables/permalink/25bc8d0b-c700-4000-1b8a-08dbb99e3fd8)

To make this clear to the user that it is a fixed data source, and easier to change to a dynamic data source in the future we are:

- Clearly labelling the columns in the UI with the date of the data (e.g. Local averages 2022/23)
- Adding detail on the source to the 'Data source' component on the page (will be added in a later PR)
- Adding the data via a C# file in a new `~Data.Hardcoded` project. This will mean we are not reading a csv file everytime the website is loaded, and that it should be easier to swap the data at a later point, using the `FreeSchoolMealsAverages` provider
- Adding an ADR to explain our decision
- Adding a task to the RSD cross-cutting backlog to replace the data source when a new one becomes available, as it is expected it will do

**Mapping data types between two services**
There are 27 establishment types stored by Get information about Schools (GIAS), which is the source of data to display information about academies (via the academies database). 

Percentages of pupils eligible for free school meals is broken down into 6 establishment types, which do not match the types we are displaying from GIAS.

The Schools Statistics team have provided us with a mapping, which we are using in a switch expression in the `FreeSchoolMealsAveragesProvider` in the method `GetPhaseTypeKey`. This returns the matching phase type in the statistics data given the phase and establishment type of the academy.

The types referenced in the Schools Statistics data on free school meals are not referenced elsewhere in our application, and we have only taken the cases and types relevant to our data:

- State-funded special school
- State-funded primary
- Pupil referral unit
- State-funded secondary

## Changes

- Add a new library project `DfE.FindInformationAcademiesTrusts.Data.Hardcoded` which is used to store the hardcoded data and mechanism for accessing that data in our application (`FreeSchoolMealsAverageProvider`)
- Add the Free School Meals Data to a  dictionary in static class `FreeSchoolMealsData` - We have only added the data relevant to our application (see above 4 establishment types)
- Create an enum of Explore Education Statistics types, and access the correct type for a given academy using a switch expression.
- Add Free School Meals razor page and populate table with data from the academies database and hardcoded Explore Education Statistics data.
- Change data type for `PercentageFreeSchoolMeals` on an academy to be of type `double`, to allow for string formatting in the view, and to keep it consistent with the other percentages.

## Screenshots of UI changes

<img width="1425" alt="Screen showing free school meals table" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/daaeda6a-a1cc-4f3d-a3ed-b3fd8dec11d8">

## Checklist

- [x] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [x] Update the ADR decision log if needed
