### PR TITLE
Get Ofsted data from MIS schema

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/AcademiesDbContext.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/AcademiesDbContext.cs
@@ -16,6 +16,7 @@ public interface IAcademiesDbContext
     DbSet<MstrTrust> MstrTrusts { get; }
     DbSet<CdmAccount> CdmAccounts { get; }
     DbSet<MisEstablishment> MisEstablishments { get; }
+    DbSet<MisFurtherEducationEstablishment> MisFurtherEducationEstablishments { get; }
     DbSet<CdmSystemuser> CdmSystemusers { get; }
     DbSet<MstrTrustGovernance> MstrTrustGovernances { get; }
 }
@@ -39,6 +40,7 @@ public class AcademiesDbContext : DbContext, IAcademiesDbContext
     public DbSet<MstrTrust> MstrTrusts { get; set; }
     public DbSet<CdmAccount> CdmAccounts { get; set; }
     public DbSet<MisEstablishment> MisEstablishments { get; set; }
+    public DbSet<MisFurtherEducationEstablishment> MisFurtherEducationEstablishments { get; set; }
     public DbSet<CdmSystemuser> CdmSystemusers { get; set; }
     public DbSet<MstrTrustGovernance> MstrTrustGovernances { get; set; }
 
@@ -1289,7 +1291,57 @@ public class AcademiesDbContext : DbContext, IAcademiesDbContext
                 .HasColumnName("URN at time of the section 8 inspection");
             entity.Property(e => e.WebLink).HasColumnName("Web link");
         });
