### PR TITLE
Pupil numbers performance update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Reduced the load time of the Academies in trust pupil numbers page
+
+
 ## [Release-5][release-5] (production-2024-09-05.2971)
 
 ### Added

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
@@ -87,6 +87,22 @@ public class AcademyRepository(IAcademiesDbContext academiesDbContext, ILogger<A
         return ofstedRatings.ToDictionary(o => o.Urn.ToString(), o => o);
     }
 
+    public async Task<AcademyPupilNumbers[]> GetAcademiesInTrustPupilNumbersAsync(string uid)
+    {
+        return await academiesDbContext.GiasGroupLinks
+            .Where(gl => gl.GroupUid == uid)
+            .Join(academiesDbContext.GiasEstablishments,
+                gl => gl.Urn!, e => e.Urn.ToString(),
+                (_, e) =>
+                    new AcademyPupilNumbers(e.Urn.ToString(),
+                        e.EstablishmentName,
+                        e.PhaseOfEducationName,
+                        new AgeRange(e.StatutoryLowAge!, e.StatutoryHighAge!),
+                        e.NumberOfPupils.ParseAsNullableInt(),
+                        e.SchoolCapacity.ParseAsNullableInt()))
+            .ToArrayAsync();
+    }
+
     public async Task<int> GetNumberOfAcademiesInTrustAsync(string uid)
     {
         return await academiesDbContext.GiasGroupLinks.CountAsync(gl => gl.GroupUid == uid && gl.Urn != null);

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/AcademyPupilNumbers.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/AcademyPupilNumbers.cs
@@ -1,0 +1,10 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
+
+public record AcademyPupilNumbers(
+    string Urn,
+    string? EstablishmentName,
+    string? PhaseOfEducation,
+    AgeRange AgeRange,
+    int? NumberOfPupils,
+    int? SchoolCapacity
+);

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/IAcademyRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/IAcademyRepository.cs
@@ -6,4 +6,5 @@ public interface IAcademyRepository
     Task<int> GetNumberOfAcademiesInTrustAsync(string uid);
     Task<AcademyDetails[]> GetAcademiesInTrustDetailsAsync(string uid);
     Task<AcademyOfsted[]> GetAcademiesInTrustOfstedAsync(string uid);
+    Task<AcademyPupilNumbers[]> GetAcademiesInTrustPupilNumbersAsync(string uid);
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml
@@ -18,15 +18,15 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      @foreach (var academy in Model.Trust.Academies)
+      @foreach (var academy in Model.Academies)
       {
         <tr class="govuk-table__row" data-testid="academy-row">
-            <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
+          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
             @academy.EstablishmentName<br/><span class="govuk-!-font-weight-regular" data-testid="urn">URN: @academy.Urn</span>
           </th>
-          <td class="govuk-body govuk-table__cell" data-sort-value="@Model.PhaseAndAgeRangeSortValue(academy)" data-testid="phase-and-age-range">
+          <td class="govuk-body govuk-table__cell" data-sort-value="@PupilNumbersModel.PhaseAndAgeRangeSortValue(academy)" data-testid="phase-and-age-range">
             @academy.PhaseOfEducation<br/>
-            @academy.AgeRange.Minimum - @academy.AgeRange.Maximum
+            @academy.AgeRange?.Minimum - @academy.AgeRange?.Maximum
           </td>
 
           <td class="govuk-body govuk-table__cell" data-sort-value="@academy.NumberOfPupils" data-testid="pupil-numbers">@academy.NumberOfPupils?.ToString("N0")</td>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml
@@ -26,7 +26,7 @@
           </th>
           <td class="govuk-body govuk-table__cell" data-sort-value="@PupilNumbersModel.PhaseAndAgeRangeSortValue(academy)" data-testid="phase-and-age-range">
             @academy.PhaseOfEducation<br/>
-            @academy.AgeRange?.Minimum - @academy.AgeRange?.Maximum
+            @academy.AgeRange.Minimum - @academy.AgeRange.Maximum
           </td>
 
           <td class="govuk-body govuk-table__cell" data-sort-value="@academy.NumberOfPupils" data-testid="pupil-numbers">@academy.NumberOfPupils?.ToString("N0")</td>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
@@ -8,12 +9,15 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
 public class PupilNumbersModel : TrustsAreaModel, IAcademiesAreaModel
 {
-    public Trust Trust { get; set; } = default!;
+    public IAcademyService AcademyService { get; }
+    public AcademyPupilNumbersServiceModel[] Academies { get; set; } = default!;
 
     public PupilNumbersModel(ITrustProvider trustProvider, IDataSourceService dataSourceService,
-        ILogger<PupilNumbersModel> logger, ITrustService trustService) : base(trustProvider, dataSourceService,
+        ILogger<PupilNumbersModel> logger, ITrustService trustService, IAcademyService academyService) : base(
+        trustProvider, dataSourceService,
         trustService, logger, "Academies in this trust")
     {
+        AcademyService = academyService;
         PageTitle = "Academies pupil numbers";
     }
 
@@ -23,7 +27,7 @@ public class PupilNumbersModel : TrustsAreaModel, IAcademiesAreaModel
 
         if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
 
-        Trust = (await TrustProvider.GetTrustByUidAsync(Uid))!;
+        Academies = await AcademyService.GetAcademiesInTrustPupilNumbersAsync(Uid);
 
         DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.Gias),
             new List<string> { "Pupil numbers" }));
