### PR TITLE
Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,27 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "config:recommended",
     "group:linters",
     "group:test",
-    "schedule:weekly"
+    "schedule:weekly",
+    ":approveMajorUpdates",
+    ":automergeLinters",
+    ":automergePatch",
+    ":automergePr",
+    ":automergeRequireAllStatusChecks",
+    ":automergeTesters",
+    ":maintainLockFilesWeekly",
+    ":dependencyDashboard"
   ],
-  "minimumReleaseAge": "7 days"
+  "timezone": "Europe/London",
+  "minimumReleaseAge": "7 days",
+  "automergeSchedule": ["after 10am every weekday", "before 4pm every weekday"],
+  "labels": ["dependencies", "renovate"],
+  "vulnerabilityAlerts": {
+    "addLabels": ["security"]
+  },
+  "major": {
+    "addLabels": ["major"]
+  }
 }


### PR DESCRIPTION
* This is inspired by the default renovate config used by dxw https://github.com/dxw/renovate-config/blob/main/default.json
* PRs for Linters or Test packages will be grouped together to reduce noise
* PRs will be automerged providing status checks pass
* Enables Dependency dashboard for better visibility into pending updates
* Set default label of 'dependencies', with security patches additionally tagged with 'security'. Major versions additionally tagged with 'major'
* Automerge eligible PRs will merge only during business hours