### PR TITLE
MSTR data source wording update - Change to "Get information about schools (internal use only, do not share outside of DfE)"

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -33,7 +33,7 @@ public class TrustsAreaModel : PageModel, ITrustsAreaModel
             case Source.Gias:
                 return "Get information about schools";
             case Source.Mstr:
-                return "Get information about schools - internal";
+                return "Get information about schools (internal use only, do not share outside of DfE)";
             case Source.Cdm:
                 return "RSD (Regional Services Division) service support team";
             case Source.Mis:

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
@@ -75,7 +75,7 @@ public class TrustsAreaModelTests
 
     [Theory]
     [InlineData(Source.Gias, "Get information about schools")]
-    [InlineData(Source.Mstr, "Get information about schools - internal")]
+    [InlineData(Source.Mstr, "Get information about schools (internal use only, do not share outside of DfE)")]
     [InlineData(Source.Cdm, "RSD (Regional Services Division) service support team")]
     [InlineData(Source.Mis, "State-funded school inspections and outcomes: management information")]
     [InlineData(Source.ExploreEducationStatistics, "Explore education statistics")]

--- a/tests/playwright/ui-tests/trusts/contacts-page.spec.ts
+++ b/tests/playwright/ui-tests/trusts/contacts-page.spec.ts
@@ -9,7 +9,7 @@ test.describe('Contacts page', () => {
   let notFoundPage: NotFoundPage
   const sources: DataSourcePanelItem[] = [{ fields: 'DfE contacts:', dataSource: 'RSD (Regional Services Division) service support team', update: 'Daily' },
     { fields: 'Accounting officer name, Chief financial officer name, Chair of trustees name:', dataSource: 'Get information about schools', update: 'Daily' },
-    { fields: 'Accounting officer email, Chief financial officer email, Chair of trustees email:', dataSource: 'Get information about schools', update: 'Daily' }]
+    { fields: 'Accounting officer email, Chief financial officer email, Chair of trustees email:', dataSource: 'Get information about schools (internal use only, do not share outside of DfE)', update: 'Daily' }]
 
   test.beforeEach(async ({ page }) => {
     contactsPage = new ContactsPage(page, new FakeTestData())


### PR DESCRIPTION
Small wording change so that data fetched from MSTR is marked as internal correctly. The wording is now _Get information about schools (internal use only, do not share outside of DfE)_

## Screenshots of UI changes

### Before
![image](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/128540970/103967c4-cdaa-4dad-9f62-0c1c6f9f07c1)

### After
![image](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/assets/128540970/aaa9976c-0c4c-4dc7-956f-025a97711a1a)

## Checklist

- [ ] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
