### PR TITLE
Improve performance of academies in trust ofsted page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Update the sorting behaviour for dates on the tables
+- Reduced the load time of the Academies in trust Ofsted page
 
 ## [Release-4][release-4] (production-2024-08-22.2794)
 

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Contexts/AcadmiesDbContext.Filters.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Contexts/AcadmiesDbContext.Filters.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis;
 using Microsoft.EntityFrameworkCore;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
@@ -25,6 +26,12 @@ public partial class AcademiesDbContext
         });
 
         modelBuilder.Entity<GiasGroupLink>(entity =>
+        {
+            entity.HasQueryFilter(gl =>
+                gl.Urn != null);
+        });
+
+        modelBuilder.Entity<MisEstablishment>(entity =>
         {
             entity.HasQueryFilter(gl =>
                 gl.Urn != null);

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
@@ -1,10 +1,14 @@
+using System.Globalization;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Extensions;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 
-public class AcademyRepository(IAcademiesDbContext academiesDbContext) : IAcademyRepository
+public class AcademyRepository(IAcademiesDbContext academiesDbContext, ILogger<AcademyRepository> logger)
+    : IAcademyRepository
 {
     public async Task<AcademyDetails[]> GetAcademiesInTrustDetailsAsync(string uid)
     {
@@ -21,9 +25,94 @@ public class AcademyRepository(IAcademiesDbContext academiesDbContext) : IAcadem
             .ToArrayAsync();
     }
 
-    public Task<AcademyOfsted[]> GetAcademiesInTrustOfstedAsync(string uid)
+    public async Task<AcademyOfsted[]> GetAcademiesInTrustOfstedAsync(string uid)
     {
-        throw new NotImplementedException();
+        var giasGroupLinkData = await academiesDbContext.GiasGroupLinks
+            .Where(gl => gl.GroupUid == uid)
+            .Select(gl => new
+            {
+                Urn = gl.Urn!,
+                gl.EstablishmentName,
+                gl.JoinedDate
+            })
+            .ToListAsync();
+
+        var ofstedRatings = await GetOfstedRatings(giasGroupLinkData.Select(gl => int.Parse(gl.Urn)).ToArray());
+
+        var academyOfsteds = giasGroupLinkData.Select(gl =>
+                new AcademyOfsted(gl.Urn,
+                    gl.EstablishmentName,
+                    DateTime.ParseExact(gl.JoinedDate!, "dd/MM/yyyy", CultureInfo.InvariantCulture),
+                    ofstedRatings[gl.Urn].Previous,
+                    ofstedRatings[gl.Urn].Current
+                ))
+            .ToArray();
+
+        return academyOfsteds;
+    }
+
+    private async Task<Dictionary<string, (OfstedRating Current, OfstedRating Previous)>> GetOfstedRatings(int[] urns)
+    {
+        // Ofsted data is held in MisEstablishments for most academies
+        var ofstedRatings =
+            await academiesDbContext.MisEstablishments
+                .Where(me => urns.Contains(me.Urn!.Value))
+                .Select(me => new
+                {
+                    Urn = me.Urn!.Value,
+                    Current = me.OverallEffectiveness == null
+                        ? OfstedRating.None
+                        : new OfstedRating(
+                            (OfstedRatingScore)me.OverallEffectiveness.Value,
+                            me.InspectionEndDate.ParseAsNullableDate()
+                        ),
+                    Previous = me.PreviousFullInspectionOverallEffectiveness == null
+                        ? OfstedRating.None
+                        : new OfstedRating(
+                            (OfstedRatingScore)int.Parse(me.PreviousFullInspectionOverallEffectiveness),
+                            me.PreviousInspectionEndDate.ParseAsNullableDate()
+                        )
+                })
+                .ToListAsync();
+
+        // Look in MisFurtherEducationEstablishments for academies not found in MisEstablishments
+        // Note: if an entry is in MisEstablishments then it will not be in MisFurtherEducationEstablishments, even if it has no ofsted data
+        var urnsNotInMisEstablishments = urns.Except(ofstedRatings.Select(a => a.Urn)).ToArray();
+        if (urnsNotInMisEstablishments.Length > 0)
+        {
+            ofstedRatings.AddRange(
+                await academiesDbContext.MisFurtherEducationEstablishments
+                    .Where(mfe => urnsNotInMisEstablishments.Contains(mfe.ProviderUrn))
+                    .Select(mfe =>
+                        new
+                        {
+                            Urn = mfe.ProviderUrn,
+                            Current = mfe.OverallEffectiveness == null
+                                ? OfstedRating.None
+                                : new OfstedRating(
+                                    (OfstedRatingScore)mfe.OverallEffectiveness.Value,
+                                    mfe.LastDayOfInspection.ParseAsNullableDate()
+                                ),
+                            Previous = mfe.PreviousOverallEffectiveness == null
+                                ? OfstedRating.None
+                                : new OfstedRating(
+                                    (OfstedRatingScore)mfe.PreviousOverallEffectiveness.Value,
+                                    mfe.PreviousLastDayOfInspection.ParseAsNullableDate()
+                                )
+                        }
+                    ).ToArrayAsync()
+            );
+        }
+
+        foreach (var urn in urns.Except(ofstedRatings.Select(a => a.Urn)))
+        {
+            logger.LogError(
+                "URN {Urn} was not found in Mis.Establishments or Mis.FurtherEducationEstablishments. This indicates a data integrity issue with the Ofsted data in Academies Db.",
+                urn);
+            ofstedRatings.Add(new { Urn = urn, Current = OfstedRating.None, Previous = OfstedRating.None });
+        }
+
+        return ofstedRatings.ToDictionary(o => o.Urn.ToString(), o => (o.Current, o.Previous));
     }
 
     public async Task<int> GetNumberOfAcademiesInTrustAsync(string uid)

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
@@ -21,6 +21,11 @@ public class AcademyRepository(IAcademiesDbContext academiesDbContext) : IAcadem
             .ToArrayAsync();
     }
 
+    public Task<AcademyOfsted[]> GetAcademiesInTrustOfstedAsync(string uid)
+    {
+        throw new NotImplementedException();
+    }
+
     public async Task<int> GetNumberOfAcademiesInTrustAsync(string uid)
     {
         return await academiesDbContext.GiasGroupLinks.CountAsync(gl => gl.GroupUid == uid && gl.Urn != null);

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/AcademyOfsted.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/AcademyOfsted.cs
@@ -1,0 +1,9 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
+
+public record AcademyOfsted(
+    string Urn,
+    string? EstablishmentName,
+    DateTime DateAcademyJoinedTrust,
+    OfstedRating PreviousOfstedRating,
+    OfstedRating CurrentOfstedRating
+);

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/IAcademyRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/IAcademyRepository.cs
@@ -5,4 +5,5 @@ public interface IAcademyRepository
     Task<string?> GetSingleAcademyTrustAcademyUrnAsync(string uid);
     Task<int> GetNumberOfAcademiesInTrustAsync(string uid);
     Task<AcademyDetails[]> GetAcademiesInTrustDetailsAsync(string uid);
+    Task<AcademyOfsted[]> GetAcademiesInTrustOfstedAsync(string uid);
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml
@@ -17,10 +17,10 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      @foreach (var academy in Model.Trust.Academies)
+      @foreach (var academy in Model.Academies)
       {
         <tr class="govuk-table__row" data-testid="academy-row">
-            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
+          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
             @academy.EstablishmentName<br/><span class="govuk-!-font-weight-regular" data-testid="urn">URN: @academy.Urn</span>
           </th>
           <td class="govuk-body govuk-table__cell" data-sort-value="@academy.DateAcademyJoinedTrust.ToString(StringFormatConstants.SortDate)" data-testid="date-joined">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/OfstedRatings.cshtml.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
@@ -8,13 +9,15 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
 public class OfstedRatingsModel : TrustsAreaModel, IAcademiesAreaModel
 {
-    public Trust Trust { get; set; } = default!;
+    public AcademyOfstedServiceModel[] Academies { get; set; } = default!;
+    private IAcademyService AcademyService { get; }
 
     public OfstedRatingsModel(ITrustProvider trustProvider, IDataSourceService dataSourceService,
-        ILogger<OfstedRatingsModel> logger, ITrustService trustService) : base(trustProvider, dataSourceService,
-        trustService, logger, "Academies in this trust")
+        ILogger<OfstedRatingsModel> logger, ITrustService trustService, IAcademyService academyService) : base(
+        trustProvider, dataSourceService, trustService, logger, "Academies in this trust")
     {
         PageTitle = "Academies Ofsted ratings";
+        AcademyService = academyService;
     }
 
     public override async Task<IActionResult> OnGetAsync()
@@ -23,7 +26,7 @@ public class OfstedRatingsModel : TrustsAreaModel, IAcademiesAreaModel
 
         if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
 
-        Trust = (await TrustProvider.GetTrustByUidAsync(Uid))!;
+        Academies = await AcademyService.GetAcademiesInTrustOfstedAsync(Uid);
 
         DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.Gias),
             new[] { "Date joined trust" }));

--- a/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyOfstedServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyOfstedServiceModel.cs
@@ -1,0 +1,11 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+
+namespace DfE.FindInformationAcademiesTrusts.Services.Academy;
+
+public record AcademyOfstedServiceModel(
+    string Urn,
+    string? EstablishmentName,
+    DateTime DateAcademyJoinedTrust,
+    OfstedRating PreviousOfstedRating,
+    OfstedRating CurrentOfstedRating
+);

--- a/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyService.cs
@@ -19,8 +19,12 @@ public class AcademyService(IAcademyRepository academyRepository) : IAcademyServ
                 a.UrbanRural)).ToArray();
     }
 
