### PR TITLE
Add entity framework migrations capability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+### Dotfiles
+.dockerignore
+.DS_Store
+.env
+.idea
+.git
+.gitignore
+.github
+.vs
+.vscode
+
+### Docker
+docker-compose.yml
+docker-compose.*.yml
+docker/
+!docker/web-docker-entrypoint.sh
+
+### Docs
+docs
+
+### .NET
+**/bin/
+**/obj/
+**/dist/
+**/lib/
+**/*.user
+
+### Node
+**/node_modules
+
+### Terraform
+terraform
+
+### Tests
+test

--- a/.github/workflows/continuous-integration-dotnet-and-sonar.yml
+++ b/.github/workflows/continuous-integration-dotnet-and-sonar.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Install dotnet-coverage
       run: dotnet tool install --global dotnet-coverage
 
-    - name: Install dotnet-stryker (mutation testing tool)
+    - name: Install other dotnet tools (including stryker mutation testing tool and entity framework cli)
       run: dotnet tool restore
 
     - name: Build and Analyse solution
@@ -91,3 +91,6 @@ jobs:
         dotnet-coverage collect "dotnet test" -f xml -o "coverage.xml"
         dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
         dotnet stryker -r "cleartext" -r "html" --threshold-high 90 --threshold-low 81 --break-at 80
+
+    - name: Ensure there are no pending migrations
+      run: dotnet ef migrations has-pending-model-changes --context FiatDbContext --project DfE.FindInformationAcademiesTrusts.Data.FiatDb --startup-project DfE.FindInformationAcademiesTrusts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Run migrations for FIAT database on application container startup
+
 ## [Release-7][release-7] (production-2024-09-23.3213)
 
 ### Added

--- a/DfE.FindInformationAcademiesTrusts.Data.FiatDb/Migrations/FiatDbMigrationScript.sql
+++ b/DfE.FindInformationAcademiesTrusts.Data.FiatDb/Migrations/FiatDbMigrationScript.sql
@@ -1,0 +1,67 @@
+﻿IF OBJECT_ID(N'[__EFMigrationsHistory]') IS NULL
+BEGIN
+    CREATE TABLE [__EFMigrationsHistory] (
+        [MigrationId] nvarchar(150) NOT NULL,
+        [ProductVersion] nvarchar(32) NOT NULL,
+        CONSTRAINT [PK___EFMigrationsHistory] PRIMARY KEY ([MigrationId])
+    );
+END;
+GO
+
+BEGIN TRANSACTION;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20240918134511_InitialCreate'
+)
+BEGIN
+    DECLARE @historyTableSchema sysname = SCHEMA_NAME()
+    EXEC(N'CREATE TABLE [Contacts] (
+        [Id] int NOT NULL IDENTITY,
+        [Uid] int NOT NULL,
+        [Role] nvarchar(450) NOT NULL,
+        [Name] nvarchar(500) NOT NULL,
+        [Email] nvarchar(320) NOT NULL,
+        [PeriodEnd] datetime2 GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+        [PeriodStart] datetime2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+        [LastModifiedByName] nvarchar(500) NOT NULL,
+        [LastModifiedByEmail] nvarchar(320) NOT NULL,
+        [LastModifiedAtTime] AS [PeriodStart],
+        CONSTRAINT [PK_Contacts] PRIMARY KEY ([Id]),
+        PERIOD FOR SYSTEM_TIME([PeriodStart], [PeriodEnd])
+    ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [' + @historyTableSchema + N'].[ContactsHistory]))');
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20240918134511_InitialCreate'
+)
+BEGIN
+    CREATE INDEX [IX_Contacts_Uid] ON [Contacts] ([Uid]);
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20240918134511_InitialCreate'
+)
+BEGIN
+    CREATE UNIQUE INDEX [IX_Contacts_Uid_Role] ON [Contacts] ([Uid], [Role]);
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20240918134511_InitialCreate'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'20240918134511_InitialCreate', N'8.0.7');
+END;
+GO
+
+COMMIT;
+GO
+

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ We are a tool for everyone in DfE to find information which is collated from mul
 ## Developer set up
 
 - [Get started](docs/getting-started.md)
+- [Databases](docs/databases.md)
 - [Run tests locally](docs/run-tests-locally.md)
 - [Supercharge your dev environment](docs/supercharge-your-dev-environment.md) (Test coverage and linting)
 - [Update test data](docs/update-test-data.md)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN dotnet restore DfE.FindInformationAcademiesTrusts
 RUN dotnet build DfE.FindInformationAcademiesTrusts -c Release
 RUN dotnet publish DfE.FindInformationAcademiesTrusts -c Release -o /app --no-build
 
+COPY ./DfE.FindInformationAcademiesTrusts.Data.FiatDb/Migrations/FiatDbMigrationScript.sql /app/sql/FiatDbMigrationScript.sql
 COPY ./docker/web-docker-entrypoint.sh /app/docker-entrypoint.sh
 
 # Stage 3 - Put into Docker container that will actually be run
