### PR TITLE
Upgrade to dotnet 8

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.csproj
@@ -8,11 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.20">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.20"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.csproj
+++ b/DfE.FindInformationAcademiesTrusts.Data.Hardcoded/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/DfE.FindInformationAcademiesTrusts.Data/DfE.FindInformationAcademiesTrusts.Data.csproj
+++ b/DfE.FindInformationAcademiesTrusts.Data/DfE.FindInformationAcademiesTrusts.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
+++ b/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>7a95582b-ec63-4991-9635-addb5c80a266</UserSecretsId>

--- a/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
+++ b/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
@@ -10,14 +10,14 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.20">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Identity.Web" Version="2.19.1"/>
+        <PackageReference Include="Microsoft.Identity.Web" Version="2.20.0" />
         <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.22.0"/>
-        <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.20.0"/>
-        <PackageReference Include="Serilog.AspNetCore" Version="7.0.0"/>
+        <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.22.0" />
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
         <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0"/>
     </ItemGroup>
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,4 +25,5 @@ LABEL org.opencontainers.image.source=https://github.com/DFE-Digital/find-inform
 COPY --from=publish /app /app
 WORKDIR /app
 RUN chmod +x ./docker-entrypoint.sh
-EXPOSE 80/tcp
+
+EXPOSE 8080/tcp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-ARG ASPNET_IMAGE_TAG=7.0-bullseye-slim-amd64
+ARG ASPNET_IMAGE_TAG=8.0-bookworm-slim-amd64
 ARG NODEJS_IMAGE_TAG=18-bullseye-slim
-ARG DOTNET_SDK=7.0
+ARG DOTNET_SDK=8.0
 
 # Stage 1 - Build frontend assets
 FROM node:${NODEJS_IMAGE_TAG} as assets

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,14 +4,15 @@ ARG DOTNET_SDK=8.0
 
 # Stage 1 - Build frontend assets
 FROM node:${NODEJS_IMAGE_TAG} as assets
-COPY . .
-WORKDIR /DfE.FindInformationAcademiesTrusts
+COPY . /repo
+WORKDIR /repo/DfE.FindInformationAcademiesTrusts
 RUN npm install
 RUN npm run build
 
 # Stage 2 - Build and publish dotnet application
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK} AS publish
-COPY --from=assets . .
+COPY --from=assets /repo /repo
+WORKDIR /repo
 RUN dotnet restore DfE.FindInformationAcademiesTrusts
 RUN dotnet build DfE.FindInformationAcademiesTrusts -c Release
 RUN dotnet publish DfE.FindInformationAcademiesTrusts -c Release -o /app --no-build

--- a/docker/FakeDataGenerator.Dockerfile
+++ b/docker/FakeDataGenerator.Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG DOTNET_SDK=7.0
+﻿ARG DOTNET_SDK=8.0
 
 # Build and run console app to generate fake data
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK}

--- a/docker/docker-compose-db.yml
+++ b/docker/docker-compose-db.yml
@@ -1,4 +1,5 @@
 version: "3.8"
+name: fiat-fake-db-only
 services:
   sqlserver:
     image: mcr.microsoft.com/mssql/server:2022-latest

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -43,7 +43,7 @@ services:
     depends_on:
       - import-sql
     ports:
-      - 80:80/tcp
+      - "80:8080/tcp"
     networks:
       - test-ci
     environment:

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -1,4 +1,5 @@
 version: "3.8"
+name: fiat-ci-env
 services:
   sqlserver:
     image: mcr.microsoft.com/mssql/server:2022-latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,5 @@
 version: "3.8"
+name: fiat
 services:
   webapp:
     build:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,6 @@ services:
       dockerfile: docker/Dockerfile
     command: /bin/bash -c "./docker-entrypoint.sh dotnet DfE.FindInformationAcademiesTrusts.dll"
     ports:
-      - 80:80/tcp
+      - "80:8080/tcp"
     env_file:
       - .env

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ Use this documentation to configure your local development environment.
 
 ### Prerequisites
 
