### PR TITLE
Change the UpdatedFooterHelpLink Feature flag default to true

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/appsettings.json
+++ b/DfE.FindInformationAcademiesTrusts/appsettings.json
@@ -41,7 +41,7 @@
   "FeatureManagement": {
     "TestFlag": false,
     "EditContactsUI": false,
-    "UpdatedFooterHelpLink": false
+    "UpdatedFooterHelpLink": true
   },
   "DataProtection": {
     "KeyVaultKey": "",

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -6,7 +6,7 @@ Feature flags can be used to programatically turn features on and off. We can us
 
 - `TestFlag` (Default: false): Flag added to test the functionality of feature flags. Adds a line to the layout that shows flags are working when set to true.
 - `EditContactsUI` (Default: false): Flag added to control who can see the edit contacts UI on the Trust contacts page while that is still in development.
-- `UpdatedFooterHelpLink` (Default: false): Flag added to control when we release the updated help link in the footer.
+- `UpdatedFooterHelpLink` (Default: true): Flag added to control when we release the updated help link in the footer.
 
 ## Implementation
 


### PR DESCRIPTION
> # DO NOT RELEASE BEFORE OCTOBER 17TH!!!

[Task 184674](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/184674): Update the appsettings to make the feature live
Sets the feature flag default for UpdatedFooterHelpLink to true, meaning it can be released to production

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