+        
+        modelBuilder.Entity<MisFurtherEducationEstablishment>(entity =>
+        {
+            entity.HasKey(e => e.ProviderUrn).HasName("PK_ManagementInformationFurtherEducationSchoolTableData");
 
+            entity.ToTable("FurtherEducationEstablishments", "mis");
+
+            entity.Property(e => e.ProviderUrn)
+                .ValueGeneratedNever()
+                .HasColumnName("Provider URN");
+            entity.Property(e => e.BehaviourAndAttitudes).HasColumnName("Behaviour and attitudes");
+            entity.Property(e => e.BehaviourAndAttitudesRaw).HasColumnName("Behaviour and attitudes RAW");
+            entity.Property(e => e.DateOfLatestShortInspection).HasColumnName("Date of latest short inspection");
+            entity.Property(e => e.DatePublished).HasColumnName("Date published");
+            entity.Property(e => e.EffectivenessOfLeadershipAndManagement).HasColumnName("Effectiveness of leadership and management");
+            entity.Property(e => e.EffectivenessOfLeadershipAndManagementRaw).HasColumnName("Effectiveness of leadership and management RAW");
+            entity.Property(e => e.FirstDayOfInspection).HasColumnName("First day of inspection");
+            entity.Property(e => e.ImprovedDeclinedStayedTheSame).HasColumnName("Improved/ declined/ stayed the same");
+            entity.Property(e => e.InspectionNumber).HasColumnName("Inspection number");
+            entity.Property(e => e.InspectionType).HasColumnName("Inspection type");
+            entity.Property(e => e.IsSafeguardingEffective).HasColumnName("Is safeguarding effective?");
+            entity.Property(e => e.LastDayOfInspection).HasColumnName("Last day of Inspection");
+            entity.Property(e => e.LocalAuthority).HasColumnName("Local authority");
+            entity.Property(e => e.NumberOfShortInspectionsSinceLastFullInspection).HasColumnName("Number of short inspections since last full inspection");
+            entity.Property(e => e.NumberOfShortInspectionsSinceLastFullInspectionRaw).HasColumnName("Number of short inspections since last full inspection RAW");
+            entity.Property(e => e.OfstedRegion).HasColumnName("Ofsted region");
+            entity.Property(e => e.OverallEffectiveness).HasColumnName("Overall effectiveness");
+            entity.Property(e => e.OverallEffectivenessRaw).HasColumnName("Overall effectiveness RAW");
+            entity.Property(e => e.PersonalDevelopment).HasColumnName("Personal development");
+            entity.Property(e => e.PersonalDevelopmentRaw).HasColumnName("Personal development RAW");
+            entity.Property(e => e.PreviousBehaviourAndAttitudes).HasColumnName("Previous behaviour and attitudes");
+            entity.Property(e => e.PreviousBehaviourAndAttitudesRaw).HasColumnName("Previous behaviour and attitudes RAW");
+            entity.Property(e => e.PreviousEffectivenessOfLeadershipAndManagement).HasColumnName("Previous effectiveness of leadership and management");
+            entity.Property(e => e.PreviousEffectivenessOfLeadershipAndManagementRaw).HasColumnName("Previous effectiveness of leadership and management RAW");
+            entity.Property(e => e.PreviousInspectionNumber).HasColumnName("Previous inspection number");
+            entity.Property(e => e.PreviousLastDayOfInspection).HasColumnName("Previous last day of inspection");
+            entity.Property(e => e.PreviousOverallEffectiveness).HasColumnName("Previous overall effectiveness");
+            entity.Property(e => e.PreviousOverallEffectivenessRaw).HasColumnName("Previous overall effectiveness RAW");
+            entity.Property(e => e.PreviousPersonalDevelopment).HasColumnName("Previous personal development");
+            entity.Property(e => e.PreviousPersonalDevelopmentRaw).HasColumnName("Previous personal development RAW");
+            entity.Property(e => e.PreviousQualityOfEducation).HasColumnName("Previous quality of education");
+            entity.Property(e => e.PreviousQualityOfEducationRaw).HasColumnName("Previous quality of education RAW");
+            entity.Property(e => e.PreviousSafeguarding).HasColumnName("Previous safeguarding");
+            entity.Property(e => e.ProviderGroup).HasColumnName("Provider group");
+            entity.Property(e => e.ProviderName).HasColumnName("Provider name");
+            entity.Property(e => e.ProviderType).HasColumnName("Provider type");
+            entity.Property(e => e.ProviderUkprn).HasColumnName("Provider UKPRN");
+            entity.Property(e => e.QualityOfEducation).HasColumnName("Quality of education");
+            entity.Property(e => e.QualityOfEducationRaw).HasColumnName("Quality of education RAW");
+        });
+                
         modelBuilder.Entity<CdmSystemuser>(entity =>
         {
             entity

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/AcademyFactory.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/AcademyFactory.cs
@@ -7,13 +7,13 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
 
 public interface IAcademyFactory
 {
-    Academy CreateAcademyFrom(GiasGroupLink gl, GiasEstablishment giasEstablishment,
+    Academy CreateFrom(GiasGroupLink gl, GiasEstablishment giasEstablishment,
         MisEstablishment? misEstablishment, MisFurtherEducationEstablishment? misFurtherEducationEstablishment);
 }
 
 public class AcademyFactory : IAcademyFactory
 {
-    public Academy CreateAcademyFrom(GiasGroupLink gl, GiasEstablishment giasEstablishment,
+    public Academy CreateFrom(GiasGroupLink gl, GiasEstablishment giasEstablishment,
         MisEstablishment? misEstablishment, MisFurtherEducationEstablishment? misFurtherEducationEstablishment)
     {
         return new Academy(

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/AcademyFactory.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/AcademyFactory.cs
@@ -1,18 +1,34 @@
 using System.Globalization;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Extensions;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
 
 public interface IAcademyFactory
 {
-    Academy CreateAcademyFrom(GiasGroupLink gl, GiasEstablishment giasEstablishment);
+    Academy CreateAcademyFrom(GiasGroupLink gl, GiasEstablishment giasEstablishment,
+        MisEstablishment? misEstablishment);
 }
 
 public class AcademyFactory : IAcademyFactory
 {
-    public Academy CreateAcademyFrom(GiasGroupLink gl, GiasEstablishment giasEstablishment)
+    public Academy CreateAcademyFrom(GiasGroupLink gl, GiasEstablishment giasEstablishment,
+        MisEstablishment? misEstablishment = null)
     {
+        OfstedRating currentOfstedRating;
+        if (misEstablishment is not null)
+        {
+            currentOfstedRating = new OfstedRating(
+                (OfstedRatingScore)misEstablishment.OverallEffectiveness!.Value,
+                DateTime.ParseExact(misEstablishment.InspectionEndDate!, "dd/MM/yyyy", CultureInfo.InvariantCulture)
+            );
+        }
+        else
+        {
+            currentOfstedRating = OfstedRating.None;
+        }
+
         return new Academy(
             giasEstablishment.Urn,
             DateTime.ParseExact(gl.JoinedDate!, "dd/MM/yyyy", CultureInfo.InvariantCulture),
@@ -25,10 +41,7 @@ public class AcademyFactory : IAcademyFactory
             giasEstablishment.SchoolCapacity.ParseAsNullableInt(),
             giasEstablishment.PercentageFsm,
             new AgeRange(giasEstablishment.StatutoryLowAge!, giasEstablishment.StatutoryHighAge!),
-            giasEstablishment.OfstedRatingName != null
-                ? new OfstedRating(giasEstablishment.OfstedRatingName,
-                    giasEstablishment.OfstedLastInsp.ParseAsNullableDate())
-                : null,
+            currentOfstedRating,
             null
         );
     }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Mis/MisFurtherEducationEstablishment.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Mis/MisFurtherEducationEstablishment.cs
@@ -1,0 +1,89 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis;
+
+[ExcludeFromCodeCoverage] // Database model POCO
+public class MisFurtherEducationEstablishment
+{
+    public int ProviderUrn { get; set; }
+
+    public int? ProviderUkprn { get; set; }
+
+    public string? ProviderName { get; set; }
+
+    public string? ProviderType { get; set; }
+
+    public string? ProviderGroup { get; set; }
+
+    public string? LocalAuthority { get; set; }
+
+    public string? Region { get; set; }
+
+    public string? OfstedRegion { get; set; }
+
+    public string? DateOfLatestShortInspection { get; set; }
+
+    public string? NumberOfShortInspectionsSinceLastFullInspectionRaw { get; set; }
+
+    public int? NumberOfShortInspectionsSinceLastFullInspection { get; set; }
+
+    public string? InspectionNumber { get; set; }
+
+    public string? InspectionType { get; set; }
+
+    public string? FirstDayOfInspection { get; set; }
+
+    public string? LastDayOfInspection { get; set; }
+
+    public string? DatePublished { get; set; }
+
+    public string? OverallEffectivenessRaw { get; set; }
+
+    public int? OverallEffectiveness { get; set; }
+
+    public string? QualityOfEducationRaw { get; set; }
+
+    public int? QualityOfEducation { get; set; }
+
+    public string? BehaviourAndAttitudesRaw { get; set; }
+
+    public int? BehaviourAndAttitudes { get; set; }
+
+    public string? PersonalDevelopmentRaw { get; set; }
+
+    public int? PersonalDevelopment { get; set; }
+
+    public string? EffectivenessOfLeadershipAndManagementRaw { get; set; }
+
+    public int? EffectivenessOfLeadershipAndManagement { get; set; }
+
+    public string? IsSafeguardingEffective { get; set; }
+
+    public string? PreviousInspectionNumber { get; set; }
+
+    public string? PreviousLastDayOfInspection { get; set; }
+
+    public string? PreviousOverallEffectivenessRaw { get; set; }
+
+    public int? PreviousOverallEffectiveness { get; set; }
+
+    public string? PreviousQualityOfEducationRaw { get; set; }
+
+    public int? PreviousQualityOfEducation { get; set; }
+
+    public string? PreviousBehaviourAndAttitudesRaw { get; set; }
+
+    public int? PreviousBehaviourAndAttitudes { get; set; }
+
+    public string? PreviousPersonalDevelopmentRaw { get; set; }
+
+    public int? PreviousPersonalDevelopment { get; set; }
+
+    public string? PreviousEffectivenessOfLeadershipAndManagementRaw { get; set; }
+
+    public int? PreviousEffectivenessOfLeadershipAndManagement { get; set; }
+
+    public string? PreviousSafeguarding { get; set; }
+
+    public string? ImprovedDeclinedStayedTheSame { get; set; }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
@@ -82,8 +82,12 @@ public class TrustProvider : ITrustProvider
                     _academyFactory.CreateFrom(
                         gl,
                         _academiesDbContext.GiasEstablishments.First(e => e.Urn.ToString() == gl.Urn),
-                        _academiesDbContext.MisEstablishments.FirstOrDefault(me => me.Urn.ToString() == gl.Urn),
-                        null)
+                        _academiesDbContext.MisEstablishments.FirstOrDefault(me =>
+                            me.UrnAtTimeOfLatestFullInspection.ToString() == gl.Urn),
+                        _academiesDbContext.MisEstablishments.FirstOrDefault(me =>
+                            me.UrnAtTimeOfPreviousFullInspection.ToString() == gl.Urn),
+                        _academiesDbContext.MisFurtherEducationEstablishments.FirstOrDefault(mfe =>
+                            mfe.ProviderUrn.ToString() == gl.Urn))
             )
             .ToArrayAsync();
     }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
@@ -80,7 +80,7 @@ public class TrustProvider : ITrustProvider
             .Join(_academiesDbContext.GiasEstablishments,
                 gl => gl.Urn!,
                 e => e.Urn.ToString(),
-                (gl, e) => _academyFactory.CreateAcademyFrom(gl, e, null))
+                (gl, e) => _academyFactory.CreateAcademyFrom(gl, e, null, null))
             .ToArrayAsync();
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
@@ -77,10 +77,14 @@ public class TrustProvider : ITrustProvider
     {
         return await _academiesDbContext
             .GiasGroupLinks.Where(gl => gl.GroupUid == uid && gl.Urn != null)
-            .Join(_academiesDbContext.GiasEstablishments,
-                gl => gl.Urn!,
-                e => e.Urn.ToString(),
-                (gl, e) => _academyFactory.CreateFrom(gl, e, null, null))
+            .Select(
+                gl =>
+                    _academyFactory.CreateFrom(
+                        gl,
+                        _academiesDbContext.GiasEstablishments.First(e => e.Urn.ToString() == gl.Urn),
+                        _academiesDbContext.MisEstablishments.FirstOrDefault(me => me.Urn.ToString() == gl.Urn),
+                        null)
+            )
             .ToArrayAsync();
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
@@ -80,7 +80,7 @@ public class TrustProvider : ITrustProvider
             .Join(_academiesDbContext.GiasEstablishments,
                 gl => gl.Urn!,
                 e => e.Urn.ToString(),
-                (gl, e) => _academyFactory.CreateAcademyFrom(gl, e, null, null))
+                (gl, e) => _academyFactory.CreateFrom(gl, e, null, null))
             .ToArrayAsync();
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/TrustProvider.cs
@@ -80,7 +80,7 @@ public class TrustProvider : ITrustProvider
             .Join(_academiesDbContext.GiasEstablishments,
                 gl => gl.Urn!,
                 e => e.Urn.ToString(),
-                (gl, e) => _academyFactory.CreateAcademyFrom(gl, e))
+                (gl, e) => _academyFactory.CreateAcademyFrom(gl, e, null))
             .ToArrayAsync();
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Academy.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Academy.cs
@@ -12,7 +12,7 @@ public record Academy(
     int? SchoolCapacity,
     string? PercentageFreeSchoolMeals,
     AgeRange AgeRange,
-    OfstedRating? CurrentOfstedRating,
+    OfstedRating CurrentOfstedRating,
     OfstedRating? PreviousOfstedRating)
 {
     public float? PercentageFull

--- a/DfE.FindInformationAcademiesTrusts.Data/Academy.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Academy.cs
@@ -13,7 +13,7 @@ public record Academy(
     string? PercentageFreeSchoolMeals,
     AgeRange AgeRange,
     OfstedRating CurrentOfstedRating,
-    OfstedRating? PreviousOfstedRating)
+    OfstedRating PreviousOfstedRating)
 {
     public float? PercentageFull
     {

--- a/DfE.FindInformationAcademiesTrusts.Data/OfstedRating.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/OfstedRating.cs
@@ -1,3 +1,15 @@
 namespace DfE.FindInformationAcademiesTrusts.Data;
 
-public record OfstedRating(string OfstedRatingScore, DateTime? InspectionEndDate);
+public record OfstedRating(OfstedRatingScore OfstedRatingScore, DateTime? InspectionEndDate)
+{
+    public static readonly OfstedRating None = new(OfstedRatingScore.None, null);
+}
+
+public enum OfstedRatingScore
+{
+    None = -1,
+    Outstanding = 1,
+    Good = 2,
+    RequiresImprovement = 3,
+    Inadequate = 4
+}

--- a/docs/adrs/0007-use-mis-for-ofsted-data.md
+++ b/docs/adrs/0007-use-mis-for-ofsted-data.md
@@ -1,0 +1,23 @@
+# 7. Use MIS schema for Ofsted data
+
+Date: 2023-12-13
+
+## Status
+
+Accepted
+
+## Context
+
+We need to show previous and current Ofsted ratings to our users. GIAS gives us some information about current ratings but nothing about previous ratings. GIAS sometimes splits the "inadequate rating" into "special measures" and "serious weaknesses" and also stores the value as a descriptive string which is less useful to us than the raw numerical value.
+
+The only source of previous Ofsted ratings currently available to us is the MIS schema in the academies db (which reflects "State-funded school inspections and outcomes: management information" system) which contains both the information we need now and further information we may potentially require in the future.
+
+## Decision
+
+We've chose to use the MIS schema for both current and previous Ofsted ratings.
+
+We've chosen to use it as our source for current Ofsted data (instead of GIAS) partially for data source consistency, partially because there is scope to extend and take other values from the tables and partially because there is less processing of the scores.
+
+## Consequences
+
+Find information about academies and trusts is reliant on State-funded school inspections and outcomes: management information as a data source.

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/AcademiesDbData.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/AcademiesDbData.cs
@@ -16,13 +16,14 @@ public class AcademiesDbData
     public List<GiasGroupLink> GiasGroupLinks { get; } = new();
     public List<GiasGroup> GiasGroups { get; } = new();
     public List<MisEstablishment> MisEstablishments { get; } = new();
+    public List<MisFurtherEducationEstablishment> MisFurtherEducationEstablishments { get; } = new();
     public List<MstrTrust> MstrTrusts { get; } = new();
     public List<MstrTrustGovernance> MstrTrustGovernances { get; } = new();
 
     public IAcademiesDbContext AsAcademiesDbContext()
     {
         return new AcademiesDbDataContext(GiasEstablishments, GiasGovernances, GiasGroupLinks, GiasGroups, MstrTrusts,
-            CdmAccounts, MisEstablishments, CdmSystemusers, MstrTrustGovernances);
+            CdmAccounts, MisEstablishments, MisFurtherEducationEstablishments, CdmSystemusers, MstrTrustGovernances);
     }
 
     private class AcademiesDbDataContext : IAcademiesDbContext
@@ -34,6 +35,7 @@ public class AcademiesDbData
         public DbSet<MstrTrust> MstrTrusts { get; }
         public DbSet<CdmAccount> CdmAccounts { get; }
         public DbSet<MisEstablishment> MisEstablishments { get; }
+        public DbSet<MisFurtherEducationEstablishment> MisFurtherEducationEstablishments { get; }
         public DbSet<CdmSystemuser> CdmSystemusers { get; }
         public DbSet<MstrTrustGovernance> MstrTrustGovernances { get; }
 
@@ -45,6 +47,7 @@ public class AcademiesDbData
             IEnumerable<MstrTrust> mstrTrusts,
             IEnumerable<CdmAccount> cdmAccounts,
             IEnumerable<MisEstablishment> misEstablishments,
+            IEnumerable<MisFurtherEducationEstablishment> misFurtherEducationEstablishment,
             IEnumerable<CdmSystemuser> cdmSystemusers,
             IEnumerable<MstrTrustGovernance> mstrTrustGovernances)
         {
@@ -55,6 +58,8 @@ public class AcademiesDbData
             MstrTrusts = new MockDbSet<MstrTrust>(mstrTrusts).Object;
             CdmAccounts = new MockDbSet<CdmAccount>(cdmAccounts).Object;
             MisEstablishments = new MockDbSet<MisEstablishment>(misEstablishments).Object;
+            MisFurtherEducationEstablishments =
+                new MockDbSet<MisFurtherEducationEstablishment>(misFurtherEducationEstablishment).Object;
             CdmSystemusers = new MockDbSet<CdmSystemuser>(cdmSystemusers).Object;
             MstrTrustGovernances = new MockDbSet<MstrTrustGovernance>(mstrTrustGovernances).Object;
         }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/AcademyFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/AcademyFactoryTests.cs
@@ -43,7 +43,7 @@ public class AcademyFactoryTests
             StatutoryHighAge = "11"
         };
 
-        var result = _sut.CreateAcademyFrom(_giasGroupLink, giasEstablishment, null, null);
+        var result = _sut.CreateFrom(_giasGroupLink, giasEstablishment, null, null);
 
         result.Urn.Should().Be(1234);
         result.DateAcademyJoinedTrust.Should().Be(new DateTime(2023, 11, 16));
@@ -62,7 +62,7 @@ public class AcademyFactoryTests
     public void CreateAcademyFrom_should_set_DateAcademyJoinedTrust_from_giasGroupLink()
     {
         var groupLink = new GiasGroupLink { JoinedDate = "12/01/2022" };
-        var result = _sut.CreateAcademyFrom(groupLink, _giasEstablishment, null, null);
+        var result = _sut.CreateFrom(groupLink, _giasEstablishment, null, null);
 
         result.DateAcademyJoinedTrust.Should().Be(new DateTime(2022, 1, 12));
     }
@@ -71,7 +71,7 @@ public class AcademyFactoryTests
     public void
         CreateAcademyFrom_should_set_current_ofsted_to_none_if_no_misEstablishment_and_no_misFurtherEducationEstablishment()
     {
-        var result = _sut.CreateAcademyFrom(_giasGroupLink, _giasEstablishment, null, null);
+        var result = _sut.CreateFrom(_giasGroupLink, _giasEstablishment, null, null);
 
         result.CurrentOfstedRating.OfstedRatingScore.Should().Be(OfstedRatingScore.None);
         result.CurrentOfstedRating.InspectionEndDate.Should().BeNull();
@@ -93,7 +93,7 @@ public class AcademyFactoryTests
             OverallEffectiveness = score
         };
 
-        var result = _sut.CreateAcademyFrom(_giasGroupLink, _giasEstablishment, misEstablishment, null);
+        var result = _sut.CreateFrom(_giasGroupLink, _giasEstablishment, misEstablishment, null);
 
         result.CurrentOfstedRating.Should().NotBeNull();
         result.CurrentOfstedRating.OfstedRatingScore.Should().Be(expectedScore);
@@ -115,7 +115,7 @@ public class AcademyFactoryTests
             OverallEffectiveness = 1
         };
 
-        var result = _sut.CreateAcademyFrom(_giasGroupLink, _giasEstablishment, misEstablishment, null);
+        var result = _sut.CreateFrom(_giasGroupLink, _giasEstablishment, misEstablishment, null);
 
         result.CurrentOfstedRating.Should().NotBeNull();
         result.CurrentOfstedRating.InspectionEndDate.Should().Be(new DateTime(year, month, day));
@@ -138,7 +138,7 @@ public class AcademyFactoryTests
             OverallEffectiveness = score
         };
 
-        var result = _sut.CreateAcademyFrom(_giasGroupLink, _giasEstablishment, null, misFurtherEducationEstablishment);
+        var result = _sut.CreateFrom(_giasGroupLink, _giasEstablishment, null, misFurtherEducationEstablishment);
 
         result.CurrentOfstedRating.Should().NotBeNull();
         result.CurrentOfstedRating.OfstedRatingScore.Should().Be(expectedScore);
@@ -161,7 +161,7 @@ public class AcademyFactoryTests
             OverallEffectiveness = 1
         };
 