-    public Task<AcademyOfstedServiceModel[]> GetAcademiesInTrustOfstedAsync(string uid)
+    public async Task<AcademyOfstedServiceModel[]> GetAcademiesInTrustOfstedAsync(string uid)
     {
-        throw new NotImplementedException();
+        var academies = await academyRepository.GetAcademiesInTrustOfstedAsync(uid);
+
+        return academies.Select(a =>
+            new AcademyOfstedServiceModel(a.Urn, a.EstablishmentName, a.DateAcademyJoinedTrust, a.PreviousOfstedRating,
+                a.CurrentOfstedRating)).ToArray();
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyService.cs
@@ -5,6 +5,7 @@ namespace DfE.FindInformationAcademiesTrusts.Services.Academy;
 public interface IAcademyService
 {
     Task<AcademyDetailsServiceModel[]> GetAcademiesInTrustDetailsAsync(string uid);
+    Task<AcademyOfstedServiceModel[]> GetAcademiesInTrustOfstedAsync(string uid);
 }
 
 public class AcademyService(IAcademyRepository academyRepository) : IAcademyService
@@ -16,5 +17,10 @@ public class AcademyService(IAcademyRepository academyRepository) : IAcademyServ
         return academies.Select(a =>
             new AcademyDetailsServiceModel(a.Urn, a.EstablishmentName, a.LocalAuthority, a.TypeOfEstablishment,
                 a.UrbanRural)).ToArray();
+    }
+
+    public Task<AcademyOfstedServiceModel[]> GetAcademiesInTrustOfstedAsync(string uid)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -77,6 +77,34 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
         _giasGroupLinks.Add(giasGroupLink);
     }
 
