### PR TITLE
Add exclusion paths for build and test

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -8,6 +8,8 @@ on:
       - 'DfE.FindInformationAcademiesTrusts.Data/**'
       - 'DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/**'
       - 'tests/**'
+      - '!tests/DFE.FindInformationAcademiesTrusts.CypressTests'
+      - '*.csproj'
   pull_request:
     branches: [ main, '**-feature' ]
     types: [ opened, synchronize, reopened]
@@ -16,6 +18,8 @@ on:
       - 'DfE.FindInformationAcademiesTrusts.Data/**'
       - 'DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/**'
       - 'tests/**'
+      - '!tests/DFE.FindInformationAcademiesTrusts.CypressTests'
+      - '*.csproj'
 
 env:
   JAVA_VERSION: '17'


### PR DESCRIPTION
Sets paths to restrict when to run build and test.

This is to reduce the amount of times that sonarcloud is ran and to free up github runners