### PR TITLE
Populate Ofsted ratings table with data

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/StringFormatConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/StringFormatConstants.cs
@@ -1,0 +1,7 @@
+namespace DfE.FindInformationAcademiesTrusts.Pages;
+
+public static class StringFormatConstants
+{
+    public const string ViewDate = "d MMM yyyy";
+    public const string SortDate = "yyyy/MM/dd";
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
@@ -17,42 +17,24 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <tr class="govuk-table__row" data-testid="academy-row">
-        <th scope="row" class="govuk-body govuk-table__header" data-sort-value="Barr and Community R.C. School">
-          Barr and Community R.C. School<br/><span class="govuk-!-font-weight-regular">URN: 109174</span>
-        </th>
-        <td class="govuk-body govuk-table__cell">Nov 2018</td>
-        <td class="govuk-body govuk-table__cell">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2018, 11, 1, 0, 0, 0, DateTimeKind.Utc), "Not yet inspected", null)"></partial>
-        </td>
-        <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.NotYetInspected)">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2018, 11, 1, 0, 0, 0, DateTimeKind.Utc), "Not yet inspected", null)"></partial>
-        </td>
-      </tr>
-      <tr class="govuk-table__row" data-testid="academy-row">
-        <th scope="row" class="govuk-body govuk-table__header" data-sort-value="Fay Fort Catholic Primary Academy">
-          Fay Fort Catholic Primary Academy<br/><span class="govuk-!-font-weight-regular">URN: 109174</span>
-        </th>
-        <td class="govuk-body govuk-table__cell">Nov 2017</td>
-        <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.NotYetInspected)">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 11, 1, 0, 0, 0, DateTimeKind.Utc), "Not yet inspected", null)"></partial>
-        </td>
-        <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.Good)">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 11, 1, 0, 0, 0, DateTimeKind.Utc), "Good", new DateTime(2021, 05, 9, 0, 0, 0, DateTimeKind.Utc))"></partial>
-        </td>
-      </tr>
-      <tr class="govuk-table__row" data-testid="academy-row">
-        <th scope="row" class="govuk-body govuk-table__header" data-sort-value="Fay Fort Catholic Primary Academy">
-          George Abbey Secondary Academy<br/><span class="govuk-!-font-weight-regular">URN: 109174</span>
-        </th>
-        <td class="govuk-body govuk-table__cell">Nov 2017</td>
-        <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.RequiresImprovement)">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 10, 1, 0, 0, 0, DateTimeKind.Utc), "Requires improvement", new DateTime(2014, 11, 30, 0, 0, 0, DateTimeKind.Utc))"></partial>
-        </td>
-        <td class="govuk-body govuk-table__cell" data-sort-value="@((short)OfstedRatings.Outstanding)">
-          <partial name="_OfstedRatingCell" model="@Model.GetOfstedRatingCellModel(new DateTime(2017, 10, 1, 0, 0, 0, DateTimeKind.Utc), "Outstanding", new DateTime(2020, 11, 1, 0, 0, 0, DateTimeKind.Utc))"></partial>
-        </td>
-      </tr>
+      @foreach (var academy in Model.Trust.Academies)
+      {
+        <tr class="govuk-table__row" data-testid="academy-row">
+          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@academy.EstablishmentName">
+            @academy.EstablishmentName<br/><span class="govuk-!-font-weight-regular">URN: @academy.Urn</span>
+          </th>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@academy.DateAcademyJoinedTrust.ToString(ViewConstants.SortDateFormat)">
+            @academy.DateAcademyJoinedTrust.ToString(ViewConstants.ViewDateFormat)
+          </td>
+          @await Html.PartialAsync(
+            "_OfstedRatingCell",
+            new OfstedRatingCellModel { OfstedRating = academy.PreviousOfstedRating, AcademyJoinedDate = academy.DateAcademyJoinedTrust })
+
+          @await Html.PartialAsync(
+            "_OfstedRatingCell",
+            new OfstedRatingCellModel { OfstedRating = academy.CurrentOfstedRating, AcademyJoinedDate = academy.DateAcademyJoinedTrust })
+        </tr>
+      }
     </tbody>
   </table>
 </section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
@@ -23,8 +23,8 @@
           <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@academy.EstablishmentName">
             @academy.EstablishmentName<br/><span class="govuk-!-font-weight-regular">URN: @academy.Urn</span>
           </th>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@academy.DateAcademyJoinedTrust.ToString(ViewConstants.SortDateFormat)">