-        var result = _sut.CreateAcademyFrom(_giasGroupLink, _giasEstablishment, null, misFurtherEducationEstablishment);
+        var result = _sut.CreateFrom(_giasGroupLink, _giasEstablishment, null, misFurtherEducationEstablishment);
 
         result.CurrentOfstedRating.Should().NotBeNull();
         result.CurrentOfstedRating.InspectionEndDate.Should().Be(new DateTime(year, month, day));

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/AcademyFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/AcademyFactoryTests.cs
@@ -1,11 +1,29 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Factories;
 
 public class AcademyFactoryTests
 {
     private readonly AcademyFactory _sut = new();
+
+    private readonly GiasEstablishment _giasEstablishment = new()
+    {
+        Urn = 1234,
+        EstablishmentName = "trust 1",
+        TypeOfEstablishmentName = "Academy sponsor led",
+        LaName = "my la",
+        UrbanRuralName = "urban",
+        PhaseOfEducationName = "Primary",
+        NumberOfPupils = "999",
+        SchoolCapacity = "1000",
+        PercentageFsm = "30.40",
+        StatutoryLowAge = "5",
+        StatutoryHighAge = "11"
+    };
+
+    private readonly GiasGroupLink _giasGroupLink = new() { JoinedDate = "16/11/2023" };
 
     [Fact]
     public void CreateAcademyFrom_should_transform_a_giasEstablishment_into_an_academy()
@@ -22,28 +40,81 @@ public class AcademyFactoryTests
             SchoolCapacity = "1000",
             PercentageFsm = "30.40",
             StatutoryLowAge = "5",
-            StatutoryHighAge = "11",
-            OfstedLastInsp = "16-11-2023",
-            OfstedRatingName = "Good"
+            StatutoryHighAge = "11"
         };
 
