### PR TITLE
Annotate App Insights for each deployment release

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -88,6 +88,7 @@ jobs:
       docker-image-name: 'fiat-app'
       docker-build-file-name: 'docker/Dockerfile'
       environment: ${{ needs.set-env.outputs.environment }}
+      annotate-release: ${{ needs.set-env.outputs.environment == 'development' }}
     secrets:
       azure-acr-name: ${{ secrets.ACR_NAME }}
       azure-acr-credentials: ${{ secrets.ACR_CREDENTIALS }}


### PR DESCRIPTION
This is currently limited to Dev for testing.

This change adds an extra step post-deployment to record a custom deployment event in App Insights with the SHA that corresponds with the release. This is useful so we can review performance metrics before and after a release