### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ We are a tool for everyone in DfE to find information which is collated from mul
 ## Developer set up
 - [Get started](docs/getting-started.md)
 - [Run tests locally](docs/run-tests-locally.md)
-- [Supercharge your dev environment](docs/supercharge-your-dev-environment.md)
+- [Supercharge your dev environment](docs/supercharge-your-dev-environment.md) (Test coverage and linting)
 - [Update test data](docs/update-test-data.md)
 - [Enable Application Insights](docs/application-insights.md)
 

--- a/docs/adrs/0005-do-not-run-automated-ui-tests-on-webkit.md
+++ b/docs/adrs/0005-do-not-run-automated-ui-tests-on-webkit.md
@@ -1,4 +1,4 @@
-# 4. Do not run automated UI tests on Webkit
+# 5. Do not run automated UI tests on Webkit
 
 Date: 2023-12-06
 

--- a/docs/supercharge-your-dev-environment.md
+++ b/docs/supercharge-your-dev-environment.md
@@ -36,21 +36,21 @@ We recommend setting Rider to clean code on save.
 
 - Open settings
 - Configure JavaScript linting
-- Go to Languages & Frameworks -> JavaScript -> Code Quality Tools -> ESLint
-- Select `Manual ESLint configuration`
-- In the dropdown for ESLint package, press the down arrow and select `.../DfE.FindInformationAcademiesTrusts/node_modules/standard`. If nothing is here then ensure you have done an `npm install` in the project directory
-- Tick `Run ESLint --fix on save`
-- Go to Editor > Code style > JavaScript
-- In the top right click `Set from...` and select `JavaScript Standard Style`
+  - Go to Languages & Frameworks -> JavaScript -> Code Quality Tools -> ESLint
+  - Select `Manual ESLint configuration`
+  - In the dropdown for ESLint package, press the down arrow and select `.../DfE.FindInformationAcademiesTrusts/node_modules/standard`. If nothing is here then ensure you have done an `npm install` in the project directory
+  - Tick `Run ESLint --fix on save`
+  - Go to Editor > Code style > JavaScript
+  - In the top right click `Set from...` and select `JavaScript Standard Style`
 - Configure CSS linting
-- Go to Languages & Frameworks -> Style Sheets -> Stylelint
-- Select `Enable`
-- In the dropdown for Stylelint package, press the down arrow and select `.../DfE.FindInformationAcademiesTrusts/node_modules/styleint`. If nothing is here then ensure you have done an `npm install` in the project directory
-- In `Run for files` enter: "{\*_/_,\*}.{css,scss}"
+  - Go to Languages & Frameworks -> Style Sheets -> Stylelint
+  - Select `Enable`
+  - In the dropdown for Stylelint package, press the down arrow and select `.../DfE.FindInformationAcademiesTrusts/node_modules/styleint`. If nothing is here then ensure you have done an `npm install` in the project directory
+  - In `Run for files` enter: "{\*_/_,\*}.{css,scss}"
 - Configure C# linting
-- Go to Tools -> Actions on Save
-- Tick `Reformat and Cleanup Code`
-- Ensure that Profile is set to `DfE.FindInformationAcademiesTrusts`
+  - Go to Tools -> Actions on Save
+  - Tick `Reformat and Cleanup Code`
+  - Ensure that Profile is set to `DfE.FindInformationAcademiesTrusts`
 
 If using Rider or Resharper then the `DfE.FindInformationAcademiesTrusts.sln.DotSettings` should be automatically identified and used for manual C# code cleanup.
 
