### PR TITLE
Annotate releases in App Insights for all environments

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -88,7 +88,7 @@ jobs:
       docker-image-name: 'fiat-app'
       docker-build-file-name: 'docker/Dockerfile'
       environment: ${{ needs.set-env.outputs.environment }}
-      annotate-release: ${{ needs.set-env.outputs.environment == 'development' }}
+      annotate-release: true
     secrets:
       azure-acr-name: ${{ secrets.ACR_NAME }}
       azure-acr-credentials: ${{ secrets.ACR_CREDENTIALS }}


### PR DESCRIPTION
- For all environments, we can record an annotation in App Insights post-deployment
- This PR removes the conditional environment restriction as we were waiting for RBAC permissions to be assigned. This is now complete