-- .NET 7 SDK
+- .NET 8 SDK
 - node
 - npm
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Nullable>enable</Nullable>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Faker.csproj
@@ -11,12 +11,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="34.0.2"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.20">
+        <PackageReference Include="Bogus" Version="35.5.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.20"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj
@@ -14,12 +14,12 @@
         <PackageReference Include="FluentAssertions" Version="6.12.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
         <PackageReference Include="Moq" Version="4.20.70"/>
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
@@ -118,7 +118,6 @@ public class TrustSearchTests
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
-    [InlineData(null)]
     public async Task SearchAsync_should_return_empty_if_empty_search_term(string term)
     {
         var result = await _sut.SearchAsync(term);
@@ -128,7 +127,6 @@ public class TrustSearchTests
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
-    [InlineData(null)]
     public async Task SearchAsync_should_not_call_database_if_empty_search_term(string term)
     {
         await _sut.SearchAsync(term);

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
@@ -5,7 +5,7 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests;
 
 public class TrustSearchTests
 {
-    private readonly ITrustSearch _sut;
+    private readonly TrustSearch _sut;
     private readonly MockAcademiesDbContext _mockAcademiesDbContext;
 
     public TrustSearchTests()

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests.csproj
@@ -12,12 +12,12 @@
         <PackageReference Include="FluentAssertions" Version="6.12.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
         <PackageReference Include="Moq" Version="4.20.70"/>
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj
@@ -14,12 +14,12 @@
         <PackageReference Include="FluentAssertions" Version="6.12.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
         <PackageReference Include="Moq" Version="4.20.70"/>
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Authorization/HeaderRequirementHandlerTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Authorization/HeaderRequirementHandlerTests.cs
@@ -71,7 +71,7 @@ public class HeaderRequirementHandlerTests
     [InlineData("", "")]
     [InlineData("Bearer ", "")]
     public void ClientSecretHeaderValid_should_return_false_if_serverAuthKey_not_set(string headerAuthKey,
-        string serverAuthKey)
+        string? serverAuthKey)
     {
         _httpContext.Request.Headers.Append(HeaderNames.Authorization, $"Bearer {headerAuthKey}");
         _mockTestOverrideOptions.Setup(m => m.Value)

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Authorization/HeaderRequirementHandlerTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Authorization/HeaderRequirementHandlerTests.cs
@@ -41,7 +41,7 @@ public class HeaderRequirementHandlerTests
         bool expected)
     {
         _mockWebHostEnvironment.SetupGet(m => m.EnvironmentName).Returns(environment);
-        _httpContext.Request.Headers.Add(HeaderNames.Authorization, "Bearer 123");
+        _httpContext.Request.Headers.Append(HeaderNames.Authorization, "Bearer 123");
 
         //Create sut here because constructor decides whether or not an environment is live
         var sut = new HeaderRequirementHandler(_mockWebHostEnvironment.Object, _mockHttpAccessor.Object,
@@ -58,7 +58,7 @@ public class HeaderRequirementHandlerTests
     [InlineData("Bearer 456")]
     public void ClientSecretHeaderValid_should_return_false_if_contents_are_wrong(string headerAuthKey)
     {
-        _httpContext.Request.Headers.Add(HeaderNames.Authorization, $"Bearer {headerAuthKey}");
+        _httpContext.Request.Headers.Append(HeaderNames.Authorization, $"Bearer {headerAuthKey}");
 
         var result = _sut.IsClientSecretHeaderValid();
 
@@ -73,7 +73,7 @@ public class HeaderRequirementHandlerTests
     public void ClientSecretHeaderValid_should_return_false_if_serverAuthKey_not_set(string headerAuthKey,
         string serverAuthKey)
     {
-        _httpContext.Request.Headers.Add(HeaderNames.Authorization, $"Bearer {headerAuthKey}");
+        _httpContext.Request.Headers.Append(HeaderNames.Authorization, $"Bearer {headerAuthKey}");
         _mockTestOverrideOptions.Setup(m => m.Value)
             .Returns(new TestOverrideOptions { CypressTestSecret = serverAuthKey });
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
@@ -14,12 +14,12 @@
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/OverviewModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/OverviewModelTests.cs
@@ -79,7 +79,7 @@ public class OverviewModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_sets_pupil_percentage_on_multi_academy_trust()
+    public async Task OnGetAsync_sets_pupil_percentage_on_multi_academy_trust()
     {
         SetupTrustWithMultipleAcademies();
         await _sut.OnGetAsync();
@@ -87,7 +87,7 @@ public class OverviewModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_sets_pupil_percentage_on_single_academy_trust()
+    public async Task OnGetAsync_sets_pupil_percentage_on_single_academy_trust()
     {
         SetupTrustWithSingleAcademy();
         await _sut.OnGetAsync();
@@ -96,7 +96,7 @@ public class OverviewModelTests
 
 
     [Fact]
-    public async void OnGetAsync_sets_pupil_percentage_on_trust_with_no_academies()
+    public async Task OnGetAsync_sets_pupil_percentage_on_trust_with_no_academies()
     {
         SetupTrustWithNoAcademies();
         await _sut.OnGetAsync();
@@ -104,7 +104,7 @@ public class OverviewModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_sets_list_of_local_authorities()
+    public async Task OnGetAsync_sets_list_of_local_authorities()
     {
         SetupTrustWithMultipleAcademies();
         var expectedLocalAuthorityCount = new (string? Authority, int Total)[]
@@ -119,7 +119,7 @@ public class OverviewModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_sets_ofsted_ratings_list_correctly()
+    public async Task OnGetAsync_sets_ofsted_ratings_list_correctly()
     {
         SetupTrustWithMultipleAcademies();
         var expectedOfstedRatingCount = new (OfstedRatingScore Rating, int Total)[]
@@ -137,7 +137,7 @@ public class OverviewModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_ofsted_score_count_returns_correct_number_of_ratings()
+    public async Task OnGetAsync_ofsted_score_count_returns_correct_number_of_ratings()
     {
         SetupTrustWithMultipleAcademies();
         await _sut.OnGetAsync();
@@ -146,7 +146,7 @@ public class OverviewModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_ofsted_score_count_returns_zero_ratings_when_non_exist()
+    public async Task OnGetAsync_ofsted_score_count_returns_zero_ratings_when_non_exist()
     {
         SetupTrustWithSingleAcademy();
         await _sut.OnGetAsync();
@@ -155,7 +155,7 @@ public class OverviewModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_returns_correct_number_of_academies_for_single_academy_trust()
+    public async Task OnGetAsync_returns_correct_number_of_academies_for_single_academy_trust()
     {
         SetupTrustWithSingleAcademy();
         await _sut.OnGetAsync();
@@ -164,7 +164,7 @@ public class OverviewModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_returns_correct_number_of_academies_for_multi_academy_trust()
+    public async Task OnGetAsync_returns_correct_number_of_academies_for_multi_academy_trust()
     {
         SetupTrustWithMultipleAcademies();
         await _sut.OnGetAsync();
@@ -173,7 +173,7 @@ public class OverviewModelTests
     }
 
     [Fact]
-    public async void OnGetAsync_returns_correct_number_of_academies_for_trust_with_no_academies()
+    public async Task OnGetAsync_returns_correct_number_of_academies_for_trust_with_no_academies()
     {
         SetupTrustWithNoAcademies();
         await _sut.OnGetAsync();


### PR DESCRIPTION
This migrates the applications to LTS .NET 8
FIAT is currently on .NET 7 which Microsoft ended support for in May.

[User Story 173154](https://dev.azure.com.mcas.ms/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/173154?McasTsid=26110&McasCtx=4): Tech Debt: Upgrade to .NET 8

## Changes

- Update all csprojs to .NET 8
- Update all nuget packages to latest versions
- Fix compilation errors caused by .NET and nuget upgrades
- Update Docker to use .NET 8 SDKs and runtime
- Add names to the Docker images to distinguish them more easily when running locally

## Checklist

- [x] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] ~~Update the ADR decision log if needed~~
