### PR TITLE
Updated Ofsted logic to handle nulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
 
+- Ofsted logic can now handle null dates
 
 ## [Release-6][release-6] (production-2024-09-17.3129)
 

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/AcademyFactory.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Factories/AcademyFactory.cs
@@ -1,7 +1,7 @@
-using System.Globalization;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Extensions;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis;
+using System.Globalization;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Factories;
 
@@ -39,49 +39,53 @@ public class AcademyFactory : IAcademyFactory
     private static OfstedRating GetCurrentOfstedRating(MisEstablishment? misEstablishmentCurrentOfsted,
         MisFurtherEducationEstablishment? misFurtherEducationEstablishment)
     {
-        if (misEstablishmentCurrentOfsted is not null && misEstablishmentCurrentOfsted.OverallEffectiveness is not null)
+        if (misEstablishmentCurrentOfsted is not null
+            && misEstablishmentCurrentOfsted.OverallEffectiveness is not null
+            && !string.IsNullOrEmpty(misEstablishmentCurrentOfsted.InspectionEndDate))
         {
             return new OfstedRating(
                 (OfstedRatingScore)misEstablishmentCurrentOfsted.OverallEffectiveness.Value,
-                DateTime.ParseExact(misEstablishmentCurrentOfsted.InspectionEndDate!, "dd/MM/yyyy",
-                    CultureInfo.InvariantCulture)
+                DateTime.ParseExact(misEstablishmentCurrentOfsted.InspectionEndDate!, "dd/MM/yyyy", CultureInfo.InvariantCulture)
             );
         }
 
-        if (misFurtherEducationEstablishment is not null && misFurtherEducationEstablishment.OverallEffectiveness is not null)
+        if (misFurtherEducationEstablishment is not null
+            && misFurtherEducationEstablishment.OverallEffectiveness is not null
+            && !string.IsNullOrEmpty(misFurtherEducationEstablishment.LastDayOfInspection))
         {
             return new OfstedRating(
-                    (OfstedRatingScore)misFurtherEducationEstablishment.OverallEffectiveness.Value,
-                    DateTime.ParseExact(misFurtherEducationEstablishment.LastDayOfInspection!, "dd/MM/yyyy",
-                        CultureInfo.InvariantCulture)
-                );
+                (OfstedRatingScore)misFurtherEducationEstablishment.OverallEffectiveness.Value,
+                DateTime.ParseExact(misFurtherEducationEstablishment.LastDayOfInspection!, "dd/MM/yyyy", CultureInfo.InvariantCulture)
+            );
         }
 
         return OfstedRating.None;
     }
 
     private static OfstedRating GetPreviousOfstedRating(MisEstablishment? misEstablishmentPreviousOfsted,
-        MisFurtherEducationEstablishment? misFurtherEducationEstablishment)
+    MisFurtherEducationEstablishment? misFurtherEducationEstablishment)
     {
-        if (misEstablishmentPreviousOfsted is not null && misEstablishmentPreviousOfsted.PreviousFullInspectionOverallEffectiveness is not null)
+        if (misEstablishmentPreviousOfsted is not null
+            && !string.IsNullOrEmpty(misEstablishmentPreviousOfsted.PreviousFullInspectionOverallEffectiveness)
+            && !string.IsNullOrEmpty(misEstablishmentPreviousOfsted.PreviousInspectionEndDate))
         {
             return new OfstedRating(
-                (OfstedRatingScore)int.Parse(misEstablishmentPreviousOfsted
-                    .PreviousFullInspectionOverallEffectiveness!),
-                DateTime.ParseExact(misEstablishmentPreviousOfsted.PreviousInspectionEndDate!, "dd/MM/yyyy",
-                    CultureInfo.InvariantCulture)
+                (OfstedRatingScore)int.Parse(misEstablishmentPreviousOfsted.PreviousFullInspectionOverallEffectiveness!),
+                DateTime.ParseExact(misEstablishmentPreviousOfsted.PreviousInspectionEndDate!, "dd/MM/yyyy", CultureInfo.InvariantCulture)
             );
         }
 
-        if (misFurtherEducationEstablishment is not null && misFurtherEducationEstablishment.PreviousOverallEffectiveness is not null)
+        if (misFurtherEducationEstablishment is not null
+            && misFurtherEducationEstablishment.PreviousOverallEffectiveness is not null
+            && !string.IsNullOrEmpty(misFurtherEducationEstablishment.PreviousLastDayOfInspection))
         {
             return new OfstedRating(
-                    (OfstedRatingScore)misFurtherEducationEstablishment.PreviousOverallEffectiveness.Value,
-                    DateTime.ParseExact(misFurtherEducationEstablishment.PreviousLastDayOfInspection!, "dd/MM/yyyy",
-                        CultureInfo.InvariantCulture)
-                );
+                (OfstedRatingScore)misFurtherEducationEstablishment.PreviousOverallEffectiveness.Value,
+                DateTime.ParseExact(misFurtherEducationEstablishment.PreviousLastDayOfInspection!, "dd/MM/yyyy", CultureInfo.InvariantCulture)
+            );
         }
 
         return OfstedRating.None;
     }
