### PR TITLE
Add hard-coded data source for free school meals averages

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverageProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsAverageProvider.cs
@@ -4,7 +4,6 @@ public class FreeSchoolMealsAverageProvider : IFreeSchoolMealsAverageProvider
 {
     private const int NationalKey = -1;
 
-
     public double GetLaAverage(Academy academy)
     {
         var key = GetPhaseTypeKey(academy);
@@ -15,6 +14,12 @@ public class FreeSchoolMealsAverageProvider : IFreeSchoolMealsAverageProvider
     {
         var key = GetPhaseTypeKey(academy);
         return FreeSchoolMealsData.Averages2022To23[NationalKey].PercentOfPupilsByPhase[key];
+    }
+
+    public DataSource GetFreeSchoolMealsUpdated()
+    {
+        return new DataSource(Source.ExploreEducationStatistics, FreeSchoolMealsData.LastUpdated,
+            UpdateFrequency.Annually);
     }
 
     public static ExploreEducationStatisticsPhaseType GetPhaseTypeKey(Academy academy)

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsData.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsData.cs
@@ -7,6 +7,8 @@ public static class FreeSchoolMealsData
 {
     public static Dictionary<int, FreeSchoolMealsAverage> Averages2022To23 { get; } = new();
 
+    public static readonly DateTime LastUpdated = new(2023, 10, 2);
+
     /// <summary>
     /// Data store for School statistics data taken from https://explore-education-statistics.service.gov.uk/data-tables/permalink/25bc8d0b-c700-4000-1b8a-08dbb99e3fd8
     /// </summary>

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsData.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/FreeSchoolMealsData.cs
@@ -7,7 +7,7 @@ public static class FreeSchoolMealsData
 {
     public static Dictionary<int, FreeSchoolMealsAverage> Averages2022To23 { get; } = new();
 
-    public static readonly DateTime LastUpdated = new(2023, 10, 2);
+    public static readonly DateTime LastUpdated = new(2023, 10, 2, 0, 0, 0, DateTimeKind.Utc);
 
     /// <summary>
     /// Data store for School statistics data taken from https://explore-education-statistics.service.gov.uk/data-tables/permalink/25bc8d0b-c700-4000-1b8a-08dbb99e3fd8

--- a/DfE.FindInformationAcademiesTrusts.Data/DataSource.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/DataSource.cs
@@ -7,11 +7,13 @@ public enum Source
     Gias,
     Mstr,
     Cdm,
-    Mis
+    Mis,
+    ExploreEducationStatistics
 }
 
 public enum UpdateFrequency
 {
     Daily,
-    Monthly
+    Monthly,
+    Annually
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/IFreeSchoolMealsAverageProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/IFreeSchoolMealsAverageProvider.cs
@@ -4,4 +4,5 @@ public interface IFreeSchoolMealsAverageProvider
 {
     public double GetLaAverage(Academy academy);
     public double GetNationalAverage(Academy academy);
+    public DataSource GetFreeSchoolMealsUpdated();
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
@@ -22,10 +22,16 @@ public class FreeSchoolMealsModel : TrustsAreaModel, IAcademiesAreaModel
 
         if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
 
+        DataSources.Add(new DataSourceListEntry(await DataSourceProvider.GetGiasUpdated(),
+            new[]
+            {
+                "Pupils eligible for free school meals"
+            }));
+
         DataSources.Add(new DataSourceListEntry(_freeSchoolMealsProvider.GetFreeSchoolMealsUpdated(),
             new[]
             {
-                "Pupils eligible for free school meals", "Local authority average 2022/23", "National average 2022/23"
+                "Local authority average 2022/23", "National average 2022/23"
             }));
 
         return pageResult;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
@@ -13,6 +14,21 @@ public class FreeSchoolMealsModel : TrustsAreaModel, IAcademiesAreaModel
     {
         PageTitle = "Academies free school meals";
         _freeSchoolMealsProvider = freeSchoolMealsAverageProvider;
+    }
+
+    public override async Task<IActionResult> OnGetAsync()
+    {
+        var pageResult = await base.OnGetAsync();
+
+        if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
+
+        DataSources.Add(new DataSourceListEntry(_freeSchoolMealsProvider.GetFreeSchoolMealsUpdated(),
+            new[]
+            {
+                "Pupils eligible for free school meals", "Local authority average 2022/23", "National average 2022/23"
+            }));
+
+        return pageResult;
     }
 
     public string TabName => "Free school meals";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -38,9 +38,11 @@ public class TrustsAreaModel : PageModel, ITrustsAreaModel
                 return "RSD (Regional Services Division) service support team";
             case Source.Mis:
                 return "State-funded school inspections and outcomes: management information";
+            case Source.ExploreEducationStatistics:
+                return "Explore education statistics";
             default:
                 _logger.LogError("Data source {source} does not map to known type", source);
-                return "";
+                return "Unknown";
         }
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/FreeSchoolMealsAverageProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/FreeSchoolMealsAverageProviderTests.cs
@@ -77,4 +77,12 @@ public class FreeSchoolMealsAverageProviderTests
         act.Should().Throw<ArgumentOutOfRangeException>().WithMessage(
             "Can't get ExploreEducationStatisticsPhaseType for [PhaseOfEducation:Not a phase, TypeOfEstablishment:not an establishment type] (Parameter 'academy')");
     }
+
+    [Fact]
+    public void GetFsmUpdated_should_return_data_source()
+    {
+        var result = _sut.GetFreeSchoolMealsUpdated();
+        result.Should().Be(new DataSource(Source.ExploreEducationStatistics, new DateTime(2023, 10, 2),
+            UpdateFrequency.Annually));
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
@@ -75,10 +75,14 @@ public class FreeSchoolMealsModelTests
     {
         await _sut.OnGetAsync();
         _mockFreeSchoolMealsAverageProvider.Verify(e => e.GetFreeSchoolMealsUpdated(), Times.Once);
-        _sut.DataSources.Should().ContainSingle();
+        _sut.DataSources.Count.Should().Be(2);
         _sut.DataSources[0].Fields.Should().Contain(new[]
         {
-            "Pupils eligible for free school meals", "Local authority average 2022/23", "National average 2022/23"
+            "Pupils eligible for free school meals"
+        });
+        _sut.DataSources[1].Fields.Should().Contain(new[]
+        {
+            "Local authority average 2022/23", "National average 2022/23"
         });
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
@@ -2,6 +2,7 @@ using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies;
 
@@ -9,13 +10,16 @@ public class FreeSchoolMealsModelTests
 {
     private readonly FreeSchoolMealsModel _sut;
     private readonly Mock<IFreeSchoolMealsAverageProvider> _mockFreeSchoolMealsAverageProvider;
+    private readonly Mock<ITrustProvider> _mockTrustProvider;
 
     public FreeSchoolMealsModelTests()
     {
-        var mockTrustProvider = new Mock<ITrustProvider>();
+        _mockTrustProvider = new Mock<ITrustProvider>();
         _mockFreeSchoolMealsAverageProvider = new Mock<IFreeSchoolMealsAverageProvider>();
-        _sut = new FreeSchoolMealsModel(mockTrustProvider.Object, _mockFreeSchoolMealsAverageProvider.Object,
-            new MockDataSourceProvider().Object, new MockLogger<FreeSchoolMealsModel>().Object);
+        var dummyTrust = DummyTrustFactory.GetDummyTrust("1234");
+        _mockTrustProvider.Setup(tp => tp.GetTrustByUidAsync("1234")).ReturnsAsync(dummyTrust);
+        _sut = new FreeSchoolMealsModel(_mockTrustProvider.Object, _mockFreeSchoolMealsAverageProvider.Object,
+            new MockDataSourceProvider().Object, new MockLogger<FreeSchoolMealsModel>().Object) { Uid = "1234" };
     }
 
     [Fact]
@@ -56,5 +60,25 @@ public class FreeSchoolMealsModelTests
 
         var result = _sut.GetNationalAverageFreeSchoolMeals(dummyAcademy);
         result.Should().Be(mockPercentage);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_null()
+    {
+        _mockTrustProvider.Setup(tp => tp.GetTrustByUidAsync("1234")).ReturnsAsync((Trust?)null);
+        var result = await _sut.OnGetAsync();
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_correct_data_source_list()
+    {
+        await _sut.OnGetAsync();
+        _mockFreeSchoolMealsAverageProvider.Verify(e => e.GetFreeSchoolMealsUpdated(), Times.Once);
+        _sut.DataSources.Should().ContainSingle();
+        _sut.DataSources[0].Fields.Should().Contain(new[]
+        {
+            "Pupils eligible for free school meals", "Local authority average 2022/23", "National average 2022/23"
+        });
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
@@ -78,6 +78,7 @@ public class TrustsAreaModelTests
     [InlineData(Source.Mstr, "Get information about schools - internal")]
     [InlineData(Source.Cdm, "RSD (Regional Services Division) service support team")]
     [InlineData(Source.Mis, "State-funded school inspections and outcomes: management information")]
+    [InlineData(Source.ExploreEducationStatistics, "Explore education statistics")]
     public void MapDataSourceToName_should_return_the_correct_string_for_each_source(Source source, string expected)
     {
         var result = _sut.MapDataSourceToName(new DataSource(source, null, UpdateFrequency.Daily));
@@ -85,11 +86,11 @@ public class TrustsAreaModelTests
     }
 
     [Fact]
-    public void MapDataSourceToName_should_return_emptyString_when_source_is_not_recognised()
+    public void MapDataSourceToName_should_return_Unknown_when_source_is_not_recognised()
     {
         var dataSource = new DataSource((Source)10, null, UpdateFrequency.Daily);
         var result = _sut.MapDataSourceToName(dataSource);
         _logger.VerifyLogError($"Data source {dataSource} does not map to known type");
-        result.Should().Be("");
+        result.Should().Be("Unknown");
     }
 }

--- a/tests/playwright/page-object-model/trust/sources-and-updates-component.ts
+++ b/tests/playwright/page-object-model/trust/sources-and-updates-component.ts
@@ -49,7 +49,7 @@ export class SourcePanelComponent {
 export interface DataSourcePanelItem {
   fields: string
   dataSource: string
-  update: 'Daily' | 'Monthly'
+  update: 'Daily' | 'Monthly' | 'Annually'
 }
 
 export class SourcePanelComponentAssertions {

--- a/tests/playwright/ui-tests/trusts/academies/free-school-meals-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/academies/free-school-meals-page.spec.ts
@@ -1,14 +1,31 @@
 import { test } from '@playwright/test'
 import { FakeTestData } from '../../../fake-data/fake-test-data'
 import { AcademiesFreeSchoolMealsPage } from '../../../page-object-model/trust/academies/free-school-meals-page'
+import { DataSourcePanelItem } from '../../../page-object-model/trust/sources-and-updates-component'
+
+const sources: DataSourcePanelItem[] = [
+  {
+    fields: 'Pupils eligible for free school meals, Local authority average 2022/23, National average 2022/23',
+    dataSource: 'Explore education statistics',
+    update: 'Annually'
+  }
+]
 
 test.describe('Academies in trust details page', () => {
-  test('user should see the right information about a trust', async ({ page }) => {
-    const freeSchoolMealsPage = new AcademiesFreeSchoolMealsPage(page, new FakeTestData())
+  let freeSchoolMealsPage: AcademiesFreeSchoolMealsPage
 
+  test.beforeEach(async ({ page }) => {
+    freeSchoolMealsPage = new AcademiesFreeSchoolMealsPage(page, new FakeTestData())
     await freeSchoolMealsPage.goTo()
     await freeSchoolMealsPage.expect.toBeOnTheRightPage()
+  })
+
+  test('user should see the right information about a trust', async ({ page }) => {
     await freeSchoolMealsPage.expect.toDisplayInformationForAllAcademiesInThatTrust()
     await freeSchoolMealsPage.expect.toDisplayCorrectInformationAboutAcademiesInThatTrust()
+  })
+
+  test('user sees the correct information in the source and updates panel', async () => {
+    await freeSchoolMealsPage.expect.toSeeCorrectSourceAndUpdates(sources)
   })
 })

--- a/tests/playwright/ui-tests/trusts/academies/free-school-meals-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/academies/free-school-meals-page.spec.ts
@@ -5,7 +5,12 @@ import { DataSourcePanelItem } from '../../../page-object-model/trust/sources-an
 
 const sources: DataSourcePanelItem[] = [
   {
-    fields: 'Pupils eligible for free school meals, Local authority average 2022/23, National average 2022/23',
+    fields: 'Pupils eligible for free school meals',
+    dataSource: 'Get information about schools',
+    update: 'Daily'
+  },
+  {
+    fields: 'Local authority average 2022/23, National average 2022/23',
     dataSource: 'Explore education statistics',
     update: 'Annually'
   }


### PR DESCRIPTION
This change follows on from #294 Data source updated/next updated - and adds the final data source for Free School Meals averages, which is taken from explore education Statistics. Related to [User Story 134914](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/134914?McasTsid=26110&McasCtx=4): Build: Data source last updated/next scheduled update.

As this data source has been hardcoded into our application (in #295), we cannot check the last updated source using the database as for other data sources. Instead we have added the date referenced on the Explore Education Statistics service when we downloaded the data. 

## Changes

- Update the Free School Meals averages provider to add details of the source updated date
- Add a new update frequency, as the Free School Meals percentage data changes annually

## Screenshots of UI changes

Screenshot of free school meals page showing Explore Education Statistics data source details:
<img width="1421" alt="" src="https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/50752284/b927975c-7751-447d-9d01-a6bd6a85f321">

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [n/a] Update the ADR decision log if needed