-            @academy.DateAcademyJoinedTrust.ToString(ViewConstants.ViewDateFormat)
+          <td class="govuk-body govuk-table__cell" data-sort-value="@academy.DateAcademyJoinedTrust.ToString(StringFormatConstants.SortDate)">
+            @academy.DateAcademyJoinedTrust.ToString(StringFormatConstants.ViewDate)
           </td>
           @await Html.PartialAsync(
             "_OfstedRatingCell",

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
@@ -7,7 +7,7 @@
 }
 
 <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9 app-table-container">
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="academies-details-link">
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="ofsted-ratings-link">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">School name</th>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml.cs
@@ -2,15 +2,6 @@ using DfE.FindInformationAcademiesTrusts.Data;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
-public enum OfstedRatings
-{
-    NotYetInspected,
-    Inadequate,
-    RequiresImprovement,
-    Good,
-    Outstanding
-}
-
 public class OfstedRatingsModel : TrustsAreaModel, IAcademiesAreaModel
 {
     public OfstedRatingsModel(ITrustProvider trustProvider) : base(trustProvider, "Academies in this trust")
@@ -19,15 +10,4 @@ public class OfstedRatingsModel : TrustsAreaModel, IAcademiesAreaModel
     }
 
     public string TabName => "Ofsted ratings";
-
-    public OfstedRatingCellModel GetOfstedRatingCellModel(DateTime academyJoinedDate, string rating,
-        DateTime? ratingDate)
-    {
-        return new OfstedRatingCellModel
-        {
-            AcademyJoinedDate = academyJoinedDate,
-            Rating = rating,
-            RatingDate = ratingDate
-        };
-    }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_AcademiesLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_AcademiesLayout.cshtml
@@ -23,7 +23,7 @@
     </li>
 
     <li class="moj-sub-navigation__item">
-      <a class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Ofsted ratings")" asp-page="./OfstedRatings" asp-route-uid="@Model.Trust.Uid"><span class="visually-hidden">Academies</span>Ofsted ratings</a>
+      <a id="ofsted-ratings-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Ofsted ratings")" asp-page="./OfstedRatings" asp-route-uid="@Model.Trust.Uid"><span class="visually-hidden">Academies</span>Ofsted ratings</a>
     </li>
 
     <li class="moj-sub-navigation__item">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml
@@ -1,5 +1,5 @@
 @model OfstedRatingCellModel
-<td class="govuk-body govuk-table__cell">
+<td class="govuk-body govuk-table__cell" data-sort-value="@Model.OfstedRatingSortValue">
   <span class="govuk-!-font-weight-bold">@Model.OfstedRatingDescription</span>
   <span>
     @if (Model.OfstedRating.InspectionEndDate is not null)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml
@@ -5,7 +5,7 @@
     @if (Model.OfstedRating.InspectionEndDate is not null)
     {
       <br/>
-      @Model.OfstedRating.InspectionEndDate.Value.ToString(ViewConstants.ViewDateFormat)
+      @Model.OfstedRating.InspectionEndDate.Value.ToString(StringFormatConstants.ViewDate)
       <br/>
       <strong class="@Model.TagClasses govuk-!-margin-top-2 govuk-!-margin-bottom-1">
         @Model.TagText

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml
@@ -7,8 +7,8 @@
       <br/>
       @Model.OfstedRating.InspectionEndDate.Value.ToString(ViewConstants.ViewDateFormat)
       <br/>
-      <strong class="@Model.GetTagClasses() govuk-!-margin-top-2 govuk-!-margin-bottom-1">
-        @Model.GetTagText()
+      <strong class="@Model.TagClasses govuk-!-margin-top-2 govuk-!-margin-bottom-1">
+        @Model.TagText
       </strong>
     }
   </span>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml
@@ -1,14 +1,15 @@
 @model OfstedRatingCellModel
