### PR TITLE
Toggle internet access for the Storage account

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -223,6 +223,7 @@ No resources.
 | <a name="input_statuscake_contact_group_name"></a> [statuscake\_contact\_group\_name](#input\_statuscake\_contact\_group\_name) | Name of the contact group in StatusCake | `string` | `""` | no |
 | <a name="input_statuscake_monitored_resource_addresses"></a> [statuscake\_monitored\_resource\_addresses](#input\_statuscake\_monitored\_resource\_addresses) | The URLs to perform TLS checks on | `list(string)` | `[]` | no |
 | <a name="input_storage_account_ipv4_allow_list"></a> [storage\_account\_ipv4\_allow\_list](#input\_storage\_account\_ipv4\_allow\_list) | A list of public IPv4 address to grant access to the Storage Account | `list(string)` | `[]` | no |
+| <a name="input_storage_account_public_access_enabled"></a> [storage\_account\_public\_access\_enabled](#input\_storage\_account\_public\_access\_enabled) | Should the Azure Storage Account have Public visibility? | `bool` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | n/a | yes |
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | tfvars filename. This file is uploaded and stored encrypted within Key Vault, to ensure that the latest tfvars are stored in a shared place. | `string` | n/a | yes |
 | <a name="input_virtual_network_address_space"></a> [virtual\_network\_address\_space](#input\_virtual\_network\_address\_space) | Virtual network address space CIDR | `string` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -70,8 +70,9 @@ module "azure_container_apps_hosting" {
   monitor_email_receivers      = local.monitor_email_receivers
   monitor_endpoint_healthcheck = local.monitor_endpoint_healthcheck
 
-  enable_container_app_file_share = local.enable_container_app_file_share
-  storage_account_ipv4_allow_list = local.storage_account_ipv4_allow_list
+  enable_container_app_file_share       = local.enable_container_app_file_share
+  storage_account_ipv4_allow_list       = local.storage_account_ipv4_allow_list
+  storage_account_public_access_enabled = local.storage_account_public_access_enabled
 
   existing_logic_app_workflow                  = local.existing_logic_app_workflow
   existing_network_watcher_name                = local.existing_network_watcher_name

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -68,4 +68,5 @@ locals {
   statuscake_contact_group_email_addresses        = var.statuscake_contact_group_email_addresses
   enable_container_app_file_share                 = var.enable_container_app_file_share
   storage_account_ipv4_allow_list                 = var.storage_account_ipv4_allow_list
+  storage_account_public_access_enabled           = var.storage_account_public_access_enabled
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -444,3 +444,8 @@ variable "storage_account_ipv4_allow_list" {
   type        = list(string)
   default     = []
 }
+
+variable "storage_account_public_access_enabled" {
+  description = "Should the Azure Storage Account have Public visibility?"
+  type        = bool
+}


### PR DESCRIPTION
* In order for Terraform to manage the Storage Account it needs to be accessible from the internet
