### PR TITLE
Maintenance: Improve CI pipeline

### DIFF
--- a/.github/workflows/continuous-integration-dotnet-and-sonar.yml
+++ b/.github/workflows/continuous-integration-dotnet-and-sonar.yml
@@ -1,23 +1,27 @@
-name: Build, analyse and test .NET code
+name: Test .NET code and scan all code with SonarScanner
 
 on:
   push:
     branches: [ main ]
     paths:
-      - 'DfE.FindInformationAcademiesTrusts/**'
-      - 'DfE.FindInformationAcademiesTrusts.Data/**'
-      - 'DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/**'
-      - 'tests/**'
-      - '!tests/DFE.FindInformationAcademiesTrusts.CypressTests/**'
+      - '**'
+      - '!.gitignore'
+      - '!**.DotSettings'
+      - '!**.md'
+      - '!.config/**'
+      - '!.github/**'
+      - '!terraform/**'
   pull_request:
     branches: [ main, '**-feature' ]
     types: [ opened, synchronize, reopened]
     paths:
-       - 'DfE.FindInformationAcademiesTrusts/**'
-       - 'DfE.FindInformationAcademiesTrusts.Data/**'
-       - 'DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/**'
-       - 'tests/**'
-       - '!tests/DFE.FindInformationAcademiesTrusts.CypressTests/**'
+      - '**'
+      - '!.gitignore'
+      - '!**.DotSettings'
+      - '!**.md'
+      - '!.config/**'
+      - '!.github/**'
+      - '!terraform/**'
 
 env:
   DOTNET_VERSION: '8.x'

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -20,6 +20,7 @@ on:
        - '!tests/DFE.FindInformationAcademiesTrusts.CypressTests/**'
 
 env:
+  DOTNET_VERSION: '8.x'
   JAVA_VERSION: '17'
   LAST_COMMIT_SHA: default
 
@@ -42,7 +43,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: Set up JDK
       uses: actions/setup-java@v4


### PR DESCRIPTION
In a recent external release, SonarScanner for .NET changed from only scanning .NET code (and code directly referenced by the csprojs) to scanning all code in the repo for all languages it supports (such as Docker and TypeScript) by default. This change to the workflow is to better describe that behaviour and to trigger by default unless the path is explicitly something that isn't scanned by Sonar.

Also, we missed a change from .NET 7 to .NET 8. This didn't break the pipeline because .NET 8 SDK existed on the runner.

## Changes

- Change .NET 7 to .NET 8 and parameterise it similar to the Java version
- Rename file and change workflow name to reflect that this workflow now scans all code in repo with SonarScanner
- Change the trigger paths from whitelisting (most) known .NET code to blacklisting known files not supported by SonarScanner

## Checklist

~Pull request attached to the appropriate user story in Azure DevOps~
~ADR decision log updated (if needed)~
~Release notes added to CHANGELOG.md~
~Testing complete - all manual and automated tests pass~