-
-<span class="govuk-!-font-weight-bold">@Model.Rating</span>
-<span>
-  @if (Model.HasRating() && Model.RatingDate is not null)
-  {
-    <br/>
-    @Model.RatingDate.Value.ToString(ViewConstants.ViewDateFormat)
-    <br/>
-    <strong class="@Model.GetTagClasses() govuk-!-margin-top-2 govuk-!-margin-bottom-1">
-      @Model.GetTagText()
-    </strong>
-  }
-</span>
+<td class="govuk-body govuk-table__cell">
+  <span class="govuk-!-font-weight-bold">@Model.OfstedRatingDescription</span>
+  <span>
+    @if (Model.OfstedRating.InspectionEndDate is not null)
+    {
+      <br/>
+      @Model.OfstedRating.InspectionEndDate.Value.ToString(ViewConstants.ViewDateFormat)
+      <br/>
+      <strong class="@Model.GetTagClasses() govuk-!-margin-top-2 govuk-!-margin-bottom-1">
+        @Model.GetTagText()
+      </strong>
+    }
+  </span>
+</td>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml.cs
@@ -19,6 +19,14 @@ public class OfstedRatingCellModel
         OfstedRatingScore.Inadequate => "Inadequate",
         _ => string.Empty
     };
+    public int OfstedRatingSortValue
+    {
+        get
+        {
+            if (OfstedRating.OfstedRatingScore == OfstedRatingScore.None) return 5;
+            return (int)OfstedRating.OfstedRatingScore;
+        }
+    }
 
     public string TagClasses
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml.cs
@@ -1,25 +1,27 @@
-namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
+using DfE.FindInformationAcademiesTrusts.Data;
 
-internal static class OfstedRatingConstants
-{
-    public const string NotYetInspected = "Not yet inspected";
-}
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
 public class OfstedRatingCellModel
 {
     public required DateTime? AcademyJoinedDate { get; init; }
-    public required string Rating { get; init; }
-    public required DateTime? RatingDate { get; init; }
 
-    public bool HasRating()
-    {
-        return Rating != OfstedRatingConstants.NotYetInspected;
-    }
+    public required OfstedRating OfstedRating { get; init; }
 
     public bool IsAfterJoining()
     {
-        return RatingDate >= AcademyJoinedDate;
+        return OfstedRating.InspectionEndDate >= AcademyJoinedDate;
     }
+
+    public string? OfstedRatingDescription => OfstedRating.OfstedRatingScore switch
+    {
+        OfstedRatingScore.None => "Not yet inspected",
+        OfstedRatingScore.Outstanding => "Outstanding",
+        OfstedRatingScore.Good => "Good",
+        OfstedRatingScore.RequiresImprovement => "Requires improvement",
+        OfstedRatingScore.Inadequate => "Inadequate",
+        _ => string.Empty
+    };
 
     public string GetTagClasses()
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml.cs
@@ -8,10 +8,7 @@ public class OfstedRatingCellModel
 
     public required OfstedRating OfstedRating { get; init; }
 
-    public bool IsAfterJoining()
-    {
-        return OfstedRating.InspectionEndDate >= AcademyJoinedDate;
-    }
+    public bool IsAfterJoining => OfstedRating.InspectionEndDate >= AcademyJoinedDate;
 
     public string? OfstedRatingDescription => OfstedRating.OfstedRatingScore switch
     {
@@ -23,15 +20,15 @@ public class OfstedRatingCellModel
         _ => string.Empty
     };
 
-    public string GetTagClasses()
+    public string TagClasses
     {
-        var tag = "govuk-tag";
-        if (!IsAfterJoining()) tag += " govuk-tag--grey";
-        return tag;
+        get
+        {
+            var tag = "govuk-tag";
+            if (!IsAfterJoining) tag += " govuk-tag--grey";
+            return tag;
+        }
     }
 
-    public string GetTagText()
-    {
-        return IsAfterJoining() ? "After joining" : "Before joining";
-    }
+    public string TagText => IsAfterJoining ? "After joining" : "Before joining";
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Details.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Details.cshtml
@@ -26,7 +26,7 @@
           <dd class="govuk-summary-list__value">
             @if (Model.Trust.OpenedDate is not null)
             {
-              @Model.Trust.OpenedDate.Value.ToString("d MMM yyyy")
+              @Model.Trust.OpenedDate.Value.ToString(StringFormatConstants.ViewDate)
             }
           </dd>
         </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
@@ -12,4 +12,5 @@ public static class ViewConstants
         "https://forms.office.com.mcas.ms/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-VCFjdIWb7BPh79bON_K__tUOTdJMlZZUzBMMFhHV1lHNERFM041U0dUUy4u";
 
     public const string ViewDateFormat = "d MMM yyyy";
+    public const string SortDateFormat = "yyyy/MM/dd";
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
@@ -10,7 +10,4 @@ public static class ViewConstants
 
     public const string FeedbackFormLink =
         "https://forms.office.com.mcas.ms/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-VCFjdIWb7BPh79bON_K__tUOTdJMlZZUzBMMFhHV1lHNERFM041U0dUUy4u";
-
-    public const string ViewDateFormat = "d MMM yyyy";
-    public const string SortDateFormat = "yyyy/MM/dd";
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingCellModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingCellModelTests.cs
@@ -1,36 +1,15 @@
+using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies;
 
 public class OfstedRatingCellModelTests
 {
-    private readonly OfstedRatingCellModel _sut;
-
-    public OfstedRatingCellModelTests()
+    private readonly OfstedRatingCellModel _sut = new()
     {
-        _sut = new OfstedRatingCellModel
-        {
-            AcademyJoinedDate = new DateTime(),
-            Rating = "Good",
-            RatingDate = new DateTime()
-        };
-    }
-
-    [Fact]
-    public void HasRating_returns_true_if_rating_is_not_NotYetInspected()
-    {
-        var result = _sut.HasRating();
-        result.Should().Be(true);
-    }
-
-    [Fact]
-    public void HasRating_returns_false_if_rating_is_NotYetInspected()
-    {
-        var sut = GetSutWithNotYetInspectedRating();
-
-        var result = sut.HasRating();
-        result.Should().Be(false);
-    }
+        AcademyJoinedDate = new DateTime(),
+        OfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime())
+    };
 
     [Fact]
     public void IsAfterJoining_returns_true_if_RatingDate_is_after_AcademyJoinedDate()
