### PR TITLE
Fix the sorting dates on the sortable table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Update the sorting behaviour for dates on the tables
+
 ## [Release-4][release-4] (production-2024-08-22.2794)
 
 ### Added

--- a/DfE.FindInformationAcademiesTrusts/Pages/StringFormatConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/StringFormatConstants.cs
@@ -3,5 +3,5 @@ namespace DfE.FindInformationAcademiesTrusts.Pages;
 public static class StringFormatConstants
 {
     public const string ViewDate = "d MMM yyyy";
-    public const string SortDate = "yyyy/MM/dd";
+    public const string SortDate = "yyyyMMdd";
 }


### PR DESCRIPTION
[Bug 178358](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/178358): Sorting by date is not working as intended on sortable tables
Remove the slashes from the date sort
The sortable table was not looking at the characters after the slash, this will allow us to sort dates correctly

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
