### PR TITLE
Add feature flags to FIAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Feature flags added to allow for selectively showing features in different environments
+
 ## [Release-3][release-3] (production-2024-08-09.2694)
 
 ### Changed

--- a/DfE.FindInformationAcademiesTrusts/Configuration/FeatureFlags.cs
+++ b/DfE.FindInformationAcademiesTrusts/Configuration/FeatureFlags.cs
@@ -2,5 +2,5 @@
 
 public static class FeatureFlags
 {
-    public static readonly string TestFlag = "TestFlag";
+    public const string TestFlag = "TestFlag";
 }

--- a/DfE.FindInformationAcademiesTrusts/Configuration/FeatureFlags.cs
+++ b/DfE.FindInformationAcademiesTrusts/Configuration/FeatureFlags.cs
@@ -1,0 +1,6 @@
+﻿namespace DfE.FindInformationAcademiesTrusts.Configuration;
+
+public static class FeatureFlags
+{
+    public static readonly string TestFlag = "TestFlag";
+}

--- a/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
+++ b/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
@@ -10,14 +10,16 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0"/>
+        <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.3.0"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Identity.Web" Version="2.21.1" />
+        <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.5.0"/>
+        <PackageReference Include="Microsoft.Identity.Web" Version="2.21.1"/>
         <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.22.0"/>
-        <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.22.0" />
-        <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+        <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.22.0"/>
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.1"/>
         <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0"/>
     </ItemGroup>
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Layout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Layout.cshtml
@@ -1,11 +1,9 @@
-﻿@using NetEscapades.AspNetCore.SecurityHeaders
-@inject IWebHostEnvironment _env
-
+﻿@using DfE.FindInformationAcademiesTrusts.Configuration
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
 
 @{
-    var hasConsented = CookiesHelper.OptionalCookiesAreAccepted(Context, TempData);
+  var hasConsented = CookiesHelper.OptionalCookiesAreAccepted(Context, TempData);
 }
 
 <head>
@@ -23,10 +21,10 @@
   <link rel="stylesheet" href="~/dist/main.css"/>
   <partial name="_AppInsights"/>
 
-    @if (hasConsented)
-    {
-        <!-- Google Tag Manager -->
-        <script asp-add-nonce>
+  @if (hasConsented)
+  {
+    <!-- Google Tag Manager -->
+    <script asp-add-nonce>
             (function (w, d, s, l, i) {
                 w[l] = w[l] || []; w[l].push({
                     'gtm.start':
@@ -35,8 +33,8 @@
                     j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
                         'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
             })(window, document, 'script', 'dataLayer', 'GTM-579KCM8T');</script>
-        <!-- End Google Tag Manager -->
-    }
+    <!-- End Google Tag Manager -->
+  }
 
 </head>
 
@@ -44,12 +42,13 @@
 
   @if (hasConsented)
   {
-        <!-- Google Tag Manager (noscript) -->
-        <noscript>
-            <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-579KCM8T"
-                    height="0" width="0" style="display:none;visibility:hidden"></iframe>
-        </noscript>
-        <!-- End Google Tag Manager (noscript) -->
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-579KCM8T"
+              height="0" width="0" style="display:none;visibility:hidden">
+      </iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
   }
 
   <script asp-add-nonce>
@@ -58,6 +57,9 @@
   <partial name="_CookieBanner"/>
   <partial name="_NotificationBanner"/>
   <partial name="_Header"/>
+  <feature name="@FeatureFlags.TestFlag">
+    TEST FLAG IS ENABLED
+  </feature>
 
   @RenderBody()
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/_ViewImports.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/_ViewImports.cshtml
@@ -5,5 +5,6 @@
 @namespace DfE.FindInformationAcademiesTrusts.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, NetEscapades.AspNetCore.SecurityHeaders.TagHelpers
+@addTagHelper *, Microsoft.FeatureManagement.AspNetCore
 @inject IOptions<ApplicationInsightsOptions> ApplicationInsightsOptions
 @inject IOptions<NotificationBannerOptions> NotificationBannerOptions

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.CookiePolicy;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.FeatureManagement;
 using Microsoft.Identity.Web;
 using Serilog;
 
@@ -224,6 +225,7 @@ internal static class Program
             .Bind(builder.Configuration.GetSection(ApplicationInsightsOptions.ConfigurationSection));
         builder.Services.AddOptions<NotificationBannerOptions>()
             .Bind(builder.Configuration.GetSection(NotificationBannerOptions.ConfigurationSection));
+        builder.Services.AddFeatureManagement();
     }
 
     private static void AddAuthenticationServices(WebApplicationBuilder builder)

--- a/DfE.FindInformationAcademiesTrusts/appsettings.json
+++ b/DfE.FindInformationAcademiesTrusts/appsettings.json
@@ -36,5 +36,8 @@
     "Properties": {
       "Application": "DfE.FindInformationAcademiesTrusts"
     }
+  },
+  "FeatureManagement": {
+    "TestFlag": false
   }
 }

--- a/README.md
+++ b/README.md
@@ -3,15 +3,17 @@
 We are a tool for everyone in DfE to find information which is collated from multiple sources about academies and trusts to inform their assessments, decisions and support activities.
 
 ## Developer set up
+
 - [Get started](docs/getting-started.md)
 - [Run tests locally](docs/run-tests-locally.md)
 - [Supercharge your dev environment](docs/supercharge-your-dev-environment.md) (Test coverage and linting)
 - [Update test data](docs/update-test-data.md)
 - [Enable Application Insights](docs/application-insights.md)
 
