### PR TITLE
154490 - Tag the commit when we push to production

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       environment: ${{ steps.var.outputs.environment }}
       branch: ${{ steps.var.outputs.branch }}
+      release: ${{steps.var.outputs.release}}
     steps:
       - if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         name: Get branch name for push/dispatch event
@@ -42,8 +43,42 @@ jobs:
           GIT_BRANCH=${GIT_REF##*/}
           INPUT=${{ github.event.inputs.environment }}
           ENVIRONMENT=${INPUT:-"development"}
+          RELEASE=${ENVIRONMENT,,}-`date +%Y-%m-%d`.${{ github.run_number }}
           echo "environment=${ENVIRONMENT,,}" >> $GITHUB_OUTPUT
           echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
+          echo "release=${RELEASE,,}" >> $GITHUB_OUTPUT
+
+  create-tag:
+    if: needs.set-env.outputs.release == 'production'
+    name: Tag and release
+    needs: set-env
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Create tag
+        run: |
+          git tag ${{ needs.set-env.outputs.release }}
+          git push origin ${{ needs.set-env.outputs.release }}
+
+      - name: Create release
+        uses: "actions/github-script@v6"
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            try {
+              await github.rest.repos.createRelease({
+                generate_release_notes: true,
+                name: "${{ needs.set-env.outputs.release }}",
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: "${{ needs.set-env.outputs.release }}",
+              });
+            } catch (error) {
+              core.setFailed(error.message);
+            }
 
   deploy-image:
     name: Deploy to environment

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -49,7 +49,7 @@ jobs:
           echo "release=${RELEASE,,}" >> $GITHUB_OUTPUT
 
   create-tag:
-    if: needs.set-env.outputs.release == 'production'
+    if: needs.set-env.outputs.environment == 'production'
     name: Tag and release
     needs: set-env
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Based off of the code in prepare-academy-conversions we can now tag the releases we make to production to better track what versions when have pushed to prod and what is currently deployed.