### PR TITLE
Update $PATH to mssql-tools & trust server certificate

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -11,7 +11,7 @@ services:
     networks:
       - test-ci
     healthcheck:
-      test: /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "mySuperStrong_pa55word!!!"
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "mySuperStrong_pa55word!!!" -C
       interval: "2s"
       retries: 10
   generate-sql:


### PR DESCRIPTION
The 2022 SQL Server image has updated which means the $PATH to mssql-tools has changed.
Additionally, we should trust the self-signed certificate implicitly for the health check