### PR TITLE
Edit contact refactors

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Extensions/ContactRoleExtensions.cs
+++ b/DfE.FindInformationAcademiesTrusts/Extensions/ContactRoleExtensions.cs
@@ -8,7 +8,7 @@ public static class ContactRoleExtensions
     {
         return role switch
         {
-            ContactRole.TrustRelationshipManager => "Trust relationship manager",
+            ContactRole.TrustRelationshipManager => "Regions group trust relationship manager",
             ContactRole.SfsoLead => "SFSO (Schools financial support and oversight) lead",
             _ => throw new ArgumentOutOfRangeException(nameof(role))
         };

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
@@ -9,10 +9,8 @@
   Layout = "_TrustLayout";
 }
 
-<section class="govuk-!-margin-bottom-9">
-  <h2 class="govuk-heading-m">
-    Contacts at DfE
-  </h2>
+@section TrustPageMessage
+{
   <feature name="@FeatureFlags.EditContactsUI">
     @if (!string.IsNullOrWhiteSpace(TempData["ContactUpdatedMessage"] as string))
     {
@@ -30,6 +28,12 @@
       </div>
     }
   </feature>
+}
+
+<section class="govuk-!-margin-bottom-9">
+  <h2 class="govuk-heading-m">
+    Contacts at DfE
+  </h2>
   <div class="govuk-summary-card" data-testid="trust-relationship-manager">
     <div class="govuk-summary-card__title-wrapper">
       <h3 class="govuk-summary-card__title">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditContactModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditContactModel.cs
@@ -16,7 +16,7 @@ public abstract class EditContactModel(
     ILogger<EditContactModel> logger,
     ContactRole role)
     : TrustsAreaModel(trustProvider, dataSourceService, trustService,
-        logger, $"Edit {role.MapRoleToViewString()}")
+        logger, $"Edit {role.MapRoleToViewString()} details")
 {
     public const string NameField = "Name";
     public const string EmailField = "Email";
@@ -30,7 +30,7 @@ public abstract class EditContactModel(
     [BindRequired]
     [EmailAddress(ErrorMessage = "Enter an email address in the correct format, like name@education.gov.uk")]
     [RegularExpression(@"(?i)^\S*@education\.gov\.uk$",
-        ErrorMessage = "Enter a DfE email address ending in @education.gov.uk without any whitespace characters")]
+        ErrorMessage = "Enter a DfE email address without any spaces")]
     [MaxLength(320)]
     public string? Email { get; set; }
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
@@ -26,5 +26,3 @@ public interface ITrustsAreaModel
 
     string MapDataSourceToName(DataSourceServiceModel dataSource);
 }
-
-public record DataSourceListEntry(DataSourceServiceModel DataSource, IEnumerable<string> Fields);

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_SourceList.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_SourceList.cshtml
@@ -1,4 +1,5 @@
-﻿@model ITrustsAreaModel
+﻿@using DfE.FindInformationAcademiesTrusts.Data.Enums
+@model ITrustsAreaModel
 <details class="govuk-details" data-module="govuk-details">
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
@@ -11,16 +12,22 @@
       <li class="source-list-item govuk-!-margin-bottom-5">
         <span class="govuk-!-font-weight-bold margin-right-class">@string.Join(", ", source.Fields)</span>
 
-        <span>Last updated: @(source.DataSource.LastUpdated is null ? "Unknown" : source.DataSource.LastUpdated.Value.ToString(StringFormatConstants.ViewDate))</span>
+        <span>Last updated: @(source.LastUpdatedText)</span>
+
         @if (source.DataSource.NextUpdated is not null)
         {
           <span>Next scheduled update: @source.DataSource.NextUpdated</span>
         }
+
         @if (source.DataSource.UpdatedBy is not null)
         {
-          <span>Updated by: @source.DataSource.UpdatedBy</span>
+          <span>Updated by: @source.UpdatedByText</span>
         }
-        <span>Data taken from: @Model.MapDataSourceToName(source.DataSource)</span>
+
+        @if (source.DataSource.Source != Source.FiatDb)
+        {
+          <span>Data taken from: @Model.MapDataSourceToName(source.DataSource)</span>
+        }
       </li>
     }
   </ul>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
@@ -16,6 +16,7 @@
       </div>
       <div class="govuk-grid-column-three-quarters">
         <main id="main-content">
+          @await RenderSectionAsync("TrustPageMessage", false)
           <header>
             <span class="govuk-caption-m">@Model.Section</span>
             <h1 class="govuk-heading-l" data-testid="page-name">@Model.PageName</h1>