@@ -102,13 +81,41 @@ public class OfstedRatingCellModelTests
         result.Should().Be("Before joining");
     }
 
+    [Theory]
+    [InlineData(OfstedRatingScore.Good, "Good")]
+    [InlineData(OfstedRatingScore.None, "Not yet inspected")]
+    [InlineData(OfstedRatingScore.Inadequate, "Inadequate")]
+    [InlineData(OfstedRatingScore.Outstanding, "Outstanding")]
+    [InlineData(OfstedRatingScore.RequiresImprovement, "Requires improvement")]
+    public void OfstedRatingDescription_returns_right_description(OfstedRatingScore score, string expected)
+    {
+        var sut = new OfstedRatingCellModel
+        {
+            OfstedRating = new OfstedRating(score, new DateTime()),
+            AcademyJoinedDate = new DateTime()
+        };
+
+        sut.OfstedRatingDescription.Should().Be(expected);
+    }
+
+    [Fact]
+    public void OfstedRatingDescription_returns_empty_if_score_not_in_range()
+    {
+        var sut = new OfstedRatingCellModel
+        {
+            OfstedRating = new OfstedRating(0, new DateTime()),
+            AcademyJoinedDate = new DateTime()
+        };
+
+        sut.OfstedRatingDescription.Should().BeEmpty();
+    }
+
     private static OfstedRatingCellModel GetSutWithOfstedRatingDateAfterJoining()
     {
         return new OfstedRatingCellModel
         {
             AcademyJoinedDate = new DateTime(2020, 11, 1),
-            Rating = "Good",
-            RatingDate = new DateTime(2022, 3, 2)
+            OfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime(2022, 3, 2))
         };
     }
 
@@ -117,8 +124,7 @@ public class OfstedRatingCellModelTests
         return new OfstedRatingCellModel
         {
             AcademyJoinedDate = new DateTime(2022, 3, 2),
-            Rating = "Good",
-            RatingDate = new DateTime(2020, 11, 1)
+            OfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime(2020, 11, 1))
         };
     }
 
@@ -127,8 +133,7 @@ public class OfstedRatingCellModelTests
         return new OfstedRatingCellModel
         {
             AcademyJoinedDate = new DateTime(2022, 3, 2),
-            Rating = "Not yet inspected",
-            RatingDate = null
+            OfstedRating = new OfstedRating(OfstedRatingScore.None, null)
         };
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingCellModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingCellModelTests.cs
@@ -5,35 +5,32 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies;
 
 public class OfstedRatingCellModelTests
 {
-    private readonly OfstedRatingCellModel _sut = new()
-    {
-        AcademyJoinedDate = new DateTime(),
-        OfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime())
-    };
-
     [Fact]
     public void IsAfterJoining_returns_true_if_RatingDate_is_after_AcademyJoinedDate()
     {
         var sut = GetSutWithOfstedRatingDateAfterJoining();
 
-        var result = sut.IsAfterJoining();
+        var result = sut.IsAfterJoining;
         result.Should().Be(true);
     }
 
     [Fact]
     public void IsAfterJoining_returns_true_if_RatingDate_is_same_as_AcademyJoinedDate()
     {
-        var result = _sut.IsAfterJoining();
-        result.Should().Be(true);
+        var sut = new OfstedRatingCellModel
+        {
+            AcademyJoinedDate = new DateTime(),
+            OfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime())
+        };
+
+        sut.IsAfterJoining.Should().Be(true);
     }
 
     [Fact]
     public void IsAfterJoining_returns_false_if_RatingDate_is_before_AcademyJoinedDate()
     {
         var sut = GetSutWithOfstedRatingDateBeforeJoining();
-
-        var result = sut.IsAfterJoining();
-        result.Should().Be(false);
+        sut.IsAfterJoining.Should().Be(false);
     }
 
     [Fact]