@@ -27,3 +28,12 @@ WORKDIR /app
 RUN chmod +x ./docker-entrypoint.sh
 
 EXPOSE 8080/tcp
+
+# Stage 4 - Install SQL tools to allow migrations to be run
+RUN apt-get update
+RUN apt-get install unixodbc curl gnupg jq -y
+RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc
+RUN curl https://packages.microsoft.com/config/debian/12/prod.list | tee /etc/apt/sources.list.d/mssql-release.list
+RUN apt-get update
+RUN ACCEPT_EULA=Y apt-get install msodbcsql18 mssql-tools18 -y

--- a/docker/docker-compose-db.yml
+++ b/docker/docker-compose-db.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 name: fiat-fake-db-only
 services:
   sqlserver:
@@ -11,15 +10,15 @@ services:
     networks:
       - test-ci
     healthcheck:
-      test: /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "mySuperStrong_pa55word!!!"
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "mySuperStrong_pa55word!!!" -C
       interval: "2s"
       retries: 10
-    restart: always
   import-sql:
     image: mcr.microsoft.com/mssql-tools:latest
-    command: |
-      /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "mySuperStrong_pa55word!!!" -d master -i /data/createScript.sql
-      /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "mySuperStrong_pa55word!!!" -i /data/insertScript.sql
+    command: >
+      sh -c "/opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "mySuperStrong_pa55word!!!" -d master -i /data/createScript.sql -C &&
+             /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "mySuperStrong_pa55word!!!" -d sip -i /data/insertScript.sql -C &&
+             /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "mySuperStrong_pa55word!!!" -d master -Q \"CREATE DATABASE fiat\" -C"
     depends_on:
       sqlserver:
         condition: service_healthy

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 name: fiat-ci-env
 services:
   sqlserver:
@@ -16,9 +15,10 @@ services:
       retries: 10
   import-sql:
     image: mcr.microsoft.com/mssql-tools:latest
-    command: |
-      /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "mySuperStrong_pa55word!!!" -d master -i /data/createScript.sql
-      /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P "mySuperStrong_pa55word!!!" -d master -i /data/insertScript.sql
+    command: >
+      sh -c "/opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P \"mySuperStrong_pa55word!!!\" -d master -i /data/createScript.sql -C &&
+             /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P \"mySuperStrong_pa55word!!!\" -d sip -i /data/insertScript.sql -C &&
+             /opt/mssql-tools/bin/sqlcmd -S sqlserver -U sa -P \"mySuperStrong_pa55word!!!\" -d master -Q \"CREATE DATABASE fiat\" -C"
     depends_on:
       sqlserver:
         condition: service_healthy
@@ -32,7 +32,8 @@ services:
       dockerfile: docker/Dockerfile
     command: /bin/bash -c "./docker-entrypoint.sh dotnet DfE.FindInformationAcademiesTrusts.dll"
     depends_on:
-      - import-sql
+      import-sql:
+        condition: service_completed_successfully
     ports:
       - "80:8080/tcp"
     networks:
@@ -41,6 +42,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=CI
       - TestOverride__CypressTestSecret=TestSuperSecret
       - ConnectionStrings__AcademiesDb=Server=sqlserver;Database=sip;User Id=sa;Password=mySuperStrong_pa55word!!!;TrustServerCertificate=true;
+      - ConnectionStrings__DefaultConnection=Server=sqlserver;Database=fiat;User Id=sa;Password=mySuperStrong_pa55word!!!;TrustServerCertificate=true;
 
 networks:
   test-ci:

--- a/docker/web-docker-entrypoint.sh
+++ b/docker/web-docker-entrypoint.sh
@@ -4,4 +4,23 @@
 set -e
 set -o pipefail
 
