### PR TITLE
Move Trust governance from release 4 to release 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Release-5][release-5] (production-2024-09-05.2971)
 
+### Added
+
+- Add Trust Governance Page
+
 ### Changed
 
 - Update the sorting behaviour for dates on the tables
@@ -19,7 +23,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Feature flags added to allow for selectively showing features in different environments
 - Add search autocomplete to the header of the application
-- Add Trust Governance Page
 
 ### Changed
 


### PR DESCRIPTION
Move Trust governance from release 4 to release 5

## Checklist

- [x] Release notes added to CHANGELOG.md
