### PR TITLE
Updated accessibility statement to remove duplication of words

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Accessibility.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Accessibility.cshtml
@@ -87,7 +87,7 @@
         </h3>
         <p class="govuk-body">
             <ul class="govuk-list govuk-list--bullet">
-                <li>There is no clear not clear alternate navigation back to the home page when looking at a trust or academy. This does not meet<a href="https://www.w3.org/WAI/WCAG22/Understanding/multiple-ways" class="govuk-link" rel="noopener" target="_blank"> WCAG 2.2 AA success criteria 2.4.5.</a></li>
+                <li>There is no clear alternate navigation back to the home page when looking at a trust or academy. This does not meet<a href="https://www.w3.org/WAI/WCAG22/Understanding/multiple-ways" class="govuk-link" rel="noopener" target="_blank"> WCAG 2.2 AA success criteria 2.4.5.</a></li>
             </ul>
         </p>
         <h2 class="govuk-heading-m">


### PR DESCRIPTION
[Bug 175593](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/175593): Accessibility statement "no clear" typo

Simply removes extra words 'Not clear' from the accessibility statement