--- a/DfE.FindInformationAcademiesTrusts/Services/DataSource/DataSourceListEntry.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/DataSource/DataSourceListEntry.cs
@@ -1,0 +1,14 @@
+﻿using DfE.FindInformationAcademiesTrusts.Pages;
+
+namespace DfE.FindInformationAcademiesTrusts.Services.DataSource;
+
+public record DataSourceListEntry(DataSourceServiceModel DataSource, IEnumerable<string> Fields)
+{
+    public string LastUpdatedText => DataSource.LastUpdated is null
+        ? "Unknown"
+        : DataSource.LastUpdated.Value.ToString(StringFormatConstants.ViewDate);
+
+    public string? UpdatedByText => DataSource.UpdatedBy == "TRAMs Migration"
+        ? "TRAMS Migration"
+        : DataSource.UpdatedBy;
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/Repositories/ContactRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/Repositories/ContactRepositoryTests.cs
@@ -18,7 +18,7 @@ public class ContactRepositoryTests
 
     [Fact]
     public async Task
-        GetInternakContactsAsync_Should_Return_Valid_TrustRelationshipManager_WhenOneIsPresentForTheTrust()
+        GetInternalContactsAsync_Should_Return_Valid_TrustRelationshipManager_WhenOneIsPresentForTheTrust()
     {
         var trm = _mockFiatDbContext.CreateTrustRelationshipManager(1234, "Trust Relationship Manager",
             "trm@testemail.com");
@@ -51,6 +51,17 @@ public class ContactRepositoryTests
             _ = _mockFiatDbContext.CreateTrustRelationshipManager(1234, "Trm Lead", "trm@testemail.com");
         }
 
+        var result = await _sut.UpdateInternalContactsAsync(1234, "New Name", "new@email.com", role);
+        result.EmailUpdated.Should().Be(true);
+        result.NameUpdated.Should().Be(true);
+        _mockFiatDbContext.Verify(context => context.SaveChangesAsync(), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(ContactRole.TrustRelationshipManager)]
+    [InlineData(ContactRole.SfsoLead)]
+    public async Task UpdateInternalContactsAsync_Should_Return_Valid_When_the_contact_does_not_exist(ContactRole role)
+    {
         var result = await _sut.UpdateInternalContactsAsync(1234, "New Name", "new@email.com", role);
         result.EmailUpdated.Should().Be(true);
         result.NameUpdated.Should().Be(true);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/ContactRoleExtensionsTest.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/ContactRoleExtensionsTest.cs
@@ -1,0 +1,14 @@
+﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Extensions;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Extensions;
+
+public class ContactRoleExtensionsTest
+{
+    [Fact]
+    public void MapRoleToViewString_throws_when_mapping_is_invalid()
+    {
+        var sut = (ContactRole)9999;
+        Assert.Throws<ArgumentOutOfRangeException>(() => sut.MapRoleToViewString());
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditSfsoLeadModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditSfsoLeadModelTests.cs
@@ -36,7 +36,7 @@ public class EditSfsoLeadModelTests
     [Fact]
     public void PageName_should_be_correct()
     {
-        _sut.PageName.Should().Be("Edit SFSO (Schools financial support and oversight) lead");
+        _sut.PageName.Should().Be("Edit SFSO (Schools financial support and oversight) lead details");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
@@ -36,7 +36,7 @@ public class EditTrustRelationshipManagerModelTests
     [Fact]
     public void PageName_should_be_correct()
     {
-        _sut.PageName.Should().Be("Edit Trust relationship manager");
+        _sut.PageName.Should().Be("Edit Regions group trust relationship manager details");
     }
 
     [Fact]
@@ -58,11 +58,11 @@ public class EditTrustRelationshipManagerModelTests
 
     [Theory]
     [InlineData(true, true,
-        "Changes made to the Trust relationship manager name and email were updated.")]
+        "Changes made to the Regions group trust relationship manager name and email were updated.")]
     [InlineData(true, false,
-        "Changes made to the Trust relationship manager name were updated.")]
+        "Changes made to the Regions group trust relationship manager name were updated.")]
     [InlineData(false, true,
-        "Changes made to the Trust relationship manager email were updated.")]
+        "Changes made to the Regions group trust relationship manager email were updated.")]
     [InlineData(false, false, "")]
     public async Task OnPostAsync_sets_ContactUpdated_to_true_when_validation_is_correct(bool nameUpdated,
         bool emailUpdated, string expectedMessage)

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
@@ -131,7 +131,7 @@ public class ContactsModelTests
         _mockDataSourceService.Verify(e => e.GetAsync(Source.Mstr), Times.Once);
         _sut.DataSources.Count.Should().Be(4);
         _sut.DataSources[0].Fields.Should().Contain(new List<string>
-            { "Trust relationship manager" });
+            { "Regions group trust relationship manager" });
         _sut.DataSources[1].Fields.Should().Contain(new List<string>
             { "SFSO (Schools financial support and oversight) lead" });
         _sut.DataSources[2].Fields.Should().Contain(new List<string>

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/DataSource/DataSourceListEntryTest.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/DataSource/DataSourceListEntryTest.cs
@@ -1,0 +1,43 @@
+﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services.DataSource;
+
+public class DataSourceListEntryTest
+{
+    [Fact]
+    public void LastUpdatedText_returns_unknown_when_LastUpdated_is_null()
+    {
+        var sut = new DataSourceListEntry(new DataSourceServiceModel(Source.Cdm, null, null), []);
+        sut.LastUpdatedText.Should().Be("Unknown");
+    }
+
+    [Fact]
+    public void LastUpdatedText_returns_correctString_when_LastUpdated_is_set()
+    {
+        var date = DateTime.Today;
+        var sut = new DataSourceListEntry(new DataSourceServiceModel(Source.Cdm, date, null), []);
+        sut.LastUpdatedText.Should().Be(date.ToString("d MMM yyyy"));
+    }
+
+    [Fact]
+    public void UpdatedByText_returns_null_when_UpdatedBy_is_null()
+    {
+        var sut = new DataSourceListEntry(new DataSourceServiceModel(Source.Cdm, null, null), []);
+        sut.UpdatedByText.Should().Be(null);
+    }
+
+    [Fact]
+    public void UpdatedByText_returns_correctString_when_UpdatedBy_is_set()
+    {
+        var sut = new DataSourceListEntry(new DataSourceServiceModel(Source.Cdm, null, null, "Updated by"), []);
+        sut.UpdatedByText.Should().Be("Updated by");
+    }
+
+    [Fact]
+    public void UpdatedByText_returns_correctString_when_UpdatedBy_is_set_to_TRAMs_Migration()
+    {
+        var sut = new DataSourceListEntry(new DataSourceServiceModel(Source.Cdm, null, null, "TRAMs Migration"), []);
+        sut.UpdatedByText.Should().Be("TRAMS Migration");
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/DataSourceServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/DataSourceServiceTests.cs
@@ -13,7 +13,7 @@ public class DataSourceServiceTests
     private readonly Mock<IFreeSchoolMealsAverageProvider> _mockFreeSchoolMealsAverageProvider = new();
     private readonly MockMemoryCache _mockMemoryCache = new();
 
-    private readonly Dictionary<Source, DataSource> _dummyDataSources = new()
+    private readonly Dictionary<Source, Data.Repositories.DataSource.DataSource> _dummyDataSources = new()
     {
         { Source.Cdm, GetDummyDataSource(Source.Cdm, UpdateFrequency.Daily) },
         { Source.ExploreEducationStatistics, GetDummyDataSource(Source.Cdm, UpdateFrequency.Annually) },
@@ -36,9 +36,10 @@ public class DataSourceServiceTests
             .Returns(_dummyDataSources[Source.ExploreEducationStatistics]);
     }
 
-    private static DataSource GetDummyDataSource(Source source, UpdateFrequency updateFrequency)
+    private static Data.Repositories.DataSource.DataSource GetDummyDataSource(Source source,
+        UpdateFrequency updateFrequency)
     {
-        return new DataSource(source, new DateTime(2024, 01, 01), updateFrequency);
+        return new Data.Repositories.DataSource.DataSource(source, new DateTime(2024, 01, 01), updateFrequency);
     }
 
     [Fact]
@@ -125,7 +126,7 @@ public class DataSourceServiceTests
     public async Task GetAsync_uncached_should_not_cache_source_with_null_lastUpdated()
     {
         _mockDataSourceRepository.Setup(d => d.GetAsync(Source.Gias))
-            .ReturnsAsync(new DataSource(Source.Gias, null, UpdateFrequency.Daily));
+            .ReturnsAsync(new Data.Repositories.DataSource.DataSource(Source.Gias, null, UpdateFrequency.Daily));
 
         await _sut.GetAsync(Source.Gias);
 


### PR DESCRIPTION
[User Story 182197](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/182197): Build: Refactors to the edit contact work
Small bugfixes, wording changes and additional test coverage for the edit contacts work

## Changes

- Update Trust relationshipManager wording to include Regions group
- Move the success message to the top of the trust layout
- Added test coverage for the update contact and map role functions
- DataSource date wording moved from the razor template to the model
- Success message will now show when the contact did not exist in the db before updating

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/9ae642f9-c939-4841-b3a1-47c19b76bc0e)

### After
![image](https://github.com/user-attachments/assets/9b4c5f7f-824e-45cb-9f11-9e94cac9119d)

## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