@@ -58,6 +58,40 @@ You can also run linting on JavaScript, CSS and SCSS files using the command lin
 
 ```bash
 cd DfE.FindInformationAcademiesTrusts
+npm run lint ## for a list of issues
+npm run lint:fix ## to scan and fix issues
+```
+
+### Linting markdown
+
+We use `markdownlint` to check for lint issues on Markdown files in the pipeline.
+You can install the [VS code extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) to check your files locally.
+
+## Playwright tests
+
+We recommend using VS code to write playwright tests, so that you can take advantage of the extension [Playwright Test for VSCode](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright)
+
+### Linting playwright tests
+
+Tests are written in TypeScript and we are using `ts-standard` for linting.
+You can configure VS code to use standard as your default formatter:
+
+1. Install VS code extension [StandardJS - JavaScript Standard Style](https://marketplace.visualstudio.com/items?itemName=standard.vscode-standard)
+
+2. Edit your _Settings.json_ file (workspace or user):
+
+```json
+{
+  "[typescript]": {
+    "editor.defaultFormatter": "standard.vscode-standard"
+  }
+}
+```
+
+Alternatively you can use the CLI to check and fix lint issues:
+
+```bash
+cd tests/playwright
 npm run lint ## for a list of issues
 npm run lint:fix ## to scan and fix issues
 ```

--- a/docs/update-test-data.md
+++ b/docs/update-test-data.md
@@ -2,18 +2,34 @@
 
 Accessibility and UI tests are written using Playwright, with external dependencies (e.g. APIs) mocked using a fake database.
 
-We use a console application to generate test data, which is added to a fake version of the Academies database before [running the tests](run-tests-locally.md#accessibility-and-ui-tests).
+We use a console application to generate test data, which is added to a fake version of the Academies database before [running the tests](run-tests-locally.md#accessibility-and-ui-tests). Playwright tests are run against a saved version of this fake data.
 
-When developing you may need to update and replace this test data—particularly if you are making changes to the `DfE.FindInformationAcademiesTrusts.Data.AcademiesDb` project.
+Random data is generated using a seed, so will not change unless changes are made to the code.
+
+When developing you may need to update and replace this test data if:
+
+- A change is made to models used in the `DfE.FindInformationAcademiesTrusts.Data`, or to the `DfE.FindInformationAcademiesTrusts.Data.AcademiesDb` project.
+- A new data source is added, or we need to generate new test data using the Faker
+
+## When a change is made to production code
+
+If you have made a change to a data model, or to the `AcademiesDb` project, then the data will need updating in our playwright tests directory:
+
+1. Run the Faker project in your IDE
+2. Navigate to the project's run location  (e.g. `bin/Debug/net7.0`) and copy all json files in the new `data/` folder into `~/tests/playwright/fake-data`
+3. Commit the new fake data in the playwright directory
+4. If you are already running your tests locally you will need to stop and start the docker container to recreate the test database: `npm run docker:restart`
+5. Check that the data matches by [re-running the UI tests](run-tests-locally.md#accessibility-and-ui-tests) : `npm run test:ui`
+
+## Updating the Faker with new data
 
 1. Open the Faker project: `tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker`
-2. Add or update the relevant Faker (matching the model you have updated) and add any new Fakers to `Program.cs`
-3. Navigate to the project's run location  (e.g. `bin/Debug/net7.0`) and copy all json files in the new `data/` folder into `~/tests/playwright/fake-data`
-4. Commit both the update to the Faker project and the new fake data in the playwright directory
-5. If you are already running your tests locally you will need to stop and start the docker container to recreate the test database:
-
-```bash
-cd tests/playwright
-npm run docker:stop
-npm run docker:start
-```
+2. Add or update the relevant Faker (matching the model you have updated)
+3. Add any new Fakers to `AcademiesDbFaker` and the `AcademiesDbData` classes
+4. If adding a new Faker, add your new dataset to the `SqlGenerator.cs` > `GenerateSqlInsertScript` method
+5. We recommend testing the generated scripts locally before committing them:
+   - run the Faker project
+   - open the `data/` directory in the project's run location
+   - run the `insertScript.sql` and then `createScript.sql` on a sql server instance
+   - check the tables contain the generated data
+6. Update the data in the `tests/playwright/fake-data` directory using [the steps above](#when-a-change-is-made-to-production-code)


### PR DESCRIPTION
We have noticed a few missing gaps or inaccuracies in our docs, so updating them in this change:

- Additional linting set up for non .NET related files (Playwright tests and markdown files)
- Update docs on how and when to update test data