### PR TITLE
Update 404 text and add url to email body

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml
@@ -14,7 +14,8 @@
       <p class="govuk-body">If you typed the web address, check it is correct.</p>
       <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
       <p class="govuk-body">
-        <a class="govuk-link" href="@ViewConstants.ReportAProblemLink">Report this problem</a> if the web address is correct or you selected a link or button.
+        If the web address is correct or you selected a link or button, 
+        <a class="govuk-link" href="@($"{ViewConstants.ReportNotFoundMailtoLink}&body=Url is {Model.OriginalPathAndQuery}")">email Service Support for help with using this system</a>.
       </p>
     }
     else

--- a/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml.cs
@@ -1,16 +1,25 @@
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages;
 
-public class ErrorModel : PageModel
+public class ErrorModel(IHttpContextAccessor httpContextAccessor) : PageModel
 {
     public bool Is404Result { get; set; }
+    public string OriginalPathAndQuery { get; set; } = "Unknown";
 
     public void OnGet(string statusCode)
     {
         if (statusCode == "404")
         {
             Is404Result = true;
+
+            var notFoundData = httpContextAccessor.HttpContext!.Features.Get<IStatusCodeReExecuteFeature>();
+            if (notFoundData is not null)
+            {
+                OriginalPathAndQuery =
+                    $"{httpContextAccessor.HttpContext!.Request.Host}{notFoundData.OriginalPath}{notFoundData.OriginalQueryString}";
+            }
         }
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
@@ -5,7 +5,11 @@ public static class ViewConstants
     public const string ServiceName = "Find information about academies and trusts";
     public const string AboutTheTrustSectionName = "About the trust";
 
-    public const string ReportAProblemLink = "mailto:regionalservices.rg@education.gov.uk?subject=Report a problem with Find information about academies and trusts";
+    public const string ReportAProblemLink =
+        "mailto:regionalservices.rg@education.gov.uk?subject=Report a problem with Find information about academies and trusts";
+
+    public const string ReportNotFoundMailtoLink =
+        "mailto:regionalservices.rg@education.gov.uk?subject=Page not found – Find information about academies and trusts (FIAT)";
 
     public const string FeedbackFormLink =
         "https://forms.office.com.mcas.ms/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-VCFjdIWb7BPh79bON_K__tUOTdJMlZZUzBMMFhHV1lHNERFM041U0dUUy4u";

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/ErrorModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/ErrorModelTests.cs
@@ -1,23 +1,34 @@
 using DfE.FindInformationAcademiesTrusts.Pages;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+using Microsoft.AspNetCore.Http;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages;
 
 public class ErrorModelTests
 {
+    private readonly MockHttpContext _mockHttpContext = new();
+    private readonly ErrorModel _sut;
+
+    public ErrorModelTests()
+    {
+        Mock<IHttpContextAccessor> mockHttpAccessor = new();
+        mockHttpAccessor.Setup(m => m.HttpContext).Returns(_mockHttpContext.Object);
+
+        _sut = new ErrorModel(mockHttpAccessor.Object);
+    }
+
     [Fact]
     public void Is404Result_should_be_false_by_default()
     {
-        var sut = new ErrorModel();
-        sut.Is404Result.Should().BeFalse();
+        _sut.Is404Result.Should().BeFalse();
     }
 
     [Fact]
     public void Is404Result_should_be_true_if_404_Status_Code()
     {
-        var sut = new ErrorModel();
-        sut.OnGet("404");
+        _sut.OnGet("404");
 
-        sut.Is404Result.Should().BeTrue();
+        _sut.Is404Result.Should().BeTrue();
     }
 
     [Theory]
@@ -26,8 +37,23 @@ public class ErrorModelTests
     [InlineData("403")]
     public void Is404Result_should_be_false_if_not_Status_Code(string code)
     {
-        var sut = new ErrorModel();
-        sut.OnGet(code);
-        sut.Is404Result.Should().BeFalse();
+        _sut.OnGet(code);
+        _sut.Is404Result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OriginalPathAndQuery_should_be_unknown_by_default()
+    {
+        _sut.OriginalPathAndQuery.Should().Be("Unknown");
+    }
+
+    [Fact]
+    public void OriginalPathAndQuery_should_be_set_when_404()
+    {
+        _mockHttpContext.SetNotFoundUrl("my.fiat.host", "/notfound", "?var=something");
+
+        _sut.OnGet("404");
+
+        _sut.OriginalPathAndQuery.Should().Be("my.fiat.host/notfound?var=something");
     }
 }


### PR DESCRIPTION
Update the copy on our 404 page so that it uses [the new standard DfE design system wording](https://design-system-rsd-c10b0db1a3a1.herokuapp.com/design-system/rsd-design-system/design-patterns/page-not-found).

[User Story 173127](https://dev.azure.com.mcas.ms/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/173127?McasTsid=26110&McasCtx=4): Update "Page not found" copy (FIAT)

## Changes

- Update the text on 404 page to new content
- Mail to link opens email containing the not found url

## Screenshots of UI changes

### Before

![image](https://github.com/user-attachments/assets/3b90c8a3-a48e-4bda-af56-a24d2348af32)

### After

![image](https://github.com/user-attachments/assets/36661e8a-604f-4850-a873-f5cf0cc5501a)

## Checklist

- [x] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [x] Attach this pull request to the appropriate user story in Azure DevOps
- [ ] Update the ADR decision log if needed
