### PR TITLE
overview page and unit tests

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
@@ -1,4 +1,5 @@
 ﻿@page
+@using DfE.FindInformationAcademiesTrusts.Data
 @model OverviewModel
 
 @{
@@ -20,7 +21,7 @@
                   Total academies
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  4
+                  @Model.NumberOfAcademiesInTrust
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
@@ -28,8 +29,10 @@
                   Academies in each local authority
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  <p class="govuk-body govuk-!-margin-bottom-1">3 in North Lincolnshire</p>
-                  <p class="govuk-body govuk-!-margin-bottom-1">1 in North East Lincolnshire</p>
+                  @foreach (var (authority, total) in Model.AcademiesInEachLocalAuthority)
+                  {
+                    <p class="govuk-body govuk-!-margin-bottom-1">@total in @authority</p>
+                  }
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
@@ -37,7 +40,7 @@
                   Pupil numbers
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  4,896
+                  @($"{Model.TotalPupilNumbersInTrust:n0}")
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
@@ -45,7 +48,12 @@
                   Pupil capacity <br>(% full)
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  6,463<br>(76%)
+                  @($"{Model.TotalPupilCapacityInTrust:n0}")
+                  @if (Model.TotalPercentageCapacityInTrust is not null)
+                  {
+                    <br>
+                    @($"({Model.TotalPercentageCapacityInTrust}%)")
+                  }
                 </dd>
               </div>
             </dl>
@@ -68,23 +76,23 @@
               <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
                   <td class="govuk-body govuk-table__cell" data-sort-value="1">Outstanding</td>
-                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">3</td>
+                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">@Model.GetNumberOfAcademiesWithOfstedRating(OfstedRatingScore.Outstanding)</td>
                 </tr>
                 <tr class="govuk-table__row">
                   <td class="govuk-body govuk-table__cell" data-sort-value="2">Good</td>
-                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">5</td>
+                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">@Model.GetNumberOfAcademiesWithOfstedRating(OfstedRatingScore.Good)</td>
                 </tr>
                 <tr class="govuk-table__row">
                   <td class="govuk-body govuk-table__cell" data-sort-value="3">Requires improvement</td>
-                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">2</td>
+                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">@Model.GetNumberOfAcademiesWithOfstedRating(OfstedRatingScore.RequiresImprovement)</td>
                 </tr>
                 <tr class="govuk-table__row">
                   <td class="govuk-body govuk-table__cell" data-sort-value="4">Inadequate</td>
-                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">3</td>
+                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">@Model.GetNumberOfAcademiesWithOfstedRating(OfstedRatingScore.Inadequate)</td>
                 </tr>
                 <tr class="govuk-table__row">
                   <td class="govuk-body govuk-table__cell" data-sort-value="5">Not yet inspected</td>
-                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">4</td>
+                  <td class="govuk-body govuk-table__cell govuk-table__cell--numeric">@Model.GetNumberOfAcademiesWithOfstedRating(OfstedRatingScore.None)</td>
                 </tr>
               </tbody>
             </table>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml.cs
@@ -4,7 +4,35 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 
 public class OverviewModel : TrustsAreaModel
 {
+    public IEnumerable<(string? Authority, int Total)> AcademiesInEachLocalAuthority =>
+        Trust.Academies
+            .GroupBy(x => x.LocalAuthority)
+            .Select(c => (Authority: c.Key, Total: c.Count()))
+            .OrderByDescending(t => t.Total)
+            .ThenBy(t => t.Authority);
+
+    public IEnumerable<(OfstedRatingScore Rating, int Total)> OfstedRatings
+        => Trust.Academies
+            .GroupBy(x => x.CurrentOfstedRating.OfstedRatingScore)
+            .Select(c => (Rating: c.Key, Total: c.Count()));
+
+    public int NumberOfAcademiesInTrust => Trust.Academies.Length;
+    public int TotalPupilNumbersInTrust => Trust.Academies.Select(x => x.NumberOfPupils ?? 0).Sum();
+    public int TotalPupilCapacityInTrust => Trust.Academies.Select(x => x.SchoolCapacity ?? 0).Sum();
+
+    public int? TotalPercentageCapacityInTrust =>
+        TotalPupilCapacityInTrust > 0
+            ? (int)Math.Round(TotalPupilNumbersInTrust / (double)TotalPupilCapacityInTrust * 100)
+            : null;
+
     public OverviewModel(ITrustProvider trustProvider) : base(trustProvider, "Overview")
     {
+    }
+
+    public int GetNumberOfAcademiesWithOfstedRating(OfstedRatingScore score)
+    {
+        return OfstedRatings.Any(x => x.Rating == score)
+            ? OfstedRatings.Single(x => x.Rating == score).Total
+            : 0;
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyAcademyFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/Mocks/DummyAcademyFactory.cs
@@ -31,7 +31,8 @@ public class DummyAcademyFactory
         int? schoolCapacity = 400,
         double? percentageFreeSchoolMeals = default,
         AgeRange? ageRange = null,
-        int laCode = 334)
+        int laCode = 334,
+        OfstedRatingScore currentOfstedRatingScore = OfstedRatingScore.None)
     {
         return new Academy(urn,
             new DateTime(2023, 11, 16),
@@ -44,7 +45,7 @@ public class DummyAcademyFactory
             schoolCapacity,
             percentageFreeSchoolMeals,
             ageRange ?? new AgeRange(1, 11),
-            OfstedRating.None,
+            new OfstedRating(currentOfstedRatingScore, null),
             OfstedRating.None,
             laCode);
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/OverviewModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/OverviewModelTests.cs
@@ -1,4 +1,5 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
@@ -7,17 +8,211 @@ public class OverviewModelTests
 {
     private readonly Mock<ITrustProvider> _mockTrustProvider;
     private readonly OverviewModel _sut;
-
+    private const string TrustUid = "1234";
 
     public OverviewModelTests()
     {
         _mockTrustProvider = new Mock<ITrustProvider>();
-        _sut = new OverviewModel(_mockTrustProvider.Object);
+
+        _sut = new OverviewModel(_mockTrustProvider.Object) { Uid = TrustUid };
     }
 
     [Fact]
     public void PageName_should_be_Overview()
     {
         _sut.PageName.Should().Be("Overview");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_pupil_numbers_on_multi_academy_trust()
+    {
+        SetupTrustWithMultipleAcademies();
+        await _sut.OnGetAsync();
+        _sut.TotalPupilNumbersInTrust.Should().Be(1125);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_pupil_numbers_on_single_academy_trust()
+    {
+        SetupTrustWithSingleAcademy();
+        await _sut.OnGetAsync();
+        _sut.TotalPupilNumbersInTrust.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_pupil_numbers_on_trust_with_no_academies()
+    {
+        SetupTrustWithNoAcademies();
+        await _sut.OnGetAsync();
+        _sut.TotalPupilNumbersInTrust.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_pupil_capacity_on_multi_academy_trust()
+    {
+        SetupTrustWithMultipleAcademies();
+        await _sut.OnGetAsync();
+        _sut.TotalPupilCapacityInTrust.Should().Be(1950);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_pupil_capacity_on_single_academy_trust()
+    {
+        SetupTrustWithSingleAcademy();
+        await _sut.OnGetAsync();
+        _sut.TotalPupilCapacityInTrust.Should().Be(250);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_pupil_capacity_on_trust_with_no_academies()
+    {
+        SetupTrustWithNoAcademies();
+        await _sut.OnGetAsync();
+        _sut.TotalPupilCapacityInTrust.Should().Be(0);
+    }
+
+    [Fact]
+    public async void OnGetAsync_sets_pupil_percentage_on_multi_academy_trust()
+    {
+        SetupTrustWithMultipleAcademies();
+        await _sut.OnGetAsync();
+        _sut.TotalPercentageCapacityInTrust.Should().Be(58);
+    }
+
+    [Fact]
+    public async void OnGetAsync_sets_pupil_percentage_on_single_academy_trust()
+    {
+        SetupTrustWithSingleAcademy();
+        await _sut.OnGetAsync();
+        _sut.TotalPercentageCapacityInTrust.Should().Be(80);
+    }
+
+
+    [Fact]
+    public async void OnGetAsync_sets_pupil_percentage_on_trust_with_no_academies()
+    {
+        SetupTrustWithNoAcademies();
+        await _sut.OnGetAsync();
+        _sut.TotalPercentageCapacityInTrust.Should().BeNull();
+    }
+
+    [Fact]
+    public async void OnGetAsync_sets_list_of_local_authorities()
+    {
+        SetupTrustWithMultipleAcademies();
+        var expectedLocalAuthorityCount = new (string? Authority, int Total)[]
+        {
+            ("localAuth1", 6),
+            ("localAuth2", 1)
+        };
+
+        await _sut.OnGetAsync();
+        var result = _sut.AcademiesInEachLocalAuthority;
+        result.Should().BeEquivalentTo(expectedLocalAuthorityCount);
+    }
+
+    [Fact]
+    public async void OnGetAsync_sets_ofsted_ratings_list_correctly()
+    {
+        SetupTrustWithMultipleAcademies();
+        var expectedOfstedRatingCount = new (OfstedRatingScore Rating, int Total)[]
+        {
+            (OfstedRatingScore.Outstanding, 3),
+            (OfstedRatingScore.Good, 1),
+            (OfstedRatingScore.Inadequate, 1),
+            (OfstedRatingScore.RequiresImprovement, 1),
+            (OfstedRatingScore.None, 1)
+        };
+
+        await _sut.OnGetAsync();
+        var result = _sut.OfstedRatings;
+        result.Should().BeEquivalentTo(expectedOfstedRatingCount);
+    }
+
+    [Fact]
+    public async void OnGetAsync_ofsted_score_count_returns_correct_number_of_ratings()
+    {
+        SetupTrustWithMultipleAcademies();
+        await _sut.OnGetAsync();
+        var result = _sut.GetNumberOfAcademiesWithOfstedRating(OfstedRatingScore.Outstanding);
+        result.Should().Be(3);
+    }
+
+    [Fact]
+    public async void OnGetAsync_ofsted_score_count_returns_zero_ratings_when_non_exist()
+    {
+        SetupTrustWithSingleAcademy();
+        await _sut.OnGetAsync();
+        var result = _sut.GetNumberOfAcademiesWithOfstedRating(OfstedRatingScore.Good);
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public async void OnGetAsync_returns_correct_number_of_academies_for_single_academy_trust()
+    {
+        SetupTrustWithSingleAcademy();
+        await _sut.OnGetAsync();
+        var result = _sut.NumberOfAcademiesInTrust;
+        result.Should().Be(1);
+    }
+
+    [Fact]
+    public async void OnGetAsync_returns_correct_number_of_academies_for_multi_academy_trust()
+    {
+        SetupTrustWithMultipleAcademies();
+        await _sut.OnGetAsync();
+        var result = _sut.NumberOfAcademiesInTrust;
+        result.Should().Be(7);
+    }
+
+    [Fact]
+    public async void OnGetAsync_returns_correct_number_of_academies_for_trust_with_no_academies()
+    {
+        SetupTrustWithNoAcademies();
+        await _sut.OnGetAsync();
+        var result = _sut.NumberOfAcademiesInTrust;
+        result.Should().Be(0);
+    }
+
+    private static Academy DummyAcademy(int urn, string localAuthority, int numberOfPupils,
+        int schoolCapacity,
+        OfstedRatingScore currentOfstedRatingScore)
+    {
+        return DummyAcademyFactory.GetDummyAcademy(
+            urn,
+            localAuthority: localAuthority,
+            numberOfPupils: numberOfPupils,
+            schoolCapacity: schoolCapacity,
+            currentOfstedRatingScore: currentOfstedRatingScore);
+    }
+
+    private void SetupTrustWithMultipleAcademies()
+    {
+        _mockTrustProvider.Setup(tp => tp.GetTrustByUidAsync(TrustUid))
+            .ReturnsAsync(DummyTrustFactory.GetDummyTrust(TrustUid, academies: new[]
+            {
+                DummyAcademy(1, "localAuth1", 50, 150, OfstedRatingScore.Outstanding),
+                DummyAcademy(2, "localAuth1", 100, 200, OfstedRatingScore.Good),
+                DummyAcademy(3, "localAuth1", 150, 250, OfstedRatingScore.RequiresImprovement),
+                DummyAcademy(4, "localAuth1", 200, 300, OfstedRatingScore.Inadequate),
+                DummyAcademy(5, "localAuth1", 0, 500, OfstedRatingScore.None),
+                DummyAcademy(6, "localAuth1", 600, 500, OfstedRatingScore.Outstanding),
+                DummyAcademy(7, "localAuth2", 25, 50, OfstedRatingScore.Outstanding)
+            }));
+    }
+
+    private void SetupTrustWithSingleAcademy()
+    {
+        _mockTrustProvider.Setup(tp => tp.GetTrustByUidAsync(TrustUid))
+            .ReturnsAsync(DummyTrustFactory.GetDummyTrust(TrustUid, academies: new[]
+            {
+                DummyAcademy(42, "localAuth1", 200, 250, OfstedRatingScore.Outstanding)
+            }));
+    }
+
+    private void SetupTrustWithNoAcademies()
+    {
+        _mockTrustProvider.Setup(tp => tp.GetTrustByUidAsync(TrustUid))
+            .ReturnsAsync(DummyTrustFactory.GetDummyTrust(TrustUid, academies: null));
     }
 }

--- a/tests/playwright/accessibility-tests/trusts/overview-page.spec.ts
+++ b/tests/playwright/accessibility-tests/trusts/overview-page.spec.ts
@@ -10,7 +10,7 @@ test.describe('Overview page', () => {
     await overviewPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
     await overviewPage.trustNavigation.expect.toBeVisible()
     await overviewPage.expect.toSeeCorrectTrustSummary()
-    await overviewPage.expect.toSeeCorrectOfstedRatings()
+    await overviewPage.expect.toSeePopulatedOfstedRatings()
     await expectNoAccessibilityViolations()
   })
 })

--- a/tests/playwright/page-object-model/trust/overview-page.ts
+++ b/tests/playwright/page-object-model/trust/overview-page.ts
@@ -13,6 +13,16 @@ export class OverviewPage extends BaseTrustPage {
     this.trustSummaryCard = page.locator('[data-testid="trust-summary"]')
     this.trustOfstedTable = page.locator('[data-testid="ofsted-ratings"]')
   }
+
+  async goToMultiAcademyTrust (): Promise<void> {
+    this.currentTrust = this.fakeTestData.getOpenMultiAcademyTrust()
+    await this.goToWith(this.currentTrust.uid)
+  }
+
+  async goToTrustWithNoAcademies (): Promise<void> {
+    this.currentTrust = this.fakeTestData.getOpenSingleAcademyTrustWithNoAcademies()
+    await this.goToWith(this.currentTrust.uid)
+  }
 }
 
 class OverviewPageAssertions extends BaseTrustPageAssertions {
@@ -30,17 +40,51 @@ class OverviewPageAssertions extends BaseTrustPageAssertions {
   }
 
   async toSeeCorrectTrustSummary (): Promise<void> {
-    await expect(this.overviewPage.trustSummaryCard).toContainText('Total academies  4')
-    await expect(this.overviewPage.trustSummaryCard).toContainText('Academies in each local authority  3 in North Lincolnshire  1 in North East Lincolnshire')
-    await expect(this.overviewPage.trustSummaryCard).toContainText('Pupil numbers  4,896')
-    await expect(this.overviewPage.trustSummaryCard).toContainText('Pupil capacity (% full)  6,463(76%)')
+    await expect(this.overviewPage.trustSummaryCard).toContainText(`Total academies ${this.overviewPage.currentTrust.academies.length}`)
+
+    await expect(this.overviewPage.trustSummaryCard).toContainText('Academies in each local authority')
+
+    const ListOfAuthorities = this.overviewPage.currentTrust.academies
+      .map(x => x.localAuthority)
+      .reduce((acc: { [key: string]: number }, curr) => {
+        acc[curr] = (acc[curr] !== undefined && acc[curr] !== null) ? acc[curr] + 1 : 1
+        return acc
+      }, {})
+
+    for (const key in ListOfAuthorities) {
+      const authorityCount = `${ListOfAuthorities[key]} in ${key}`
+      await expect(this.overviewPage.trustSummaryCard).toContainText(`${authorityCount}`)
+    }
+
+    const totalTrustPupilNumbers = this.overviewPage.currentTrust.academies.reduce((sum, x) => sum + x.numberOfPupils, 0)
+    await expect(this.overviewPage.trustSummaryCard).toContainText(`Pupil numbers ${totalTrustPupilNumbers.toLocaleString()}`)
+
+    const totalTrustCapacity = this.overviewPage.currentTrust.academies.reduce((sum, x) => sum + x.schoolCapacity, 0)
+    await expect(this.overviewPage.trustSummaryCard).toContainText(`Pupil capacity (% full) ${totalTrustCapacity.toLocaleString()}`)
+
+    await expect(this.overviewPage.trustSummaryCard).toContainText(/\d+%/)
   }
 
-  async toSeeCorrectOfstedRatings (): Promise<void> {
-    await expect(this.overviewPage.trustOfstedTable).toContainText('Outstanding  3')
-    await expect(this.overviewPage.trustOfstedTable).toContainText('Good  5')
-    await expect(this.overviewPage.trustOfstedTable).toContainText('Requires improvement  2')
-    await expect(this.overviewPage.trustOfstedTable).toContainText('Inadequate  3')
-    await expect(this.overviewPage.trustOfstedTable).toContainText('Not yet inspected  4')
+  async toSeeCorrectTrustSummaryWithNoAcademies (): Promise<void> {
+    await expect(this.overviewPage.trustSummaryCard).toContainText('Total academies 0')
+    await expect(this.overviewPage.trustSummaryCard).toContainText('Academies in each local authority')
+    await expect(this.overviewPage.trustSummaryCard).toContainText('Pupil numbers 0')
+    await expect(this.overviewPage.trustSummaryCard).toContainText('Pupil capacity (% full) 0')
+  }
+
+  async toSeePopulatedOfstedRatings (): Promise<void> {
+    await expect(this.overviewPage.trustOfstedTable).toContainText(/Outstanding\s+\d+/)
+    await expect(this.overviewPage.trustOfstedTable).toContainText(/Good\s+\d+/)
+    await expect(this.overviewPage.trustOfstedTable).toContainText(/Requires improvement\s+\d+/)
+    await expect(this.overviewPage.trustOfstedTable).toContainText(/Inadequate\s+\d+/)
+    await expect(this.overviewPage.trustOfstedTable).toContainText(/Not yet inspected\s+\d+/)
+  }
+
+  async toSeeCorrectOfstedRatingsWithNoAcademies (): Promise<void> {
+    await expect(this.overviewPage.trustOfstedTable).toContainText('Outstanding 0')
+    await expect(this.overviewPage.trustOfstedTable).toContainText('Good 0')
+    await expect(this.overviewPage.trustOfstedTable).toContainText('Requires improvement 0')
+    await expect(this.overviewPage.trustOfstedTable).toContainText('Inadequate 0')
+    await expect(this.overviewPage.trustOfstedTable).toContainText('Not yet inspected 0')
   }
 }

--- a/tests/playwright/ui-tests/trusts/overview-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/overview-page.spec.ts
@@ -10,7 +10,6 @@ test.describe('Overview page', () => {
 
   test.beforeEach(async ({ page }) => {
     overviewPage = new OverviewPage(page, new FakeTestData())
-    await overviewPage.goTo()
   })
 
   for (const javaScriptContext of javaScriptContexts) {
@@ -18,13 +17,21 @@ test.describe('Overview page', () => {
       test.use({ javaScriptEnabled: javaScriptContext.isEnabled })
 
       test('user should see trust name and type', async () => {
+        await overviewPage.goTo()
         await overviewPage.expect.toBeOnTheRightPage()
         await overviewPage.expect.toSeeCorrectTrustNameAndTypeInHeader()
       })
 
       test('user should see the correct trust information', async () => {
+        await overviewPage.goToMultiAcademyTrust()
         await overviewPage.expect.toSeeCorrectTrustSummary()
-        await overviewPage.expect.toSeeCorrectOfstedRatings()
+        await overviewPage.expect.toSeePopulatedOfstedRatings()
+      })
+
+      test('user should see the correct trust information on trust with no academies', async () => {
+        await overviewPage.goToTrustWithNoAcademies()
+        await overviewPage.expect.toSeeCorrectTrustSummaryWithNoAcademies()
+        await overviewPage.expect.toSeeCorrectOfstedRatingsWithNoAcademies()
       })
 
       test.describe('given a user tries to visit the url without an existing trust', () => {


### PR DESCRIPTION
the overview page now uses data from the academies db to populate

total number of academies, total pupil numbers, total trust capacity capacity percentage

Ofsted data used to populate the Ofstead ratings table

[User Story 144008](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/144008): Build: Trust Overview page - data

## Changes


- overview page updated(no html changes made) just real data used instead of hard coded data
- ui tests updated to test multi academy trusts and trusts with no academies
- unit tests added


## Screenshots of UI changes

### Before

hardcoded date used before change
 
![image](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/123379894/8032ad3f-ddc5-4e97-9db7-c61feefc9107)

### After

real date used

![image](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/123379894/a16f075d-fd00-414a-9eb2-8bc059d35110)

## Checklist

- [ done] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [done ] Attach this pull request to the appropriate user story in Azure DevOps