+# Apply migrations to FIAT db
+ConnectionStrings__DefaultConnection=${ConnectionStrings__DefaultConnection:?}
+
+declare -A mssqlconn
+
+for keyvaluepair in $(echo "$ConnectionStrings__DefaultConnection" | sed "s/ //g; s/;/ /g")
+do
+  IFS=" " read -r -a ARR <<< "${keyvaluepair//=/ }"
+  mssqlconn[${ARR[0]}]=${ARR[1]}
+done
+
+echo "Running FIAT database migrations ..."
+until /opt/mssql-tools18/bin/sqlcmd -S "${mssqlconn[Server]}" -U "${mssqlconn[UserId]}" -P "${mssqlconn[Password]}" -d "${mssqlconn[Database]}" -C -I -i /app/sql/FiatDbMigrationScript.sql -o /app/sql/FiatDbMigrationScriptOutput.txt
+do
+  cat /app/sql/FiatDbMigrationScriptOutput.txt
+  echo "Retrying FIAT database migrations ..."
+  sleep 5
+done
+
 exec "$@"

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -1,0 +1,51 @@
+# Databases
+
+Find information about academies and trusts (FIAT) uses two databases:
+
+- Academies Db - a cross RSD SQL Server database which collates data from several different sources. It is maintained in code as part of the [academies api repository](https://github.com/DFE-Digital/academies-api). FIAT reads information from the database but doesn't update it.
+- Fiat Db - a code first SQL Server database maintained by this repository in `DfE.FindInformationAcademiesTrusts.Data.FiatDb`. FIAT reads and writes information in this database.
+
+## Local development
+
+For local development you can either connect to the databases in the Development environment or you can use local databases by installing SQL Server or using a SQL Server Docker container. The connection strings should be set in user secrets.
+
+```bash
+cd DfE.FindInformationAcademiesTrusts
+
+dotnet user-secrets set "ConnectionStrings:AcademiesDb" "[secret goes here for AcademiesDb]"
+dotnet user-secrets set "ConnectionStrings:DefaultConnection" "[secret goes here for FiatDb]"
+```
+
+## Migrations for Fiat Db
+
+```bash
+### These commands should be run from repository root
+
+# Ensure dotnet ef is installed and up to date
+dotnet tool restore
+
+# Check whether there needs to be a new migration
+dotnet ef migrations has-pending-model-changes --context FiatDbContext --project DfE.FindInformationAcademiesTrusts.Data.FiatDb --startup-project DfE.FindInformationAcademiesTrusts
+
+# Add new migration
+dotnet ef migrations add NameOfMigrationGoesHere --context FiatDbContext --project DfE.FindInformationAcademiesTrusts.Data.FiatDb --startup-project DfE.FindInformationAcademiesTrusts
+```
+
+A new migration and snapshot should be created in `DfE.FindInformationAcademiesTrusts.Data.FiatDb/Migrations`. Look to ensure that only the changes you were expecting are there and add any custom migration code to this new migration file.
+
+Ensure that you test the new migration on a local copy of the database (which contains pre-existing data) before committing the code to ensure that there is no data loss.
+
+```bash
+# Update db to latest migration
+dotnet ef database update --context FiatDbContext --project DfE.FindInformationAcademiesTrusts.Data.FiatDb --startup-project DfE.FindInformationAcademiesTrusts
+
+# Undo all known updates to db (note that removed migrations can't be removed from db by EF)
+dotnet ef database update 0 --context FiatDbContext --project DfE.FindInformationAcademiesTrusts.Data.FiatDb --startup-project DfE.FindInformationAcademiesTrusts
+```
+
+Once happy, **run the script below** to generate the SQL script which is used by the pipeline to deploy the migrations. You may want to double check that the SQL output is as expected but do not alter this SQL script directly as it will be overwritten by the next migration.
+
+```bash
+# Turn migrations into SQL
+dotnet ef migrations script --idempotent -o ./DfE.FindInformationAcademiesTrusts.Data.FiatDb/Migrations/FiatDbMigrationScript.sql --context FiatDbContext --project DfE.FindInformationAcademiesTrusts.Data.FiatDb --startup-project DfE.FindInformationAcademiesTrusts
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,8 +28,12 @@ cd DfE.FindInformationAcademiesTrusts
 dotnet user-secrets set "AzureAd:ClientID" "[secret goes here]"
 dotnet user-secrets set "AzureAd:ClientSecret" "[secret goes here]"
 dotnet user-secrets set "AzureAd:TenantID" "[secret goes here]"
-dotnet user-secrets set "ConnectionStrings:AcademiesDb" "[secret goes here]"
+
+dotnet user-secrets set "ConnectionStrings:AcademiesDb" "[secret goes here for AcademiesDb]"
+dotnet user-secrets set "ConnectionStrings:DefaultConnection" "[secret goes here for FiatDb]"
 ```
+
+See [database local development](./databases.md#local-development) for information on configuring a local database.
 
 ### Build and watch frontend assets
 


### PR DESCRIPTION
Add entity framework migrations for FIAT database

[User Story 179920](https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/179920?McasTsid=26110&McasCtx=4): Build: Implement Generic Auditing

## Changes

- Updated CI pipeline to ensure that there are no code changes without a correlated migration (doesn't check that the SQL script is up date though)
- Added documentation on how to create migrations
- Added temporary behaviour to dockerfile to run migrations on container start
  - SQL tools are installed in the prod docker image
  - SQL migration script is run on container start and will cause container to retry migrations (forever) if there is an error
  - Errors are written to container stdout log
  - Web application will not start until the migration has successfully completed
- Added docker ignore file to speed up docker image builds
- Added fiat db to test docker compose files to ensure that the application starts up correctly in test

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
~ADR decision log updated (if needed)~ - ADRs to be added in separate PR
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