@@ -41,44 +38,38 @@ public class OfstedRatingCellModelTests
     {
         var sut = GetSutWithNotYetInspectedRating();
 
-        var result = sut.IsAfterJoining();
-        result.Should().Be(false);
+        sut.IsAfterJoining.Should().Be(false);
     }
 
     [Fact]
-    public void GetTagClasses_returns_default_tag_class_if_IsAfterJoining()
+    public void TagClasses_returns_default_tag_class_if_IsAfterJoining()
     {
         var sut = GetSutWithOfstedRatingDateAfterJoining();
 
-        var result = sut.GetTagClasses();
-        result.Should().Be("govuk-tag");
+        sut.TagClasses.Should().Be("govuk-tag");
     }
 
     [Fact]
-    public void GetTagClasses_returns_grey_tag_class_variant_if_IsAfterJoining_is_false()
+    public void TagClasses_returns_grey_tag_class_variant_if_IsAfterJoining_is_false()
     {
         var sut = GetSutWithOfstedRatingDateBeforeJoining();
 
-        var result = sut.GetTagClasses();
-        result.Should().Be("govuk-tag govuk-tag--grey");
+        sut.TagClasses.Should().Be("govuk-tag govuk-tag--grey");
     }
 
     [Fact]
-    public void GetTagText_returns_AfterJoining_If_Rating_Is_AfterJoining()
+    public void TagText_returns_AfterJoining_If_Rating_Is_AfterJoining()
     {
         var sut = GetSutWithOfstedRatingDateAfterJoining();
-
-        var result = sut.GetTagText();
-        result.Should().Be("After joining");
+        sut.TagText.Should().Be("After joining");
     }
 
     [Fact]
-    public void GetTagText_returns_BeforeJoining_If_Rating_Is_Not_AfterJoining()
+    public void TagText_returns_BeforeJoining_If_Rating_Is_Not_AfterJoining()
     {
         var sut = GetSutWithOfstedRatingDateBeforeJoining();
 
-        var result = sut.GetTagText();
-        result.Should().Be("Before joining");
+        sut.TagText.Should().Be("Before joining");
     }
 
     [Theory]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingCellModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingCellModelTests.cs
@@ -101,6 +101,23 @@ public class OfstedRatingCellModelTests
         sut.OfstedRatingDescription.Should().BeEmpty();
     }
 
+    [Theory]
+    [InlineData(OfstedRatingScore.Outstanding, 1)]
+    [InlineData(OfstedRatingScore.Good, 2)]
+    [InlineData(OfstedRatingScore.RequiresImprovement, 3)]
+    [InlineData(OfstedRatingScore.Inadequate, 4)]
+    [InlineData(OfstedRatingScore.None, 5)]
+    public void OfstedRatingSortValue_returns_right_value(OfstedRatingScore score, int expected)
+    {
+        var sut = new OfstedRatingCellModel
+        {
+            OfstedRating = new OfstedRating(score, new DateTime()),
+            AcademyJoinedDate = new DateTime()
+        };
+
+        sut.OfstedRatingSortValue.Should().Be(expected);
+    }
+
     private static OfstedRatingCellModel GetSutWithOfstedRatingDateAfterJoining()
     {
         return new OfstedRatingCellModel

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingsModelTests.cs
@@ -14,6 +14,12 @@ public class OfstedRatingsModelTests
     }
 
     [Fact]
