### PR TITLE
Update font to the inter font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Changed when we intercept automation headers to give automation users claims for Edit contact tests
 - Academies in this trust export now includes Age Range
+- Updated the font to use the DfE standard Inter font
 
 ## [Release-9][release-9] (production-2024-10-02.3440)
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_PageSearchForm.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_PageSearchForm.cshtml
@@ -1,6 +1,6 @@
 @model IPageSearchFormModel
 <div data-testid="app-search-form">
-    <h3 class="govuk-heading govuk-!-margin-bottom-3">
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-3">
         Enter a trust reference number or name
     </h3>
   <div class="govuk-hint">

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_imports.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_imports.scss
@@ -1,8 +1,9 @@
+@import "inter-ui/inter.css";
 $govuk-assets-path: "/node_modules/govuk-frontend/dist/govuk/assets/";
 
 // Add DfE design system styles
-$govuk-font-family: blinkmacsystemfont, "Segoe UI", roboto, oxygen-sans, ubuntu,
-  cantarell, "Helvetica Neue", sans-serif;
+$govuk-font-family: "Inter", blinkmacsystemfont, "Segoe UI", roboto, oxygen-sans,
+  ubuntu, cantarell, "Helvetica Neue", sans-serif;
 $govuk-page-width: 1200px;
 
 @import "govuk-frontend";
@@ -10,3 +11,4 @@ $govuk-page-width: 1200px;
 @import "./imports/dfe-frontend";
 @import "./imports/digital-scotland";
 @import "./imports/ministry-of-justice";
+$govuk-new-typography-scale: true;

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_header-search.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_header-search.scss
@@ -4,6 +4,7 @@
 
 .dfe-header__content {
   float: none;
+  @include govuk-font($size: 19);
 
   @include mq($from: tablet) {
     position: absolute;
@@ -16,6 +17,7 @@
 
     .autocomplete__input,
     .dfe-search__input {
+      @include govuk-font($size: 19);
       background-color: govuk-colour("white");
       -webkit-appearance: listbox;
       padding: 0 dfe-spacing(3);
@@ -63,6 +65,10 @@
 
     .autocomplete__menu {
       text-align: left;
+    }
+
+    .autocomplete__option {
+      @include govuk-font($size: 19);
     }
 
     .autocomplete__option-hint {

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_side-navigation.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_side-navigation.scss
@@ -9,6 +9,10 @@
     @include govuk-responsive-margin(6, "top");
     @include govuk-responsive-margin(6, "bottom");
   }
+
+  .ds_side-navigation__expand {
+    @include govuk-font($size: 19, $weight: bold);
+  }
 }
 
 @include ds_media-query(medium) {

--- a/DfE.FindInformationAcademiesTrusts/package-lock.json
+++ b/DfE.FindInformationAcademiesTrusts/package-lock.json
@@ -14,6 +14,7 @@
         "accessible-autocomplete": "^3.0.0",
         "dfe-frontend": "^2.0.1",
         "govuk-frontend": "^5.4.1",
+        "inter-ui": "^4.0.2",
         "jquery": "^3.7.1"
       },
       "devDependencies": {
@@ -5227,6 +5228,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/inter-ui": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/inter-ui/-/inter-ui-4.0.2.tgz",
+      "integrity": "sha512-YmfzwEtzuVzEenQwSB/tmmqi/A0a2GnFk4mG4ZFULXiO5DNk0fJWiO3o9i1sdVKuMVGx9iiNQnCq8ghWZJVVHw==",
+      "license": "OFL-1.1",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",

--- a/DfE.FindInformationAcademiesTrusts/package.json
+++ b/DfE.FindInformationAcademiesTrusts/package.json
@@ -34,6 +34,7 @@
     "accessible-autocomplete": "^3.0.0",
     "dfe-frontend": "^2.0.1",
     "govuk-frontend": "^5.4.1",
+    "inter-ui": "^4.0.2",
     "jquery": "^3.7.1"
   },
   "standard": {

--- a/docs/adrs/0018-use-the-inter-font-npm-package.md
+++ b/docs/adrs/0018-use-the-inter-font-npm-package.md
@@ -1,0 +1,22 @@
+# 18. Run FIAT database migrations on Docker container start
+
+**Date**: 2024-10-09
+
+## Status
+
+Accepted
+
+## Context
+
+We have been asked to update our font to match the new DfE standard font named [Inter](https://rsms.me/inter/). We tried following the steps outlined in the [DfE design manual](https://design.education.gov.uk/design-system/dfe-frontend/styles/typography) to update the font through Sass, however even after updating Content Security Policy and adding exceptions did not allow the font to load, and it was blocked by COEP policy. Exact error is as follows:
+`net::ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep`.
+
+## Decision
+
+So as to not take up an extended amount of time solving this issue, we chose to host the fonts ourselves and use a NPM package to help manage and install them. The Inter font project recommended the package [Inter UI](https://www.npmjs.com/package/inter-ui) which we will use to load the fonts. However we should look into trying to load the fonts from the CDN in the future as this is the recommended way of doing it and will decrease our reliance on external packages.
+A tech debt ticket has been created to review this in the future [here](User Story 183724: Tech debt: Review how we are serving the Inter font).
+
+## Consequences
+
+- Added the NPM package inter-ui to the project.
+- Although this works we may have to incurr technical debt to switch to using the CDN method in the future or update/change the package to update the font in the future.


### PR DESCRIPTION
[User Story 176873](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/176873): Tech Debt: Update Typography to comply with DfE design system and GOV.UK frontend
Update the font in FIAT to the Inter font to match the DfE design manual https://design.education.gov.uk/design-system/dfe-frontend/styles/typography

## Changes

Update the the font to Inter
Install the Inter ui npm package to use the font
Update the class on the search form so it uses the proper font

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/df5e8ac1-0cd7-42bf-ad39-ce45c042e30f)

### After
![image](https://github.com/user-attachments/assets/cab8a1ec-8d2d-4ab8-9fda-857d1ed656c3)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