+    public void AddGiasGroupLinks(IEnumerable<GiasGroupLink> giasGroupLink)
+    {
+        _giasGroupLinks.AddRange(giasGroupLink);
+    }
+
+    public void AddGiasGroupLinksForGiasEstablishmentsToGiasGroup(IEnumerable<GiasEstablishment> giasEstablishments,
+        GiasGroup giasGroup)
+    {
+        var newGroupLinks = giasEstablishments
+            .Select(giasEstablishment => new GiasGroupLink
+            {
+                GroupUid = giasGroup.GroupUid,
+                Urn = giasEstablishment.Urn.ToString(),
+                GroupType = giasGroup.GroupType
+            }).ToArray();
+        _giasGroupLinks.AddRange(newGroupLinks);
+    }
+
+    public void AddMisEstablishments(IEnumerable<MisEstablishment> misEstablishments)
+    {
+        _misEstablishments.AddRange(misEstablishments);
+    }
+    
+    public void AddMisFurtherEducationEstablishments(IEnumerable<MisFurtherEducationEstablishment> misFurtherEducationEstablishments)
+    {
+        _misFurtherEducationEstablishments.AddRange(misFurtherEducationEstablishments);
+    }
+
     public GiasEstablishment AddGiasEstablishment(int urn, string? establishmentName = "my academy")
     {
         var giasEstablishment = new GiasEstablishment

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
@@ -1,7 +1,9 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;
 
@@ -9,10 +11,11 @@ public class AcademyRepositoryTests
 {
     private readonly AcademyRepository _sut;
     private readonly MockAcademiesDbContext _mockAcademiesDbContext = new();
+    private readonly MockLogger<AcademyRepository> _mockLogger = new();
 
     public AcademyRepositoryTests()
     {
-        _sut = new AcademyRepository(_mockAcademiesDbContext.Object);
+        _sut = new AcademyRepository(_mockAcademiesDbContext.Object, _mockLogger.Object);
     }
 
     [Fact]
@@ -28,7 +31,7 @@ public class AcademyRepositoryTests
             UrbanRuralName = $"UrbanRuralName {n}"
         }).ToArray();
         _mockAcademiesDbContext.AddGiasEstablishments(giasEstablishments);