+    public void PageName_should_be_AcademiesInThisTrust()
+    {
+        _sut.PageName.Should().Be("Academies in this trust");
+    }
+
+    [Fact]
     public void PageTitle_should_be_AcademiesDetails()
     {
         _sut.PageTitle.Should().Be("Academies Ofsted ratings");

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingsModelTests.cs
@@ -24,19 +24,4 @@ public class OfstedRatingsModelTests
     {
         _sut.TabName.Should().Be("Ofsted ratings");
     }
-
-    [Fact]
-    public void GetOfstedRatingCellModel_returns_an_OfstedRatingCellModel()
-    {
-        OfstedRatingCellModel expected = new()
-        {
-            AcademyJoinedDate = new DateTime(2018, 11, 1),
-            Rating = "Not yet inspected",
-            RatingDate = null
-        };
-
-        var result = _sut.GetOfstedRatingCellModel(
-            new DateTime(2018, 11, 1), "Not yet inspected", null);
-        result.Should().BeEquivalentTo(expected);
-    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingsModelTests.cs
@@ -20,13 +20,13 @@ public class OfstedRatingsModelTests
     }
 
     [Fact]
-    public void PageTitle_should_be_AcademiesDetails()
+    public void PageTitle_should_be_AcademiesOfstedRatingsPage()
     {
         _sut.PageTitle.Should().Be("Academies Ofsted ratings");
     }
 
     [Fact]
-    public void TabName_should_be_Details()
+    public void TabName_should_be_OfstedRatings()
     {
         _sut.TabName.Should().Be("Ofsted ratings");
     }

--- a/tests/playwright/fake-data/fake-test-data.ts
+++ b/tests/playwright/fake-data/fake-test-data.ts
@@ -32,6 +32,9 @@ export interface FakeAcademy {
   }
   percentageFull: number
   percentageFreeSchoolMeals: number
+  dateAcademyJoinedTrust: Date
+  currentOfstedRating: FakeOfstedRating
+  previousOfstedRating: FakeOfstedRating
 }
 
 export interface FakePerson {
@@ -44,6 +47,12 @@ export interface FakeGovernor {
   email: string
   role: string
 }
+
+export interface FakeOfstedRating {
+  ofstedRatingScore: number
+  inspectionEndDate: Date | null
+}
+
 export class FakeTestData {
   _fakeTrusts: FakeTrust[]
 

--- a/tests/playwright/fake-data/fake-test-data.ts
+++ b/tests/playwright/fake-data/fake-test-data.ts
@@ -1,57 +1,5 @@
 import * as testDataJson from '../fake-data/trusts.json'
-
-export interface FakeTrust {
-  name: string
-  address: string
-  uid: string
-  groupId: string
-  type: string
-  ukprn: string
-  openedDate: string
-  companiesHouseNumber: string
-  regionAndTerritory: string
-  status: string
-  sfsoLead: FakePerson
-  trustRelationshipManager: FakePerson
-  governors: FakeGovernor[]
-  academies: FakeAcademy[]
-}
-
-export interface FakeAcademy {
-  urn: number
-  establishmentName: string
-  typeOfEstablishment: string
-  localAuthority: string
-  urbanRural: string
-  phaseOfEducation: string
-  numberOfPupils: number
-  schoolCapacity: number
-  ageRange: {
-    minimum: number
-    maximum: number
-  }
-  percentageFull: number
-  percentageFreeSchoolMeals: number
-  dateAcademyJoinedTrust: Date
-  currentOfstedRating: FakeOfstedRating
-  previousOfstedRating: FakeOfstedRating
-}
-
-export interface FakePerson {
-  fullName: string
-  email: string
-}
-
-export interface FakeGovernor {
-  fullName: string
-  email: string
-  role: string
-}
-
-export interface FakeOfstedRating {
-  ofstedRatingScore: number
-  inspectionEndDate: Date | null
-}
+import { FakeAcademy, FakeTrust } from './types'
 
 export class FakeTestData {
   _fakeTrusts: FakeTrust[]

--- a/tests/playwright/fake-data/types.ts
+++ b/tests/playwright/fake-data/types.ts
@@ -1,0 +1,52 @@
+export interface FakeTrust {
+  name: string
+  address: string
+  uid: string
+  groupId: string
+  type: string
+  ukprn: string
+  openedDate: string
+  companiesHouseNumber: string
+  regionAndTerritory: string
+  status: string
+  sfsoLead: FakePerson
+  trustRelationshipManager: FakePerson
+  governors: FakeGovernor[]
+  academies: FakeAcademy[]
+}
+
+export interface FakeAcademy {
+  urn: number
+  establishmentName: string
+  typeOfEstablishment: string
+  localAuthority: string
+  urbanRural: string
+  phaseOfEducation: string
+  numberOfPupils: number
+  schoolCapacity: number
+  ageRange: {
+    minimum: number
+    maximum: number
+  }
+  percentageFull: number
+  percentageFreeSchoolMeals: number
+  dateAcademyJoinedTrust: Date
+  currentOfstedRating: FakeOfstedRating
+  previousOfstedRating: FakeOfstedRating
+}
+
+export interface FakePerson {
+  fullName: string
+  email: string
+}
+
+export interface FakeGovernor {
+  fullName: string
+  email: string
+  role: string
+}
+
+export interface FakeOfstedRating {
+  ofstedRatingScore: number
+  inspectionEndDate: Date | null
+}

--- a/tests/playwright/helpers.ts
+++ b/tests/playwright/helpers.ts
@@ -1,8 +1,13 @@
 export const javaScriptContexts = [{ name: 'enabled', isEnabled: true }, { name: 'disabled', isEnabled: false }]
 
-export const formatDateAsExpected = (date: string): string => {
+export const formatDateAsExpected = (date: string | Date): string => {
   const options: Intl.DateTimeFormatOptions = {
     day: 'numeric', month: 'short', year: 'numeric'
   }
-  return new Date(date).toLocaleDateString('en-GB', options)
+  const formattedDate = new Date(date).toLocaleDateString('en-GB', options).split(' ')
+
+  // fixing an issue where Sept is 4 characters in Chromium using `toLocaleDateString`
+  const shortMonth = formattedDate[1].slice(0, 3)
+  formattedDate.splice(1, 1, shortMonth)
+  return formattedDate.join(' ')
 }

--- a/tests/playwright/page-object-model/search-page.ts
+++ b/tests/playwright/page-object-model/search-page.ts
@@ -1,9 +1,10 @@
 import { Locator, Page, expect } from '@playwright/test'
 import { CurrentSearch, SearchFormComponent } from './shared/search-form-component'
-import { FakeTestData, FakeTrust } from '../fake-data/fake-test-data'
+import { FakeTestData } from '../fake-data/fake-test-data'
 import { SearchTerms } from '../fake-data/search-terms'
 import { PaginationComponent } from './shared/pagination-component'
 import { BasePage, BasePageAssertions } from './base-page'
+import { FakeTrust } from '../fake-data/types'
 
 export class SearchPage extends BasePage {
   readonly expect: SearchPageAssertions

--- a/tests/playwright/page-object-model/trust/academies/base-academies-page.ts
+++ b/tests/playwright/page-object-model/trust/academies/base-academies-page.ts
@@ -1,8 +1,9 @@
 import { Locator, Page, expect } from '@playwright/test'
-import { FakeAcademy, FakeTestData } from '../../../fake-data/fake-test-data'
+import { FakeTestData } from '../../../fake-data/fake-test-data'
 import { BaseTrustPage, BaseTrustPageAssertions } from '../base-trust-page'
 import { NavigationComponent } from '../../shared/navigation-component'
 import { TableComponent } from '../../shared/table-component'
+import { FakeAcademy } from '../../../fake-data/types'
 
 export class BaseAcademiesPage extends BaseTrustPage {
   readonly expect: BaseAcademiesPageAssertions

--- a/tests/playwright/page-object-model/trust/academies/details-page.ts
+++ b/tests/playwright/page-object-model/trust/academies/details-page.ts
@@ -1,7 +1,8 @@
 import { Page, expect } from '@playwright/test'
-import { FakeAcademy, FakeTestData } from '../../../fake-data/fake-test-data'
+import { FakeTestData } from '../../../fake-data/fake-test-data'
 import { BaseAcademiesPage, BaseAcademiesPageAssertions } from './base-academies-page'
 import { RowComponent } from '../../shared/table-component'
+import { FakeAcademy } from '../../../fake-data/types'
 
 enum ColumnHeading {
   LocalAuthority,

--- a/tests/playwright/page-object-model/trust/academies/free-school-meals-page.ts
+++ b/tests/playwright/page-object-model/trust/academies/free-school-meals-page.ts
@@ -1,7 +1,8 @@
 import { Page, expect } from '@playwright/test'
-import { FakeAcademy, FakeTestData } from '../../../fake-data/fake-test-data'
+import { FakeTestData } from '../../../fake-data/fake-test-data'
 import { BaseAcademiesPage, BaseAcademiesPageAssertions } from './base-academies-page'
 import { RowComponent } from '../../shared/table-component'
+import { FakeAcademy } from '../../../fake-data/types'
 
 enum ColumnHeading {
   PupilsEligableForFreeSchoolMeals,

--- a/tests/playwright/page-object-model/trust/academies/ofsted-ratings-page.ts
+++ b/tests/playwright/page-object-model/trust/academies/ofsted-ratings-page.ts
@@ -1,8 +1,9 @@
 import { Locator, Page, expect } from '@playwright/test'
-import { FakeAcademy, FakeOfstedRating, FakeTestData } from '../../../fake-data/fake-test-data'
+import { FakeTestData } from '../../../fake-data/fake-test-data'
 import { BaseAcademiesPage, BaseAcademiesPageAssertions } from './base-academies-page'
 import { RowComponent } from '../../shared/table-component'
 import { formatDateAsExpected } from '../../../helpers'
+import { FakeAcademy, FakeOfstedRating } from '../../../fake-data/types'
 
 enum ColumnHeading {
   DateJoined,

--- a/tests/playwright/page-object-model/trust/academies/pupil-numbers-page .ts
+++ b/tests/playwright/page-object-model/trust/academies/pupil-numbers-page .ts
@@ -1,10 +1,11 @@
 import { Page, expect } from '@playwright/test'
-import { FakeAcademy, FakeTestData } from '../../../fake-data/fake-test-data'
+import { FakeTestData } from '../../../fake-data/fake-test-data'
 import {
   BaseAcademiesPage,
   BaseAcademiesPageAssertions
 } from './base-academies-page'
 import { RowComponent } from '../../shared/table-component'
+import { FakeAcademy } from '../../../fake-data/types'
 
 enum ColumnHeading {
   PhaseAndAgeRange,

--- a/tests/playwright/page-object-model/trust/base-trust-page.ts
+++ b/tests/playwright/page-object-model/trust/base-trust-page.ts
@@ -1,8 +1,9 @@
 import { Page } from '@playwright/test'
-import { FakeTestData, FakeTrust } from '../../fake-data/fake-test-data'
+import { FakeTestData } from '../../fake-data/fake-test-data'
 import { TrustHeaderComponent } from '../shared/trust-header-component'
 import { NavigationComponent } from '../shared/navigation-component'
 import { BasePage, BasePageAssertions } from '../base-page'
+import { FakeTrust } from '../../fake-data/types'
 
 export class BaseTrustPage extends BasePage {
   readonly expect: BaseTrustPageAssertions

--- a/tests/playwright/ui-tests/trusts/academies/ofsted-ratings-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/academies/ofsted-ratings-page.spec.ts
@@ -9,6 +9,5 @@ test.describe('Academies in trust ofsted ratings page', () => {
     await ofstedRatingsPage.expect.toBeOnTheRightPage()
     await ofstedRatingsPage.expect.toDisplayInformationForAllAcademiesInThatTrust()
     await ofstedRatingsPage.expect.toDisplayCorrectInformationAboutAcademiesInThatTrust()
-    await ofstedRatingsPage.expect.toDisplayTheCorrectTagsForEachOfstedRating()
   })
 })


### PR DESCRIPTION
This change follows on from #250  and adds data about Academies in a trust to the Academies - Ofsted ratings table

- The table contains a row for every academy in a trust, with the correct data for each academy
- The correct Ofsted rating description is shown for an Ofsted rating score
- The correct Before/After joining tag is shown depending on if a rating date is before or after an academy joined a trust
- The Ofsted rating columns are sortable by Ofsted rating score

[User Story 147256](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/147256?McasTsid=26110&McasCtx=4): Build: Academies in Trust Page - Ofsted ratings - Add data

## Changes

- Update the `OfstedRatingCell` model to deal with the `OfstedRating` model on an Academy
- Add enum to match score to description, with an extension method to get the display name
- Update UI tests to test against fake data
- Add `StringFormatConstants` class to store common values passed to `ToString` method in view - particularly date formats to the GDS style guide, or to a sortable format for the cell sort value
- Improve Stryker mutation score for Ofsted ratings page

## Screenshots of UI changes

No changes to UI, but correct sorting was added in this story:

Ofsted ratings table sorted by date:
<img width="1275" alt="" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/d844900c-8483-4d87-ad9b-ba1c8d28b979">

Table sorted by previous Ofsted rating:
<img width="1435" alt="" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/a200196d-ef8e-4eb0-acbc-588ecc37468c">

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
