### PR TITLE
Constrain deployment tests to Dev and Test envs only

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -65,6 +65,7 @@ jobs:
      name: Run deployment tests
      uses: ./.github/workflows/test-deployment.yml
      needs: [ deploy-image, set-env ]
+     if: ${{ needs.set-env.outputs.environment == 'development' || needs.set-env.outputs.environment == 'test' }}
      with:
        environment: ${{ needs.set-env.outputs.environment }}
        branch-name: ${{ needs.set-env.outputs.branch }}


### PR DESCRIPTION
- The playwright tests rely on a test secret which must not be set on the Production environment, therefore it makes sense to only run these tests in Dev / Test environments