### PR TITLE
Scan the built docker image for CVEs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,25 @@
+name: Run Docker build
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build docker image
+        uses: docker/build-push-action@v6
+        with:
+          secrets: github_token=${{ secrets.GITHUB_TOKEN }}
+          cache-from: type=gha
+          cache-to: type=gha
+          push: false

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,47 @@
+name: Scan Docker image
+
+on:
+  push:
+    branches: main
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.build.outputs.imageid }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build docker image
+        uses: docker/build-push-action@v6
+        id: build
+        with:
+          secrets: github_token=${{ secrets.GITHUB_TOKEN }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha
+          push: false
+
+      - name: Export docker image as tar
+        run: docker save -o ${{ github.ref_name }}.tar ${{ steps.build.outputs.imageid }}
+
+      - name: Scan Docker image for CVEs
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          input: ${{ github.ref_name }}.tar
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          limit-severities-for-sarif: true
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
I've added a new GitHub Workflow that will run on pushes to `main`. It will build and scan a Docker image, and report any CVE findings in the GitHub Security tab.

There's also an additional GitHub Workflow that runs on Pull Requests which simply ensures the Dockerfile can build successfully if it changes at all.