-        var result = _sut.CreateAcademyFrom(new GiasGroupLink { JoinedDate = "16/11/2023" }, giasEstablishment);
+        var result = _sut.CreateAcademyFrom(_giasGroupLink, giasEstablishment);
 
-        result.Should().BeEquivalentTo(new Academy(
-                1234,
-                new DateTime(2023, 11, 16),
-                "trust 1",
-                "Academy sponsor led",
-                "my la",
-                "urban",
-                "Primary",
-                999,
-                1000,
-                "30.40",
-                new AgeRange(5, 11),
-                new OfstedRating("Good", new DateTime(2023, 11, 16)),
-                null
-            )
-        );
+        result.Urn.Should().Be(1234);
+        result.DateAcademyJoinedTrust.Should().Be(new DateTime(2023, 11, 16));
+        result.EstablishmentName.Should().Be("trust 1");
+        result.TypeOfEstablishment.Should().Be("Academy sponsor led");
+        result.LocalAuthority.Should().Be("my la");
+        result.UrbanRural.Should().Be("urban");
+        result.PhaseOfEducation.Should().Be("Primary");
+        result.NumberOfPupils.Should().Be(999);
+        result.SchoolCapacity.Should().Be(1000);
+        result.PercentageFreeSchoolMeals.Should().Be("30.40");
+        result.AgeRange.Should().Be(new AgeRange(5, 11));
+    }
+
+    [Fact]
+    public void CreateAcademyFrom_should_set_DateAcademyJoinedTrust_from_giasGroupLink()
+    {
+        var groupLink = new GiasGroupLink { JoinedDate = "12/01/2022" };
+        var result = _sut.CreateAcademyFrom(groupLink, _giasEstablishment);
+
+        result.DateAcademyJoinedTrust.Should().Be(new DateTime(2022, 1, 12));
+    }
+
+    [Fact]
+    public void CreateAcademyFrom_should_set_current_ofsted_to_none_if_no_misEstablishment()
+    {
+        var result = _sut.CreateAcademyFrom(_giasGroupLink, _giasEstablishment);
+
+        result.CurrentOfstedRating.OfstedRatingScore.Should().Be(OfstedRatingScore.None);
+        result.CurrentOfstedRating.InspectionEndDate.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(1, OfstedRatingScore.Outstanding)]
+    [InlineData(2, OfstedRatingScore.Good)]
+    [InlineData(3, OfstedRatingScore.RequiresImprovement)]
+    [InlineData(4, OfstedRatingScore.Inadequate)]
+    public void CreateAcademyFrom_should_create_current_ofsted_rating_score_from_misEstablishment(int score,
+        OfstedRatingScore expectedScore)
+    {
+        var misEstablishment = new MisEstablishment
+        {
+            UrnAtTimeOfLatestFullInspection = _giasEstablishment.Urn,
+            InspectionEndDate = "11/05/2022",
+            OverallEffectiveness = score
+        };
+
+        var result = _sut.CreateAcademyFrom(_giasGroupLink, _giasEstablishment, misEstablishment);
+
+        result.CurrentOfstedRating.Should().NotBeNull();
+        result.CurrentOfstedRating.OfstedRatingScore.Should().Be(expectedScore);
+    }
+
+    [Theory]
+    [InlineData(2022, 12, 1)]
+    [InlineData(2022, 1, 12)]
+    [InlineData(2023, 6, 6)]
+    [InlineData(2020, 2, 29)]
+    public void CreateAcademyFrom_should_create_current_ofsted_rating_date_from_misEstablishment(int year, int month,
+        int day)
+    {
+        var misEstablishment = new MisEstablishment
+        {
+            UrnAtTimeOfLatestFullInspection = _giasEstablishment.Urn,
+            InspectionEndDate = $"{day:00}/{month:00}/{year}",
+            OverallEffectiveness = 1
+        };
+
+        var result = _sut.CreateAcademyFrom(_giasGroupLink, _giasEstablishment, misEstablishment);
+
+        result.CurrentOfstedRating.Should().NotBeNull();
+        result.CurrentOfstedRating.InspectionEndDate.Should().Be(new DateTime(year, month, day));
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -11,6 +11,7 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
 {
     private readonly List<GiasGroupLink> _giasGroupLinks = new();
     private readonly List<MisEstablishment> _misEstablishments = new();
+    private readonly List<MisFurtherEducationEstablishment> _misFurtherEducationEstablishments = new();
     private readonly List<CdmSystemuser> _cdmSystemusers = new();
     private readonly List<CdmAccount> _cdmAccounts = new();
     private List<GiasGroup>? _addedGiasGroups;
@@ -22,6 +23,8 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
             .Returns(new MockDbSet<GiasGroupLink>(_giasGroupLinks).Object);
         Setup(academiesDbContext => academiesDbContext.MisEstablishments)
             .Returns(new MockDbSet<MisEstablishment>(_misEstablishments).Object);
+        Setup(academiesDbContext => academiesDbContext.MisFurtherEducationEstablishments)
+            .Returns(new MockDbSet<MisFurtherEducationEstablishment>(_misFurtherEducationEstablishments).Object);
         Setup(academiesDbContext => academiesDbContext.CdmSystemusers)
             .Returns(new MockDbSet<CdmSystemuser>(_cdmSystemusers).Object);
         Setup(academiesDbContext => academiesDbContext.CdmAccounts)
@@ -152,7 +155,7 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
         return establishmentGroupLinks;
     }
 
-    public List<MisEstablishment> CreateMisEstablishments(
+    public List<MisEstablishment> CreateCurrentMisEstablishments(
         IEnumerable<GiasEstablishment> giasEstablishmentsLinkedToTrust)
     {
         var misEstablishments = new List<MisEstablishment>();
@@ -160,12 +163,46 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
         {
             var misEstablishment = new MisEstablishment
             {
-                Urn = giasEstablishment.Urn
+                UrnAtTimeOfLatestFullInspection = giasEstablishment.Urn
             };
             _misEstablishments.Add(misEstablishment);
             misEstablishments.Add(misEstablishment);
         }
 
         return misEstablishments;
+    }
+
+    public List<MisEstablishment> CreatePreviousMisEstablishments(
+        IEnumerable<GiasEstablishment> giasEstablishmentsLinkedToTrust)
+    {
+        var misEstablishments = new List<MisEstablishment>();
+        foreach (var giasEstablishment in giasEstablishmentsLinkedToTrust)
+        {
+            var misEstablishment = new MisEstablishment
+            {
+                UrnAtTimeOfPreviousFullInspection = giasEstablishment.Urn
+            };
+            _misEstablishments.Add(misEstablishment);
+            misEstablishments.Add(misEstablishment);
+        }
+
+        return misEstablishments;
+    }
+
+    public List<MisFurtherEducationEstablishment> CreateMisFurtherEducationEstablishments(
+        GiasEstablishment[] giasEstablishmentsLinkedToTrust)
+    {
+        var misFurtherEducationEstablishments = new List<MisFurtherEducationEstablishment>();
+        foreach (var giasEstablishment in giasEstablishmentsLinkedToTrust)
+        {
+            var misFurtherEducationEstablishment = new MisFurtherEducationEstablishment
+            {
+                ProviderUrn = giasEstablishment.Urn
+            };
+            _misFurtherEducationEstablishments.Add(misFurtherEducationEstablishment);
+            misFurtherEducationEstablishments.Add(misFurtherEducationEstablishment);
+        }
+
+        return misFurtherEducationEstablishments;
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Cdm;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
 using Microsoft.EntityFrameworkCore;
 
@@ -9,6 +10,7 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
 {
     private readonly List<GiasGroupLink> _giasGroupLinks = new();
+    private readonly List<MisEstablishment> _misEstablishments = new();
     private readonly List<CdmSystemuser> _cdmSystemusers = new();
     private readonly List<CdmAccount> _cdmAccounts = new();
     private List<GiasGroup>? _addedGiasGroups;
@@ -18,6 +20,8 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
     {
         Setup(academiesDbContext => academiesDbContext.GiasGroupLinks)
             .Returns(new MockDbSet<GiasGroupLink>(_giasGroupLinks).Object);
+        Setup(academiesDbContext => academiesDbContext.MisEstablishments)
+            .Returns(new MockDbSet<MisEstablishment>(_misEstablishments).Object);
         Setup(academiesDbContext => academiesDbContext.CdmSystemusers)
             .Returns(new MockDbSet<CdmSystemuser>(_cdmSystemusers).Object);
         Setup(academiesDbContext => academiesDbContext.CdmAccounts)
@@ -146,5 +150,22 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
         }
 
         return establishmentGroupLinks;
+    }
+
+    public List<MisEstablishment> CreateMisEstablishments(
+        IEnumerable<GiasEstablishment> giasEstablishmentsLinkedToTrust)
+    {
+        var misEstablishments = new List<MisEstablishment>();
+        foreach (var giasEstablishment in giasEstablishmentsLinkedToTrust)
+        {
+            var misEstablishment = new MisEstablishment
+            {
+                Urn = giasEstablishment.Urn
+            };
+            _misEstablishments.Add(misEstablishment);
+            misEstablishments.Add(misEstablishment);
+        }
+
+        return misEstablishments;
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
@@ -200,7 +200,7 @@ public class TrustProviderTests
         foreach (var (giasEstablishment, giasGroupLink) in establishmentGroupLinks)
         {
             var dummyAcademy = DummyAcademyFactory.GetDummyAcademy(giasEstablishment.Urn);
-            _mockAcademyFactory.Setup(a => a.CreateAcademyFrom(giasGroupLink, giasEstablishment, null))
+            _mockAcademyFactory.Setup(a => a.CreateAcademyFrom(giasGroupLink, giasEstablishment, null, null))
                 .Returns(dummyAcademy);
             academiesLinkedToTrust.Add(dummyAcademy);
         }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
@@ -200,7 +200,7 @@ public class TrustProviderTests
         foreach (var (giasEstablishment, giasGroupLink) in establishmentGroupLinks)
         {
             var dummyAcademy = DummyAcademyFactory.GetDummyAcademy(giasEstablishment.Urn);
-            _mockAcademyFactory.Setup(a => a.CreateAcademyFrom(giasGroupLink, giasEstablishment, null, null))
+            _mockAcademyFactory.Setup(a => a.CreateFrom(giasGroupLink, giasEstablishment, null, null))
                 .Returns(dummyAcademy);
             academiesLinkedToTrust.Add(dummyAcademy);
         }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustProviderTests.cs
@@ -200,7 +200,7 @@ public class TrustProviderTests
         foreach (var (giasEstablishment, giasGroupLink) in establishmentGroupLinks)
         {
             var dummyAcademy = DummyAcademyFactory.GetDummyAcademy(giasEstablishment.Urn);
-            _mockAcademyFactory.Setup(a => a.CreateAcademyFrom(giasGroupLink, giasEstablishment))
+            _mockAcademyFactory.Setup(a => a.CreateAcademyFrom(giasGroupLink, giasEstablishment, null))
                 .Returns(dummyAcademy);
             academiesLinkedToTrust.Add(dummyAcademy);
         }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyAcademyFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyAcademyFactory.cs
@@ -30,9 +30,7 @@ public class DummyAcademyFactory
         int? numberOfPupils = 300,
         int? schoolCapacity = 400,
         string? percentageFreeSchoolMeals = "test",
-        AgeRange? ageRange = null,
-        OfstedRating? currentOfstedRating = null,
-        OfstedRating? previousOfstedRating = null)
+        AgeRange? ageRange = null)
     {
         return new Academy(urn,
             new DateTime(2023, 11, 16),
@@ -45,7 +43,7 @@ public class DummyAcademyFactory
             schoolCapacity,
             percentageFreeSchoolMeals,
             ageRange ?? new AgeRange(1, 11),
-            currentOfstedRating,
-            previousOfstedRating);
+            OfstedRating.None,
+            OfstedRating.None);
     }
 }


### PR DESCRIPTION
This PR brings in Ofsted data from the MIS schema in Academies db.

The MIS schema is our only source of previous ofsted data which is a requirement for our application.
We've chosen to also use it as our source for current Ofsted data (instead of GIAS) partially for data source consistency, partially because there is scope to extend and take other values from the tables and partially because there is less processing of the scores. GIAS sometimes splits the "inadequate rating" into "special measures" and "serious weaknesses" and also stores the value as a descriptive string rather than the numerical rating we require for sorting.

[User Story 146083](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/146083): Build: Get all the data we need from Academies DB for MVP

## Changes

- Add `MisFurtherEducationEstablishment` table
- Utilise the `MIS` schema for Ofsted ratings
- Change the `OfstedRating` record to use an enum and have a concept of `None` which prevents us needing to use it as a nullable type

## Checklist

- [n/a] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [x] Update the ADR decision log if needed
