### PR TITLE
Set default container port

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -173,6 +173,7 @@ No resources.
 | <a name="input_container_max_replicas"></a> [container\_max\_replicas](#input\_container\_max\_replicas) | Container max replicas | `number` | n/a | yes |
 | <a name="input_container_memory"></a> [container\_memory](#input\_container\_memory) | Container memory in GB | `number` | n/a | yes |
 | <a name="input_container_min_replicas"></a> [container\_min\_replicas](#input\_container\_min\_replicas) | Container min replicas | `number` | n/a | yes |
+| <a name="input_container_port"></a> [container\_port](#input\_container\_port) | Container port | `number` | `80` | no |
 | <a name="input_container_scale_http_concurrency"></a> [container\_scale\_http\_concurrency](#input\_container\_scale\_http\_concurrency) | When the number of concurrent HTTP requests exceeds this value, then another replica is added. Replicas continue to add to the pool up to the max-replicas amount. | `number` | `10` | no |
 | <a name="input_container_secret_environment_variables"></a> [container\_secret\_environment\_variables](#input\_container\_secret\_environment\_variables) | Container secret environment variables | `map(string)` | n/a | yes |
 | <a name="input_dns_mx_records"></a> [dns\_mx\_records](#input\_dns\_mx\_records) | DNS MX records to add to the DNS Zone | <pre>map(<br>    object({<br>      ttl : optional(number, 300),<br>      records : list(<br>        object({<br>          preference : number,<br>          exchange : string<br>        })<br>      )<br>    })<br>  )</pre> | `{}` | no |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -27,6 +27,7 @@ module "azure_container_apps_hosting" {
   container_health_probe_path            = local.container_health_probe_path
   container_cpu                          = local.container_cpu
   container_memory                       = local.container_memory
+  container_port                         = local.container_port
   container_min_replicas                 = local.container_min_replicas
   container_max_replicas                 = local.container_max_replicas
   container_scale_http_concurrency       = local.container_scale_http_concurrency

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -17,6 +17,7 @@ locals {
   container_memory                             = var.container_memory
   container_min_replicas                       = var.container_min_replicas
   container_max_replicas                       = var.container_max_replicas
+  container_port                               = var.container_port
   container_scale_http_concurrency             = var.container_scale_http_concurrency
   enable_redis_cache                           = var.enable_redis_cache
   enable_mssql_database                        = var.enable_mssql_database

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -55,6 +55,12 @@ variable "registry_server" {
   default     = ""
 }
 
+variable "container_port" {
+  description = "Container port"
+  type        = number
+  default     = 80
+}
+
 variable "registry_admin_enabled" {
   description = "Do you want to enable access key based authentication for your Container Registry?"
   type        = bool


### PR DESCRIPTION
- Creates a variable called 'container_port' that allows us to override the default port 80 for different environments.
- Having the default value set to `80` ensures nothing breaks in existing environments
- Once all environments are using the same port, we can update the default definition to match
- Without this, any changes to Ports in the Dockerfile will fail to deploy to Azure