-
 ## Approach and decisions
+
 - [Architecture Decision Records (ADRs)](docs/adrs)
 - [Archive branches](docs/archive-branches.md)
 - [Hardcoded data](docs/hardcoded-data.md)
 - [Test Approach](docs/test-approach.md)
+- [Feature Flags](docs/feature-flags.md)

--- a/docs/adrs/0011-use-feature-managment-to-control-release-of-upcoming-features.md
+++ b/docs/adrs/0011-use-feature-managment-to-control-release-of-upcoming-features.md
@@ -1,0 +1,19 @@
+# 11. Use feature management to control the release of upcoming features
+
+Date: 2024-08-07
+
+## Status
+
+Accepted
+
+## Context
+
+Development of future features may have to be started before supporting work is completed. We need a system that allows us to create new features without having them released to users.
+
+## Decision
+
+Using the ASP.Net Feature managment nuget package we will implement feature flags. This will allow us to place upcoming features/pages behind feature gates meaning that development can be completed on future features and the release of these can be controlled using environment variables and using the app settings files.
+
+## Consequences
+
+Features can now be restricted to certain versions or environments. Feature flags available will need to be kept track of using a constants file in the code and additional documentation.

--- a/docs/adrs/0011-use-feature-managment-to-control-release-of-upcoming-features.md
+++ b/docs/adrs/0011-use-feature-managment-to-control-release-of-upcoming-features.md
@@ -12,7 +12,7 @@ Development of future features may have to be started before supporting work is 
 
 ## Decision
 
-Using the ASP.Net Feature managment nuget package we will implement feature flags. This will allow us to place upcoming features/pages behind feature gates meaning that development can be completed on future features and the release of these can be controlled using environment variables and using the app settings files.
+Using the ASP.Net Feature managment nuget package we will implement feature flags. This will allow us to place upcoming features/pages behind feature gates meaning that development can be completed on future features and the release of these can be controlled using environment variables and using the app settings files. A list of feature flags will be kept in documentation so we can track which flags are available and what features they restrict. For each User story or feature that involves adding feature flag, a work task will be created to remove the flag when it is no longer needed. Flags should be removed after a appropriate amount of time after the feature is released.
 
 ## Consequences
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,21 @@
+# Feature flags
+
+Feature flags can be used to programatically turn features on and off. We can use them to control the release of features in different environments or at different times.
+
+## Adding a flag
+
+To create a flag you need to add it as a constant to `DfE.FindInformationAcadmiesTrusts/Configuration/FeatureFlags.cs` and add a default value to the appsettings.json file. Finally add the flag name, default value (used in appsettings.json) and reason for creating the flag/what the flag controls to the list at the end of this file.
+
+## Using a flag
+
+Flag can be used in 3 ways to restrict parts of the code:
+
+- Using the tag helper in a razor page
+- Using a attribute on a class or function
+- Using dependency injection with the IFeatureManagement class
+
+They can then be toggled using enviroment variables in each of the different environments, or using the appsettings.json file to override them when developing locally.
+
+## List of flags
+
+- `TestFlag` (Default: false): Flag added to test the functionallity of feature flags. Adds a line to the layout that shows flags are working when set to true.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -2,20 +2,24 @@
 
 Feature flags can be used to programatically turn features on and off. We can use them to control the release of features in different environments or at different times.
 
-## Adding a flag
+## List of current flags
+
+- `TestFlag` (Default: false): Flag added to test the functionality of feature flags. Adds a line to the layout that shows flags are working when set to true.
+
+## Implementation
+
+We have followed what is more or less the default DotNet appoach for adding feature flags to our application. More documentation on using feature flags can be found on the [Microsoft docs here](https://learn.microsoft.com/en-us/azure/azure-app-configuration/use-feature-flags-dotnet-core).
+
+### Adding a flag
 
 To create a flag you need to add it as a constant to `DfE.FindInformationAcadmiesTrusts/Configuration/FeatureFlags.cs` and add a default value to the appsettings.json file. Finally add the flag name, default value (used in appsettings.json) and reason for creating the flag/what the flag controls to the list at the end of this file.
 
-## Using a flag
+### Using a flag
 
-Flag can be used in 3 ways to restrict parts of the code:
+Flags can be used in 3 main ways to restrict parts of the code:
 
 - Using the tag helper in a razor page
-- Using a attribute on a class or function
+- Using an attribute on a class or function
 - Using dependency injection with the IFeatureManagement class
 
 They can then be toggled using enviroment variables in each of the different environments, or using the appsettings.json file to override them when developing locally.
-
-## List of flags
-
-- `TestFlag` (Default: false): Flag added to test the functionallity of feature flags. Adds a line to the layout that shows flags are working when set to true.


### PR DESCRIPTION
Feature flags are now enabled! They can be used with FeatureGate attribute in our page models or using the feature tag helper on razor pages. They are controlled using the app settings which themselves can be overridden using env variables.

## Changes

Add packages to use feature flags
Add in an initial test flag that can be used to confirm feature flags are functioning

## Checklist

- [x] Deploy this branch to the test environment for manual testing once comments have been resolved and checks have passed 
- [ ] Attach this pull request to the appropriate user story in Azure DevOps
- [x] Update the ADR decision log if needed
- [x] Add release notes to CHANGELOG.md
