### PR TITLE
Add trust governance page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Feature flags added to allow for selectively showing features in different environments
 - Add search autocomplete to the header of the application
+- Add Trust Governance Page
 
 ### Changed
 

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustRepository.cs
@@ -60,7 +60,7 @@ public class TrustRepository(IAcademiesDbContext academiesDbContext) : ITrustRep
         return trustDetailsDto;
     }
 
-    public async Task<TrustGoverenance> GetTrustGovernanceAsync(string uid)
+    public async Task<TrustGovernance> GetTrustGovernanceAsync(string uid)
     {
         var governors = await academiesDbContext.GiasGovernances
             .Where(g => g.Uid == uid)
@@ -68,7 +68,7 @@ public class TrustRepository(IAcademiesDbContext academiesDbContext) : ITrustRep
                 governance.Role!, governance.AppointingBody!, governance.DateOfAppointment.ParseAsNullableDate(),
                 governance.DateTermOfOfficeEndsEnded.ParseAsNullableDate(), null))
             .ToArrayAsync();
-        var governersDto = new TrustGoverenance(
+        var governersDto = new TrustGovernance(
             governors.Where(governor => governor is { IsCurrentGovernor: true, HasRoleLeadership: true }).ToArray(),
             governors.Where(governor => governor is { IsCurrentGovernor: true, HasRoleMemeber: true })
                 .ToArray(),

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustRepository.cs
@@ -1,6 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Extensions;
-using DfE.FindInformationAcademiesTrusts.Data.Repositories.Models;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 using Microsoft.EntityFrameworkCore;
 

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustRepository.cs
@@ -1,6 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Extensions;
-using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Models;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 using Microsoft.EntityFrameworkCore;
@@ -64,7 +63,8 @@ public class TrustRepository(IAcademiesDbContext academiesDbContext) : ITrustRep
     {
         var governors = await academiesDbContext.GiasGovernances
             .Where(g => g.Uid == uid)
-            .Select(governance => new Governor(governance.Gid!, governance.Uid!, GetFullName(governance),
+            .Select(governance => new Governor(governance.Gid!, governance.Uid!,
+                GetFullName(governance.Forename1!, governance.Forename2!, governance.Surname!),
                 governance.Role!, governance.AppointingBody!, governance.DateOfAppointment.ParseAsNullableDate(),
                 governance.DateTermOfOfficeEndsEnded.ParseAsNullableDate(), null))
             .ToArrayAsync();
@@ -87,15 +87,15 @@ public class TrustRepository(IAcademiesDbContext academiesDbContext) : ITrustRep
             .SingleOrDefaultAsync() ?? string.Empty;
     }
 
-    private static string GetFullName(GiasGovernance giasGovernance)
+    private static string GetFullName(string forename1, string forename2, string surname)
     {
-        var fullName = giasGovernance.Forename1!; //Forename1 is always populated
+        var fullName = forename1; //Forename1 is always populated
 
-        if (!string.IsNullOrWhiteSpace(giasGovernance.Forename2))
-            fullName += $" {giasGovernance.Forename2}";
+        if (!string.IsNullOrWhiteSpace(forename2))
+            fullName += $" {forename2}";
 
-        if (!string.IsNullOrWhiteSpace(giasGovernance.Surname))
-            fullName += $" {giasGovernance.Surname}";
+        if (!string.IsNullOrWhiteSpace(surname))
+            fullName += $" {surname}";
 
         return fullName;
     }

--- a/DfE.FindInformationAcademiesTrusts.Data/Governor.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Governor.cs
@@ -11,4 +11,18 @@ public record Governor(
     string? Email) : Person(FullName, Email)
 {
     public bool IsCurrentGovernor => DateOfTermEnd == null || DateOfTermEnd >= DateTime.Today;
+
+    public bool HasRoleLeadership =>
+        HasRoleAccountingOfficer || HasRoleChiefFinancialOfficer ||
+        HasRoleChairOfTrustees;
+
+    public bool HasRoleMemeber => Role == "Member";
+
+    public bool HasRoleTrustee => Role == "Trustee";
+
+    private bool HasRoleAccountingOfficer => Role == "Accounting Officer";
+
+    private bool HasRoleChiefFinancialOfficer => Role == "Chief Financial Officer";
+
+    private bool HasRoleChairOfTrustees => Role == "Chair of Trustees";
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Models/TrustGoverenance.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Models/TrustGoverenance.cs
@@ -1,0 +1,7 @@
+﻿namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.Models;
+
+public record TrustGoverenance(
+    Governor[] TrustLeadership,
+    Governor[] Members,
+    Governor[] Trustees,
+    Governor[] HistoricMembers);

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Models/TrustGovernance.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Models/TrustGovernance.cs
@@ -1,6 +1,6 @@
 ﻿namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.Models;
 
-public record TrustGoverenance(
+public record TrustGovernance(
     Governor[] TrustLeadership,
     Governor[] Members,
     Governor[] Trustees,

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/ITrustRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/ITrustRepository.cs
@@ -1,3 +1,5 @@
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.Models;
+
 namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 
 public interface ITrustRepository

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/ITrustRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/ITrustRepository.cs
@@ -4,5 +4,5 @@ public interface ITrustRepository
 {
     Task<TrustSummary?> GetTrustSummaryAsync(string uid);
     Task<TrustDetails> GetTrustDetailsAsync(string uid);
-    Task<TrustGoverenance> GetTrustGovernanceAsync(string uid);
+    Task<TrustGovernance> GetTrustGovernanceAsync(string uid);
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/ITrustRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/ITrustRepository.cs
@@ -4,4 +4,5 @@ public interface ITrustRepository
 {
     Task<TrustSummary?> GetTrustSummaryAsync(string uid);
     Task<TrustDetails> GetTrustDetailsAsync(string uid);
+    Task<TrustGoverenance> GetTrustGovernanceAsync(string uid);
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/ITrustRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/ITrustRepository.cs
@@ -1,5 +1,3 @@
-using DfE.FindInformationAcademiesTrusts.Data.Repositories.Models;
-
 namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 
 public interface ITrustRepository

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/TrustGovernance.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Trust/TrustGovernance.cs
@@ -1,4 +1,4 @@
-﻿namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.Models;
+﻿namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 
 public record TrustGovernance(
     Governor[] TrustLeadership,

--- a/DfE.FindInformationAcademiesTrusts/Extensions/DateTimeExtensions.cs
+++ b/DfE.FindInformationAcademiesTrusts/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,16 @@
+﻿using DfE.FindInformationAcademiesTrusts.Pages;
+
+namespace DfE.FindInformationAcademiesTrusts.Extensions;
+
+public static class DateTimeExtensions
+{
+    public static string ShowDateStringOrReplaceWithText(this DateTime? date)
+    {
+        if (date.HasValue)
+        {
+            return date.Value.ToString(StringFormatConstants.ViewDate);
+        }
+
+        return ViewConstants.NoDataText;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
@@ -1,0 +1,139 @@
+﻿@page
+@model GovernanceModel
+
+@{
+  Layout = "_TrustLayout";
+}
+
+<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
+  <h3>Trust Leadership</h3>
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Role</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">From</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">To</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      @foreach (var governor in Model.TrustGovernance.TrustLeadership)
+      {
+        <tr class="govuk-table__row" data-testid="academy-row">
+          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
+            @governor.FullName
+          </th>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.Role" data-testid="phase-and-age-range">
+            @governor.Role
+          </td>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
+            @governor.DateOfAppointment?.ToString(StringFormatConstants.ViewDate)
+          </td>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
+            @governor.DateOfTermEnd?.ToString(StringFormatConstants.ViewDate)
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+</section>
+<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
+  <h3>Trustees</h3>
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">From</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">To</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      @foreach (var governor in Model.TrustGovernance.Trustees)
+      {
+        <tr class="govuk-table__row" data-testid="academy-row">
+          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
+            @governor.FullName
+          </th>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="phase-and-age-range">
+            @governor.AppointingBody
+          </td>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
+            @governor.DateOfAppointment?.ToString(StringFormatConstants.ViewDate)
+          </td>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
+            @governor.DateOfTermEnd?.ToString(StringFormatConstants.ViewDate)
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+</section>
+<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
+  <h3>Members</h3>
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">From</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">To</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      @foreach (var governor in Model.TrustGovernance.Members)
+      {
+        <tr class="govuk-table__row" data-testid="academy-row">
+          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
+            @governor.FullName
+          </th>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="phase-and-age-range">
+            @governor.AppointingBody
+          </td>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
+            @governor.DateOfAppointment?.ToString(StringFormatConstants.ViewDate)
+          </td>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
+            @governor.DateOfTermEnd?.ToString(StringFormatConstants.ViewDate)
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+</section>
+<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
+  <h3>Historic members</h3>
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Role</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">From</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">To</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      @foreach (var governor in Model.TrustGovernance.HistoricMembers)
+      {
+        <tr class="govuk-table__row" data-testid="academy-row">
+          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
+            @governor.FullName
+          </th>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.Role" data-testid="phase-and-age-range">
+            @governor.Role
+          </td>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="phase-and-age-range">
+            @governor.AppointingBody
+          </td>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
+            @governor.DateOfAppointment?.ToString(StringFormatConstants.ViewDate)
+          </td>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
+            @governor.DateOfTermEnd?.ToString(StringFormatConstants.ViewDate)
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+</section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
@@ -6,11 +6,11 @@
   Layout = "_TrustLayout";
 }
 
-<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
-  <h3>Trust Leadership</h3>
+<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container" data-testid="trust-leadership">
   @if (Model.TrustGovernance.TrustLeadership.Length > 0)
   {
-    <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+    <table class="govuk-table govuk-!-margin-bottom-0" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+      <caption class="govuk-table__caption govuk-table__caption--m" id="trust-leadership">Trust Leadership</caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
@@ -22,17 +22,17 @@
       <tbody class="govuk-table__body">
         @foreach (var governor in Model.TrustGovernance.TrustLeadership)
         {
-          <tr class="govuk-table__row" data-testid="academy-row">
-            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
+          <tr class="govuk-table__row" data-testid="trust-leadership-row">
+            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="trust-leadership-name">
               @governor.FullName
             </th>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.Role" data-testid="phase-and-age-range">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.Role" data-testid="trust-leadership-role">
               @governor.Role
             </td>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="trust-leadership-from">
               @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
             </td>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="trust-leadership-to">
               @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
             </td>
           </tr>
@@ -42,14 +42,16 @@
   }
   else
   {
-    <span>No Trust Leadership</span>
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-3">Trust Leadership</h3>
+    <p class="govuk-body govuk-!-margin-bottom-0">No Trust Leadership</p>
   }
 </section>
-<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
-  <h3>Trustees</h3>
+
+<section class="govuk-!-margin-bottom-9 app-table-container" data-testid="trustees">
   @if (Model.TrustGovernance.Trustees.Length > 0)
   {
-    <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+    <table class="govuk-table govuk-!-margin-bottom-0" data-module="moj-sortable-table" aria-describedby="trustees">
+      <caption class="govuk-table__caption govuk-table__caption--m" id="trustees">Trustees</caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
@@ -61,17 +63,17 @@
       <tbody class="govuk-table__body">
         @foreach (var governor in Model.TrustGovernance.Trustees)
         {
-          <tr class="govuk-table__row" data-testid="academy-row">
-            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
+          <tr class="govuk-table__row" data-testid="trustees-row">
+            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="trustees-name">
               @governor.FullName
             </th>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="phase-and-age-range">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="trustees-appointed">
               @governor.AppointingBody
             </td>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="trustees-from">
               @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
             </td>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="trustees-to">
               @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
             </td>
           </tr>
@@ -81,14 +83,16 @@
   }
   else
   {
-    <span>No Trustees</span>
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-3">Trustees</h3>
+    <p class="govuk-body govuk-!-margin-bottom-0">No Trustees</p>
   }
 </section>
-<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
-  <h3>Members</h3>
+
+<section class="govuk-!-margin-bottom-9 app-table-container" data-testid="members">
   @if (Model.TrustGovernance.Members.Length > 0)
   {
-    <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+    <table class="govuk-table govuk-!-margin-bottom-0" data-module="moj-sortable-table" aria-describedby="members">
+      <caption class="govuk-table__caption govuk-table__caption--m" id="members">Members</caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
@@ -100,17 +104,17 @@
       <tbody class="govuk-table__body">
         @foreach (var governor in Model.TrustGovernance.Members)
         {
-          <tr class="govuk-table__row" data-testid="academy-row">
-            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
+          <tr class="govuk-table__row" data-testid="members-row">
+            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="members-name">
               @governor.FullName
             </th>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="phase-and-age-range">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="members-appointed">
               @governor.AppointingBody
             </td>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="members-from">
               @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
             </td>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="members-to">
               @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
             </td>
           </tr>
@@ -120,14 +124,16 @@
   }
   else
   {
-    <span>No Members</span>
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-3">Members</h3>
+    <p class="govuk-body govuk-!-margin-bottom-0">No Members</p>
   }
 </section>
-<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
-  <h3>Historic members</h3>
+
+<section class="app-table-container govuk-!-margin-bottom-9" data-testid="historic-members">
   @if (Model.TrustGovernance.HistoricMembers.Length > 0)
   {
-    <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+    <table class="govuk-table govuk-!-margin-bottom-0" data-module="moj-sortable-table" aria-describedby="historic-members">
+      <caption class="govuk-table__caption govuk-table__caption--m" id="historic-members">Historic members</caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
@@ -140,20 +146,20 @@
       <tbody class="govuk-table__body">
         @foreach (var governor in Model.TrustGovernance.HistoricMembers)
         {
-          <tr class="govuk-table__row" data-testid="academy-row">
-            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
+          <tr class="govuk-table__row" data-testid="historic-members-row">
+            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="historic-members-name">
               @governor.FullName
             </th>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.Role" data-testid="phase-and-age-range">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.Role" data-testid="historic-members-role">
               @governor.Role
             </td>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="phase-and-age-range">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="historic-members-appointed">
               @governor.AppointingBody
             </td>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="historic-members-from">
               @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
             </td>
-            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="historic-members-to">
               @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
             </td>
           </tr>
@@ -163,6 +169,7 @@
   }
   else
   {
-    <span>No Historic Members</span>
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-3">Historic members</h3>
+    <p class="govuk-body govuk-!-margin-bottom-0">No Historic members</p>
   }
 </section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
@@ -1,4 +1,5 @@
 ﻿@page
+@using DfE.FindInformationAcademiesTrusts.Extensions
 @model GovernanceModel
 
 @{
@@ -29,10 +30,10 @@
               @governor.Role
             </td>
             <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
-              @Model.ShowFormmatedDateOrNoData(governor.DateOfAppointment)
+              @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
             </td>
             <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
-              @Model.ShowFormmatedDateOrNoData(governor.DateOfTermEnd)
+              @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
             </td>
           </tr>
         }
@@ -68,10 +69,10 @@
               @governor.AppointingBody
             </td>
             <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
-              @Model.ShowFormmatedDateOrNoData(governor.DateOfAppointment)
+              @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
             </td>
             <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
-              @Model.ShowFormmatedDateOrNoData(governor.DateOfTermEnd)
+              @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
             </td>
           </tr>
         }
@@ -107,10 +108,10 @@
               @governor.AppointingBody
             </td>
             <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
-              @Model.ShowFormmatedDateOrNoData(governor.DateOfAppointment)
+              @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
             </td>
             <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
-              @Model.ShowFormmatedDateOrNoData(governor.DateOfTermEnd)
+              @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
             </td>
           </tr>
         }
@@ -150,10 +151,10 @@
               @governor.AppointingBody
             </td>
             <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
-              @Model.ShowFormmatedDateOrNoData(governor.DateOfAppointment)
+              @governor.DateOfAppointment.ShowDateStringOrReplaceWithText()
             </td>
             <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
-              @Model.ShowFormmatedDateOrNoData(governor.DateOfTermEnd)
+              @governor.DateOfTermEnd.ShowDateStringOrReplaceWithText()
             </td>
           </tr>
         }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
@@ -7,133 +7,161 @@
 
 <section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
   <h3>Trust Leadership</h3>
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Role</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">From</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">To</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      @foreach (var governor in Model.TrustGovernance.TrustLeadership)
-      {
-        <tr class="govuk-table__row" data-testid="academy-row">
-          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
-            @governor.FullName
-          </th>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.Role" data-testid="phase-and-age-range">
-            @governor.Role
-          </td>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
-            @governor.DateOfAppointment?.ToString(StringFormatConstants.ViewDate)
-          </td>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
-            @governor.DateOfTermEnd?.ToString(StringFormatConstants.ViewDate)
-          </td>
+  @if (Model.TrustGovernance.TrustLeadership.Length > 0)
+  {
+    <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
+          <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Role</th>
+          <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">From</th>
+          <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">To</th>
         </tr>
-      }
-    </tbody>
-  </table>
+      </thead>
+      <tbody class="govuk-table__body">
+        @foreach (var governor in Model.TrustGovernance.TrustLeadership)
+        {
+          <tr class="govuk-table__row" data-testid="academy-row">
+            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
+              @governor.FullName
+            </th>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.Role" data-testid="phase-and-age-range">
+              @governor.Role
+            </td>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
+              @Model.ShowFormmatedDateOrNoData(governor.DateOfAppointment)
+            </td>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
+              @Model.ShowFormmatedDateOrNoData(governor.DateOfTermEnd)
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+  else
+  {
+    <span>No Trust Leadership</span>
+  }
 </section>
 <section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
   <h3>Trustees</h3>
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">From</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">To</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      @foreach (var governor in Model.TrustGovernance.Trustees)
-      {
-        <tr class="govuk-table__row" data-testid="academy-row">
-          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
-            @governor.FullName
-          </th>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="phase-and-age-range">
-            @governor.AppointingBody
-          </td>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
-            @governor.DateOfAppointment?.ToString(StringFormatConstants.ViewDate)
-          </td>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
-            @governor.DateOfTermEnd?.ToString(StringFormatConstants.ViewDate)
-          </td>
+  @if (Model.TrustGovernance.Trustees.Length > 0)
+  {
+    <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
+          <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
+          <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">From</th>
+          <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">To</th>
         </tr>
-      }
-    </tbody>
-  </table>
+      </thead>
+      <tbody class="govuk-table__body">
+        @foreach (var governor in Model.TrustGovernance.Trustees)
+        {
+          <tr class="govuk-table__row" data-testid="academy-row">
+            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
+              @governor.FullName
+            </th>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="phase-and-age-range">
+              @governor.AppointingBody
+            </td>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
+              @Model.ShowFormmatedDateOrNoData(governor.DateOfAppointment)
+            </td>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
+              @Model.ShowFormmatedDateOrNoData(governor.DateOfTermEnd)
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+  else
+  {
+    <span>No Trustees</span>
+  }
 </section>
 <section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
   <h3>Members</h3>
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">From</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">To</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      @foreach (var governor in Model.TrustGovernance.Members)
-      {
-        <tr class="govuk-table__row" data-testid="academy-row">
-          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
-            @governor.FullName
-          </th>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="phase-and-age-range">
-            @governor.AppointingBody
-          </td>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
-            @governor.DateOfAppointment?.ToString(StringFormatConstants.ViewDate)
-          </td>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
-            @governor.DateOfTermEnd?.ToString(StringFormatConstants.ViewDate)
-          </td>
+  @if (Model.TrustGovernance.Members.Length > 0)
+  {
+    <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
+          <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
+          <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">From</th>
+          <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">To</th>
         </tr>
-      }
-    </tbody>
-  </table>
+      </thead>
+      <tbody class="govuk-table__body">
+        @foreach (var governor in Model.TrustGovernance.Members)
+        {
+          <tr class="govuk-table__row" data-testid="academy-row">
+            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
+              @governor.FullName
+            </th>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="phase-and-age-range">
+              @governor.AppointingBody
+            </td>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
+              @Model.ShowFormmatedDateOrNoData(governor.DateOfAppointment)
+            </td>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
+              @Model.ShowFormmatedDateOrNoData(governor.DateOfTermEnd)
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+  else
+  {
+    <span>No Members</span>
+  }
 </section>
 <section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
   <h3>Historic members</h3>
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Role</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">From</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">To</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      @foreach (var governor in Model.TrustGovernance.HistoricMembers)
-      {
-        <tr class="govuk-table__row" data-testid="academy-row">
-          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
-            @governor.FullName
-          </th>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.Role" data-testid="phase-and-age-range">
-            @governor.Role
-          </td>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="phase-and-age-range">
-            @governor.AppointingBody
-          </td>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
-            @governor.DateOfAppointment?.ToString(StringFormatConstants.ViewDate)
-          </td>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
-            @governor.DateOfTermEnd?.ToString(StringFormatConstants.ViewDate)
-          </td>
+  @if (Model.TrustGovernance.HistoricMembers.Length > 0)
+  {
+    <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="trust-leadership">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">Name</th>
+          <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Role</th>
+          <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Appointed by</th>
+          <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">From</th>
+          <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">To</th>
         </tr>
-      }
-    </tbody>
-  </table>
+      </thead>
+      <tbody class="govuk-table__body">
+        @foreach (var governor in Model.TrustGovernance.HistoricMembers)
+        {
+          <tr class="govuk-table__row" data-testid="academy-row">
+            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@governor.FullName" data-testid="school-name">
+              @governor.FullName
+            </th>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.Role" data-testid="phase-and-age-range">
+              @governor.Role
+            </td>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.AppointingBody" data-testid="phase-and-age-range">
+              @governor.AppointingBody
+            </td>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfAppointment?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-numbers">
+              @Model.ShowFormmatedDateOrNoData(governor.DateOfAppointment)
+            </td>
+            <td class="govuk-body govuk-table__cell" data-sort-value="@governor.DateOfTermEnd?.ToString(StringFormatConstants.SortDate)" data-testid="pupil-capacity">
+              @Model.ShowFormmatedDateOrNoData(governor.DateOfTermEnd)
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+  else
+  {
+    <span>No Historic Members</span>
+  }
 </section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
@@ -21,7 +21,7 @@ public class GovernanceModel(
 
         if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
 
-        TrustGovernance = await TrustService.GetTrustGoverenaceAsync(Uid);
+        TrustGovernance = await TrustService.GetTrustGovernanceAsync(Uid);
 
         DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.Gias),
             new List<string> { "Governance" }));

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
@@ -1,6 +1,5 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
-using DfE.FindInformationAcademiesTrusts.ServiceModels;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
@@ -2,6 +2,8 @@
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.ServiceModels;
 using DfE.FindInformationAcademiesTrusts.Services;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
@@ -29,14 +29,4 @@ public class GovernanceModel(
 
         return pageResult;
     }
-
-    public string ShowFormmatedDateOrNoData(DateTime? date)
-    {
-        if (date.HasValue)
-        {
-            return date.Value.ToString(StringFormatConstants.ViewDate);
-        }
-
-        return "No Data";
-    }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
@@ -1,7 +1,6 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.ServiceModels;
-using DfE.FindInformationAcademiesTrusts.Services;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
@@ -29,5 +28,15 @@ public class GovernanceModel(
             new List<string> { "Governance" }));
 
         return pageResult;
+    }
+
+    public string ShowFormmatedDateOrNoData(DateTime? date)
+    {
+        if (date.HasValue)
+        {
+            return date.Value.ToString(StringFormatConstants.ViewDate);
+        }
+
+        return "No Data";
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
@@ -1,0 +1,31 @@
+﻿using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.ServiceModels;
+using DfE.FindInformationAcademiesTrusts.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+
+public class GovernanceModel(
+    ITrustProvider trustProvider,
+    IDataSourceService dataSourceService,
+    ILogger<GovernanceModel> logger,
+    ITrustService trustService)
+    : TrustsAreaModel(trustProvider, dataSourceService, trustService, logger, "Governance")
+{
+    public TrustGovernanceServiceModel TrustGovernance { get; set; } = default!;
+
+    public override async Task<IActionResult> OnGetAsync()
+    {
+        var pageResult = await base.OnGetAsync();
+
+        if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
+
+        TrustGovernance = await TrustService.GetTrustGoverenaceAsync(Uid);
+
+        DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.Gias),
+            new List<string> { "Governance" }));
+
+        return pageResult;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
@@ -39,7 +39,7 @@
           </a>
         </li>
         <li class="ds_side-navigation__item app-side-navigation-highlight-item">
-          <a asp-page="/Trusts/Governance" asp-route-uid="@Model.TrustSummary.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Governance")" data-testid="academies-nav">
+          <a asp-page="/Trusts/Governance" asp-route-uid="@Model.TrustSummary.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Governance")" data-testid="governance-nav">
             Governance
           </a>
         </li>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
@@ -38,6 +38,11 @@
             Academies in this trust (@Model.TrustSummary.NumberOfAcademies)
           </a>
         </li>
+        <li class="ds_side-navigation__item app-side-navigation-highlight-item">
+          <a asp-page="/Trusts/Governance" asp-route-uid="@Model.TrustSummary.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Governance")" data-testid="academies-nav">
+            Governance
+          </a>
+        </li>
       </ul>
     </li>
   </ul>

--- a/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
@@ -16,4 +16,6 @@ public static class ViewConstants
 
     public const string SuggestChangeFormLink =
         "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-fkHK2JGo_BIpVChpLMaBFpUNUFDSzhQN0FHVklTV0JWTzFZTjNKWTNJUi4u";
+
+    public const string NoDataText = "No Data";
 }

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustGovernanceServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustGovernanceServiceModel.cs
@@ -1,6 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 
-namespace DfE.FindInformationAcademiesTrusts.ServiceModels;
+namespace DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 public record TrustGovernanceServiceModel(
     Governor[] TrustLeadership,

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustGovernanceServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustGovernanceServiceModel.cs
@@ -1,0 +1,9 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+
+namespace DfE.FindInformationAcademiesTrusts.ServiceModels;
+
+public record TrustGovernanceServiceModel(
+    Governor[] TrustLeadership,
+    Governor[] Members,
+    Governor[] Trustees,
+    Governor[] HistoricMembers);

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
@@ -8,7 +8,7 @@ public interface ITrustService
 {
     Task<TrustSummaryServiceModel?> GetTrustSummaryAsync(string uid);
     Task<TrustDetailsServiceModel> GetTrustDetailsAsync(string uid);
-    Task<TrustGovernanceServiceModel> GetTrustGoverenaceAsync(string uid);
+    Task<TrustGovernanceServiceModel> GetTrustGovernanceAsync(string uid);
 }
 
 public class TrustService(
@@ -64,7 +64,7 @@ public class TrustService(
         return trustDetailsDto;
     }
 
-    public async Task<TrustGovernanceServiceModel> GetTrustGoverenaceAsync(string uid)
+    public async Task<TrustGovernanceServiceModel> GetTrustGovernanceAsync(string uid)
     {
         var (trustLeadership, members, trustees, historicMembers) = await trustRepository.GetTrustGovernanceAsync(uid);
         var governanceDto = new TrustGovernanceServiceModel(trustLeadership, members, trustees, historicMembers);

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
+using DfE.FindInformationAcademiesTrusts.ServiceModels;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace DfE.FindInformationAcademiesTrusts.Services.Trust;

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
@@ -65,7 +65,7 @@ public class TrustService(
         return trustDetailsDto;
     }
 
-    public async Task<TrustGovernanceServiceModel> GetTrustGovernanceAsync(string uid)
+    public async Task<TrustGovernanceServiceModel> GetTrustGoverenaceAsync(string uid)
     {
         var (trustLeadership, members, trustees, historicMembers) = await trustRepository.GetTrustGovernanceAsync(uid);
         var governanceDto = new TrustGovernanceServiceModel(trustLeadership, members, trustees, historicMembers);

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
@@ -8,6 +8,7 @@ public interface ITrustService
 {
     Task<TrustSummaryServiceModel?> GetTrustSummaryAsync(string uid);
     Task<TrustDetailsServiceModel> GetTrustDetailsAsync(string uid);
+    Task<TrustGovernanceServiceModel> GetTrustGoverenaceAsync(string uid);
 }
 
 public class TrustService(
@@ -61,5 +62,12 @@ public class TrustService(
         );
 
         return trustDetailsDto;
+    }
+
+    public async Task<TrustGovernanceServiceModel> GetTrustGoverenaceAsync(string uid)
+    {
+        var (trustLeadership, members, trustees, historicMembers) = await trustRepository.GetTrustGovernanceAsync(uid);
+        var governanceDto = new TrustGovernanceServiceModel(trustLeadership, members, trustees, historicMembers);
+        return governanceDto;
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
@@ -65,7 +65,7 @@ public class TrustService(
         return trustDetailsDto;
     }
 
-    public async Task<TrustGovernanceServiceModel> GetTrustGoverenaceAsync(string uid)
+    public async Task<TrustGovernanceServiceModel> GetTrustGovernanceAsync(string uid)
     {
         var (trustLeadership, members, trustees, historicMembers) = await trustRepository.GetTrustGovernanceAsync(uid);
         var governanceDto = new TrustGovernanceServiceModel(trustLeadership, members, trustees, historicMembers);

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
@@ -1,6 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
-using DfE.FindInformationAcademiesTrusts.ServiceModels;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace DfE.FindInformationAcademiesTrusts.Services.Trust;

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
@@ -18,4 +18,8 @@
       right: 0;
     }
   }
+
+  .column-header-date {
+    width: 15%;
+  }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -231,6 +231,19 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
         return newItems;
     }
 
+    public void AddGiasGovernance(GiasGovernance governance)
+    {
+        var existing = _giasGovernances.FirstOrDefault(g => g.Gid == governance.Gid);
+        if (existing is not null)
+        {
+            var index = _giasGovernances.IndexOf(existing);
+            _giasGovernances[index] = governance;
+            return;
+        }
+
+        _giasGovernances.Add(governance);
+    }
+
     public List<(GiasGovernance, MstrTrustGovernance)> AddGovernancesLinkedToTrust(int num, string groupUid)
     {
         var numExistingGovernances = _giasGovernances.Count;

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
@@ -133,10 +132,154 @@ public class TrustRepositoryTests
         result.Should().BeEquivalentTo(new TrustGoverenance([], [], [], []));
     }
 
-    [Fact]
-    public async Task GetTrustGovernanceAsync_ShouldReturnValidGovernors_WithGovernenceSet()
+    [Theory]
+    [InlineData("Member")]
+    [InlineData("Trustee")]
+    [InlineData("Accounting Officer")]
+    [InlineData("Chief Financial Officer")]
+    [InlineData("Chair of Trustees")]
+    public async Task GetTrustGovernanceAsync_ShouldReturnValidGovernors_WithTheCorrectRole(string role)
     {
-        var member = new GiasGovernance
+        var startDate = DateTime.Today.AddYears(-1);
+        var endDate = DateTime.Today.AddYears(1);
+        var input = new GiasGovernance
+        {
+            Gid = "9999",
+            Uid = "1234",
+            Role = role,
+            Forename1 = "First",
+            Forename2 = "Second",
+            Surname = "Last",
+            DateOfAppointment = startDate.ToShortDateString(),
+            DateTermOfOfficeEndsEnded = endDate.ToShortDateString(),
+            AppointingBody = "Nick Warms"
+        };
+        var output = new Governor(
+            "9999",
+            "1234",
+            Role: role,
+            FullName: "First Second Last",
+            DateOfAppointment: startDate,
+            DateOfTermEnd: endDate,
+            AppointingBody: "Nick Warms",
+            Email: null
+        );
+
+
+        _mockAcademiesDbContext.AddGiasGovernance(input);
+        var result = await _sut.GetTrustGovernanceAsync("1234");
+
+        var members = new List<Governor>();
+
+        var trustees = new List<Governor>();
+        var trustLeadership = new List<Governor>();
+        switch (role)
+        {
+            case "Member":
+                members.Add(output);
+                break;
+            case "Trustee":
+                trustees.Add(output);
+                break;
+            case "Accounting Officer":
+            case "Chief Financial Officer":
+            case "Chair of Trustees":
+                trustLeadership.Add(output);
+                break;
+        }
+
+        result.Should().BeEquivalentTo(
+            new TrustGoverenance(trustLeadership.ToArray(), members.ToArray(), trustees.ToArray(), [])
+        );
+    }
+
+    [Theory]
+    [InlineData("Shared Chair of Local Governing Body - Group")]
+    [InlineData("Shared Local Governor - Group")]
+    [InlineData("Governor")]
+    [InlineData("Local Govenor")]
+    public async Task GetTrustGovernanceAsync_ShouldReturnNoGovernors_WithTheIncorrectRole(string role)
+    {
+        var startDate = DateTime.Today.AddYears(-1);
+        var endDate = DateTime.Today.AddYears(1);
+        var input = new GiasGovernance
+        {
+            Gid = "9999",
+            Uid = "1234",
+            Role = role,
+            Forename1 = "First",
+            Forename2 = "Second",
+            Surname = "Last",
+            DateOfAppointment = startDate.ToShortDateString(),
+            DateTermOfOfficeEndsEnded = endDate.ToShortDateString(),
+            AppointingBody = "Nick Warms"
+        };
+
+        _mockAcademiesDbContext.AddGiasGovernance(input);
+        var result = await _sut.GetTrustGovernanceAsync("1234");
+
+        result.Should().BeEquivalentTo(
+            new TrustGoverenance([], [], [], [])
+        );
+    }
+
+    [Theory]
+    [InlineData("Member")]
+    [InlineData("Trustee")]
+    [InlineData("Accounting Officer")]
+    [InlineData("Chief Financial Officer")]
+    [InlineData("Chair of Trustees")]
+    [InlineData("Shared Chair of Local Governing Body - Group")]
+    [InlineData("Shared Local Governor - Group")]
+    [InlineData("Governor")]
+    [InlineData("Local Govenor")]
+    public async Task GetTrustGovernanceAsync_ShouldReturnHistoricGovernors_WhenTheyExist_IrrespectiveOfRole(
+        string role)
+    {
+        var startDate = DateTime.Today.AddYears(-3);
+        var endDate = DateTime.Today.AddYears(-1);
+        var input = new GiasGovernance
+        {
+            Gid = "9999",
+            Uid = "1234",
+            Role = role,
+            Forename1 = "First",
+            Forename2 = "Second",
+            Surname = "Last",
+            DateOfAppointment = startDate.ToShortDateString(),
+            DateTermOfOfficeEndsEnded = endDate.ToShortDateString(),
+            AppointingBody = "Nick Warms"
+        };
+        var output = new Governor(
+            "9999",
+            "1234",
+            Role: role,
+            FullName: "First Second Last",
+            DateOfAppointment: startDate,
+            DateOfTermEnd: endDate,
+            AppointingBody: "Nick Warms",
+            Email: null
+        );
+
+
+        _mockAcademiesDbContext.AddGiasGovernance(input);
+        var result = await _sut.GetTrustGovernanceAsync("1234");
+
+        var historicMembers = new List<Governor> { output };
+
+        result.Should().BeEquivalentTo(
+            new TrustGoverenance([], [], [], historicMembers.ToArray())
+        );
+    }
+
+    [Fact]
+    public async Task GetTrustGovernanceAsync_ShouldSortHistoricAndCurrentGoverors()
+    {
+        var startDate = DateTime.Today.AddYears(-3);
+        var yesterday = DateTime.Today.AddDays(-1);
+        var today = DateTime.Today;
+        var tomorrow = DateTime.Today.AddDays(1);
+        var currentMember = new GiasGovernance
         {
             Gid = "9999",
             Uid = "1234",
@@ -144,25 +287,74 @@ public class TrustRepositoryTests
             Forename1 = "First",
             Forename2 = "Second",
             Surname = "Last",
-            DateOfAppointment = DateTime.Today.AddYears(-1).ToString(CultureInfo.InvariantCulture),
-            DateTermOfOfficeEndsEnded = DateTime.Today.AddYears(1).ToString(CultureInfo.InvariantCulture)
+            DateOfAppointment = startDate.ToShortDateString(),
+            DateTermOfOfficeEndsEnded = today.ToShortDateString(),
+            AppointingBody = "Nick Warms"
         };
-        var governor = new Governor(
+        var currentMemberOutput = new Governor(
             "9999",
             "1234",
             Role: "Member",
             FullName: "First Second Last",
-            DateOfAppointment: DateTime.Today.AddYears(-1),
-            DateOfTermEnd: DateTime.Today.AddYears(1),
+            DateOfAppointment: startDate,
+            DateOfTermEnd: today,
+            AppointingBody: "Nick Warms",
+            Email: null
+        );
+        var currentMember2 = new GiasGovernance
+        {
+            Gid = "9998",
+            Uid = "1234",
+            Role = "Member",
+            Forename1 = "First",
+            Forename2 = "Second",
+            Surname = "Last",
+            DateOfAppointment = startDate.ToShortDateString(),
+            DateTermOfOfficeEndsEnded = tomorrow.ToShortDateString(),
+            AppointingBody = "Nick Warms"
+        };
+        var currentMember2Output = new Governor(
+            "9998",
+            "1234",
+            Role: "Member",
+            FullName: "First Second Last",
+            DateOfAppointment: startDate,
+            DateOfTermEnd: tomorrow,
+            AppointingBody: "Nick Warms",
+            Email: null
+        );
+        var historicMember = new GiasGovernance
+        {
+            Gid = "9997",
+            Uid = "1234",
+            Role = "Member",
+            Forename1 = "First",
+            Forename2 = "Second",
+            Surname = "Last",
+            DateOfAppointment = startDate.ToShortDateString(),
+            DateTermOfOfficeEndsEnded = yesterday.ToShortDateString(),
+            AppointingBody = "Nick Warms"
+        };
+        var historicMemberOutput = new Governor(
+            "9997",
+            "1234",
+            Role: "Member",
+            FullName: "First Second Last",
+            DateOfAppointment: startDate,
+            DateOfTermEnd: yesterday,
             AppointingBody: "Nick Warms",
             Email: null
         );
 
-        _mockAcademiesDbContext.AddGiasGovernance(member);
+
+        _mockAcademiesDbContext.AddGiasGovernance(currentMember);
+        _mockAcademiesDbContext.AddGiasGovernance(currentMember2);
+        _mockAcademiesDbContext.AddGiasGovernance(historicMember);
         var result = await _sut.GetTrustGovernanceAsync("1234");
 
-        result.Should().BeEquivalentTo(new TrustGoverenance(
-            Members: [governor], HistoricMembers: [], TrustLeadership: [], Trustees: []
-        ));
+
+        result.Should().BeEquivalentTo(
+            new TrustGovernance([], [currentMemberOutput, currentMember2Output], [], [historicMemberOutput])
+        );
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
@@ -129,7 +129,7 @@ public class TrustRepositoryTests
     {
         var result = await _sut.GetTrustGovernanceAsync("1234");
 
-        result.Should().BeEquivalentTo(new TrustGoverenance([], [], [], []));
+        result.Should().BeEquivalentTo(new TrustGovernance([], [], [], []));
     }
 
     [Theory]
@@ -189,7 +189,7 @@ public class TrustRepositoryTests
         }
 
         result.Should().BeEquivalentTo(
-            new TrustGoverenance(trustLeadership.ToArray(), members.ToArray(), trustees.ToArray(), [])
+            new TrustGovernance(trustLeadership.ToArray(), members.ToArray(), trustees.ToArray(), [])
         );
     }
 
@@ -219,7 +219,7 @@ public class TrustRepositoryTests
         var result = await _sut.GetTrustGovernanceAsync("1234");
 
         result.Should().BeEquivalentTo(
-            new TrustGoverenance([], [], [], [])
+            new TrustGovernance([], [], [], [])
         );
     }
 
@@ -268,7 +268,7 @@ public class TrustRepositoryTests
         var historicMembers = new List<Governor> { output };
 
         result.Should().BeEquivalentTo(
-            new TrustGoverenance([], [], [], historicMembers.ToArray())
+            new TrustGovernance([], [], [], historicMembers.ToArray())
         );
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
@@ -121,6 +122,47 @@ public class TrustRepositoryTests
             "",
             "",
             new DateTime(2007, 6, 28)
+        ));
+    }
+
+    [Fact]
+    public async Task GetTrustGovernanceAsync_ShouldReturnEmpty_WithNoGovernenceSet()
+    {
+        var result = await _sut.GetTrustGovernanceAsync("1234");
+
+        result.Should().BeEquivalentTo(new TrustGoverenance([], [], [], []));
+    }
+
+    [Fact]
+    public async Task GetTrustGovernanceAsync_ShouldReturnValidGovernors_WithGovernenceSet()
+    {
+        var member = new GiasGovernance
+        {
+            Gid = "9999",
+            Uid = "1234",
+            Role = "Member",
+            Forename1 = "First",
+            Forename2 = "Second",
+            Surname = "Last",
+            DateOfAppointment = DateTime.Today.AddYears(-1).ToString(CultureInfo.InvariantCulture),
+            DateTermOfOfficeEndsEnded = DateTime.Today.AddYears(1).ToString(CultureInfo.InvariantCulture)
+        };
+        var governor = new Governor(
+            "9999",
+            "1234",
+            Role: "Member",
+            FullName: "First Second Last",
+            DateOfAppointment: DateTime.Today.AddYears(-1),
+            DateOfTermEnd: DateTime.Today.AddYears(1),
+            AppointingBody: "Nick Warms",
+            Email: null
+        );
+
+        _mockAcademiesDbContext.AddGiasGovernance(member);
+        var result = await _sut.GetTrustGovernanceAsync("1234");
+
+        result.Should().BeEquivalentTo(new TrustGoverenance(
+            Members: [governor], HistoricMembers: [], TrustLeadership: [], Trustees: []
         ));
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
@@ -126,7 +126,7 @@ public class TrustRepositoryTests
     }
 
     [Fact]
-    public async Task GetTrustGovernanceAsync_ShouldReturnEmpty_WithNoGovernenceSet()
+    public async Task GetTrustGovernanceAsync_ShouldReturnEmpty_WithNoGovernanceSet()
     {
         var result = await _sut.GetTrustGovernanceAsync("1234");
 
@@ -274,7 +274,7 @@ public class TrustRepositoryTests
     }
 
     [Fact]
-    public async Task GetTrustGovernanceAsync_ShouldSortHistoricAndCurrentGoverors()
+    public async Task GetTrustGovernanceAsync_ShouldSortHistoricAndCurrentGovernors()
     {
         var startDate = DateTime.Today.AddYears(-3);
         var yesterday = DateTime.Today.AddDays(-1);

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
@@ -1,7 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
-using DfE.FindInformationAcademiesTrusts.Data.Repositories.Models;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
@@ -151,8 +152,8 @@ public class TrustRepositoryTests
             Forename1 = "First",
             Forename2 = "Second",
             Surname = "Last",
-            DateOfAppointment = startDate.ToShortDateString(),
-            DateTermOfOfficeEndsEnded = endDate.ToShortDateString(),
+            DateOfAppointment = startDate.ToString("dd/MM/yyyy"),
+            DateTermOfOfficeEndsEnded = endDate.ToString("dd/MM/yyyy"),
             AppointingBody = "Nick Warms"
         };
         var output = new Governor(
@@ -211,8 +212,8 @@ public class TrustRepositoryTests
             Forename1 = "First",
             Forename2 = "Second",
             Surname = "Last",
-            DateOfAppointment = startDate.ToShortDateString(),
-            DateTermOfOfficeEndsEnded = endDate.ToShortDateString(),
+            DateOfAppointment = startDate.ToString("dd/MM/yyyy"),
+            DateTermOfOfficeEndsEnded = endDate.ToString("dd/MM/yyyy"),
             AppointingBody = "Nick Warms"
         };
 
@@ -247,8 +248,8 @@ public class TrustRepositoryTests
             Forename1 = "First",
             Forename2 = "Second",
             Surname = "Last",
-            DateOfAppointment = startDate.ToShortDateString(),
-            DateTermOfOfficeEndsEnded = endDate.ToShortDateString(),
+            DateOfAppointment = startDate.ToString("dd/MM/yyyy"),
+            DateTermOfOfficeEndsEnded = endDate.ToString("dd/MM/yyyy"),
             AppointingBody = "Nick Warms"
         };
         var output = new Governor(
@@ -288,8 +289,8 @@ public class TrustRepositoryTests
             Forename1 = "First",
             Forename2 = "Second",
             Surname = "Last",
-            DateOfAppointment = startDate.ToShortDateString(),
-            DateTermOfOfficeEndsEnded = today.ToShortDateString(),
+            DateOfAppointment = startDate.ToString("dd/MM/yyyy"),
+            DateTermOfOfficeEndsEnded = today.ToString("dd/MM/yyyy"),
             AppointingBody = "Nick Warms"
         };
         var currentMemberOutput = new Governor(
@@ -310,8 +311,8 @@ public class TrustRepositoryTests
             Forename1 = "First",
             Forename2 = "Second",
             Surname = "Last",
-            DateOfAppointment = startDate.ToShortDateString(),
-            DateTermOfOfficeEndsEnded = tomorrow.ToShortDateString(),
+            DateOfAppointment = startDate.ToString("dd/MM/yyyy"),
+            DateTermOfOfficeEndsEnded = tomorrow.ToString("dd/MM/yyyy"),
             AppointingBody = "Nick Warms"
         };
         var currentMember2Output = new Governor(
@@ -332,8 +333,8 @@ public class TrustRepositoryTests
             Forename1 = "First",
             Forename2 = "Second",
             Surname = "Last",
-            DateOfAppointment = startDate.ToShortDateString(),
-            DateTermOfOfficeEndsEnded = yesterday.ToShortDateString(),
+            DateOfAppointment = startDate.ToString("dd/MM/yyyy"),
+            DateTermOfOfficeEndsEnded = yesterday.ToString("dd/MM/yyyy"),
             AppointingBody = "Nick Warms"
         };
         var historicMemberOutput = new Governor(

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
@@ -1,6 +1,7 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.Models;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/DateTimeExtensionsTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/DateTimeExtensionsTests.cs
@@ -1,0 +1,23 @@
+﻿using DfE.FindInformationAcademiesTrusts.Extensions;
+using DfE.FindInformationAcademiesTrusts.Pages;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Extensions;
+
+public class DateTimeExtensionsTests
+{
+    [Fact]
+    public void ShowDateStringOrReplaceWithText_ReturnsFormattedDate_WhenNotNull()
+    {
+        DateTime? testTime = DateTime.Today;
+        var result = testTime.ShowDateStringOrReplaceWithText();
+        result.Should().BeEquivalentTo(DateTime.Today.ToString(StringFormatConstants.ViewDate));
+    }
+
+    [Fact]
+    public void ShowDateStringOrReplaceWithText_returns_NoData_WhenNull()
+    {
+        DateTime? testTime = null;
+        var result = testTime.ShowDateStringOrReplaceWithText();
+        result.Should().BeEquivalentTo("No Data");
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
@@ -69,7 +69,7 @@ public class GovernanceModelTests
 
     public GovernanceModelTests()
     {
-        _mockTrustRepository.Setup(t => t.GetTrustGoverenaceAsync(TestUid))
+        _mockTrustRepository.Setup(t => t.GetTrustGovernanceAsync(TestUid))
             .ReturnsAsync(DummyTrustGovernanceServiceModel);
         _mockTrustRepository.Setup(t => t.GetTrustSummaryAsync(TestUid))
             .ReturnsAsync(new TrustSummaryServiceModel(TestUid, "My trust", "", 0));
@@ -112,7 +112,7 @@ public class GovernanceModelTests
     public async Task OnGetAsync_sets_Governance_Service()
     {
         await _sut.OnGetAsync();
-        _mockTrustRepository.Verify(e => e.GetTrustGoverenaceAsync(TestUid), Times.Once);
+        _mockTrustRepository.Verify(e => e.GetTrustGovernanceAsync(TestUid), Times.Once);
         _sut.TrustGovernance.Should().BeEquivalentTo(DummyTrustGovernanceServiceModel);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
@@ -89,6 +89,12 @@ public class GovernanceModelTests
     }
 
     [Fact]
+    public void ShowHeaderSearch_should_be_true()
+    {
+        _sut.ShowHeaderSearch.Should().Be(true);
+    }
+
+    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_null()
     {
         _mockTrustRepository.Setup(t => t.GetTrustSummaryAsync(TestUid)).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
@@ -1,0 +1,115 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+using DfE.FindInformationAcademiesTrusts.ServiceModels;
+using DfE.FindInformationAcademiesTrusts.Services;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
+
+public class GovernanceModelTests
+{
+    private readonly GovernanceModel _sut;
+    private readonly Mock<IOtherServicesLinkBuilder> _mockLinksToOtherServices = new();
+    private readonly Mock<ITrustProvider> _mockTrustProvider = new();
+    private static readonly DateTime startDate = DateTime.Today.AddYears(-3);
+    private static readonly DateTime futureEndDate = DateTime.Today.AddYears(1);
+    private static readonly DateTime historicEndDate = DateTime.Today.AddYears(-1);
+
+    private static readonly Governor member = new(
+        "9999",
+        "1234",
+        Role: "Member",
+        FullName: "First Second Last",
+        DateOfAppointment: startDate,
+        DateOfTermEnd: futureEndDate,
+        AppointingBody: "Nick Warms",
+        Email: null
+    );
+
+    private static readonly Governor trustee = new(
+        "9998",
+        "1234",
+        Role: "Trustee",
+        FullName: "First Second Last",
+        DateOfAppointment: startDate,
+        DateOfTermEnd: futureEndDate,
+        AppointingBody: "Nick Warms",
+        Email: null
+    );
+
+    private static readonly Governor leader = new(
+        "9999",
+        "1234",
+        Role: "Chair of Trustees",
+        FullName: "First Second Last",
+        DateOfAppointment: startDate,
+        DateOfTermEnd: futureEndDate,
+        AppointingBody: "Nick Warms",
+        Email: null
+    );
+
+    private static readonly Governor historic = new(
+        "9999",
+        "1234",
+        Role: "Trustee",
+        FullName: "First Second Last",
+        DateOfAppointment: startDate,
+        DateOfTermEnd: historicEndDate,
+        AppointingBody: "Nick Warms",
+        Email: null
+    );
+
+    private static readonly TrustGovernanceServiceModel DummyTrustGovernanceServiceModel =
+        new([leader], [member], [trustee], [historic]);
+
+    private readonly MockDataSourceService _mockDataSourceService = new();
+    private readonly Mock<ITrustService> _mockTrustRepository = new();
+
+    private static readonly string TestUid = "1234";
+
+    public GovernanceModelTests()
+    {
+        _mockTrustRepository.Setup(t => t.GetTrustGoverenaceAsync(TestUid))
+            .ReturnsAsync(DummyTrustGovernanceServiceModel);
+        _mockTrustRepository.Setup(t => t.GetTrustSummaryAsync(TestUid))
+            .ReturnsAsync(new TrustSummaryServiceModel(TestUid, "My trust", "", 0));
+
+        _sut = new GovernanceModel(_mockTrustProvider.Object, _mockDataSourceService.Object,
+                new MockLogger<GovernanceModel>().Object, _mockTrustRepository.Object)
+            { Uid = TestUid };
+    }
+
+    [Fact]
+    public void PageName_should_be_Governance()
+    {
+        _sut.PageName.Should().Be("Governance");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_null()
+    {
+        _mockTrustRepository.Setup(t => t.GetTrustSummaryAsync(TestUid)).ReturnsAsync((TrustSummaryServiceModel?)null);
+        var result = await _sut.OnGetAsync();
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_correct_data_source_list()
+    {
+        await _sut.OnGetAsync();
+        _mockDataSourceService.Verify(e => e.GetAsync(Source.Gias), Times.Once);
+        _sut.DataSources.Should().ContainSingle();
+        _sut.DataSources[0].Fields.Should().Contain(new List<string> { "Governance" });
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_Governance_Service()
+    {
+        await _sut.OnGetAsync();
+        _mockTrustRepository.Verify(e => e.GetTrustGoverenaceAsync(TestUid), Times.Once);
+        _sut.TrustGovernance.Should().BeEquivalentTo(DummyTrustGovernanceServiceModel);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
@@ -3,7 +3,6 @@ using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 using DfE.FindInformationAcademiesTrusts.ServiceModels;
-using DfE.FindInformationAcademiesTrusts.Services;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Mvc;
@@ -13,58 +12,57 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
 public class GovernanceModelTests
 {
     private readonly GovernanceModel _sut;
-    private readonly Mock<IOtherServicesLinkBuilder> _mockLinksToOtherServices = new();
     private readonly Mock<ITrustProvider> _mockTrustProvider = new();
-    private static readonly DateTime startDate = DateTime.Today.AddYears(-3);
-    private static readonly DateTime futureEndDate = DateTime.Today.AddYears(1);
-    private static readonly DateTime historicEndDate = DateTime.Today.AddYears(-1);
+    private static readonly DateTime StartDate = DateTime.Today.AddYears(-3);
+    private static readonly DateTime FutureEndDate = DateTime.Today.AddYears(1);
+    private static readonly DateTime HistoricEndDate = DateTime.Today.AddYears(-1);
 
-    private static readonly Governor member = new(
+    private static readonly Governor Member = new(
         "9999",
         "1234",
         Role: "Member",
         FullName: "First Second Last",
-        DateOfAppointment: startDate,
-        DateOfTermEnd: futureEndDate,
+        DateOfAppointment: StartDate,
+        DateOfTermEnd: FutureEndDate,
         AppointingBody: "Nick Warms",
         Email: null
     );
 
-    private static readonly Governor trustee = new(
+    private static readonly Governor Trustee = new(
         "9998",
         "1234",
         Role: "Trustee",
         FullName: "First Second Last",
-        DateOfAppointment: startDate,
-        DateOfTermEnd: futureEndDate,
+        DateOfAppointment: StartDate,
+        DateOfTermEnd: FutureEndDate,
         AppointingBody: "Nick Warms",
         Email: null
     );
 
-    private static readonly Governor leader = new(
+    private static readonly Governor Leader = new(
         "9999",
         "1234",
         Role: "Chair of Trustees",
         FullName: "First Second Last",
-        DateOfAppointment: startDate,
-        DateOfTermEnd: futureEndDate,
+        DateOfAppointment: StartDate,
+        DateOfTermEnd: FutureEndDate,
         AppointingBody: "Nick Warms",
         Email: null
     );
 
-    private static readonly Governor historic = new(
+    private static readonly Governor Historic = new(
         "9999",
         "1234",
         Role: "Trustee",
         FullName: "First Second Last",
-        DateOfAppointment: startDate,
-        DateOfTermEnd: historicEndDate,
+        DateOfAppointment: StartDate,
+        DateOfTermEnd: HistoricEndDate,
         AppointingBody: "Nick Warms",
         Email: null
     );
 
     private static readonly TrustGovernanceServiceModel DummyTrustGovernanceServiceModel =
-        new([leader], [member], [trustee], [historic]);
+        new([Leader], [Member], [Trustee], [Historic]);
 
     private readonly MockDataSourceService _mockDataSourceService = new();
     private readonly Mock<ITrustService> _mockTrustRepository = new();

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
@@ -1,6 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
-using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 using DfE.FindInformationAcademiesTrusts.ServiceModels;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
@@ -4,6 +4,7 @@ using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 using DfE.FindInformationAcademiesTrusts.ServiceModels;
 using DfE.FindInformationAcademiesTrusts.Services;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Mvc;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
@@ -1,7 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
-using DfE.FindInformationAcademiesTrusts.ServiceModels;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Mvc;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
@@ -182,7 +182,7 @@ public class TrustServiceTests
         _mockTrustRepository.Setup(t => t.GetTrustGovernanceAsync("1234"))
             .ReturnsAsync(new TrustGovernance([leader], [member], [trustee], [historic]));
 
-        var result = await _sut.GetTrustGoverenaceAsync("1234");
+        var result = await _sut.GetTrustGovernanceAsync("1234");
 
         result.HistoricMembers.Should().ContainSingle().Which.Should().BeEquivalentTo(historic);
         result.Members.Should().ContainSingle().Which.Should().BeEquivalentTo(member);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
@@ -2,7 +2,6 @@ using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using DfE.FindInformationAcademiesTrusts.Data;
-using DfE.FindInformationAcademiesTrusts.Data.Repositories.Models;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
@@ -1,6 +1,11 @@
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.Models;
+using DfE.FindInformationAcademiesTrusts.ServiceModels;
+using DfE.FindInformationAcademiesTrusts.Services;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
@@ -130,5 +135,62 @@ public class TrustServiceTests
             null,
             new DateTime(2007, 6, 28)
         ));
+    }
+
+    [Fact]
+    public async Task GetTrustGovernanceAsync_should_get_governanceResults_for_single_trust()
+    {
+        var startDate = DateTime.Today.AddYears(-3);
+        var futureEndDate = DateTime.Today.AddYears(1);
+        var historicEndDate = DateTime.Today.AddYears(-1);
+        var member = new Governor(
+            "9999",
+            "1234",
+            Role: "Member",
+            FullName: "First Second Last",
+            DateOfAppointment: startDate,
+            DateOfTermEnd: futureEndDate,
+            AppointingBody: "Nick Warms",
+            Email: null
+        );
+        var trustee = new Governor(
+            "9998",
+            "1234",
+            Role: "Trustee",
+            FullName: "First Second Last",
+            DateOfAppointment: startDate,
+            DateOfTermEnd: futureEndDate,
+            AppointingBody: "Nick Warms",
+            Email: null
+        );
+        var leader = new Governor(
+            "9999",
+            "1234",
+            Role: "Chair of Trustees",
+            FullName: "First Second Last",
+            DateOfAppointment: startDate,
+            DateOfTermEnd: futureEndDate,
+            AppointingBody: "Nick Warms",
+            Email: null
+        );
+        var historic = new Governor(
+            "9999",
+            "1234",
+            Role: "Trustee",
+            FullName: "First Second Last",
+            DateOfAppointment: startDate,
+            DateOfTermEnd: historicEndDate,
+            AppointingBody: "Nick Warms",
+            Email: null
+        );
+        _mockTrustRepository.Setup(t => t.GetTrustGovernanceAsync("1234"))
+            .ReturnsAsync(new TrustGovernance([leader], [member], [trustee], [historic]));
+
+        var result = await _sut.GetTrustGoverenaceAsync("1234");
+
+        result.HistoricMembers.Should().ContainSingle().Which.Should().BeEquivalentTo(historic);
+        result.Members.Should().ContainSingle().Which.Should().BeEquivalentTo(member);
+        result.Trustees.Should().ContainSingle().Which.Should().BeEquivalentTo(trustee);
+        result.TrustLeadership.Should().ContainSingle().Which.Should().BeEquivalentTo(leader);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
@@ -2,10 +2,7 @@ using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using DfE.FindInformationAcademiesTrusts.Data;
-using DfE.FindInformationAcademiesTrusts.Data.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Models;
-using DfE.FindInformationAcademiesTrusts.ServiceModels;
-using DfE.FindInformationAcademiesTrusts.Services;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;

--- a/tests/NewCypress/cypress/e2e/regression/trusts/governance-page.cy.ts
+++ b/tests/NewCypress/cypress/e2e/regression/trusts/governance-page.cy.ts
@@ -1,0 +1,47 @@
+import governancePage from "../../../pages/trusts/governancePage";
+
+describe("Testing the components of the Governance page", () => {
+
+    describe("On a Governance page with data", () => {
+        beforeEach(() => {
+            cy.login()
+            governancePage
+                .navigateToFullGovernancePage()
+        });
+
+        it("The page loads with the correct headings and data", () => {
+            // No missing tables messages
+            governancePage.checkNoTrustLeadershipMessageIsNotVisble()
+                .checkNoTrusteesMessageIsNotVisble()
+                .checkNoMembersMessageIsNotVisble()
+                .checkNoHistoricMembersMessageIsNotVisble();
+
+            // Column headers are visible
+            governancePage.checkTrustLeadershipColumnHeaders()
+                .checkTrusteeColumnHeaders()
+                .checkMembersColumnHeaders()
+                .checkHistoricMembersColumnHeaders();
+
+            // Check table sorting is working
+            governancePage.checkTrustLeadershipSorting();
+            governancePage.checkTrusteesSorting();
+            governancePage.checkMembersSorting();
+            governancePage.checkHistoricMembersSorting();
+        })
+
+    })
+
+    describe("On a Governance page without data", () => {
+        beforeEach(() => {
+            cy.login()
+            governancePage.navigateToEmptyGovernancePage();
+        });
+
+        it("The tables should be replaced with messages", () => {
+            governancePage.checkNoTrustLeadershipMessageIsVisble();
+            governancePage.checkNoTrusteesMessageIsVisble();
+            governancePage.checkNotMembersMessageIsVisble();
+            governancePage.checkNoHistoricMembersMessageIsVisble();
+        })
+    })
+})

--- a/tests/NewCypress/cypress/e2e/regression/trusts/governance-page.cy.ts
+++ b/tests/NewCypress/cypress/e2e/regression/trusts/governance-page.cy.ts
@@ -21,8 +21,17 @@ describe("Testing the components of the Governance page", () => {
                 .checkTrusteeColumnHeaders()
                 .checkMembersColumnHeaders()
                 .checkHistoricMembersColumnHeaders();
+        })
 
-            // Check table sorting is working
+        it("The correct roles are selected for the trust leadership table", () => {
+            governancePage.checkRolesOnTrustLeadershipTable()
+        })
+
+        it("The correct data is show on the correct tables, historic data is only on the historic table", () => {
+            governancePage.checkDatesInTablesAreValid();
+        })
+
+        it("Table sorting is working", () => {
             governancePage.checkTrustLeadershipSorting();
             governancePage.checkTrusteesSorting();
             governancePage.checkMembersSorting();

--- a/tests/NewCypress/cypress/pages/trusts/governancePage.ts
+++ b/tests/NewCypress/cypress/pages/trusts/governancePage.ts
@@ -1,0 +1,339 @@
+class GovernancePage {
+
+    elements = {
+        TrustLeadership: {
+            Section: () => cy.get('[data-testid="trust-leadership"]'),
+            Names: () => this.elements.TrustLeadership.Section().find('[data-testid="trust-leadership-name"]'),
+            NameHeader: () => this.elements.TrustLeadership.Section().find("th:contains('Name')"),
+            NameHeaderButton: () => this.elements.TrustLeadership.NameHeader().contains("Name"),
+            Roles: () => this.elements.TrustLeadership.Section().find('[data-testid="trust-leadership-role"]'),
+            RoleHeader: () => this.elements.TrustLeadership.Section().find("th:contains('Role')"),
+            RoleHeaderButton: () => this.elements.TrustLeadership.RoleHeader().contains("Role"),
+            From: () => this.elements.TrustLeadership.Section().find('[data-testid="trust-leadership-from"]'),
+            FromHeader: () => this.elements.TrustLeadership.Section().find("th:contains('From')"),
+            FromHeaderButton: () => this.elements.TrustLeadership.FromHeader().contains("From"),
+            To: () => this.elements.TrustLeadership.Section().find('[data-testid="trust-leadership-to"]'),
+            ToHeader: () => this.elements.TrustLeadership.Section().find("th:contains('To')"),
+            ToHeaderButton: () => this.elements.TrustLeadership.ToHeader().contains("To"),
+            NoDataMessage: () => this.elements.TrustLeadership.Section().contains('No Trust Leadership')
+        },
+        Trustees: {
+            Section: () => cy.get('[data-testid="trustees"]'),
+            Names: () => this.elements.Trustees.Section().find('[data-testid="trustees-name"]'),
+            NameHeader: () => this.elements.Trustees.Section().find("th:contains('Name')"),
+            NameHeaderButton: () => this.elements.Trustees.NameHeader().contains("Name"),
+            AppointedBys: () => this.elements.Trustees.Section().find('[data-testid="trustees-appointed"]'),
+            AppointedHeader: () => this.elements.Trustees.Section().find("th:contains('Appointed by')"),
+            AppointedHeaderButton: () => this.elements.Trustees.AppointedHeader().contains("Appointed by"),
+            From: () => this.elements.Trustees.Section().find('[data-testid="trustees-from"]'),
+            FromHeader: () => this.elements.Trustees.Section().find("th:contains('From')"),
+            FromHeaderButton: () => this.elements.Trustees.FromHeader().contains("From"),
+            To: () => this.elements.Trustees.Section().find('[data-testid="trustees-to"]'),
+            ToHeader: () => this.elements.Trustees.Section().find("th:contains('To')"),
+            ToHeaderButton: () => this.elements.Trustees.ToHeader().contains("To"),
+            NoDataMessage: () => this.elements.Trustees.Section().contains('No Trustees')
+        },
+        Members: {
+            Section: () => cy.get('[data-testid="members"]'),
+            Names: () => this.elements.Members.Section().find('[data-testid="members-name"]'),
+            NameHeader: () => this.elements.Members.Section().find("th:contains('Name')"),
+            NameHeaderButton: () => this.elements.Members.NameHeader().contains("Name"),
+            AppointedBys: () => this.elements.Members.Section().find('[data-testid="members-appointed"]'),
+            AppointedHeader: () => this.elements.Members.Section().find("th:contains('Appointed by')"),
+            AppointedHeaderButton: () => this.elements.Members.AppointedHeader().contains("Appointed by"),
+            From: () => this.elements.Members.Section().find('[data-testid="members-from"]'),
+            FromHeader: () => this.elements.Members.Section().find("th:contains('From')"),
+            FromHeaderButton: () => this.elements.Members.FromHeader().contains("From"),
+            To: () => this.elements.Members.Section().find('[data-testid="members-to"]'),
+            ToHeader: () => this.elements.Members.Section().find("th:contains('To')"),
+            ToHeaderButton: () => this.elements.Members.ToHeader().contains("To"),
+            NoDataMessage: () => this.elements.Members.Section().contains('No Members')
+        },
+        HistoricMembers: {
+            Section: () => cy.get('[data-testid="historic-members"]'),
+            Names: () => this.elements.HistoricMembers.Section().find('[data-testid="historic-members-name"]'),
+            NameHeader: () => this.elements.HistoricMembers.Section().find("th:contains('Name')"),
+            NameHeaderButton: () => this.elements.HistoricMembers.NameHeader().contains("Name"),
+            Roles: () => this.elements.HistoricMembers.Section().find('[data-testid="historic-members-role"]'),
+            RoleHeader: () => this.elements.HistoricMembers.Section().find("th:contains('Role')"),
+            RoleHeaderButton: () => this.elements.HistoricMembers.RoleHeader().contains("Role"),
+            AppointedBys: () => this.elements.HistoricMembers.Section().find('[data-testid="historic-members-appointed"]'),
+            AppointedHeader: () => this.elements.HistoricMembers.Section().find("th:contains('Appointed by')"),
+            AppointedHeaderButton: () => this.elements.HistoricMembers.AppointedHeader().contains("Appointed by"),
+            From: () => this.elements.HistoricMembers.Section().find('[data-testid="historic-members-from"]'),
+            FromHeader: () => this.elements.HistoricMembers.Section().find("th:contains('From')"),
+            To: () => this.elements.HistoricMembers.Section().find('[data-testid="historic-members-to"]'),
+            FromHeaderButton: () => this.elements.HistoricMembers.FromHeader().contains("From"),
+            ToHeader: () => this.elements.HistoricMembers.Section().find("th:contains('To')"),
+            ToHeaderButton: () => this.elements.HistoricMembers.ToHeader().contains("To"),
+            NoDataMessage: () => this.elements.HistoricMembers.Section().contains('No Historic Members')
+        }
+    }
+
+    // **********
+    //
+    // NAVIGATION
+    //
+    // **********
+
+    public navigateToFullGovernancePage(): this {
+        cy.visit('/trusts/governance?uid=5712')
+
+        return this;
+    }
+
+    public navigateToEmptyGovernancePage(): this {
+        cy.visit('/trusts/governance?uid=5527')
+
+        return this;
+    }
+
+    // *************
+    //
+    // HEADER CHECKS
+    //
+    // *************
+
+    public checkTrustLeadershipColumnHeaders() {
+        this.elements.TrustLeadership.NameHeader().should('be.visible');
+        this.elements.TrustLeadership.RoleHeader().should('be.visible');
+        this.elements.TrustLeadership.FromHeader().should('be.visible');
+        this.elements.TrustLeadership.ToHeader().should('be.visible');
+        return this;
+    }
+
+    public checkTrusteeColumnHeaders() {
+        this.elements.Trustees.NameHeader().should('be.visible');
+        this.elements.Trustees.AppointedHeader().should('be.visible');
+        this.elements.Trustees.FromHeader().should('be.visible');
+        this.elements.Trustees.ToHeader().should('be.visible');
+        return this;
+    }
+
+    public checkMembersColumnHeaders() {
+        this.elements.Members.NameHeader().should('be.visible');
+        this.elements.Members.AppointedHeader().should('be.visible');
+        this.elements.Members.FromHeader().should('be.visible');
+        this.elements.Members.ToHeader().should('be.visible');
+        return this;
+    }
+
+    public checkHistoricMembersColumnHeaders() {
+        this.elements.HistoricMembers.NameHeader().should('be.visible');
+        this.elements.HistoricMembers.RoleHeader().should('be.visible');
+        this.elements.HistoricMembers.AppointedHeader().should('be.visible');
+        this.elements.HistoricMembers.FromHeader().should('be.visible');
+        this.elements.HistoricMembers.ToHeader().should('be.visible');
+        return this;
+    }
+
+    // **************
+    //
+    // SORTING CHECKS
+    //
+    // **************
+
+
+    public checkTrustLeadershipSorting() {
+        const { TrustLeadership } = this.elements;
+        this.checkSorting(TrustLeadership.Names, TrustLeadership.NameHeader, TrustLeadership.NameHeaderButton);
+        this.checkSorting(TrustLeadership.Roles, TrustLeadership.RoleHeader, TrustLeadership.RoleHeaderButton);
+        this.checkSorting(TrustLeadership.From, TrustLeadership.FromHeader, TrustLeadership.FromHeaderButton);
+        this.checkSorting(TrustLeadership.To, TrustLeadership.ToHeader, TrustLeadership.ToHeaderButton);
+    }
+
+    public checkTrusteesSorting() {
+        const { Trustees } = this.elements;
+        this.checkSorting(Trustees.Names, Trustees.NameHeader, Trustees.NameHeaderButton);
+        this.checkSorting(Trustees.AppointedBys, Trustees.AppointedHeader, Trustees.AppointedHeaderButton);
+        this.checkSorting(Trustees.From, Trustees.FromHeader, Trustees.FromHeaderButton);
+        this.checkSorting(Trustees.To, Trustees.ToHeader, Trustees.ToHeaderButton);
+    }
+
+    public checkMembersSorting() {
+        const { Members } = this.elements;
+        this.checkSorting(Members.Names, Members.NameHeader, Members.NameHeaderButton);
+        this.checkSorting(Members.AppointedBys, Members.AppointedHeader, Members.AppointedHeaderButton);
+        this.checkSorting(Members.From, Members.FromHeader, Members.FromHeaderButton);
+        this.checkSorting(Members.To, Members.ToHeader, Members.ToHeaderButton);
+    }
+
+    public checkHistoricMembersSorting() {
+        const { HistoricMembers } = this.elements;
+        this.checkSorting(HistoricMembers.Names, HistoricMembers.NameHeader, HistoricMembers.NameHeaderButton);
+        this.checkSorting(HistoricMembers.Roles, HistoricMembers.RoleHeader, HistoricMembers.RoleHeaderButton);
+        this.checkSorting(HistoricMembers.AppointedBys, HistoricMembers.AppointedHeader, HistoricMembers.AppointedHeaderButton);
+        this.checkSorting(HistoricMembers.From, HistoricMembers.FromHeader, HistoricMembers.FromHeaderButton);
+        this.checkSorting(HistoricMembers.To, HistoricMembers.ToHeader, HistoricMembers.ToHeaderButton);
+    }
+
+    private checkSorting(elements: () => Cypress.Chainable<JQuery<HTMLElement>>, header: () => Cypress.Chainable<JQuery<HTMLElement>>, headerButton: () => Cypress.Chainable<JQuery<HTMLElement>>) {
+        //Get current sort status
+        header().invoke("attr", "aria-sort").then(value => {
+            //Reset sort to asc
+            if (value === "descending" || value === "none" || !value) {
+                headerButton().click();
+            }
+            //Check sorting is set to asc
+            header().should("have.attr", "aria-sort", "ascending");
+            //Collect the actual elements and add the values to an array
+            const actualAscElements: { value: string, sortValue: string }[] = [];
+            elements().each($elements => {
+                actualAscElements.push({
+                    value: $elements.text().trim(),
+                    sortValue: $elements.attr("data-sort-value") ?? ""
+                })
+            }).then(() => {
+                //Sort the elements so they will be in ascending order
+                const ascendingValues = actualAscElements.toSorted((a, b) => a.sortValue.localeCompare(b.sortValue))
+                //Compare the sorted list to the actual list
+                expect(actualAscElements, "Values are sorted").to.deep.equal(ascendingValues, "Values are sorted")
+            });
+
+            //click the button to sort by descending
+            headerButton().click();
+            //Check sorting is set to dsc
+            header().should("have.attr", "aria-sort", "descending");
+            //Collect the actual elements and add the values to an array
+            const actualDscElements: { value: string, sortValue: string }[] = [];
+            elements().each($elements => {
+                actualDscElements.push({
+                    value: $elements.text().trim(),
+                    sortValue: $elements.attr("data-sort-value") ?? ""
+                })
+            }).then(() => {
+                //Sort the elements so they will be in descending order
+                const descendingValues = actualDscElements.toSorted((a, b) => b.sortValue.localeCompare(a.sortValue))
+                //Compare the sorted list to the actual list
+                expect(actualDscElements, "Values are sorted").to.deep.equal(descendingValues, "Values are sorted")
+            });
+        })
+    }
+
+    // ***********
+    //
+    // DATE CHECKS
+    //
+    // ***********
+
+    public checkDatesInTablesAreValid(): this {
+        governancePage.elements.TrustLeadership.From().each(element => { governancePage.checkDateCellIsBeforeToday(element) })
+        governancePage.elements.TrustLeadership.To().each(element => { governancePage.checkDateCellIsAfterToday(element) })
+
+        governancePage.elements.Trustees.From().each(element => { governancePage.checkDateCellIsBeforeToday(element) })
+        governancePage.elements.Trustees.To().each(element => { governancePage.checkDateCellIsAfterToday(element) })
+
+        governancePage.elements.Members.From().each(element => { governancePage.checkDateCellIsBeforeToday(element) })
+        governancePage.elements.Members.To().each(element => { governancePage.checkDateCellIsAfterToday(element) })
+
+        governancePage.elements.HistoricMembers.From().each(element => { governancePage.checkDateCellIsBeforeToday(element) })
+        governancePage.elements.HistoricMembers.To().each(element => { governancePage.checkDateCellIsBeforeToday(element) })
+        return this;
+    }
+
+    private checkDateCellIsBeforeToday(element: JQuery<HTMLElement>) {
+        if (this.checkForSortValueOrNoData(element)) {
+            const today = new Date(Date.now());
+            today.setHours(0);
+            today.setMinutes(0);
+            today.setSeconds(0);
+            today.setMilliseconds(0);
+            const date = this.convertDataSortValueToDate(element);
+            expect(date.getTime()).to.be.lessThan(today.getTime());
+        }
+    }
+
+    private checkDateCellIsAfterToday(element: JQuery<HTMLElement>) {
+        if (this.checkForSortValueOrNoData(element)) {
+            const today = new Date(Date.now());
+            today.setHours(0);
+            today.setMinutes(0);
+            today.setSeconds(0);
+            today.setMilliseconds(0);
+            const date = this.convertDataSortValueToDate(element);
+            expect(date.getTime()).to.be.greaterThan(today.getTime());
+        }
+    }
+
+    private convertDataSortValueToDate(element: JQuery<HTMLElement>) {
+        const sortValue = element.attr('data-sort-value');
+        if (!sortValue) {
+            throw "Sort value not found on element";
+        }
+        const year = parseInt(sortValue.substring(0, 4));
+        const month = parseInt(sortValue.substring(4, 6));
+        const day = parseInt(sortValue.substring(6));
+        return new Date(year, month - 1, day);
+    }
+
+    // **********************
+    //
+    // NO DATA MESSAGE CHECKS
+    //
+    // **********************
+
+    public checkNoTrustLeadershipMessageIsVisble(): this {
+        this.elements.TrustLeadership.NoDataMessage().should('be.visible');
+        return this;
+    }
+
+    public checkNoTrusteesMessageIsVisble(): this {
+        this.elements.Trustees.NoDataMessage().should('be.visible');
+        return this;
+    }
+
+    public checkNotMembersMessageIsVisble(): this {
+        this.elements.Members.NoDataMessage().should('be.visible');
+        return this;
+    }
+
+    public checkNoHistoricMembersMessageIsVisble(): this {
+        this.elements.HistoricMembers.NoDataMessage().should('be.visible');
+        return this;
+    }
+
+    public checkNoTrustLeadershipMessageIsNotVisble(): this {
+        this.elements.TrustLeadership.NoDataMessage().should('not.exist');
+        return this;
+    }
+
+    public checkNoTrusteesMessageIsNotVisble(): this {
+        this.elements.Trustees.NoDataMessage().should('not.exist');
+        return this;
+    }
+
+    public checkNoMembersMessageIsNotVisble(): this {
+        this.elements.Members.NoDataMessage().should('not.exist');
+        return this;
+    }
+
+    public checkNoHistoricMembersMessageIsNotVisble(): this {
+        this.elements.HistoricMembers.NoDataMessage().should('not.exist');
+        return this;
+    }
+
+    private checkForSortValueOrNoData(element: JQuery<HTMLElement>) {
+        const sortValue = element.attr('data-sort-value');
+        if (!sortValue) {
+            expect(element.text().trim()).to.be.equal("No Data")
+            return false;
+        }
+        return true;
+    }
+
+    // ***********
+    //
+    // ROLE CHECKS
+    //
+    // ***********
+
+    public checkRolesOnTrustLeadershipTable() {
+        this.elements.TrustLeadership.Roles().each(element => {
+            expect(element.text().trim()).to.be.oneOf(["Chief Financial Officer", "Accounting Officer", "Chair of Trustees"])
+        });
+    }
+}
+
+const governancePage = new GovernancePage();
+
+export default governancePage;

--- a/tests/NewCypress/cypress/pages/trusts/governancePage.ts
+++ b/tests/NewCypress/cypress/pages/trusts/governancePage.ts
@@ -258,7 +258,7 @@ class GovernancePage {
     private convertDataSortValueToDate(element: JQuery<HTMLElement>) {
         const sortValue = element.attr('data-sort-value');
         if (!sortValue) {
-            throw "Sort value not found on element";
+            throw new Error("Sort value not found on element");
         }
         const year = parseInt(sortValue.substring(0, 4));
         const month = parseInt(sortValue.substring(4, 6));

--- a/tests/NewCypress/tsconfig.json
+++ b/tests/NewCypress/tsconfig.json
@@ -104,7 +104,7 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
-    "lib": ["es5", "dom"],
+    "lib": ["ES2023.Array","es5", "dom"],
     "types": ["cypress", "node"]
   },
   "include": ["**/*.ts"]


### PR DESCRIPTION
[User Story 134803](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/134803): Build: Trust Governance Page
Add the governance page to the trusts section. 

## Changes

- Add Trust Governance fetching to the trust repository
- Update the Governor class to have role checks
- Create the TrustGovernance class
- Create DateTimeExtensions for extensions methods (specifically a method to convert the date to a string or replace it with a string
- Create the Governance page and model
- Add governance link to Trust Navigation
- Create Trust GovernanceServiceModel
- Add method to fetch Trust Governance to the TrustService
- Add a style for dates in a table
- Add unit tests for the added code
- Add automation tests for the Governance page
- Add modern ES2023 array features to the automation suite

## Screenshots of UI changes

![image](https://github.com/user-attachments/assets/c1c6aaad-d40b-44b7-a54b-2bb65cea6edb)

Missing data fields
![image](https://github.com/user-attachments/assets/3477ad6d-e465-4eb5-8bcf-96bdbabc69ef)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