@@ -33,8 +37,8 @@ public class PupilNumbersModel : TrustsAreaModel, IAcademiesAreaModel
 
     public string TabName => "Pupil numbers";
 
-    public string PhaseAndAgeRangeSortValue(Academy academy)
+    public static string PhaseAndAgeRangeSortValue(AcademyPupilNumbersServiceModel academy)
     {
-        return $"{academy.PhaseOfEducation}{academy.AgeRange.Minimum:D2}{academy.AgeRange.Maximum:D2}";
+        return $"{academy.PhaseOfEducation}{academy.AgeRange?.Minimum:D2}{academy.AgeRange?.Maximum:D2}";
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml.cs
@@ -39,6 +39,6 @@ public class PupilNumbersModel : TrustsAreaModel, IAcademiesAreaModel
 
     public static string PhaseAndAgeRangeSortValue(AcademyPupilNumbersServiceModel academy)
     {
-        return $"{academy.PhaseOfEducation}{academy.AgeRange?.Minimum:D2}{academy.AgeRange?.Maximum:D2}";
+        return $"{academy.PhaseOfEducation}{academy.AgeRange.Minimum:D2}{academy.AgeRange.Maximum:D2}";
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyPupilNumbersServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyPupilNumbersServiceModel.cs
@@ -1,0 +1,27 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+
+namespace DfE.FindInformationAcademiesTrusts.Services.Academy;
+
+public record AcademyPupilNumbersServiceModel(
+    string Urn,
+    string? EstablishmentName,
+    string? PhaseOfEducation,
+    AgeRange AgeRange,
+    int? NumberOfPupils,
+    int? SchoolCapacity
+)
+{
+    public float? PercentageFull
+    {
+        get
+        {
+            if (this is { NumberOfPupils: not null, SchoolCapacity: not null } &&
+                SchoolCapacity != 0)
+            {
+                return (float)Math.Round((int)NumberOfPupils / (float)SchoolCapacity * 100);
+            }
+
+            return null;
+        }
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyService.cs
@@ -6,6 +6,7 @@ public interface IAcademyService
 {
     Task<AcademyDetailsServiceModel[]> GetAcademiesInTrustDetailsAsync(string uid);
     Task<AcademyOfstedServiceModel[]> GetAcademiesInTrustOfstedAsync(string uid);
+    Task<AcademyPupilNumbersServiceModel[]> GetAcademiesInTrustPupilNumbersAsync(string uid);
 }
 
 public class AcademyService(IAcademyRepository academyRepository) : IAcademyService
@@ -26,5 +27,15 @@ public class AcademyService(IAcademyRepository academyRepository) : IAcademyServ
         return academies.Select(a =>
             new AcademyOfstedServiceModel(a.Urn, a.EstablishmentName, a.DateAcademyJoinedTrust, a.PreviousOfstedRating,
                 a.CurrentOfstedRating)).ToArray();
+    }
+
+    public async Task<AcademyPupilNumbersServiceModel[]> GetAcademiesInTrustPupilNumbersAsync(string uid)
+    {
+        var academies = await academyRepository.GetAcademiesInTrustPupilNumbersAsync(uid);
+
+        return academies.Select(a =>
+            new AcademyPupilNumbersServiceModel(a.Urn, a.EstablishmentName, a.PhaseOfEducation,
+                a.AgeRange, a.NumberOfPupils,
+                a.SchoolCapacity)).ToArray();
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyPupilNumbersServiceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyPupilNumbersServiceModelTests.cs
@@ -1,0 +1,72 @@
+﻿using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Services.Academy;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
+
+public class AcademyPupilNumbersServiceModelTests
+{
+    [Theory]
+    [InlineData(25, 100, 25F)]
+    [InlineData(1, 4, 25F)]
+    [InlineData(816, 1074, 76F)]
+    [InlineData(100, 100, 100F)]
+    [InlineData(101, 100, 101F)]
+    [InlineData(0, 100, 0F)]
+    public void PercentageFull_should_return_the_correct_percentage_calculation(int numberOfPupils,
+        int capacity, float expected)
+    {
+        var sut =
+            BuildDummyAcademyPupilNumbersServiceModel("111",
+                numberOfPupils: numberOfPupils, schoolCapacity: capacity);
+        var result = sut.PercentageFull;
+        result.Should().BeApproximately(expected, 0.01F);
+    }
+
+    [Fact]
+    public void PercentageFull_should_return_null_string_if_number_of_pupils_has_no_value()
+    {
+        var sut =
+            BuildDummyAcademyPupilNumbersServiceModel("111", numberOfPupils: null,
+                schoolCapacity: 12);
+        var result = sut.PercentageFull;
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    public void PercentageFull_should_return_null_if_school_capacity_has_no_value(int? schoolCapacity)
+    {
+        var sut = BuildDummyAcademyPupilNumbersServiceModel("111",
+            numberOfPupils: 100, schoolCapacity: schoolCapacity);
+        var result = sut.PercentageFull;
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, 0)]
+    public void PercentageFull_should_return_null_if_both_values_are_null_or_capacity_0(int? numberOfPupils,
+        int? capacity)
+    {
+        var sut =
+            BuildDummyAcademyPupilNumbersServiceModel("111",
+                numberOfPupils: numberOfPupils, schoolCapacity: capacity);
+        var result = sut.PercentageFull;
+        result.Should().BeNull();
+    }
+
+    private static AcademyPupilNumbersServiceModel BuildDummyAcademyPupilNumbersServiceModel(string urn,
+        string phaseOfEducation = "test",
+        int? numberOfPupils = 300,
+        int? schoolCapacity = 400,
+        AgeRange? ageRange = null)
+    {
+        return new AcademyPupilNumbersServiceModel(urn,
+            $"Academy {urn}",
+            phaseOfEducation,
+            ageRange ?? new AgeRange(1, 11),
+            numberOfPupils,
+            schoolCapacity);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
@@ -60,4 +60,38 @@ public class AcademyServiceTests
         result.Should().BeOfType<AcademyOfstedServiceModel[]>();
         result.Should().BeEquivalentTo(academies);
     }
+
+    [Fact]
+    public async Task GetAcademiesInTrustPupilNumbersAsync_should_return_mapped_result_from_repository()
+    {
+        const string uid = "1234";
+        AcademyPupilNumbers[] academies =
+        [
+            BuildDummyAcademyPupilNumbers("9876", "phase1", new AgeRange(2, 15), 100, 200),
+            BuildDummyAcademyPupilNumbers("8765", "phase2", new AgeRange(7, 12), 2, 5)
+        ];
+
+        _mockAcademyRepository.Setup(a => a.GetAcademiesInTrustPupilNumbersAsync(uid))
+            .ReturnsAsync(academies);
+
+        var result = await _sut.GetAcademiesInTrustPupilNumbersAsync(uid);
+
+        result.Should().BeOfType<AcademyPupilNumbersServiceModel[]>();
+        result.Should().BeEquivalentTo(academies);
+    }
+
+    private static AcademyPupilNumbers BuildDummyAcademyPupilNumbers(string urn,
+        string phaseOfEducation = "test",
+        AgeRange? ageRange = null,
+        int? numberOfPupils = 300,
+        int? schoolCapacity = 400
+    )
+    {
+        return new AcademyPupilNumbers(urn,
+            $"Academy {urn}",
+            phaseOfEducation,
+            ageRange ?? new AgeRange(11, 18),
+            numberOfPupils,
+            schoolCapacity);
+    }
 }


### PR DESCRIPTION
[User Story 174255](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/174255): Build: Improve performance of Academies in this Trust pupil numbers page
Improved the performance of the Pupil numbers page in the academies in trust section.

## Changes

- Add methods for fetching pupil numbers to the academies repository and service
- Updated the the Pupil Numbers page to use the Academies Service over the trust provider
- Created the AcademyPupilNumbers and AcademyPupilNumbersServiceModel classes
- Created and added unit tests for the code

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
