### PR TITLE
Improve flaky search test

### DIFF
--- a/tests/playwright/ui-tests/search-page.spec.ts
+++ b/tests/playwright/ui-tests/search-page.spec.ts
@@ -44,12 +44,10 @@ test.describe('Search page', () => {
 
         test('the user can edit their search and search again', async () => {
           await searchPage.searchForm.expect.inputToContainSearchTerm()
-          await searchPage.searchForm.searchForATrust()
-          await searchPage.expect.toBeOnPageWithMatchingResults()
           await searchPage.searchForm.searchForADifferentTrust()
-          await searchPage.searchForm.expect.inputToContainSearchTerm()
           await searchPage.expect.toBeOnPageWithMatchingResults()
           await searchPage.expect.toSeeInformationForUpToMaximumNumberOfResultsPerPage()
+          await searchPage.searchForm.expect.inputToContainSearchTerm()
         })
 
         test('when the user clicks on different results they are taken to different trust details pages', async () => {


### PR DESCRIPTION
This test was occasionally failing in CI, possibly because it was asserting the value of the input on the page  (set by JavaScript) before the page has reloaded.

Swapping the order of the assertions to check for the heading text before the component which is reliant on JavaScript.

Also reducing the number of times the user searches, as we only need to do that once in this test, and the beforeEach is already going to a page with a search term entered.


## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
