### PR TITLE
Data protection path must be absolute

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/appsettings.json
+++ b/DfE.FindInformationAcademiesTrusts/appsettings.json
@@ -43,6 +43,6 @@
   },
   "DataProtection": {
     "KeyVaultKey": "",
-    "Path": "srv/app/storage"
+    "Path": "/srv/app/storage"
   }
 }


### PR DESCRIPTION
The Container App has it's volume mounted from the root filesystem so the file path defined in app settings must be absolute