### PR TITLE
Always use linux/amd64 builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG ASPNET_IMAGE_TAG=7.0-bullseye-slim
+ARG ASPNET_IMAGE_TAG=7.0-bullseye-slim-amd64
 ARG NODEJS_IMAGE_TAG=18-bullseye-slim
 ARG DOTNET_SDK=7.0
 


### PR DESCRIPTION
Without specifying `amd64`, docker will build based on the host arch which on macOS is arm64 which is incompatible with Azure Container Apps
