### PR TITLE
Create Edit contacts UI and hide behind feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Created Edit contacts UI and feature flag to hide it on production environment
+
 ### Changed
 
 - Ofsted logic can now handle null dates
+- Updated contacts page UI to split each contact into it own section
 
 ## [Release-6][release-6] (production-2024-09-17.3129)
 

--- a/DfE.FindInformationAcademiesTrusts/Configuration/FeatureFlags.cs
+++ b/DfE.FindInformationAcademiesTrusts/Configuration/FeatureFlags.cs
@@ -3,4 +3,5 @@
 public static class FeatureFlags
 {
     public const string TestFlag = "TestFlag";
+    public const string EditContactsUI = "EditContactsUI";
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Search.cshtml.cs
@@ -49,7 +49,7 @@ public class SearchModel : ContentPageModel, IPageSearchFormModel, IPaginationMo
         Trusts = await GetTrustsForKeywords();
 
         PageStatus = Trusts.PageStatus;
-        PaginationRouteData = new Dictionary<string, string> { { "Keywords", KeyWords } };
+        PaginationRouteData = new Dictionary<string, string> { { "Keywords", KeyWords ?? string.Empty } };
         return new PageResult();
     }
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/BasePageModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/BasePageModel.cs
@@ -6,5 +6,5 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Shared;
 public abstract class BasePageModel : PageModel
 {
     public bool ShowHeaderSearch { get; init; } = true;
-    [BindProperty(SupportsGet = true)] public string KeyWords { get; set; } = string.Empty;
+    [BindProperty(SupportsGet = true)] public string? KeyWords { get; set; } = string.Empty;
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/IPageSearchFormModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/IPageSearchFormModel.cs
@@ -2,6 +2,6 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Shared;
 
 public interface IPageSearchFormModel
 {
-    string KeyWords { get; set; }
+    string? KeyWords { get; set; }
     string PageSearchFormInputId { get; }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_ErrorSummary.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_ErrorSummary.cshtml
@@ -1,0 +1,25 @@
+﻿@model Microsoft.AspNetCore.Mvc.RazorPages.PageModel
+
+@if (!Model.ModelState.IsValid)
+{
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" tabindex="-1" data-module="govuk-error-summary">
+    <div role="alert">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+      </h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list" data-testid="error-summary">
+          @foreach (var (key, modelState) in Model.ModelState)
+          {
+            @foreach (var error in modelState.Errors)
+            {
+              <li>
+                <a href="#@key" data-testid="error-link-@key">@error.ErrorMessage</a>
+              </li>
+            }
+          }
+        </ul>
+      </div>
+    </div>
+  </div>
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
@@ -1,4 +1,5 @@
 @page
+@using DfE.FindInformationAcademiesTrusts.Configuration
 @using DfE.FindInformationAcademiesTrusts.Data
 @model ContactsModel
 
@@ -6,58 +7,82 @@
   Layout = "_TrustLayout";
 }
 
-<section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
-  <div class="govuk-summary-card">
+<section class="govuk-!-margin-bottom-9">
+  <h2 class="govuk-heading-m">
+    Contacts at DfE
+  </h2>
+  <feature name="@FeatureFlags.EditContactsUI">
+    @if (!string.IsNullOrWhiteSpace(TempData["ContactUpdatedMessage"] as string))
+    {
+      <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Success
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+          <h3 class="govuk-notification-banner__heading">
+            @TempData["ContactUpdatedMessage"]
+          </h3>
+        </div>
+      </div>
+    }
+  </feature>
+  <div class="govuk-summary-card" data-testid="trust-relationship-manager">
     <div class="govuk-summary-card__title-wrapper">
-      <h2 class="govuk-summary-card__title">DfE contacts</h2>
-    </div>
-    <div class="govuk-summary-card__content">
-      <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row" data-testid="trust-relationship-manager">
-          <dt class="govuk-summary-list__key">
-            Trust relationship manager
-          </dt>
-          @{ DisplayContact(Model.TrustRelationshipManager); }
+      <h3 class="govuk-summary-card__title">
+        Trust relationship manager
+      </h3>
+      <feature name="@FeatureFlags.EditContactsUI">
+        <div class="govuk-summary-card__actions">
+          <a class="govuk-link" asp-page="/Trusts/Contacts/EditTrustRelationshipManager" asp-route-uid="@Model.Uid">Change<span class="govuk-visually-hidden"> details of this contact (Trust relationship manager)</span></a>
         </div>
-        <div class="govuk-summary-list__row" data-testid="sfso-lead">
-          <dt class="govuk-summary-list__key">
-            SFSO (Schools financial support and oversight) lead
-          </dt>
-          @{ DisplayContact(Model.SfsoLead); }
-        </div>
-      </dl>
+      </feature>
     </div>
+    @{ DisplayContact(Model.TrustRelationshipManager); }
+  </div>
+  <div class="govuk-summary-card" data-testid="sfso-lead">
+    <div class="govuk-summary-card__title-wrapper">
+      <h3 class="govuk-summary-card__title">
+        SFSO (Schools financial support and oversight) lead
+      </h3>
+      <feature name="@FeatureFlags.EditContactsUI">
+        <div class="govuk-summary-card__actions">
+          <a class="govuk-link" asp-page="/Trusts/Contacts/EditSfsoLead" asp-route-uid="@Model.Uid">Change<span class="govuk-visually-hidden"> details of this contact (SFSO Lead)</span></a>
+        </div>
+      </feature>
+    </div>
+    @{ DisplayContact(Model.SfsoLead); }
   </div>
 </section>
 
 <section class="govuk-!-margin-top-8 govuk-!-margin-bottom-9">
-  <div class="govuk-summary-card">
+  <h2 class="govuk-heading-m">
+    Contacts at the trust
+  </h2>
+  <div class="govuk-summary-card" data-testid="accounting-officer">
     <div class="govuk-summary-card__title-wrapper">
-      <h2 class="govuk-summary-card__title">Trust contacts</h2>
+      <h3 class="govuk-summary-card__title">
+        Accounting officer
+      </h3>
     </div>
-    <div class="govuk-summary-card__content">
-      <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row" data-testid="accounting-officer">
-          <dt class="govuk-summary-list__key">
-            Accounting officer
-          </dt>
-          @{ DisplayContact(Model.AccountingOfficer); }
-        </div>
-        <div class="govuk-summary-list__row" data-testid="chair-of-trustees">
-          <dt class="govuk-summary-list__key">
-            Chair of trustees
-          </dt>
-          @{ DisplayContact(Model.ChairOfTrustees); }
-        </div>
-        <div class="govuk-summary-list__row" data-testid="chief-financial-officer">
-          <dt class="govuk-summary-list__key">
-            Chief financial officer
-          </dt>
-          @{ DisplayContact(Model.ChiefFinancialOfficer); }
-        </div>
-
-      </dl>
+    @{ DisplayContact(Model.AccountingOfficer); }
+  </div>
+  <div class="govuk-summary-card" data-testid="chair-of-trustees">
+    <div class="govuk-summary-card__title-wrapper">
+      <h3 class="govuk-summary-card__title">
+        Chair of trustees
+      </h3>
     </div>
+    @{ DisplayContact(Model.ChairOfTrustees); }
+  </div>
+  <div class="govuk-summary-card" data-testid="chief-financial-officer">
+    <div class="govuk-summary-card__title-wrapper">
+      <h3 class="govuk-summary-card__title">
+        Chief financial officer
+      </h3>
+    </div>
+    @{ DisplayContact(Model.ChiefFinancialOfficer); }
   </div>
 </section>
 
@@ -65,35 +90,38 @@
 
   private void DisplayContact(Person? contactToDisplay)
   {
-    <dd class="govuk-summary-list__value">
-
-      @if (contactToDisplay is null)
-      {
-        <p class="govuk-body">@ContactsModel.ContactInformationNotAvailableMessage</p>
-      }
-      else
-      {
-        @if (!string.IsNullOrWhiteSpace(contactToDisplay.FullName))
-        {
-          <p class="govuk-body" data-testid="contact-name">@contactToDisplay.FullName</p>
-        }
-        else
-        {
-          <p class="govuk-body">@ContactsModel.ContactNameNotAvailableMessage</p>
-        }
-
-        <p class="govuk-body">
-          @if (contactToDisplay.Email is not null)
+    <div class="govuk-summary-card__content">
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Name
+          </dt>
+          @if (!string.IsNullOrWhiteSpace(contactToDisplay?.FullName))
           {
-            <a class="govuk-link" href="mailto:@contactToDisplay.Email" rel="noopener" target="_blank" data-testid="contact-email">@contactToDisplay.Email</a>
+            <dd class="govuk-summary-list__value" data-testid="contact-name">@contactToDisplay.FullName</dd>
           }
           else
           {
-            <a class="govuk-body">@ContactsModel.ContactEmailNotAvailableMessage</a>
+            <dd class="govuk-summary-list__value" data-testid="contact-name">@ContactsModel.ContactNameNotAvailableMessage</dd>
           }
-        </p>
-      }
-    </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Email address
+          </dt>
+          @if (contactToDisplay?.Email is not null)
+          {
+            <dd class="govuk-summary-list__value">
+              <a class="govuk-link" href="mailto:@contactToDisplay.Email" rel="noopener" target="_blank" data-testid="contact-email">@contactToDisplay.Email</a>
+            </dd>
+          }
+          else
+          {
+            <dd class="govuk-summary-list__value" data-testid="contact-email">@ContactsModel.ContactEmailNotAvailableMessage</dd>
+          }
+        </div>
+      </dl>
+    </div>
   }
 
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml.cs
@@ -23,8 +23,6 @@ public class ContactsModel(
 
     public const string ContactEmailNotAvailableMessage = "No contact email available";
 
-    public const string ContactInformationNotAvailableMessage = "No contact information available";
-
     public override async Task<IActionResult> OnGetAsync()
     {
         var pageResult = await base.OnGetAsync();

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditContactModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditContactModel.cs
@@ -1,0 +1,69 @@
+﻿using System.ComponentModel.DataAnnotations;
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Contacts;
+
+public abstract class EditContactModel(
+    ITrustProvider trustProvider,
+    IDataSourceService dataSourceService,
+    ITrustService trustService,
+    ILogger<EditContactModel> logger,
+    string roleText)
+    : TrustsAreaModel(trustProvider, dataSourceService, trustService,
+        logger, $"Edit {roleText}")
+{
+    public const string NameField = "Name";
+    public const string EmailField = "Email";
+
+    [BindProperty] [BindRequired] public string? Name { get; set; }
+
+    [BindProperty]
+    [BindRequired]
+    [EmailAddress(ErrorMessage = "Enter an email address in the correct format, like name@education.gov.uk")]
+    [RegularExpression(".*@education.gov.uk$", ErrorMessage = "Enter a DfE email address ending in @education.gov.uk")]
+    public string? Email { get; set; }
+
+    [TempData] public string ContactUpdatedMessage { get; set; } = string.Empty;
+
+    private string RoleText { get; init; } = roleText;
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return await base.OnGetAsync();
+        }
+
+        ContactUpdatedMessage = $"Changes made to the {RoleText} were successfully updated.";
+        return RedirectToPage("/Trusts/Contacts", new { Uid });
+    }
+
+    public string GetErrorClass(string key)
+    {
+        return ModelState.ContainsKey(key) && ModelState[key]!.Errors.Any() ? "govuk-form-group--error" : string.Empty;
+    }
+
+    public string GenerateErrorAriaDescribedBy(string key)
+    {
+        return string.Join(" ", GetErrorList(key).Select(value => $"error-{key}-{value.index}"));
+    }
+
+    public (int index, string errorMessage)[] GetErrorList(string key)
+    {
+        if (ModelState.ContainsKey(key))
+        {
+            return ModelState[key]!.Errors.Select((error, index) => (index, error.ErrorMessage)).ToArray();
+        }
+
+        return [];
+    }
+
+    public string GeneratePageTitle()
+    {
+        return $"{(ModelState.IsValid ? string.Empty : "Error: ")}{PageTitle ?? PageName} - {TrustSummary.Name}";
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditSfsoLead.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditSfsoLead.cshtml
@@ -1,0 +1,9 @@
+@page
+@model EditSfsoLeadModel
+
+@{
+  Layout = "_Layout";
+  ViewData["Title"] = Model.GeneratePageTitle();
+}
+
+<partial name="_EditContactsForm" model="@Model"/>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditSfsoLead.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditSfsoLead.cshtml.cs
@@ -1,0 +1,31 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Contacts;
+
+[FeatureGate(FeatureFlags.EditContactsUI)]
+public class EditSfsoLeadModel(
+    ITrustProvider trustProvider,
+    IDataSourceService dataSourceService,
+    ILogger<EditSfsoLeadModel> logger,
+    ITrustService trustService)
+    : EditContactModel(trustProvider, dataSourceService, trustService,
+        logger, "SFSO (Schools financial support and oversight) lead")
+{
+    public override async Task<IActionResult> OnGetAsync()
+    {
+        var pageResult = await base.OnGetAsync();
+
+        if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
+
+        var contacts = await TrustService.GetTrustContactsAsync(Uid);
+
+        Email = contacts.SfsoLead?.Email;
+        Name = contacts.SfsoLead?.FullName;
+        return pageResult;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditTrustRelationshipManager.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditTrustRelationshipManager.cshtml
@@ -1,0 +1,9 @@
+@page
+@model EditTrustRelationshipManagerModel
+
+@{
+  Layout = "_Layout";
+  ViewData["Title"] = Model.GeneratePageTitle();
+}
+
+<partial name="_EditContactsForm" model="@Model"/>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditTrustRelationshipManager.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditTrustRelationshipManager.cshtml.cs
@@ -1,0 +1,32 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Contacts;
+
+[FeatureGate(FeatureFlags.EditContactsUI)]
+public class EditTrustRelationshipManagerModel(
+    ITrustProvider trustProvider,
+    IDataSourceService dataSourceService,
+    ILogger<EditTrustRelationshipManagerModel> logger,
+    ITrustService trustService)
+    : EditContactModel(trustProvider, dataSourceService, trustService,
+        logger, "Trust relationship manager")
+{
+    public override async Task<IActionResult> OnGetAsync()
+    {
+        var pageResult = await base.OnGetAsync();
+
+        if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
+
+        var contacts = await TrustService.GetTrustContactsAsync(Uid);
+
+        Email = contacts.TrustRelationshipManager?.Email;
+        Name = contacts.TrustRelationshipManager?.FullName;
+
+        return pageResult;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/_EditContactsForm.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/_EditContactsForm.cshtml
@@ -1,0 +1,62 @@
+﻿@model EditContactModel
+
+<partial name="Trusts/_TrustBanner" model="@Model"/>
+
+<div class="govuk-main-wrapper govuk-!-padding-top-0">
+  <div class="dfe-width-container">
+    <partial name="Trusts/_TrustBreadcrumbs" model="@Model"/>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <main id="main-content">
+          <form method="post">
+            <fieldset class="govuk-fieldset">
+              <div>
+                <span class="govuk-caption-m">@Model.Section</span>
+                <legend class="govuk-!-padding-0">
+                  <h1 class="govuk-heading-l">@Model.PageName</h1>
+                </legend>
+              </div>
+              <partial name="Shared/_ErrorSummary" model="@Model"/>
+              <div class="govuk-form-group @Model.GetErrorClass("Name")">
+                <label class="govuk-label govuk-label--m" for="Name">
+                  Full name
+                </label>
+                @foreach (var error in Model.GetErrorList(EditContactModel.NameField))
+                {
+                  <p id="error-@EditContactModel.NameField-@error.index" class="govuk-error-message">
+                    <span class="govuk-visually-hidden">Error:</span> @error.errorMessage
+                  </p>
+                }
+                <input asp-for="@Model.Name" class="govuk-input govuk-!-width-two-thirds" id="Name" type="text" spellcheck="false" aria-describedby="@Model.GenerateErrorAriaDescribedBy(EditContactModel.NameField)"/>
+              </div>
+              <div class="govuk-form-group @Model.GetErrorClass(EditContactModel.EmailField)">
+                <label class="govuk-label govuk-label--m" for="@EditContactModel.EmailField">
+                  Email address
+                </label>
+                <div id="email-hint" class="govuk-hint">
+                  Only valid DfE email addresses can be used e.g. joe.bloggs@education.gov.uk
+                </div>
+                @foreach (var error in Model.GetErrorList(EditContactModel.EmailField))
+                {
+                  <p id="error-@EditContactModel.EmailField-@error.index" class="govuk-error-message">
+                    <span class="govuk-visually-hidden">Error:</span> @error.errorMessage
+                  </p>
+                }
+                <input asp-for="@Model.Email" class="govuk-input govuk-!-width-two-thirds" id="Email" type="email" spellcheck="false" autocomplete="email" aria-describedby="email-hint @Model.GenerateErrorAriaDescribedBy(EditContactModel.EmailField)"/>
+              </div>
+              <div class="govuk-button-group">
+                <button type="submit" class="govuk-button" data-module="govuk-button" formnovalidate>
+                  Save and continue
+                </button>
+                <a class="govuk-link" asp-page="/Trusts/Contacts" asp-route-uid="@Model.Uid">
+                  Cancel
+                </a>
+              </div>
+            </fieldset>
+          </form>
+          <partial name="_ReportProblemLink"/>
+        </main>
+      </div>
+    </div>
+  </div>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
@@ -17,7 +17,7 @@ public interface ITrustsAreaModel
     /// <summary>
     /// The name of the page as displayed in the browser title
     /// </summary>
-    string? PageTitle { get; init; }
+    string? PageTitle { get; set; }
 
     /// <summary>
     /// The name of the section the page sits under in side navigation

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -23,7 +23,7 @@ public class TrustsAreaModel(
     public TrustSummaryServiceModel TrustSummary { get; set; } = default!;
     public List<DataSourceListEntry> DataSources { get; set; } = [];
     public string PageName { get; init; } = pageName;
-    public string? PageTitle { get; init; }
+    public string? PageTitle { get; set; }
     public string Section => ViewConstants.AboutTheTrustSectionName;
 
     public string MapDataSourceToName(DataSourceServiceModel dataSource)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBanner.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBanner.cshtml
@@ -1,0 +1,12 @@
+﻿@model ITrustsAreaModel
+
+<aside class="app-banner" data-testid="app-trust-header">
+  <div class="dfe-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-three-quarters">
+        <h2 class="govuk-heading-l app-banner--heading govuk-!-margin-bottom-3" data-testid="trust-name-heading">@Model.TrustSummary.Name</h2>
+        <p class="govuk-body app-banner--body govuk-!-margin-bottom-0" data-testid="trust-type">@Model.TrustSummary.Type</p>
+      </div>
+    </div>
+  </div>
+</aside>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBreadcrumbs.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBreadcrumbs.cshtml
@@ -1,0 +1,16 @@
+﻿@model ITrustsAreaModel
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <nav class="govuk-breadcrumbs govuk-!-margin-top-6 govuk-!-margin-bottom-6" aria-label="Breadcrumb">
+      <ol class="govuk-breadcrumbs__list">
+        <li class="govuk-breadcrumbs__list-item">
+          <a class="govuk-breadcrumbs__link" asp-page="/Index">Home</a>
+        </li>
+        <li class="govuk-breadcrumbs__list-item">
+          @Model.TrustSummary.Name
+        </li>
+      </ol>
+    </nav>
+  </div>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
@@ -5,33 +5,11 @@
   ViewData["Title"] = $"{Model.PageTitle ?? Model.PageName} - {Model.TrustSummary.Name}";
 }
 
-<aside class="app-banner" data-testid="app-trust-header">
-  <div class="dfe-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-three-quarters">
-        <h2 class="govuk-heading-l app-banner--heading govuk-!-margin-bottom-3" data-testid="trust-name-heading">@Model.TrustSummary.Name</h2>
-        <p class="govuk-body app-banner--body govuk-!-margin-bottom-0" data-testid="trust-type">@Model.TrustSummary.Type</p>
-      </div>
-    </div>
-  </div>
-</aside>
+<partial name="_TrustBanner" model="@Model"/>
 
 <div class="govuk-main-wrapper govuk-!-padding-top-0">
   <div class="dfe-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <nav class="govuk-breadcrumbs govuk-!-margin-top-6 govuk-!-margin-bottom-6" aria-label="Breadcrumb">
-          <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item">
-              <a class="govuk-breadcrumbs__link" asp-page="/Index">Home</a>
-            </li>
-            <li class="govuk-breadcrumbs__list-item">
-              @Model.TrustSummary.Name
-            </li>
-          </ol>
-        </nav>
-      </div>
-    </div>
+    <partial name="_TrustBreadcrumbs" model="@Model"/>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-quarter">
         <partial name="_TrustNavigation" model="@Model"/>

--- a/DfE.FindInformationAcademiesTrusts/appsettings.json
+++ b/DfE.FindInformationAcademiesTrusts/appsettings.json
@@ -39,7 +39,8 @@
     }
   },
   "FeatureManagement": {
-    "TestFlag": false
+    "TestFlag": false,
+    "EditContactsUI": false
   },
   "DataProtection": {
     "KeyVaultKey": "",

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -5,6 +5,7 @@ Feature flags can be used to programatically turn features on and off. We can us
 ## List of current flags
 
 - `TestFlag` (Default: false): Flag added to test the functionality of feature flags. Adds a line to the layout that shows flags are working when set to true.
+- `EditContactsUI` (Default: false): Flag added to control who can see the edit contacts UI on the Trust contacts page while that is still in development.
 
 ## Implementation
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trustContactsPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trustContactsPage.ts
@@ -40,7 +40,11 @@ class TrustContacts {
 
     private assertEmptyContact(id: string): void {
         cy.getByTestId(id)
-            .find("p").should("contain.text", "No contact information available");
+            .find("[data-testid='contact-name']").should("contain.text", "No contact name available");
+
+        cy.getByTestId(id)
+            .find("[data-testid='contact-email']")
+            .should("contain.text", "No contact email available");
     }
 
     private assertContact(id: string, name: string, email: string): void {

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditContactModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditContactModelTests.cs
@@ -1,0 +1,136 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Contacts;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Contacts;
+
+public class EditContactModelTests
+{
+    private EditContactModel _sut;
+    private readonly Mock<ITrustProvider> _mockTrustProvider = new();
+    private readonly MockDataSourceService _mockDataSourceService = new();
+    private readonly Mock<ITrustService> _mockTrustService = new();
+
+    private readonly TrustSummaryServiceModel _fakeTrust = new("1234", "My Trust", "Multi-academy trust", 3);
+
+    public EditContactModelTests()
+    {
+        _mockTrustService.Setup(tp => tp.GetTrustContactsAsync("1234")).ReturnsAsync(
+            new TrustContactsServiceModel(null, null, null, null, null));
+        _mockTrustService.Setup(t => t.GetTrustSummaryAsync(_fakeTrust.Uid))
+            .ReturnsAsync(_fakeTrust);
+
+        _sut = new EditSfsoLeadModel(_mockTrustProvider.Object, _mockDataSourceService.Object,
+                new MockLogger<EditSfsoLeadModel>().Object, _mockTrustService.Object)
+            { Uid = "1234" };
+    }
+
+    [Fact]
+    public async Task OnPostAsync_sets_ContactUpdated_to_true_when_validation_is_correct()
+    {
+        _sut.TrustSummary = _fakeTrust;
+        var result = await _sut.OnPostAsync();
+        result.Should().BeOfType<RedirectToPageResult>();
+        _sut.ContactUpdatedMessage.Should()
+            .Be("Changes made to the SFSO (Schools financial support and oversight) lead were successfully updated.");
+        var redirect = result as RedirectToPageResult;
+        redirect!.PageName.Should().Be("/Trusts/Contacts");
+        _sut.GeneratePageTitle().Should().NotContain("Error: ");
+    }
+
+    [Fact]
+    public async Task OnPostAsync_sets_ContactUpdated_to_false_when_validation_is_incorrect()
+    {
+        _sut.ModelState.AddModelError("Test", "Test");
+        var result = await _sut.OnPostAsync();
+        result.Should().BeOfType<PageResult>();
+        _sut.GeneratePageTitle().Should().Contain("Error: ");
+    }
+
+    [Fact]
+    public void GetErrorClass_returns_the_class_string_when_validation_is_incorrect()
+    {
+        _sut.ModelState.AddModelError("Test", "Test");
+        var result = _sut.GetErrorClass("Test");
+        result.Should().Be("govuk-form-group--error");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Name")]
+    [InlineData("Email")]
+    public void GetErrorClass_returns_empty_string_when_validation_is_correct(string key)
+    {
+        var result = _sut.GetErrorClass(key);
+        result.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void GenerateErrorAriaDescribedBy_returns_the_correct_string_when_validation_is_incorrect()
+    {
+        _sut.ModelState.AddModelError("Test", "Test");
+        var result = _sut.GenerateErrorAriaDescribedBy("Test");
+        result.Should().Be("error-Test-0");
+    }
+
+    [Fact]
+    public void GenerateErrorAriaDescribedBy_returns_empty_when_validation_is_correct()
+    {
+        var result = _sut.GenerateErrorAriaDescribedBy("Test");
+        result.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void GetErrorList_returns_the_correct_list_when_validation_is_incorrect()
+    {
+        _sut.ModelState.AddModelError("Test", "Test");
+        var result = _sut.GetErrorList("Test");
+        result.Should().HaveCount(1);
+        result.Should().BeEquivalentTo([(0, "Test")]);
+    }
+
+    [Fact]
+    public void GetErrorList_returns_an_empty_list_when_validation_is_correct()
+    {
+        var result = _sut.GetErrorList("Test");
+        result.Should().HaveCount(0);
+        result.Should().BeEquivalentTo(Array.Empty<(int, string)>());
+    }
+
+    [Theory]
+    [InlineData("title", null, null, "title - My Trust")]
+    [InlineData("title", "name", null, "title - My Trust")]
+    [InlineData(null, "name", null, "name - My Trust")]
+    [InlineData("title", null, "error", "Error: title - My Trust")]
+    [InlineData("title", "name", "error", "Error: title - My Trust")]
+    [InlineData(null, "name", "error", "Error: name - My Trust")]
+    public void GeneratePageTitle_returns_correctly_(string? pageTitle, string? pageName, string? error,
+        string expected)
+    {
+        if (pageName != null)
+        {
+            _sut = new EditSfsoLeadModel(_mockTrustProvider.Object, _mockDataSourceService.Object,
+                    new MockLogger<EditSfsoLeadModel>().Object, _mockTrustService.Object)
+                { Uid = "1234", PageName = pageName, PageTitle = pageTitle };
+        }
+        else
+        {
+            _sut = new EditSfsoLeadModel(_mockTrustProvider.Object, _mockDataSourceService.Object,
+                    new MockLogger<EditSfsoLeadModel>().Object, _mockTrustService.Object)
+                { Uid = "1234", PageTitle = pageTitle };
+        }
+
+        _sut.TrustSummary = _fakeTrust;
+
+        if (error is not null)
+        {
+            _sut.ModelState.AddModelError(error, error);
+        }
+
+        var result = _sut.GeneratePageTitle();
+        result.Should().Be(expected);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditSfsoLeadModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditSfsoLeadModelTests.cs
@@ -1,0 +1,56 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Contacts;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Contacts;
+
+public class EditSfsoLeadModelTests
+{
+    private readonly EditSfsoLeadModel _sut;
+    private readonly Mock<ITrustProvider> _mockTrustProvider = new();
+
+    private readonly MockDataSourceService _mockDataSourceService = new();
+    private readonly Mock<ITrustService> _mockTrustService = new();
+
+    private readonly TrustSummaryServiceModel _fakeTrust = new("1234", "My Trust", "Multi-academy trust", 3);
+
+    private readonly Person _sfsoLead = new("Sfso Lead", "sfso.lead@test.com");
+
+    public EditSfsoLeadModelTests()
+    {
+        _mockTrustService.Setup(tp => tp.GetTrustContactsAsync("1234")).ReturnsAsync(
+            new TrustContactsServiceModel(null, _sfsoLead, null, null, null));
+        _mockTrustService.Setup(t => t.GetTrustSummaryAsync(_fakeTrust.Uid))
+            .ReturnsAsync(_fakeTrust);
+
+        _sut = new EditSfsoLeadModel(_mockTrustProvider.Object, _mockDataSourceService.Object,
+                new MockLogger<EditSfsoLeadModel>().Object, _mockTrustService.Object)
+            { Uid = "1234" };
+    }
+
+    [Fact]
+    public void PageName_should_be_correct()
+    {
+        _sut.PageName.Should().Be("Edit SFSO (Schools financial support and oversight) lead");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
+    {
+        _mockTrustService.Setup(r => r.GetTrustSummaryAsync("1234")).ReturnsAsync((TrustSummaryServiceModel?)null);
+        var result = await _sut.OnGetAsync();
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task OnGetAsync_loads_the_correct_name_and_email()
+    {
+        var result = await _sut.OnGetAsync();
+        result.Should().BeOfType<PageResult>();
+        _sut.Name.Should().Be(_sfsoLead.FullName);
+        _sut.Email.Should().Be(_sfsoLead.Email);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
@@ -1,0 +1,56 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Contacts;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Contacts;
+
+public class EditTrustRelationshipManagerModelTests
+{
+    private readonly EditTrustRelationshipManagerModel _sut;
+    private readonly Mock<ITrustProvider> _mockTrustProvider = new();
+
+    private readonly MockDataSourceService _mockDataSourceService = new();
+    private readonly Mock<ITrustService> _mockTrustService = new();
+
+    private readonly TrustSummaryServiceModel _fakeTrust = new("1234", "My Trust", "Multi-academy trust", 3);
+
+    private readonly Person _trustRelationshipManager = new("Trust Relationship Manager", "trm@test.com");
+
+    public EditTrustRelationshipManagerModelTests()
+    {
+        _mockTrustService.Setup(tp => tp.GetTrustContactsAsync("1234")).ReturnsAsync(
+            new TrustContactsServiceModel(_trustRelationshipManager, null, null, null, null));
+        _mockTrustService.Setup(t => t.GetTrustSummaryAsync(_fakeTrust.Uid))
+            .ReturnsAsync(_fakeTrust);
+
+        _sut = new EditTrustRelationshipManagerModel(_mockTrustProvider.Object, _mockDataSourceService.Object,
+                new MockLogger<EditTrustRelationshipManagerModel>().Object, _mockTrustService.Object)
+            { Uid = "1234" };
+    }
+
+    [Fact]
+    public void PageName_should_be_correct()
+    {
+        _sut.PageName.Should().Be("Edit Trust relationship manager");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
+    {
+        _mockTrustService.Setup(r => r.GetTrustSummaryAsync("1234")).ReturnsAsync((TrustSummaryServiceModel?)null);
+        var result = await _sut.OnGetAsync();
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task OnGetAsync_loads_the_correct_name_and_email()
+    {
+        var result = await _sut.OnGetAsync();
+        result.Should().BeOfType<PageResult>();
+        _sut.Name.Should().Be(_trustRelationshipManager.FullName);
+        _sut.Email.Should().Be(_trustRelationshipManager.Email);
+    }
+}


### PR DESCRIPTION
[User Story 179916](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/179916): Build: Edit DfE Contacts Page UI
Adds the UI for editing contacts.
This does not add functionally for saving updated contact information and it does not add the UI for the source and updates panel to display the when the contacts were updated. These will be done in a separate PR.

## Changes

Adds a feature flag for controlling when the edit contact UI is visible
Add options to hide the source and updates panel and the trust navigation to the trust layout
Created an error summary partial
Created Pages to edit Trust relationship manager and Sfso Lead
Created Edit Contact model
Updated the contacts page to change the layout and add the change links
Make search keywords nullable so it doesn't interfere with form validation

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/387670f2-13ca-4450-9595-37a0c1065490)

### After
![image](https://github.com/user-attachments/assets/dfa912db-9264-41a5-a597-db5e00bf6f43)
![image](https://github.com/user-attachments/assets/e9a16482-1640-4f24-b686-7ade8fc89fc0)
![image](https://github.com/user-attachments/assets/019e3860-9249-4344-b0f6-b11328b4ff5e)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
