### PR TITLE
Track 'v2.4.0' tag of deployment workflow

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -83,7 +83,7 @@ jobs:
   deploy-image:
     name: Deploy to environment
     needs: [ set-env ]
-    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v2.3.0
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v2.4.0
     with:
       docker-image-name: 'fiat-app'
       docker-build-file-name: 'docker/Dockerfile'


### PR DESCRIPTION
Fixes an upstream problem where Microsoft changed their Docker image to Azure Linux which dropped jq support.

This version of the shared workflow has a pinned Az CLI version so will not receive any upstream changes unless updated

https://github.com/DFE-Digital/deploy-azure-container-apps-action/releases/tag/v2.4.0