-        _mockAcademiesDbContext.LinkGiasEstablishmentsToGiasGroup(giasEstablishments, giasGroup);
+        _mockAcademiesDbContext.AddGiasGroupLinksForGiasEstablishmentsToGiasGroup(giasEstablishments, giasGroup);
 
         var result = await _sut.GetAcademiesInTrustDetailsAsync("1234");
 
@@ -48,6 +51,217 @@ public class AcademyRepositoryTests
     {
         var result = await _sut.GetAcademiesInTrustDetailsAsync("1234");
         result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAcademiesInTrustOfstedAsync_should_return_empty_array_when_no_academies_linked_to_trust()
+    {
+        var result = await _sut.GetAcademiesInTrustOfstedAsync("1234");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAcademiesInTrustOfstedAsync_should_only_return_academies_linked_to_trust()
+    {
+        _mockAcademiesDbContext.AddGiasGroupLink(new GiasGroupLink
+            { GroupUid = "some other trust", Urn = "some other academy" });
+
+        var giasGroupLinks = AddGiasGroupLinksToMockDb(6);
+
+        var result = await _sut.GetAcademiesInTrustOfstedAsync("1234");
+
+        result.Select(a => a.Urn).Should().BeEquivalentTo(giasGroupLinks.Select(g => g.Urn));
+        result.Select(a => a.EstablishmentName).Should()
+            .BeEquivalentTo(giasGroupLinks.Select(g => g.EstablishmentName));
+    }
+
+
+    [Fact]
+    public async Task GetAcademiesInTrustOfstedAsync_should_set_EstablishmentName_from_giasGroupLink()
+    {
+        var giasGroupLinks = AddGiasGroupLinksToMockDb(6);
+
+        var result = await _sut.GetAcademiesInTrustOfstedAsync("1234");
+
+        result.Select(a => a.EstablishmentName).Should()
+            .BeEquivalentTo(giasGroupLinks.Select(g => g.EstablishmentName));
+    }
+
+    [Fact]
+    public async Task GetAcademiesInTrustOfstedAsync_should_set_DateAcademyJoinedTrust_from_giasGroupLink()
+    {
+        var giasGroupLinks = AddGiasGroupLinksToMockDb(3);
+        giasGroupLinks[0].JoinedDate = "01/01/2022";
+        giasGroupLinks[1].JoinedDate = "29/02/2024";
+        giasGroupLinks[2].JoinedDate = "31/12/1999";
+
+        var result = await _sut.GetAcademiesInTrustOfstedAsync("1234");
+
+        result.Select(a => a.DateAcademyJoinedTrust)
+            .Should()
+            .BeEquivalentTo(new[]
+            {
+                new DateTime(2022, 01, 01),
+                new DateTime(2024, 02, 29),
+                new DateTime(1999, 12, 31)
+            });
+    }
+
+    // @formatter:max_line_length 500 - these tests are very difficult to read after line wrapping is enforced so increase max line length
+    [Fact]
+    public async Task GetAcademiesInTrustOfstedAsync_should_set_current_ofsted()
+    {
+        var giasGroupLinks = AddGiasGroupLinksToMockDb(10);
+        var urns = giasGroupLinks.Select(gl => gl.Urn!).ToArray();
+        var urnsAsInt = urns.Select(int.Parse).ToArray();
+
+        _mockAcademiesDbContext.AddMisEstablishments(new[]
+        {
+            new MisEstablishment { Urn = urnsAsInt[0], OverallEffectiveness = 1, InspectionEndDate = "01/01/2022" },
+            new MisEstablishment { Urn = urnsAsInt[1], OverallEffectiveness = 2, InspectionEndDate = "29/02/2024" },
+            new MisEstablishment { Urn = urnsAsInt[2], OverallEffectiveness = 3, InspectionEndDate = "31/12/2022" },
+            new MisEstablishment { Urn = urnsAsInt[3], OverallEffectiveness = 4, InspectionEndDate = "15/10/2023" },
+            new MisEstablishment { Urn = urnsAsInt[4], OverallEffectiveness = null, InspectionEndDate = null }
+        });
+        _mockAcademiesDbContext.AddMisFurtherEducationEstablishments(new[]
+        {
+            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[5], OverallEffectiveness = 1, LastDayOfInspection = "01/01/2022" },
+            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[6], OverallEffectiveness = 2, LastDayOfInspection = "29/02/2024" },
+            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[7], OverallEffectiveness = 3, LastDayOfInspection = "31/12/2022" },
+            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[8], OverallEffectiveness = 4, LastDayOfInspection = "15/10/2023" },
+            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[9], OverallEffectiveness = null, LastDayOfInspection = null }
+        });
+
+        var result = await _sut.GetAcademiesInTrustOfstedAsync("1234");
+
+        var dummyAcademyOfsted = new AcademyOfsted(string.Empty, default, default, OfstedRating.None, OfstedRating.None);
+
+        result.Should().BeEquivalentTo(new[]
+            {
+                dummyAcademyOfsted with { Urn = urns[0], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.Outstanding, new DateTime(2022, 01, 01)) },
+                dummyAcademyOfsted with { Urn = urns[1], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime(2024, 02, 29)) },
+                dummyAcademyOfsted with { Urn = urns[2], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2022, 12, 31)) },
+                dummyAcademyOfsted with { Urn = urns[3], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.Inadequate, new DateTime(2023, 10, 15)) },
+                dummyAcademyOfsted with { Urn = urns[4], CurrentOfstedRating = OfstedRating.None },
+                dummyAcademyOfsted with { Urn = urns[5], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.Outstanding, new DateTime(2022, 01, 01)) },
+                dummyAcademyOfsted with { Urn = urns[6], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime(2024, 02, 29)) },
+                dummyAcademyOfsted with { Urn = urns[7], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2022, 12, 31)) },
+                dummyAcademyOfsted with { Urn = urns[8], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.Inadequate, new DateTime(2023, 10, 15)) },
+                dummyAcademyOfsted with { Urn = urns[9], CurrentOfstedRating = OfstedRating.None }
+            },
+            options => options
+                .Including(a => a.Urn)
+                .Including(a => a.CurrentOfstedRating)
+        );
+    }
+
+    [Fact]
+    public async Task GetAcademiesInTrustOfstedAsync_should_set_previous_ofsted()
+    {
+        var giasGroupLinks = AddGiasGroupLinksToMockDb(10);
+        var urns = giasGroupLinks.Select(gl => gl.Urn!).ToArray();
+        var urnsAsInt = urns.Select(int.Parse).ToArray();
+
+        _mockAcademiesDbContext.AddMisEstablishments(new[]
+        {
+            new MisEstablishment { Urn = urnsAsInt[0], PreviousFullInspectionOverallEffectiveness = "1", PreviousInspectionEndDate = "01/01/2022" },
+            new MisEstablishment { Urn = urnsAsInt[1], PreviousFullInspectionOverallEffectiveness = "2", PreviousInspectionEndDate = "29/02/2024" },
+            new MisEstablishment { Urn = urnsAsInt[2], PreviousFullInspectionOverallEffectiveness = "3", PreviousInspectionEndDate = "31/12/2022" },
+            new MisEstablishment { Urn = urnsAsInt[3], PreviousFullInspectionOverallEffectiveness = "4", PreviousInspectionEndDate = "15/10/2023" },
+            new MisEstablishment { Urn = urnsAsInt[4], PreviousFullInspectionOverallEffectiveness = null, PreviousInspectionEndDate = null }
+        });
+        _mockAcademiesDbContext.AddMisFurtherEducationEstablishments(new[]
+        {
+            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[5], PreviousOverallEffectiveness = 1, PreviousLastDayOfInspection = "01/01/2022" },
+            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[6], PreviousOverallEffectiveness = 2, PreviousLastDayOfInspection = "29/02/2024" },
+            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[7], PreviousOverallEffectiveness = 3, PreviousLastDayOfInspection = "31/12/2022" },
+            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[8], PreviousOverallEffectiveness = 4, PreviousLastDayOfInspection = "15/10/2023" },
+            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[9], PreviousOverallEffectiveness = null, PreviousLastDayOfInspection = null }
+        });
+
+        var result = await _sut.GetAcademiesInTrustOfstedAsync("1234");
+
+        var dummyAcademyOfsted = new AcademyOfsted(string.Empty, default, default, OfstedRating.None, OfstedRating.None);
+
+        result.Should().BeEquivalentTo(new[]
+            {
+                dummyAcademyOfsted with { Urn = urns[0], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.Outstanding, new DateTime(2022, 01, 01)) },
+                dummyAcademyOfsted with { Urn = urns[1], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime(2024, 02, 29)) },
+                dummyAcademyOfsted with { Urn = urns[2], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2022, 12, 31)) },
+                dummyAcademyOfsted with { Urn = urns[3], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.Inadequate, new DateTime(2023, 10, 15)) },
+                dummyAcademyOfsted with { Urn = urns[4], PreviousOfstedRating = OfstedRating.None },
+                dummyAcademyOfsted with { Urn = urns[5], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.Outstanding, new DateTime(2022, 01, 01)) },
+                dummyAcademyOfsted with { Urn = urns[6], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime(2024, 02, 29)) },
+                dummyAcademyOfsted with { Urn = urns[7], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2022, 12, 31)) },
+                dummyAcademyOfsted with { Urn = urns[8], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.Inadequate, new DateTime(2023, 10, 15)) },
+                dummyAcademyOfsted with { Urn = urns[9], PreviousOfstedRating = OfstedRating.None }
+            },
+            options => options
+                .Including(a => a.Urn)
+                .Including(a => a.PreviousOfstedRating)
+        );
+    }
+    // @formatter:max_line_length restore
+
+    [Fact]
+    public async Task GetAcademiesInTrustOfstedAsync_should_log_error_and_return_ofsted_none_when_urn_not_found_in_mis()
+    {
+        var giasGroupLink = AddGiasGroupLinksToMockDb(1).Single();
+
+        var result = await _sut.GetAcademiesInTrustOfstedAsync("1234");
+
+        var academyOfsted = result.Should().ContainSingle().Which;
+        academyOfsted.Urn.Should().Be(giasGroupLink.Urn);
+        academyOfsted.CurrentOfstedRating.Should().Be(OfstedRating.None);
+        academyOfsted.PreviousOfstedRating.Should().Be(OfstedRating.None);
+
+        _mockLogger.VerifyLogError(
+            $"URN {giasGroupLink.Urn} was not found in Mis.Establishments or Mis.FurtherEducationEstablishments. This indicates a data integrity issue with the Ofsted data in Academies Db.");
+    }
+
+    [Fact]
+    public async Task GetAcademiesInTrustOfstedAsync_should_not_log_error_when_urns_are_all_found_in_mis()
+    {
+        var giasGroupLinks = AddGiasGroupLinksToMockDb(2);
+        var urns = giasGroupLinks.Select(gl => int.Parse(gl.Urn!)).ToArray();
+
+        _mockAcademiesDbContext.AddMisEstablishments(new[]
+        {
+            new MisEstablishment
+            {
+                Urn = urns[0], 
+                PreviousFullInspectionOverallEffectiveness = "1",
+                PreviousInspectionEndDate = "01/01/2022"
+            }
+        });
+        _mockAcademiesDbContext.AddMisFurtherEducationEstablishments(new[]
+        {
+            new MisFurtherEducationEstablishment
+            {
+                ProviderUrn = urns[1],
+                PreviousOverallEffectiveness = 1, 
+                PreviousLastDayOfInspection = "01/01/2022"
+            }
+        });
+
+        await _sut.GetAcademiesInTrustOfstedAsync("1234");
+
+        _mockLogger.VerifyNoOtherCalls();
+    }
+
+    private GiasGroupLink[] AddGiasGroupLinksToMockDb(int count, int offset = 1000)
+    {
+        var giasGroupLinks = Enumerable.Range(0, count).Select(n => new GiasGroupLink
+        {
+            GroupUid = "1234",
+            Urn = $"{n + offset}",
+            EstablishmentName = $"Academy {n + offset}",
+            JoinedDate = "13/06/2023"
+        }).ToArray();
+
+        _mockAcademiesDbContext.AddGiasGroupLinks(giasGroupLinks);
+
+        return giasGroupLinks;
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 
@@ -31,6 +32,32 @@ public class AcademyServiceTests
         var result = await _sut.GetAcademiesInTrustDetailsAsync(uid);
 
         result.Should().BeOfType<AcademyDetailsServiceModel[]>();
+        result.Should().BeEquivalentTo(academies);
+    }
+
+    [Fact]
+    public async Task GetAcademiesInTrustOfstedAsync_should_return_mapped_result_from_repository()
+    {
+        const string uid = "1234";
+        var academies = new[]
+        {
+            new AcademyOfsted("1", "Academy 1", new DateTime(2022, 12, 1),
+                new OfstedRating(OfstedRatingScore.Good, new DateTime(2023, 1, 1)),
+                new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2023, 2, 1))),
+            new AcademyOfsted("2", "Academy 2", new DateTime(2022, 11, 2),
+                new OfstedRating(OfstedRatingScore.Good, new DateTime(2023, 1, 2)),
+                new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2023, 3, 1))),
+            new AcademyOfsted("3", "Academy 3", new DateTime(2022, 10, 3),
+                new OfstedRating(OfstedRatingScore.Good, new DateTime(2023, 1, 3)),
+                new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2023, 4, 1)))
+        };
+
+        _mockAcademyRepository.Setup(a => a.GetAcademiesInTrustOfstedAsync(uid))
+            .ReturnsAsync(academies);
+
+        var result = await _sut.GetAcademiesInTrustOfstedAsync(uid);
+
+        result.Should().BeOfType<AcademyOfstedServiceModel[]>();
         result.Should().BeEquivalentTo(academies);
     }
 }


### PR DESCRIPTION
Rearchitects the Ofsted data retrieval to improve performance of the Academies in Trust Ofsted page.

[User Story 174250](https://dev.azure.com.mcas.ms/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/174250?McasTsid=26110&McasCtx=4): Build: Improve performance of Academies in this trust ofsted page

## Changes

- Get only the data needed to render the Academies in Trust Ofsted page
- Add filter to ensure that Mis.Establishment.Urn is never null (to enable SQL to be more efficient when querying this column)
- Match Ofsted data only on the Mis.Establishment.Urn, not the `UrnAtTimeOfLatestFullInspection` or `UrnAtTimeOfPreviousFullInspection` as those columns will never be more up to date than the Urn so there is no need to query them
- Log error if urns from GIAS and urns from MIS do not match as this will require an investigation into db data integrity

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
~ADR decision log updated (if needed)~
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
