### PR TITLE
Update the links on the error page so the links open in a new tab

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml
@@ -19,8 +19,8 @@
         <feature name="@FeatureFlags.UpdatedFooterHelpLink" negate="true">
           <a class="govuk-link" href="@($"{ViewConstants.ReportNotFoundMailtoLink}&body=Url is {Model.OriginalPathAndQuery}")">email Service Support for help with using this system</a>.
         </feature>
-        <feature name="@FeatureFlags.UpdatedFooterHelpLink" >
-          <a class="govuk-link" href="@ViewConstants.GetHelpFormLink" rel="noopener" target="_blank">report this to Service Support for help with using this system</a>.
+        <feature name="@FeatureFlags.UpdatedFooterHelpLink">
+          <a class="govuk-link" href="@ViewConstants.GetHelpFormLink" rel="noopener" target="_blank">report this to Service Support for help with using this system (opens in new tab)</a>.
         </feature>
       </p>
     }
@@ -33,7 +33,7 @@
           <a class="govuk-link" href="@ViewConstants.ReportAProblemMailToLink">Report this problem</a>
         </feature>
         <feature name="@FeatureFlags.UpdatedFooterHelpLink">
-          <a class="govuk-link" href="@ViewConstants.GetHelpFormLink" rel="noopener" target="_blank">Report this problem</a>
+          <a class="govuk-link" href="@ViewConstants.GetHelpFormLink" rel="noopener" target="_blank">Report this problem (opens in new tab)</a>
         </feature> if it continues.
       </p>
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Error.cshtml
@@ -19,8 +19,8 @@
         <feature name="@FeatureFlags.UpdatedFooterHelpLink" negate="true">
           <a class="govuk-link" href="@($"{ViewConstants.ReportNotFoundMailtoLink}&body=Url is {Model.OriginalPathAndQuery}")">email Service Support for help with using this system</a>.
         </feature>
-        <feature name="@FeatureFlags.UpdatedFooterHelpLink">
-          <a class="govuk-link" href="@ViewConstants.GetHelpFormLink">report this to Service Support for help with using this system</a>.
+        <feature name="@FeatureFlags.UpdatedFooterHelpLink" >
+          <a class="govuk-link" href="@ViewConstants.GetHelpFormLink" rel="noopener" target="_blank">report this to Service Support for help with using this system</a>.
         </feature>
       </p>
     }
@@ -33,7 +33,7 @@
           <a class="govuk-link" href="@ViewConstants.ReportAProblemMailToLink">Report this problem</a>
         </feature>
         <feature name="@FeatureFlags.UpdatedFooterHelpLink">
-          <a class="govuk-link" href="@ViewConstants.GetHelpFormLink">Report this problem</a>
+          <a class="govuk-link" href="@ViewConstants.GetHelpFormLink" rel="noopener" target="_blank">Report this problem</a>
         </feature> if it continues.
       </p>
     }


### PR DESCRIPTION
[Task 184812](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/184812): Fix the links on the error page
Update the links that report issues to the PASS form on the error page so the links open in a new tab.

## Changes

Links on the error page now open in a new tab

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
