### PR TITLE
Add "No Access" page

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Authorization/AutomationAuthorizationHandler.cs
+++ b/DfE.FindInformationAcademiesTrusts/Authorization/AutomationAuthorizationHandler.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
+using DfE.FindInformationAcademiesTrusts.Extensions;
 using DfE.FindInformationAcademiesTrusts.Options;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Infrastructure;

--- a/DfE.FindInformationAcademiesTrusts/Authorization/AutomationAuthorizationHandler.cs
+++ b/DfE.FindInformationAcademiesTrusts/Authorization/AutomationAuthorizationHandler.cs
@@ -1,9 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
+using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Extensions;
 using DfE.FindInformationAcademiesTrusts.Options;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 
@@ -13,8 +13,7 @@ public class AutomationAuthorizationHandler(
     IWebHostEnvironment environment,
     IHttpContextAccessor httpContextAccessor,
     IOptions<TestOverrideOptions> testOverrideOptions)
-    : AuthorizationHandler<DenyAnonymousAuthorizationRequirement>,
-        IAuthorizationRequirement
+    : AuthorizationHandler<IAuthorizationRequirement>
 {
     private readonly string? _cypressTestSecret = testOverrideOptions.Value.CypressTestSecret;
     private readonly bool _isLiveEnvironment = environment.IsLiveEnvironment();
@@ -38,23 +37,31 @@ public class AutomationAuthorizationHandler(
         var identity = new ClaimsIdentity(new List<Claim>
         {
             new("name", "Automation User - name"),
-            new("preferred_username", "Automation User - email")
+            new("preferred_username", "Automation User - email"),
+            new(ClaimTypes.Role, UserRoles.AuthorisedFiatUser)
         });
         var user = new ClaimsPrincipal(identity);
 
         httpContextAccessor.HttpContext!.User = user;
     }
 
-    [ExcludeFromCodeCoverage] // This method is difficult to test, everything that can be tested has been extracted to IsClientSecretHeaderValid
-    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context,
-        DenyAnonymousAuthorizationRequirement requirement)
+    [ExcludeFromCodeCoverage] // This method is difficult to test, everything that can be tested has been extracted to other public methods
+    public override Task HandleAsync(AuthorizationHandlerContext context)
     {
         if (IsClientSecretHeaderValid())
         {
             SetupAutomationUser();
-            context.Succeed(requirement);
+            foreach (var requirement in context.Requirements)
+                context.Succeed(requirement);
         }
 
         return Task.CompletedTask;
+    }
+
+    [ExcludeFromCodeCoverage] // This method is difficult to test because it is protected and not invoked
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context,
+        IAuthorizationRequirement requirement)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Authorization/AutomationAuthorizationHandler.cs
+++ b/DfE.FindInformationAcademiesTrusts/Authorization/AutomationAuthorizationHandler.cs
@@ -15,8 +15,9 @@ public class AutomationAuthorizationHandler(
     IOptions<TestOverrideOptions> testOverrideOptions)
     : AuthorizationHandler<IAuthorizationRequirement>
 {
-    private record AutomationUserContext(string Name, string Email, string[] Roles);
+    private sealed record AutomationUserContext(string Name, string Email, string[] Roles);
 
+    private static readonly JsonSerializerOptions WebJsonSerializerOptions = new(JsonSerializerDefaults.Web);
     private readonly string? _cypressTestSecret = testOverrideOptions.Value.CypressTestSecret;
     private readonly bool _isLiveEnvironment = environment.IsLiveEnvironment();
 
@@ -39,8 +40,8 @@ public class AutomationAuthorizationHandler(
         var httpContext = httpContextAccessor.HttpContext!;
 
         var userContextJson = httpContext.Request.Headers["x-user-context"].ToString();
-        var automationUserContext = JsonSerializer.Deserialize<AutomationUserContext>(userContextJson,
-            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var automationUserContext =
+            JsonSerializer.Deserialize<AutomationUserContext>(userContextJson, WebJsonSerializerOptions);
 
         if (automationUserContext == null)
             throw new InvalidOperationException("Could not deserialize automation user context");

--- a/DfE.FindInformationAcademiesTrusts/Configuration/FiatCookies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Configuration/FiatCookies.cs
@@ -1,0 +1,8 @@
+namespace DfE.FindInformationAcademiesTrusts.Configuration;
+
+public static class FiatCookies
+{
+    public const string Antiforgery = ".FindInformationAcademiesTrusts.Antiforgery";
+    public const string CookieConsent = ".FindInformationAcademiesTrusts.CookieConsent";
+    public const string Login = ".FindInformationAcademiesTrusts.Login";
+}

--- a/DfE.FindInformationAcademiesTrusts/Configuration/UserRoles.cs
+++ b/DfE.FindInformationAcademiesTrusts/Configuration/UserRoles.cs
@@ -1,0 +1,6 @@
+namespace DfE.FindInformationAcademiesTrusts.Configuration;
+
+public static class UserRoles
+{
+    public const string AuthorisedFiatUser = "User.Role.Authorised";
+}

--- a/DfE.FindInformationAcademiesTrusts/CookiesHelper.cs
+++ b/DfE.FindInformationAcademiesTrusts/CookiesHelper.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
+﻿using DfE.FindInformationAcademiesTrusts.Configuration;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
 namespace DfE.FindInformationAcademiesTrusts;
 
 public static class CookiesHelper
 {
-    public const string ConsentCookieName = ".FindInformationAcademiesTrust.CookieConsent";
     public const string DeleteCookieTempDataName = "DeleteCookie";
     public const string CookieChangedTempDataName = "CookieResponse";
     public const string ReturnPathQuery = "returnPath";
@@ -22,8 +22,8 @@ public static class CookiesHelper
             return false;
         }
 
-        return context.Request.Cookies.ContainsKey(ConsentCookieName) &&
-               bool.Parse(context.Request.Cookies[ConsentCookieName]!);
+        return context.Request.Cookies.ContainsKey(FiatCookies.CookieConsent) &&
+               bool.Parse(context.Request.Cookies[FiatCookies.CookieConsent]!);
     }
 
     public static string ReturnPath(HttpContext context)
@@ -35,7 +35,7 @@ public static class CookiesHelper
 
     public static bool ShowCookieBanner(HttpContext context, ITempDataDictionary tempData)
     {
-        return !context.Request.Cookies.ContainsKey(ConsentCookieName) &&
+        return !context.Request.Cookies.ContainsKey(FiatCookies.CookieConsent) &&
                tempData[DeleteCookieTempDataName] is null;
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Extensions/ClaimsPrincipleExtensions.cs
+++ b/DfE.FindInformationAcademiesTrusts/Extensions/ClaimsPrincipleExtensions.cs
@@ -1,0 +1,11 @@
+using System.Security.Claims;
+
+namespace DfE.FindInformationAcademiesTrusts.Extensions;
+
+public static class ClaimsPrincipleExtensions
+{
+    public static bool HasAccessToFiat(this ClaimsPrincipal user)
+    {
+        return user.IsInRole("User.Role.Authorised");
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Extensions/ClaimsPrincipleExtensions.cs
+++ b/DfE.FindInformationAcademiesTrusts/Extensions/ClaimsPrincipleExtensions.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using DfE.FindInformationAcademiesTrusts.Configuration;
 
 namespace DfE.FindInformationAcademiesTrusts.Extensions;
 
@@ -6,6 +7,6 @@ public static class ClaimsPrincipleExtensions
 {
     public static bool HasAccessToFiat(this ClaimsPrincipal user)
     {
-        return user.IsInRole("User.Role.Authorised");
+        return user.IsInRole(UserRoles.AuthorisedFiatUser);
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Extensions/EnvironmentExtensions.cs
+++ b/DfE.FindInformationAcademiesTrusts/Extensions/EnvironmentExtensions.cs
@@ -1,4 +1,4 @@
-namespace DfE.FindInformationAcademiesTrusts;
+namespace DfE.FindInformationAcademiesTrusts.Extensions;
 
 public static class EnvironmentExtensions
 {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Accessibility.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Accessibility.cshtml
@@ -1,5 +1,5 @@
 @page
-@model DfE.FindInformationAcademiesTrusts.Pages.Shared.ContentPageModel
+@model AccessibilityModel
 
 @{
   Layout = "_ContentLayout";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Accessibility.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Accessibility.cshtml
@@ -1,5 +1,5 @@
 @page
-@model AccessibilityModel
+@model DfE.FindInformationAcademiesTrusts.Pages.Shared.AnonymousPageModel
 
 @{
   Layout = "_ContentLayout";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Accessibility.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Accessibility.cshtml.cs
@@ -1,0 +1,7 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using Microsoft.AspNetCore.Authorization;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages;
+
+[AllowAnonymous]
+public class AccessibilityModel : ContentPageModel;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Accessibility.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Accessibility.cshtml.cs
@@ -1,7 +1,0 @@
-using DfE.FindInformationAcademiesTrusts.Pages.Shared;
-using Microsoft.AspNetCore.Authorization;
-
-namespace DfE.FindInformationAcademiesTrusts.Pages;
-
-[AllowAnonymous]
-public class AccessibilityModel : ContentPageModel;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Cookies.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Cookies.cshtml
@@ -1,157 +1,158 @@
 @page
+@using DfE.FindInformationAcademiesTrusts.Configuration
 @model CookiesModel
 
 @{
-    Layout = "_ContentLayout";
-    ViewData["Title"] = "Cookies";
+  Layout = "_ContentLayout";
+  ViewData["Title"] = "Cookies";
 }
 
 @if (Model.DisplayCookieChangedMessageOnCookiesPage)
 {
-    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Success
-            </h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">
-                You’ve set your cookie preferences. <a class="govuk-notification-banner__link" href="@Model.ReturnPath" data-testid="return-to-previous-page">Go back to the page you were looking at</a>.
-            </p>
-        </div>
+  <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+        Success
+      </h2>
     </div>
+    <div class="govuk-notification-banner__content">
+      <p class="govuk-notification-banner__heading">
+        You’ve set your cookie preferences. <a class="govuk-notification-banner__link" href="@Model.ReturnPath" data-testid="return-to-previous-page">Go back to the page you were looking at</a>.
+      </p>
+    </div>
+  </div>
 }
 
 <h1 class="govuk-heading-l">Cookie preferences</h1>
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-        <p class="govuk-body">
-            Cookies are small files saved on your phone, tablet or computer when you visit a website.
-        </p>
-        <p class="govuk-body">
-            We use cookies to make Find information about academies and trusts work and collect information about how you use our service.
-        </p>
-        <h2 class="govuk-heading-m">Essential cookies</h2>
-        <p class="govuk-body">
-            Essential cookies keep your information secure while you use this site. We do not need to ask permission to use them.
-        </p>
-        <table class="govuk-table" aria-label="Essential cookies">
-            <thead class="govuk-table__header">
-                <tr>
-                    <th class="govuk-table__header">Name</th>
-                    <th class="govuk-table__header">Purpose</th>
-                    <th class="govuk-table__header">Expires</th>
-                </tr>
-            </thead>
-            <tbody class="govuk-table__body">
-                <tr>
-                    <td class="govuk-table__cell">.FindInformationAcademiesTrusts.Login</td>
-                    <td class="govuk-table__cell">Used to keep you signed in</td>
-                    <td class="govuk-table__cell">With browser settings (Session)</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">.FindInformationAcademiesTrusts.CookieConsent </td>
-                    <td class="govuk-table__cell">Stores your consent to optional cookies </td>
-                    <td class="govuk-table__cell">1 year</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">ASLBSA </td>
-                    <td class="govuk-table__cell">Used to balance the load on our servers </td>
-                    <td class="govuk-table__cell">With browser settings (Session)</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">ASLBSACORS </td>
-                    <td class="govuk-table__cell">Used to balance the load on our servers </td>
-                    <td class="govuk-table__cell">With browser settings (Session)</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">.FindInformationAcademiesTrusts.Antiforgery </td>
-                    <td class="govuk-table__cell">Secures you and our service against Cross Site Scripting Attacks (CSRF) </td>
-                    <td class="govuk-table__cell">With browser settings (Session)</td>
-                </tr>
-            </tbody>
-        </table>
+  <div class="govuk-grid-column-three-quarters">
+    <p class="govuk-body">
+      Cookies are small files saved on your phone, tablet or computer when you visit a website.
+    </p>
+    <p class="govuk-body">
+      We use cookies to make Find information about academies and trusts work and collect information about how you use our service.
+    </p>
+    <h2 class="govuk-heading-m">Essential cookies</h2>
+    <p class="govuk-body">
+      Essential cookies keep your information secure while you use this site. We do not need to ask permission to use them.
+    </p>
+    <table class="govuk-table" aria-label="Essential cookies">
+      <thead class="govuk-table__header">
+        <tr>
+          <th class="govuk-table__header">Name</th>
+          <th class="govuk-table__header">Purpose</th>
+          <th class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr>
+          <td class="govuk-table__cell">@FiatCookies.Login</td>
+          <td class="govuk-table__cell">Used to keep you signed in</td>
+          <td class="govuk-table__cell">With browser settings (Session)</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">@FiatCookies.CookieConsent</td>
+          <td class="govuk-table__cell">Stores your consent to optional cookies </td>
+          <td class="govuk-table__cell">1 year</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">ASLBSA </td>
+          <td class="govuk-table__cell">Used to balance the load on our servers </td>
+          <td class="govuk-table__cell">With browser settings (Session)</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">ASLBSACORS </td>
+          <td class="govuk-table__cell">Used to balance the load on our servers </td>
+          <td class="govuk-table__cell">With browser settings (Session)</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">@FiatCookies.Antiforgery</td>
+          <td class="govuk-table__cell">Secures you and our service against Cross Site Scripting Attacks (CSRF) </td>
+          <td class="govuk-table__cell">With browser settings (Session)</td>
+        </tr>
+      </tbody>
+    </table>
 
-        <h2 class="govuk-heading-m">Optional analytics cookies</h2>
-        <p class="govuk-body">
-            With your permission, we use Application Insights and Google Analytics to collect data about how you use this site. This information helps us to improve our service.
-        </p>
-        <p class="govuk-body">
-            Application Insights and Google Analytics are not allowed to use or share our analytics data with anyone. Application Insights and Google Analytics store information about:
-        </p>
-        <ul class="govuk-list govuk-list--bullet">
-            <li>how you got to this site</li>
-            <li>the pages you visit on this site and how long you spend on them</li>
-            <li>any errors you see while using this site</li>
-            <li>what you click on while you are visiting the site</li>
-            <li>whether you’ve visited before</li>
-            <li>your unique user identity</li>
-        </ul>
+    <h2 class="govuk-heading-m">Optional analytics cookies</h2>
+    <p class="govuk-body">
+      With your permission, we use Application Insights and Google Analytics to collect data about how you use this site. This information helps us to improve our service.
+    </p>
+    <p class="govuk-body">
+      Application Insights and Google Analytics are not allowed to use or share our analytics data with anyone. Application Insights and Google Analytics store information about:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>how you got to this site</li>
+      <li>the pages you visit on this site and how long you spend on them</li>
+      <li>any errors you see while using this site</li>
+      <li>what you click on while you are visiting the site</li>
+      <li>whether you’ve visited before</li>
+      <li>your unique user identity</li>
+    </ul>
 
-        <table class="govuk-table" aria-label="Essential cookies">
-            <thead class="govuk-table__header">
-                <tr>
-                    <th class="govuk-table__header">Name</th>
-                    <th class="govuk-table__header">Purpose</th>
-                    <th class="govuk-table__header">Expires</th>
-                </tr>
-            </thead>
-            <tbody class="govuk-table__body">
-                <tr>
-                    <td class="govuk-table__cell">ai_user</td>
-                    <td class="govuk-table__cell">Checks if you have visited this site before. This helps us count how many people visit our site.</td>
-                    <td class="govuk-table__cell">1 year</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">ai_session</td>
-                    <td class="govuk-table__cell">Checks if you have visited this site before. This helps us count how many people visit our site.</td>
-                    <td class="govuk-table__cell">30 minutes</td>
-                </tr>
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell">ai_authUser</td>
-                    <td class="govuk-table__cell">This helps us to identify authenticated users and how they interact with the site</td>
-                    <td class="govuk-table__cell">When you close your browser</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">_ga</td>
-                    <td class="govuk-table__cell">Tracks your activity on the site. This helps us to improve our service.</td>
-                    <td class="govuk-table__cell">2 years</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">_gid</td>
-                    <td class="govuk-table__cell">Tracks a number of users. This helps us determine patterns in behaviour.</td>
-                    <td class="govuk-table__cell">24 hours</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
+    <table class="govuk-table" aria-label="Essential cookies">
+      <thead class="govuk-table__header">
+        <tr>
+          <th class="govuk-table__header">Name</th>
+          <th class="govuk-table__header">Purpose</th>
+          <th class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr>
+          <td class="govuk-table__cell">ai_user</td>
+          <td class="govuk-table__cell">Checks if you have visited this site before. This helps us count how many people visit our site.</td>
+          <td class="govuk-table__cell">1 year</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">ai_session</td>
+          <td class="govuk-table__cell">Checks if you have visited this site before. This helps us count how many people visit our site.</td>
+          <td class="govuk-table__cell">30 minutes</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">ai_authUser</td>
+          <td class="govuk-table__cell">This helps us to identify authenticated users and how they interact with the site</td>
+          <td class="govuk-table__cell">When you close your browser</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">_ga</td>
+          <td class="govuk-table__cell">Tracks your activity on the site. This helps us to improve our service.</td>
+          <td class="govuk-table__cell">2 years</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">_gid</td>
+          <td class="govuk-table__cell">Tracks a number of users. This helps us determine patterns in behaviour.</td>
+          <td class="govuk-table__cell">24 hours</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <form method="post" name="frmCookies">
-            <div class="govuk-form-group">
-                <input type="hidden" name="redirectPath" value="@(HttpContext.Request.Path + HttpContext.Request.QueryString)"/>
-                <fieldset class="govuk-fieldset">
-                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                        <h3 class="govuk-fieldset__heading">Do you want to accept cookies that measure your website use?</h3>
-                    </legend>
-                    <div class="govuk-radios">
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="cookies-accept" type="radio" name="consent" value="true" checked="@Model.Consent">
-                            <label class="govuk-label govuk-radios__label" for="cookies-accept">
-                                Yes
-                            </label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="cookies-reject" type="radio" name="consent" value="false" checked="@(!Model.Consent)">
-                            <label class="govuk-label govuk-radios__label" for="cookies-reject">
-                                No
-                            </label>
-                        </div>
-                    </div>
-                </fieldset>
+  <div class="govuk-grid-column-two-thirds">
+    <form method="post" name="frmCookies">
+      <div class="govuk-form-group">
+        <input type="hidden" name="redirectPath" value="@(HttpContext.Request.Path + HttpContext.Request.QueryString)"/>
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h3 class="govuk-fieldset__heading">Do you want to accept cookies that measure your website use?</h3>
+          </legend>
+          <div class="govuk-radios">
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="cookies-accept" type="radio" name="consent" value="true" checked="@Model.Consent">
+              <label class="govuk-label govuk-radios__label" for="cookies-accept">
+                Yes
+              </label>
             </div>
-            <button type="submit" class="govuk-button" data-module="govuk-button" data-testid="save-cookie-preferences-button">Save changes</button>
-        </form>
-    </div>
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="cookies-reject" type="radio" name="consent" value="false" checked="@(!Model.Consent)">
+              <label class="govuk-label govuk-radios__label" for="cookies-reject">
+                No
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <button type="submit" class="govuk-button" data-module="govuk-button" data-testid="save-cookie-preferences-button">Save changes</button>
+    </form>
+  </div>
 </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Cookies.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Cookies.cshtml.cs
@@ -1,9 +1,11 @@
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages;
 
+[AllowAnonymous]
 public class CookiesModel : ContentPageModel
 {
     private readonly IHttpContextAccessor _httpContextAccessor;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Cookies.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Cookies.cshtml.cs
@@ -1,13 +1,11 @@
 using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages;
 
-[AllowAnonymous]
-public class CookiesModel(IHttpContextAccessor httpContextAccessor) : ContentPageModel
+public class CookiesModel(IHttpContextAccessor httpContextAccessor) : AnonymousPageModel
 {
     public bool DisplayCookieChangedMessageOnCookiesPage { get; set; }
     [BindProperty(SupportsGet = true)] public string? ReturnPath { get; set; }

--- a/DfE.FindInformationAcademiesTrusts/Pages/NoAccess.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/NoAccess.cshtml
@@ -1,0 +1,21 @@
+@page "/no-access"
+@model NoAccessModel
+
+@{
+  Layout = "_ContentLayout";
+  ViewData["Title"] = "You do not have access to this service";
+}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <h1 class="govuk-heading-l">
+      You do not have access to this service
+    </h1>
+    <p class="govuk-body">
+      You must <a href="https://dfe.service-now.com/ithelpcentre?id=sc_cat_item&sys_id=19732a3b1b181250593ddce7b04bcbc2">request access to Find information about academies and trusts</a> before you can use it.
+    </p>
+    <p class="govuk-body">
+      It can take up to 5 days for access to be granted and you will be notified when this has happened.
+    </p>
+  </div>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/NoAccess.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/NoAccess.cshtml.cs
@@ -1,0 +1,7 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using Microsoft.AspNetCore.Authorization;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages;
+
+[AllowAnonymous]
+public class NoAccessModel : ContentPageModel;

--- a/DfE.FindInformationAcademiesTrusts/Pages/NoAccess.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/NoAccess.cshtml.cs
@@ -1,7 +1,58 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
+using DfE.FindInformationAcademiesTrusts.Extensions;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages;
 
 [AllowAnonymous]
-public class NoAccessModel : ContentPageModel;
+public class NoAccessModel : ContentPageModel
+{
+    private const string RetryingLogin = "RetryingLogin";
+
+    public ActionResult OnGet(string? returnUrl)
+    {
+        if (User.HasAccessToFiat())
+        {
+            return Url.IsLocalUrl(returnUrl) ? LocalRedirect(returnUrl) : Page();
+        }
+
+        // Users may be redirected to Access Denied because the login cookie stored in their browser contains
+        // stale information about their roles
+        // We can force an update of their role claims by removing this login cookie and redirecting them 
+        // back to their intended destination
+        if (NotRetriedLoginYet())
+        {
+            RemoveLoginCookie();
+
+            // We use temp data to ensure we don't end up in a redirect loop for genuine unauthorised users
+            TempData.Add(RetryingLogin, "true");
+
+            return Url.IsLocalUrl(returnUrl) ? LocalRedirect(returnUrl) : Page();
+        }
+
+        TempData.Remove(RetryingLogin);
+        return Page();
+    }
+
+    private bool NotRetriedLoginYet()
+    {
+        return !TempData.ContainsKey(RetryingLogin);
+    }
+
+    private void RemoveLoginCookie()
+    {
+        if (Request.Cookies.ContainsKey(FiatCookies.Login))
+        {
+            Response.Cookies.Delete(FiatCookies.Login,
+                new CookieOptions
+                {
+                    HttpOnly = true,
+                    IsEssential = true,
+                    SameSite = SameSiteMode.Strict,
+                    Secure = true
+                });
+        }
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/NoAccess.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/NoAccess.cshtml.cs
@@ -13,9 +13,12 @@ public class NoAccessModel : ContentPageModel
 
     public ActionResult OnGet(string? returnUrl)
     {
+        if (string.IsNullOrEmpty(returnUrl) || !Url.IsLocalUrl(returnUrl))
+            return Page();
+
         if (User.HasAccessToFiat())
         {
-            return Url.IsLocalUrl(returnUrl) ? LocalRedirect(returnUrl) : Page();
+            return LocalRedirect(returnUrl);
         }
 
         // Users may be redirected to Access Denied because the login cookie stored in their browser contains
@@ -29,7 +32,7 @@ public class NoAccessModel : ContentPageModel
             // We use temp data to ensure we don't end up in a redirect loop for genuine unauthorised users
             TempData.Add(RetryingLogin, "true");
 
-            return Url.IsLocalUrl(returnUrl) ? LocalRedirect(returnUrl) : Page();
+            return LocalRedirect(returnUrl);
         }
 
         TempData.Remove(RetryingLogin);

--- a/DfE.FindInformationAcademiesTrusts/Pages/NoAccess.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/NoAccess.cshtml.cs
@@ -1,13 +1,11 @@
 using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Extensions;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages;
 
-[AllowAnonymous]
-public class NoAccessModel : ContentPageModel
+public class NoAccessModel : AnonymousPageModel
 {
     private const string RetryingLogin = "RetryingLogin";
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Privacy.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Privacy.cshtml
@@ -7,7 +7,7 @@
 }
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-l">
       Privacy notice for Find information about academies and trusts
     </h1>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Privacy.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Privacy.cshtml
@@ -1,5 +1,5 @@
 @page
-@model DfE.FindInformationAcademiesTrusts.Pages.Shared.ContentPageModel
+@model PrivacyModel
 
 @{
   Layout = "_ContentLayout";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Privacy.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Privacy.cshtml
@@ -1,5 +1,5 @@
 @page
-@model PrivacyModel
+@model DfE.FindInformationAcademiesTrusts.Pages.Shared.AnonymousPageModel
 
 @{
   Layout = "_ContentLayout";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Privacy.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Privacy.cshtml.cs
@@ -1,0 +1,7 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using Microsoft.AspNetCore.Authorization;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages;
+
+[AllowAnonymous]
+public class PrivacyModel : ContentPageModel;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Privacy.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Privacy.cshtml.cs
@@ -1,7 +1,0 @@
-using DfE.FindInformationAcademiesTrusts.Pages.Shared;
-using Microsoft.AspNetCore.Authorization;
-
-namespace DfE.FindInformationAcademiesTrusts.Pages;
-
-[AllowAnonymous]
-public class PrivacyModel : ContentPageModel;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/AnonymousPageModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/AnonymousPageModel.cs
@@ -1,0 +1,6 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Shared;
+
+[AllowAnonymous]
+public class AnonymousPageModel : ContentPageModel;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/BasePageModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/BasePageModel.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
@@ -5,6 +6,13 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Shared;
 
 public abstract class BasePageModel : PageModel
 {
-    public bool ShowHeaderSearch { get; init; } = true;
+    private readonly bool _showHeaderSearch = true;
+
+    public bool ShowHeaderSearch
+    {
+        get => _showHeaderSearch && User.HasAccessToFiat();
+        init => _showHeaderSearch = value;
+    }
+
     [BindProperty(SupportsGet = true)] public string? KeyWords { get; set; } = string.Empty;
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/ContentPageModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/ContentPageModel.cs
@@ -1,6 +1,14 @@
+using DfE.FindInformationAcademiesTrusts.Extensions;
+
 namespace DfE.FindInformationAcademiesTrusts.Pages.Shared;
 
-public class ContentPageModel : BasePageModel
+public abstract class ContentPageModel : BasePageModel
 {
-    public bool ShowBreadcrumb { get; set; } = true;
+    private bool _showBreadcrumb = true;
+
+    public bool ShowBreadcrumb
+    {
+        get => _showBreadcrumb && User.HasAccessToFiat();
+        set => _showBreadcrumb = value;
+    }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Footer.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Footer.cshtml
@@ -1,4 +1,5 @@
 @using DfE.FindInformationAcademiesTrusts.Configuration
+@using DfE.FindInformationAcademiesTrusts.Extensions
 <footer class="govuk-footer">
   <div class="govuk-width-container">
     <div class="govuk-footer__navigation">
@@ -23,17 +24,20 @@
           </li>
         </ul>
       </div>
-      <div class="govuk-footer__section govuk-grid-column-one-half">
-        <h2 class="govuk-footer__heading govuk-heading-m">Give feedback</h2>
-        <ul class="govuk-footer__list">
-          <li class="govuk-footer__list-item">
-            <a class="govuk-footer__link" href="@ViewConstants.FeedbackFormLink" target="_blank" rel="noopener noreferrer">Give feedback (opens in a new tab)</a>
-          </li>
-          <li class="govuk-footer__list-item">
-            <a class="govuk-footer__link" href="@ViewConstants.SuggestChangeFormLink" target="_blank" rel="noopener noreferrer">Suggest a change (opens in a new tab)</a>
-          </li>
-        </ul>
-      </div>
+      @if (User.HasAccessToFiat())
+      {
+        <div class="govuk-footer__section govuk-grid-column-one-half">
+          <h2 class="govuk-footer__heading govuk-heading-m">Give feedback</h2>
+          <ul class="govuk-footer__list">
+            <li class="govuk-footer__list-item">
+              <a class="govuk-footer__link" href="@ViewConstants.FeedbackFormLink" target="_blank" rel="noopener noreferrer">Give feedback (opens in a new tab)</a>
+            </li>
+            <li class="govuk-footer__list-item">
+              <a class="govuk-footer__link" href="@ViewConstants.SuggestChangeFormLink" target="_blank" rel="noopener noreferrer">Suggest a change (opens in a new tab)</a>
+            </li>
+          </ul>
+        </div>
+      }
     </div>
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Header.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Header.cshtml
@@ -15,24 +15,27 @@
       @if (Model.ShowHeaderSearch)
       {
         <div class="dfe-header__search">
-          <partial name="_HeaderSearchForm" model="Model"/>
+          <partial name="Shared/_HeaderSearchForm" model="Model"/>
         </div>
       }
     </div>
   </div>
 </header>
 
-<div class="app-banner app-banner--s">
-  <div class="dfe-width-container">
-    <div class="govuk-phase-banner">
-      <p class="govuk-phase-banner__content">
-        <strong class="govuk-tag govuk-phase-banner__content__tag">
-          Beta
-        </strong>
-        <span class="govuk-phase-banner__text">
-          This is a new product – your <a class="govuk-link" href="@ViewConstants.FeedbackFormLink" target="_blank">feedback (opens in a new tab)</a> will help us to improve it.
-        </span>
-      </p>
+@if (Model.ShowHeaderSearch)
+{
+  <div class="app-banner app-banner--s">
+    <div class="dfe-width-container">
+      <div class="govuk-phase-banner">
+        <p class="govuk-phase-banner__content">
+          <strong class="govuk-tag govuk-phase-banner__content__tag">
+            Beta
+          </strong>
+          <span class="govuk-phase-banner__text">
+            This is a new product – your <a class="govuk-link" href="@ViewConstants.FeedbackFormLink" target="_blank">feedback (opens in a new tab)</a> will help us to improve it.
+          </span>
+        </p>
+      </div>
     </div>
   </div>
-</div>
+}

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -251,9 +251,10 @@ internal static class Program
     {
         builder.Services.AddAuthorization(options =>
         {
-            var policyBuilder = new AuthorizationPolicyBuilder();
-            policyBuilder.RequireAuthenticatedUser();
-            options.DefaultPolicy = policyBuilder.Build();
+            options.DefaultPolicy = new AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .RequireRole("User.Role.Authorised")
+                .Build();
             options.FallbackPolicy = options.DefaultPolicy;
         });
 
@@ -269,6 +270,8 @@ internal static class Program
                 options.Cookie.IsEssential = true;
                 options.Cookie.SameSite = SameSiteMode.None;
                 options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+
+                options.AccessDeniedPath = "/no-access";
             });
 
         builder.Services.AddAntiforgery(opts => { opts.Cookie.Name = ".FindInformationAcademiesTrusts.Antiforgery"; });

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -10,6 +10,7 @@ using DfE.FindInformationAcademiesTrusts.Data.Hardcoded;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.DataSource;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
+using DfE.FindInformationAcademiesTrusts.Extensions;
 using DfE.FindInformationAcademiesTrusts.Options;
 using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -229,7 +229,6 @@ internal static class Program
         builder.Services.AddScoped<IAcademyService, AcademyService>();
         builder.Services.AddScoped<IExportService, ExportService>();
 
-        builder.Services.AddScoped<IAuthorizationHandler, AutomationAuthorizationHandler>();
         builder.Services.AddScoped<IOtherServicesLinkBuilder, OtherServicesLinkBuilder>();
         builder.Services.AddScoped<IFreeSchoolMealsAverageProvider, FreeSchoolMealsAverageProvider>();
         builder.Services.AddHttpContextAccessor();
@@ -276,6 +275,8 @@ internal static class Program
             });
 
         builder.Services.AddAntiforgery(opts => { opts.Cookie.Name = FiatCookies.Antiforgery; });
+
+        builder.Services.AddScoped<IAuthorizationHandler, AutomationAuthorizationHandler>();
     }
 
     private static void AddDataProtectionServices(WebApplicationBuilder builder)

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -1,3 +1,6 @@
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Azure.Identity;
 using DfE.FindInformationAcademiesTrusts.Authorization;
 using DfE.FindInformationAcademiesTrusts.Configuration;
@@ -28,9 +31,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.FeatureManagement;
 using Microsoft.Identity.Web;
 using Serilog;
-using System.Data;
-using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 
 namespace DfE.FindInformationAcademiesTrusts;
 
@@ -266,7 +266,7 @@ internal static class Program
             CookieAuthenticationDefaults.AuthenticationScheme,
             options =>
             {
-                options.Cookie.Name = ".FindInformationAcademiesTrusts.Login";
+                options.Cookie.Name = FiatCookies.Login;
                 options.Cookie.HttpOnly = true;
                 options.Cookie.IsEssential = true;
                 options.Cookie.SameSite = SameSiteMode.None;
@@ -275,7 +275,7 @@ internal static class Program
                 options.AccessDeniedPath = "/no-access";
             });
 
-        builder.Services.AddAntiforgery(opts => { opts.Cookie.Name = ".FindInformationAcademiesTrusts.Antiforgery"; });
+        builder.Services.AddAntiforgery(opts => { opts.Cookie.Name = FiatCookies.Antiforgery; });
     }
 
     private static void AddDataProtectionServices(WebApplicationBuilder builder)

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -269,7 +269,7 @@ internal static class Program
                 options.Cookie.Name = FiatCookies.Login;
                 options.Cookie.HttpOnly = true;
                 options.Cookie.IsEssential = true;
-                options.Cookie.SameSite = SameSiteMode.None;
+                options.Cookie.SameSite = SameSiteMode.Lax;
                 options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
 
                 options.AccessDeniedPath = "/no-access";

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -1,5 +1,6 @@
 using Azure.Identity;
 using DfE.FindInformationAcademiesTrusts.Authorization;
+using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
@@ -253,7 +254,7 @@ internal static class Program
         {
             options.DefaultPolicy = new AuthorizationPolicyBuilder()
                 .RequireAuthenticatedUser()
-                .RequireRole("User.Role.Authorised")
+                .RequireRole(UserRoles.AuthorisedFiatUser)
                 .Build();
             options.FallbackPolicy = options.DefaultPolicy;
         });

--- a/docs/adrs/0020-handle-users-authorisation-state-with-roles.md
+++ b/docs/adrs/0020-handle-users-authorisation-state-with-roles.md
@@ -1,0 +1,113 @@
+# 20. Handle users authorisation state with roles
+
+**Date**: 2024-10-28
+
+## Status
+
+Accepted
+
+## Context
+
+Currently, when a new user tries to access FIAT without having been added to the correct Azure AD group, they encounter a daunting default error page from Mucrosoft which tells them to contact their "admin".
+
+We want to create a better user experience for people trying to get access to FIAT by redirecting unauthorised users to a page with helpful information.
+
+We were entirely delegating both the **authorisation** and **authentication** to the Microsoft Azure Enterprise application which meant that we were unable to redirect on login failure. Some other applications in the program have enabled a no access page redirect by assigning Roles to user groups in the Microsoft Azure Enterprise application and then moving **authorisation** into the actual web application's codebase.
+
+## Decision
+
+We want to keep consistency with other products in RSD and we also couldn't see another way to enable a redirect to one of our own pages so we decided to adopt the same approach.
+
+- Users permitted to use FIAT will still be onboarded in the same way by being added to the correct Microsoft Entra group.
+- **Authentication** is still managed by `Microsoft.Identity.Web` and Microsoft Entra.
+- **Authorisation** will be managed by role claims configured in the Microsoft Azure Enterprise application and then evaluated by the FIAT application.
+
+This requires some changes to the authorisation process in FIAT and has implications for security.
+
+- By default every page and route in FIAT will be secured and require the correct user role claim to access.
+- The no-access, accessibility, cookies and privacy pages will be specifically opened to unauthorised users.
+- The cookies banner should still function for unauthorised users.
+- The header and footer will not render components which link to protected areas of the site (such as the Home breadcrumb or header trust search box) for unauthorised users.
+
+## Consequences
+
+There is a disconnect between how we persist login information (in a cookie) and what a user's most up to date role information may be.
+
+When we release the role based authorisation some current users of the may have outdated role claims in their login cookie - we don't want these existing users to face any change or interruption to their use of the application so we mapped out the different states a user can be in at the point they try to access a page on FIAT and whether or not they should be able to access secured pages.
+
+| Example user                                                                                                                                              | Has login cookie   | Has FIAT user role claim in login cookie | Has FIAT user role in azure | Should have access to secured FIAT pages?         |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ---------------------------------------- | --------------------------- | ------------------------------------------------- |
+| A long-term FIAT user                                                                                                                                     | :heavy_check_mark: | :heavy_check_mark:                       | :heavy_check_mark:          | :muscle: has access                               |
+| FIAT User that has just had permissions revoked                                                                                                           | :heavy_check_mark: | :heavy_check_mark:                       | :x:                         | :warning: has access until end of browser session |
+| User that followed the get access link on the no access page and has just had access granted (also existing users at the time of release of this feature) | :heavy_check_mark: | :x:                                      | :heavy_check_mark:          | :muscle: has access                               |
+| User that has not been setup to use FIAT but has tried to access FIAT before                                                                              | :heavy_check_mark: | :x:                                      | :x:                         | :no_entry: no access                              |
+| Invalid state - a cookie can't contain a role if the cookie does not exist                                                                                | ~~:x:~~            | ~~:heavy_check_mark:~~                   | ~~:heavy_check_mark:~~      | n/a                                               |
+| Invalid state - a cookie can't contain a role if the cookie does not exist                                                                                | ~~:x:~~            | ~~:heavy_check_mark:~~                   | ~~:x:~~                     | n/a                                               |
+| Brand new User that has just been told they have access                                                                                                   | :x:                | :x:                                      | :heavy_check_mark:          | :muscle: has access                               |
+| Brand new User that has not been setup to use FIAT                                                                                                        | :x:                | :x:                                      | :x:                         | :no_entry: no access                              |
+
+This exercise allows us to ensure that we cover all permutations of user state to ensure that the user journey for each user is as simple and intuitive as possible for both new and existing users.
+
+We also found that there were several different types of journey that an authorised or unauthorised user might want to make and we needed to behave differently for each
+
+| Request                                                         | Authorised FIAT user outcome | Unauthorised user outcome                                                            |
+| --------------------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------ |
+| Is navigating to a standard fiat page (like home or a trust)    | Should go to intended page   | Should be redirected to no-access with return url of page they were trying to access |
+| Is navigating to an always accessible fiat page (like cookies)  | Should go to intended page   | Should go to intended page                                                           |
+| Is navigating to no-access with return url                      | Should go to return url      | Should go to no-access page with return url                                          |
+| Is navigating to no-access on purpose (i.e. without return url) | Should go to no-access page  | Should go to no-access page                                                          |
+
+## Implementation
+
+We created a new flow triggered upon navigation to the "No Access" page to ensure that a user's role is up to date and we're not relying on stale claims in a cookie:
+
+```mermaid
+---
+title: Flow upon navigating to "No Access" page 
+---
+flowchart TB
+    %% ~~~~~ Node declarations ~~~~~
+    %% Entry nodes
+    auth-fail-redirect(["**Entry point**: ASP.NET core framework redirecting to no-access due to auth failure (original path included as return url)"])
+    direct-nav-with-return(["**Entry point**: Direct visit to no-access page with return url (e.g. page refresh)"])
+    direct-nav-no-return(["**Entry point**: Direct visit to no-access page without return url"])
+
+    %% Main nodes
+    local-return-url{Is there a local return url?}
+    on-get[On GET for no-access page]
+    has-role{"`Does user have FIAT user role claim? 
+            (Note that claims are persisted in the login cookie and will not be retrieved from Azure)`"}
+    refresh-login-cookie["Force re-login by removing login cookie (if it exists)"]
+    login-retry["Mark in TempData that we're 'RetryingLogin'"]
+    login-redirect-return-url[Redirect to local return url]
+    login-retry-auth-fail-redirect[ASP.NET core framework redirects back to no-access page]
+    login-user-logs-in[User logins in]
+    already-retried-login{Does TempData show that we've already retried the login to update the role claims?}
+    remove-tempdata["Remove 'RetryingLogin' from TempData"]
+    redirect-return-url[Redirect to local return url]
+
+    %% Exit nodes
+    render-no-access([Render no-access page])
+    render-requested-page([Render requested page])
+
+    %% ~~~~~ Chart links ~~~~~
+    auth-fail-redirect --> on-get
+    direct-nav-with-return --> on-get
+    direct-nav-no-return --> on-get
+
+    on-get --> local-return-url
+    local-return-url -- yes --> has-role
+    local-return-url -- no --> render-no-access
+
+    has-role -- yes - auth success --> redirect-return-url --> render-requested-page
+    has-role -- no --> already-retried-login
+
+    already-retried-login -- no - cookie might be stale --> refresh-login-cookie --> login-retry
+    already-retried-login -- yes - auth has failed --> remove-tempdata --> render-no-access
+    
+    login-retry --> login-redirect-return-url --> login-user-logs-in
+    login-user-logs-in -- auth success --> render-requested-page
+    login-user-logs-in -- auth failure --> login-retry-auth-fail-redirect --> on-get
+```
+
+Triggering this flow on the `OnGet` of the no access page (rather than by using an authentication handler or cookie authentication events) ensures that we're only doing this extra work in the exceptional circumstance of a user auth failure and gives us easy access to the intended route and the Tempdata. It also allows us to handle cases such as when auth succeeds for a new user but they're just refreshing an old browser tab which had previously redirected to the no-access page.

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/auth/authenticationInterceptor.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/auth/authenticationInterceptor.ts
@@ -1,7 +1,6 @@
 
 export class AuthenticationInterceptor {
-
-    register(params?: AuthenticationInterceptorParams) {
+    register(automationUserProperties: AutomationUserProperties) {
         cy.intercept(
             {
                 url: Cypress.env("URL") + "/**",
@@ -11,14 +10,16 @@ export class AuthenticationInterceptor {
                 // Set an auth header on every request made by the browser
                 req.headers = {
                     ...req.headers,
-                    'Authorization': `Bearer ${Cypress.env("AUTH_KEY")}`
+                    'Authorization': `Bearer ${Cypress.env("AUTH_KEY")}`,
+                    'x-user-context': JSON.stringify(automationUserProperties)
                 };
             }
         ).as("AuthInterceptor");
     }
 }
 
-export type AuthenticationInterceptorParams = {
-    role?: string;
-    username?: string;
+export type AutomationUserProperties = {
+    name: string;
+    email: string;
+    roles: string[];
 }

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/no-access-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/no-access-page.cy.ts
@@ -1,0 +1,55 @@
+import navigation from "../../pages/navigation";
+
+describe("Testing the components of the no access page", () => {
+
+    describe("As an unauthorised user", () => {
+
+        beforeEach(() => {
+            cy.login({
+                name: "Unauthorised User - name",
+                email: "Unauthorised User - email",
+                roles: []
+            });
+        });
+
+        ['/', '/search', '/notfound', '/trusts/details?uid=5712', '/trusts/contacts?uid=5143', '/trusts/governance?5527'].forEach((url) => {
+            it(`Should redirect to no access page when accessing ${url}`, () => {
+                cy.visit(url);
+
+                navigation
+                    .checkCurrentURLIsCorrect('no-access');
+
+                //todo: this test might get upset if the application redirects to microsoft login
+                // ideally we want to check that it tries to go to MS login and then redirects to no access page
+                // with the correct return url!
+                //This may not be possible though
+            });
+        });
+
+        ['/cookies', '/accessibility', '/privacy'].forEach((url) => {
+            it(`Should be able to go to ${url}`, () => {
+                cy.visit(url);
+
+                navigation
+                    .checkCurrentURLIsCorrect(url);
+            });
+        });
+    });
+
+    describe("As an authorised user", () => {
+        beforeEach(() => {
+            cy.login();
+        });
+
+        ['/', '/search', '/notfound', '/trusts/details?uid=5712', '/trusts/contacts?uid=5143', '/trusts/governance?5527', '/cookies', '/accessibility', '/privacy'].forEach((url) => {
+            it(`Should be able to go to ${url}`, () => {
+                cy.visit(url);
+
+                navigation
+                    .checkCurrentURLIsCorrect(url);
+            });
+        });
+    });
+
+    //Todo: Other tests - when not authenticated - no breadcrumb or search box or feedback footer section
+});

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/support/commands.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/support/commands.ts
@@ -1,12 +1,16 @@
-import { AuthenticationInterceptor } from "../auth/authenticationInterceptor";
+import { AuthenticationInterceptor, AutomationUserProperties } from "../auth/authenticationInterceptor";
 
-Cypress.Commands.add("login", (params) => {
-	cy.clearCookies();
-	cy.clearLocalStorage();
+Cypress.Commands.add("login", (automationUserProperties?: AutomationUserProperties) => {
+
+	if (!automationUserProperties)
+		automationUserProperties = {
+			name: "Automation User - name",
+			email: "Automation User - email",
+			roles: ["User.Role.Authorised"]
+		};
 
 	// Intercept all browser requests and add our special auth header
-	// Means we don't have to use azure to authenticate
-	new AuthenticationInterceptor().register(params);
+	new AuthenticationInterceptor().register(automationUserProperties);
 
 	cy.visit("/");
-}); 
+});

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/support/e2e.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/support/e2e.ts
@@ -1,10 +1,10 @@
-import { AuthenticationInterceptorParams } from '../auth/authenticationInterceptor';
+import { AutomationUserProperties } from '../auth/authenticationInterceptor';
 import './commands'
 
 declare global {
     namespace Cypress {
         interface Chainable {
-            login(params?: AuthenticationInterceptorParams): Chainable<Element>;
+            login(automationUserProperties?: AutomationUserProperties): Chainable<Element>;
         }
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Authorization/AutomationAuthorizationHandlerTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Authorization/AutomationAuthorizationHandlerTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using DfE.FindInformationAcademiesTrusts.Authorization;
+using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Options;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -98,7 +99,8 @@ public class AutomationAuthorizationHandlerTests
         var expected = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
         {
             new("name", "Automation User - name"),
-            new("preferred_username", "Automation User - email")
+            new("preferred_username", "Automation User - email"),
+            new(ClaimTypes.Role, UserRoles.AuthorisedFiatUser)
         }));
         var actual = _httpContext.User;
         // Exclude subject due to cyclical references

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/CookiesHelperTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/CookiesHelperTests.cs
@@ -16,7 +16,7 @@ public class CookiesHelperTests
     [Fact]
     public void OptionalCookiesAreAccepted_is_true_when_Accepted_cookie_exists()
     {
-        _mockContext.SetupAcceptedCookie();
+        _mockContext.MockRequestCookies.SetupAcceptedCookie();
         var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData.Object);
         result.Should().BeTrue();
     }
@@ -24,7 +24,7 @@ public class CookiesHelperTests
     [Fact]
     public void OptionalCookiesAreAccepted_is_false_when_Rejected_cookie_exists()
     {
-        _mockContext.SetupRejectedCookie();
+        _mockContext.MockRequestCookies.SetupRejectedCookie();
         var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData.Object);
         result.Should().BeFalse();
     }
@@ -35,7 +35,7 @@ public class CookiesHelperTests
     [InlineData(null)]
     public void OptionalCookiesAreAccepted_is_false_when_DeleteCookieTempData_exists(bool? cookieAccepted)
     {
-        _mockContext.SetupConsentCookie(cookieAccepted);
+        _mockContext.MockRequestCookies.SetupConsentCookie(cookieAccepted);
 
         SetTempDataCookieDeleted();
         var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData.Object);
@@ -81,7 +81,7 @@ public class CookiesHelperTests
     [InlineData(false)]
     public void ShowCookieBanner_is_false_when_consent_cookie_exists_and_temp_data_does_not_exist(bool cookieAccepted)
     {
-        _mockContext.SetupConsentCookie(cookieAccepted);
+        _mockContext.MockRequestCookies.SetupConsentCookie(cookieAccepted);
 
         var result = CookiesHelper.ShowCookieBanner(_mockContext.Object, _mockTempData.Object);
         result.Should().BeFalse();
@@ -100,7 +100,7 @@ public class CookiesHelperTests
     [InlineData(false)]
     public void ShowCookieBanner_is_false_when_consent_cookie_exists_and_temp_data_exists(bool cookieAccepted)
     {
-        _mockContext.SetupConsentCookie(cookieAccepted);
+        _mockContext.MockRequestCookies.SetupConsentCookie(cookieAccepted);
 
         SetTempDataCookieDeleted();
         var result = CookiesHelper.ShowCookieBanner(_mockContext.Object, _mockTempData.Object);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/EnvironmentExtensionsTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/EnvironmentExtensionsTests.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Extensions;
 using Microsoft.AspNetCore.Hosting;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockHttpContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockHttpContext.cs
@@ -20,6 +20,7 @@ public class MockHttpContext : Mock<HttpContext>
 
         ClaimsPrincipal user = new();
         user.AddIdentity(_claimsIdentity);
+        AddUserClaim(_claimsIdentity.RoleClaimType, "User.Role.Authorised");
 
         _mockRequest.Setup(m => m.Cookies).Returns(_mockRequestCookies.Object);
         _mockRequest.Setup(m => m.Query[It.IsAny<string>()]).Returns("");
@@ -33,6 +34,12 @@ public class MockHttpContext : Mock<HttpContext>
         Setup(m => m.Response).Returns(mockResponse.Object);
         Setup(m => m.Features).Returns(_mockFeatureCollection.Object);
         Setup(m => m.User).Returns(user);
+    }
+
+    public void SetupUnauthorizedUser()
+    {
+        var roleClaim = _claimsIdentity.Claims.Single(c => c.Type == _claimsIdentity.RoleClaimType);
+        _claimsIdentity.RemoveClaim(roleClaim);
     }
 
     public void AddUserClaim(string type, string value)

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockHttpContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockHttpContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Claims;
+using DfE.FindInformationAcademiesTrusts.Configuration;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -26,8 +27,8 @@ public class MockHttpContext : Mock<HttpContext>
         _mockRequest.Setup(m => m.Query[It.IsAny<string>()]).Returns("");
 
         _mockRequestCookies.Setup(m => m[It.IsAny<string>()]).Returns("False");
-        _mockRequestCookies.Setup(m => m.ContainsKey(".FindInformationAcademiesTrusts.Login")).Returns(true);
-        _mockRequestCookies.Setup(m => m[".FindInformationAcademiesTrusts.Login"]).Returns("You are logged in");
+        _mockRequestCookies.Setup(m => m.ContainsKey(FiatCookies.Login)).Returns(true);
+        _mockRequestCookies.Setup(m => m[FiatCookies.Login]).Returns("You are logged in");
         _mockRequestCookies.Setup(m => m.Keys).Returns(new List<string>());
 
         Setup(m => m.Request).Returns(_mockRequest.Object);
@@ -61,16 +62,16 @@ public class MockHttpContext : Mock<HttpContext>
 
     public void SetupAcceptedCookie()
     {
-        _mockRequestCookies.Setup(m => m.Keys).Returns(new List<string> { CookiesHelper.ConsentCookieName });
-        _mockRequestCookies.Setup(m => m.ContainsKey(CookiesHelper.ConsentCookieName)).Returns(true);
-        _mockRequestCookies.Setup(m => m[CookiesHelper.ConsentCookieName]).Returns("True");
+        _mockRequestCookies.Setup(m => m.Keys).Returns(new List<string> { FiatCookies.CookieConsent });
+        _mockRequestCookies.Setup(m => m.ContainsKey(FiatCookies.CookieConsent)).Returns(true);
+        _mockRequestCookies.Setup(m => m[FiatCookies.CookieConsent]).Returns("True");
     }
 
     public void SetupRejectedCookie()
     {
         _mockRequestCookies.Setup(m => m.Keys).Returns(new List<string>());
-        _mockRequestCookies.Setup(m => m.ContainsKey(CookiesHelper.ConsentCookieName)).Returns(true);
-        _mockRequestCookies.Setup(m => m[CookiesHelper.ConsentCookieName]).Returns("False");
+        _mockRequestCookies.Setup(m => m.ContainsKey(FiatCookies.CookieConsent)).Returns(true);
+        _mockRequestCookies.Setup(m => m[FiatCookies.CookieConsent]).Returns("False");
     }
 
     public void SetupOptionalCookies()

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockRequestCookies.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockRequestCookies.cs
@@ -1,0 +1,46 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
+using Microsoft.AspNetCore.Http;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+
+public class MockRequestCookies : Mock<IRequestCookieCollection>
+{
+    public Dictionary<string, string> Data { get; } = new();
+
+    public MockRequestCookies()
+    {
+        Setup(m => m.Keys).Returns(Data.Keys);
+        Setup(m => m.ContainsKey(It.IsAny<string>())).Returns((string key) => Data.ContainsKey(key));
+        Setup(m => m[It.IsAny<string>()]).Returns((string key) => Data.TryGetValue(key, out var value) ? value : null);
+    }
+
+    public void SetupConsentCookie(bool? accepted)
+    {
+        if (accepted is true)
+        {
+            SetupAcceptedCookie();
+        }
+        else if (accepted is false)
+        {
+            SetupRejectedCookie();
+        }
+    }
+
+    public void SetupAcceptedCookie()
+    {
+        Data.Add(FiatCookies.CookieConsent, "True");
+    }
+
+    public void SetupRejectedCookie()
+    {
+        Data.Add(FiatCookies.CookieConsent, "False");
+    }
+
+    public void SetupOptionalCookies()
+    {
+        Data.Add("ai_user", "True");
+        Data.Add("ai_session", "True");
+        Data.Add("_gid", "True");
+        Data.Add("_ga", "True");
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockResponseCookies.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockResponseCookies.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Http;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+
+public class MockResponseCookies : Mock<IResponseCookies>
+{
+    public void VerifySecureCookieAdded(string key, string value)
+    {
+        Verify(m => m.Append(key, value,
+            It.Is<CookieOptions>(c => c.Secure == true && c.HttpOnly == true)), Times.Once);
+    }
+
+    public void VerifyCookieDeleted(string key)
+    {
+        Verify(m => m.Delete(key), Times.Once);
+    }
+
+    public void VerifyCookieDeleted(string key, CookieOptions options)
+    {
+        Verify(m => m.Delete(key, It.Is<CookieOptions>(cookieOptions =>
+                cookieOptions.HttpOnly == options.HttpOnly
+                && cookieOptions.IsEssential == options.IsEssential
+                && cookieOptions.SameSite == options.SameSite
+                && cookieOptions.Secure == options.Secure
+            )),
+            Times.Once);
+    }
+
+    public void VerifyNoCookiesDeleted()
+    {
+        Verify(m => m.Delete(It.IsAny<string>()), Times.Exactly(0));
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/CookiesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/CookiesModelTests.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Http;
@@ -183,7 +184,7 @@ public class CookiesModelTests
     {
         _sut.Consent = consent;
         _sut.OnGet();
-        _mockHttpContext.VerifySecureCookieAdded(CookiesHelper.ConsentCookieName, value);
+        _mockHttpContext.VerifySecureCookieAdded(FiatCookies.CookieConsent, value);
     }
 
     [Theory]
@@ -193,7 +194,7 @@ public class CookiesModelTests
     {
         _sut.Consent = consent;
         _sut.OnPost();
-        _mockHttpContext.VerifySecureCookieAdded(CookiesHelper.ConsentCookieName, value);
+        _mockHttpContext.VerifySecureCookieAdded(FiatCookies.CookieConsent, value);
     }
 
     // (Cookie appended Delete called if needed/TempData is not null)

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/CookiesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/CookiesModelTests.cs
@@ -93,7 +93,7 @@ public class CookiesModelTests
     [InlineData(false, false)]
     public void OnGet_should_not_change_consent_when_it_is_provided(bool consent, bool? accepted)
     {
-        _mockHttpContext.SetupConsentCookie(accepted);
+        _mockHttpContext.MockRequestCookies.SetupConsentCookie(accepted);
         _sut.Consent = consent;
         _sut.OnGet();
         _sut.Consent.Should().Be(consent);
@@ -108,7 +108,7 @@ public class CookiesModelTests
     [InlineData(false, false)]
     public void OnPost_should_not_change_consent_when_it_is_provided(bool consent, bool? accepted)
     {
-        _mockHttpContext.SetupConsentCookie(accepted);
+        _mockHttpContext.MockRequestCookies.SetupConsentCookie(accepted);
         _sut.Consent = consent;
         _sut.OnPost();
         _sut.Consent.Should().Be(consent);
@@ -119,7 +119,7 @@ public class CookiesModelTests
     [InlineData(false)]
     public void OnGet_should_set_consent_when_it_not_provided_and_the_cookie_has_been_set(bool accepted)
     {
-        _mockHttpContext.SetupConsentCookie(accepted);
+        _mockHttpContext.MockRequestCookies.SetupConsentCookie(accepted);
         _sut.OnGet();
         _sut.Consent.Should().Be(accepted);
     }
@@ -184,7 +184,7 @@ public class CookiesModelTests
     {
         _sut.Consent = consent;
         _sut.OnGet();
-        _mockHttpContext.VerifySecureCookieAdded(FiatCookies.CookieConsent, value);
+        _mockHttpContext.MockResponseCookies.VerifySecureCookieAdded(FiatCookies.CookieConsent, value);
     }
 
     [Theory]
@@ -194,7 +194,7 @@ public class CookiesModelTests
     {
         _sut.Consent = consent;
         _sut.OnPost();
-        _mockHttpContext.VerifySecureCookieAdded(FiatCookies.CookieConsent, value);
+        _mockHttpContext.MockResponseCookies.VerifySecureCookieAdded(FiatCookies.CookieConsent, value);
     }
 
     // (Cookie appended Delete called if needed/TempData is not null)
@@ -205,10 +205,10 @@ public class CookiesModelTests
     [InlineData("_gid")]
     public void OnGet_removes_optional_cookie_when_consent_is_false(string cookieName)
     {
-        _mockHttpContext.SetupOptionalCookies();
+        _mockHttpContext.MockRequestCookies.SetupOptionalCookies();
         _sut.Consent = false;
         _sut.OnGet();
-        _mockHttpContext.VerifyCookieDeleted(cookieName);
+        _mockHttpContext.MockResponseCookies.VerifyCookieDeleted(cookieName);
     }
 
     [Theory]
@@ -218,48 +218,48 @@ public class CookiesModelTests
     [InlineData("_gid")]
     public void OnPost_removes_optional_cookie_when_consent_is_false(string cookieName)
     {
-        _mockHttpContext.SetupOptionalCookies();
+        _mockHttpContext.MockRequestCookies.SetupOptionalCookies();
         _sut.Consent = false;
         _sut.OnPost();
-        _mockHttpContext.VerifyCookieDeleted(cookieName);
+        _mockHttpContext.MockResponseCookies.VerifyCookieDeleted(cookieName);
     }
 
     [Fact]
     public void OnGet_does_not_remove_cookies_when_consent_is_true()
     {
-        _mockHttpContext.SetupOptionalCookies();
-        _mockHttpContext.SetupAcceptedCookie();
+        _mockHttpContext.MockRequestCookies.SetupOptionalCookies();
+        _mockHttpContext.MockRequestCookies.SetupAcceptedCookie();
         _sut.Consent = true;
         _sut.OnGet();
-        _mockHttpContext.VerifyNoCookiesDeleted();
+        _mockHttpContext.MockResponseCookies.VerifyNoCookiesDeleted();
     }
 
     [Fact]
     public void OnPost_does_not_remove_cookies_when_consent_is_true()
     {
-        _mockHttpContext.SetupOptionalCookies();
-        _mockHttpContext.SetupAcceptedCookie();
+        _mockHttpContext.MockRequestCookies.SetupOptionalCookies();
+        _mockHttpContext.MockRequestCookies.SetupAcceptedCookie();
         _sut.Consent = true;
         _sut.OnPost();
-        _mockHttpContext.VerifyNoCookiesDeleted();
+        _mockHttpContext.MockResponseCookies.VerifyNoCookiesDeleted();
     }
 
     [Fact]
     public void OnGet_does_not_remove_cookies_when_there_are_no_optional_cookies_to_remove()
     {
-        _mockHttpContext.SetupRejectedCookie();
+        _mockHttpContext.MockRequestCookies.SetupRejectedCookie();
         _sut.Consent = false;
         _sut.OnGet();
-        _mockHttpContext.VerifyNoCookiesDeleted();
+        _mockHttpContext.MockResponseCookies.VerifyNoCookiesDeleted();
     }
 
     [Fact]
     public void OnPost_does_not_remove_cookies_when_there_are_no_optional_cookies_to_remove()
     {
-        _mockHttpContext.SetupRejectedCookie();
+        _mockHttpContext.MockRequestCookies.SetupRejectedCookie();
         _sut.Consent = false;
         _sut.OnPost();
-        _mockHttpContext.VerifyNoCookiesDeleted();
+        _mockHttpContext.MockResponseCookies.VerifyNoCookiesDeleted();
     }
 
     //TempData

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/ErrorModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/ErrorModelTests.cs
@@ -1,6 +1,7 @@
 using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages;
 
@@ -14,7 +15,13 @@ public class ErrorModelTests
         Mock<IHttpContextAccessor> mockHttpAccessor = new();
         mockHttpAccessor.Setup(m => m.HttpContext).Returns(_mockHttpContext.Object);
 
-        _sut = new ErrorModel(mockHttpAccessor.Object);
+        _sut = new ErrorModel(mockHttpAccessor.Object)
+        {
+            PageContext = new PageContext
+            {
+                HttpContext = _mockHttpContext.Object
+            }
+        };
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/NoAccessModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/NoAccessModelTests.cs
@@ -1,0 +1,117 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
+using DfE.FindInformationAcademiesTrusts.Pages;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+using FluentAssertions.Execution;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages;
+
+public class NoAccessModelTests
+{
+    private readonly MockHttpContext _mockHttpContext = new();
+    private readonly NoAccessModel _sut;
+    private readonly TempDataDictionary _tempDataDictionary;
+
+    private const string LocalUrl = "/search";
+    private const string ExternalUrl = "https://google.com";
+
+    public NoAccessModelTests()
+    {
+        var mockUrlHelper = new Mock<IUrlHelper>();
+        mockUrlHelper.Setup(u => u.IsLocalUrl(LocalUrl)).Returns(true);
+        mockUrlHelper.Setup(u => u.IsLocalUrl(ExternalUrl)).Returns(false);
+
+        _tempDataDictionary = new TempDataDictionary(_mockHttpContext.Object, Mock.Of<ITempDataProvider>());
+        _sut = new NoAccessModel
+        {
+            PageContext = new PageContext
+            {
+                HttpContext = _mockHttpContext.Object
+            },
+            TempData = _tempDataDictionary,
+            Url = mockUrlHelper.Object
+        };
+    }
+
+    [Fact]
+    public void OnGet_should_redirect_to_local_return_url_when_user_is_authorised()
+    {
+        var result = _sut.OnGet(LocalUrl);
+
+        result.Should().BeOfType<LocalRedirectResult>();
+        result.As<LocalRedirectResult>().Url.Should().Be(LocalUrl);
+    }
+
+    [Theory]
+    [InlineData(MockHttpContext.UserAuthState.Authorised)]
+    [InlineData(MockHttpContext.UserAuthState.Unauthenticated)]
+    [InlineData(MockHttpContext.UserAuthState.Unauthorised)]
+    public void OnGet_should_render_page_when_no_return_url_specified(MockHttpContext.UserAuthState authState)
+    {
+        _mockHttpContext.SetUserTo(authState);
+
+        var result = _sut.OnGet(null);
+
+        result.Should().BeOfType<PageResult>();
+    }
+
+    [Theory]
+    [InlineData(MockHttpContext.UserAuthState.Authorised)]
+    [InlineData(MockHttpContext.UserAuthState.Unauthenticated)]
+    [InlineData(MockHttpContext.UserAuthState.Unauthorised)]
+    public void OnGet_should_never_redirect_to_external_return_url(MockHttpContext.UserAuthState authState)
+    {
+        _mockHttpContext.SetUserTo(authState);
+
+        var result = _sut.OnGet(ExternalUrl);
+
+        result.Should().BeOfType<PageResult>();
+        result.Should().NotBeOfType<LocalRedirectResult>();
+    }
+
+    [Fact]
+    public void OnGet_should_prompt_login_when_user_is_unauthenticated()
+    {
+        _mockHttpContext.SetUserTo(MockHttpContext.UserAuthState.Unauthenticated);
+
+        var result = _sut.OnGet(LocalUrl);
+
+        using var scope = new AssertionScope();
+
+        result.Should().BeOfType<LocalRedirectResult>();
+        result.As<LocalRedirectResult>().Url.Should().Be(LocalUrl);
+        _tempDataDictionary.Should().ContainKey("RetryingLogin").WhoseValue.Should().Be("true");
+        _mockHttpContext.MockResponseCookies.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void OnGet_should_retry_login_when_user_is_unauthorised_and_not_retried_login()
+    {
+        _mockHttpContext.SetUserTo(MockHttpContext.UserAuthState.Unauthorised);
+
+        var result = _sut.OnGet(LocalUrl);
+
+        using var scope = new AssertionScope();
+
+        result.Should().BeOfType<LocalRedirectResult>();
+        result.As<LocalRedirectResult>().Url.Should().Be(LocalUrl);
+        _tempDataDictionary.Should().ContainKey("RetryingLogin").WhoseValue.Should().Be("true");
+        _mockHttpContext.MockResponseCookies.VerifyCookieDeleted(FiatCookies.Login,
+            new CookieOptions { HttpOnly = true, IsEssential = true, SameSite = SameSiteMode.Strict, Secure = true });
+    }
+
+    [Fact]
+    public void OnGet_should_return_no_access_page_when_user_is_unauthorised_and_has_retried_login()
+    {
+        _mockHttpContext.SetUserTo(MockHttpContext.UserAuthState.Unauthorised);
+        _tempDataDictionary.Add("RetryingLogin", "true");
+
+        var result = _sut.OnGet(LocalUrl);
+
+        result.Should().BeOfType<PageResult>();
+        _tempDataDictionary.Should().NotContainKey("RetryingLogin");
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/NoAccessModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/NoAccessModelTests.cs
@@ -62,6 +62,19 @@ public class NoAccessModelTests
     [InlineData(MockHttpContext.UserAuthState.Authorised)]
     [InlineData(MockHttpContext.UserAuthState.Unauthenticated)]
     [InlineData(MockHttpContext.UserAuthState.Unauthorised)]
+    public void OnGet_should_render_page_when_return_url_is_empty(MockHttpContext.UserAuthState authState)
+    {
+        _mockHttpContext.SetUserTo(authState);
+
+        var result = _sut.OnGet(string.Empty);
+
+        result.Should().BeOfType<PageResult>();
+    }
+
+    [Theory]
+    [InlineData(MockHttpContext.UserAuthState.Authorised)]
+    [InlineData(MockHttpContext.UserAuthState.Unauthenticated)]
+    [InlineData(MockHttpContext.UserAuthState.Unauthorised)]
     public void OnGet_should_never_redirect_to_external_return_url(MockHttpContext.UserAuthState authState)
     {
         _mockHttpContext.SetUserTo(authState);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/BasePageModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/BasePageModelTests.cs
@@ -47,7 +47,7 @@ public class BasePageModelTests
     [Fact]
     public void ShowHeaderSearch_should_default_to_false_for_unauthorized_user()
     {
-        _mockHttpContext.SetupUnauthorizedUser();
+        _mockHttpContext.SetUserTo(MockHttpContext.UserAuthState.Unauthorised);
         var sut = new BasePageModelImplementation
         {
             PageContext = _pageContext,
@@ -62,7 +62,7 @@ public class BasePageModelTests
     [InlineData(false)]
     public void ShowHeaderSearch_should_be_always_be_false_for_unauthorized_user(bool value)
     {
-        _mockHttpContext.SetupUnauthorizedUser();
+        _mockHttpContext.SetUserTo(MockHttpContext.UserAuthState.Unauthorised);
         var sut = new BasePageModelImplementation
         {
             PageContext = _pageContext,

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/BasePageModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/BasePageModelTests.cs
@@ -1,0 +1,74 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Shared;
+
+public class BasePageModelTests
+{
+    private readonly MockHttpContext _mockHttpContext = new();
+    private readonly PageContext _pageContext;
+
+    private class BasePageModelImplementation : BasePageModel;
+
+    public BasePageModelTests()
+    {
+        _pageContext = new PageContext
+        {
+            HttpContext = _mockHttpContext.Object
+        };
+    }
+
+    [Fact]
+    public void ShowHeaderSearch_should_default_to_true_for_authorized_user()
+    {
+        var sut = new BasePageModelImplementation
+        {
+            PageContext = _pageContext
+        };
+
+        sut.ShowHeaderSearch.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ShowHeaderSearch_should_retain_setting_for_authorized_user(bool value)
+    {
+        var sut = new BasePageModelImplementation
+        {
+            PageContext = _pageContext,
+            ShowHeaderSearch = value
+        };
+
+        sut.ShowHeaderSearch.Should().Be(value);
+    }
+
+    [Fact]
+    public void ShowHeaderSearch_should_default_to_false_for_unauthorized_user()
+    {
+        _mockHttpContext.SetupUnauthorizedUser();
+        var sut = new BasePageModelImplementation
+        {
+            PageContext = _pageContext,
+            ShowHeaderSearch = true
+        };
+
+        sut.ShowHeaderSearch.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ShowHeaderSearch_should_be_always_be_false_for_unauthorized_user(bool value)
+    {
+        _mockHttpContext.SetupUnauthorizedUser();
+        var sut = new BasePageModelImplementation
+        {
+            PageContext = _pageContext,
+            ShowHeaderSearch = value
+        };
+
+        sut.ShowHeaderSearch.Should().BeFalse();
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/ContentPageModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/ContentPageModelTests.cs
@@ -40,7 +40,7 @@ public class ContentPageModelTests
     [Fact]
     public void ShowBreadcrumb_should_default_to_false_for_unauthorized_user()
     {
-        _mockHttpContext.SetupUnauthorizedUser();
+        _mockHttpContext.SetUserTo(MockHttpContext.UserAuthState.Unauthorised);
         _sut.ShowBreadcrumb.Should().BeFalse();
     }
 
@@ -49,7 +49,7 @@ public class ContentPageModelTests
     [InlineData(false)]
     public void ShowBreadcrumb_should_be_always_be_false_for_unauthorized_user(bool value)
     {
-        _mockHttpContext.SetupUnauthorizedUser();
+        _mockHttpContext.SetUserTo(MockHttpContext.UserAuthState.Unauthorised);
         _sut.ShowBreadcrumb = value;
         _sut.ShowBreadcrumb.Should().BeFalse();
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/ContentPageModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/ContentPageModelTests.cs
@@ -1,0 +1,56 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Shared;
+
+public class ContentPageModelTests
+{
+    private readonly ContentPageModel _sut;
+    private readonly MockHttpContext _mockHttpContext = new();
+
+    private class ContentPageModelImplementation : ContentPageModel;
+
+    public ContentPageModelTests()
+    {
+        _sut = new ContentPageModelImplementation
+        {
+            PageContext = new PageContext
+            {
+                HttpContext = _mockHttpContext.Object
+            }
+        };
+    }
+
+    [Fact]
+    public void ShowBreadcrumb_should_default_to_true_for_authorized_user()
+    {
+        _sut.ShowBreadcrumb.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ShowBreadcrumb_should_retain_setting_when_set_to_true_for_authorized_user(bool value)
+    {
+        _sut.ShowBreadcrumb = value;
+        _sut.ShowBreadcrumb.Should().Be(value);
+    }
+
+    [Fact]
+    public void ShowBreadcrumb_should_default_to_false_for_unauthorized_user()
+    {
+        _mockHttpContext.SetupUnauthorizedUser();
+        _sut.ShowBreadcrumb.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ShowBreadcrumb_should_be_always_be_false_for_unauthorized_user(bool value)
+    {
+        _mockHttpContext.SetupUnauthorizedUser();
+        _sut.ShowBreadcrumb = value;
+        _sut.ShowBreadcrumb.Should().BeFalse();
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
@@ -85,12 +85,6 @@ public class GovernanceModelTests
     }
 
     [Fact]
-    public void ShowHeaderSearch_should_be_true()
-    {
-        _sut.ShowHeaderSearch.Should().Be(true);
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_null()
     {
         _mockTrustRepository.Setup(t => t.GetTrustSummaryAsync(TestUid)).ReturnsAsync((TrustSummaryServiceModel?)null);


### PR DESCRIPTION
Changes the auth processes in FIAT to allow unauthorised users to be redirected to a "No Access" page.

[User Story 135671](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/135671): Build: Authentication - Add access-denied screen

## Changes

### No Access specific changes

- Add ADR about "No Access" page
- Create authorised FIAT user role and add role requirement to authorisation
- Add no access page and add redirect logic (described in ADR)
- Hide header and footer areas not accessible to users without FIAT access
- Make cookies, accessibility statement and privacy notice pages accessible to users without FIAT access
- Update MockHttpContext to have separate cookie mocks and to mock user authentication state

### Other changes:

- Fix Privacy page having incorrect width
- Move EnvironmentExtensions.cs into the Extensions folder
- Change `SameSite` setting for the login cookie to current Microsoft recommendation of `Lax`
- Move FIAT cookie names to static config class
- Update name of cookie consent cookie to be consistent with application name and what is displayed in the Cookie UI

(This was a long running piece of work with change of direction which originally touched these areas)

## Screenshots of UI changes

<details>
<summary>New "No Access" page</summary>

![image](https://github.com/user-attachments/assets/f02e72bf-1aa3-402f-9b4f-022a47d845fc)

</details>

<details>
<summary>Header changes</summary>

### Authorised user (No change)

![image](https://github.com/user-attachments/assets/62aa2e0c-8fac-4098-9d6d-caa3b5a8de76)

### Unauthorised user

![image](https://github.com/user-attachments/assets/b704f660-2f13-4bf4-9055-88b163659bb8)

</details>

<details>
<summary>Footer changes</summary>

### Authorised user (No change)

![image](https://github.com/user-attachments/assets/8cfdfb13-0e9c-4983-8177-8c59951e56bb)

### Unauthorised user

![image](https://github.com/user-attachments/assets/57560bf8-d2ee-4f45-9f4d-87a2ef35ecf3)

</details>

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