+
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/AcademyFactoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factories/AcademyFactoryTests.cs
@@ -276,4 +276,56 @@ public class AcademyFactoryTests
         result.PreviousOfstedRating.Should().NotBeNull();
         result.PreviousOfstedRating.InspectionEndDate.Should().Be(new DateTime(year, month, day));
     }
+    [Fact]
+    public void CreateAcademyFrom_should_set_current_ofsted_inspection_date_to_null_if_InspectionEndDate_is_null_or_empty()
+    {
+        var misEstablishmentWithNullDate = new MisEstablishment
+        {
+            UrnAtTimeOfLatestFullInspection = _giasEstablishment.Urn,
+            InspectionEndDate = null,
+            OverallEffectiveness = 1
+        };
+
+        var misEstablishmentWithEmptyDate = new MisEstablishment
+        {
+            UrnAtTimeOfLatestFullInspection = _giasEstablishment.Urn,
+            InspectionEndDate = "",
+            OverallEffectiveness = 1
+        };
+
+        // Test when InspectionEndDate is null
+        var resultWithNullDate = _sut.CreateFrom(_giasGroupLink, _giasEstablishment, misEstablishmentWithNullDate);
+        resultWithNullDate.CurrentOfstedRating.InspectionEndDate.Should().BeNull(); // The date should be null
+
+        // Test when InspectionEndDate is empty
+        var resultWithEmptyDate = _sut.CreateFrom(_giasGroupLink, _giasEstablishment, misEstablishmentWithEmptyDate);
+        resultWithEmptyDate.CurrentOfstedRating.InspectionEndDate.Should().BeNull(); // The date should be null
+    }
+
+    [Fact]
+    public void CreateAcademyFrom_should_set_previous_ofsted_inspection_date_to_null_if_PreviousInspectionEndDate_is_null_or_empty()
+    {
+        var misEstablishmentWithNullDate = new MisEstablishment
+        {
+            UrnAtTimeOfPreviousFullInspection = _giasEstablishment.Urn,
+            PreviousInspectionEndDate = null,
+            PreviousFullInspectionOverallEffectiveness = "1"
+        };
+
+        var misEstablishmentWithEmptyDate = new MisEstablishment
+        {
+            UrnAtTimeOfPreviousFullInspection = _giasEstablishment.Urn,
+            PreviousInspectionEndDate = "",
+            PreviousFullInspectionOverallEffectiveness = "1"
+        };
+
+        // Test when PreviousInspectionEndDate is null
+        var resultWithNullDate = _sut.CreateFrom(_giasGroupLink, _giasEstablishment, misEstablishmentWithNullDate);
+        resultWithNullDate.PreviousOfstedRating.InspectionEndDate.Should().BeNull(); // The date should be null
+
+        // Test when PreviousInspectionEndDate is empty
+        var resultWithEmptyDate = _sut.CreateFrom(_giasGroupLink, _giasEstablishment, misEstablishmentWithEmptyDate);
+        resultWithEmptyDate.PreviousOfstedRating.InspectionEndDate.Should().BeNull(); // The date should be null
+    }
+
 }


### PR DESCRIPTION
After the latest nightly pipeline run, new data entered into the academies database contains null entries for some dates and times. This is unusual and causes our logic to fail when parsing these dates into readable strings for users.

Affected Areas:

Overview pages fail to load.
"Before Joining" and "After Joining" tags are not present.
Data export results in a system error.
Impact:

This issue affects both the Test and Production environments. Users are unable to access key features, which may lead to increased support queries.

[Bug 181183](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/181183): Bug: Overview pages fail to load due to null date entries in Ofsted data

## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
