### PR TITLE
Add disclaimer text to the contacts page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Updated the contacts page to include disclaimer text for the trust contacts
+
 ## [Release-11][release-11] (production-2024-10-17.3654)
 
 ### Changed

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_SummaryCardDisclaimerText.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_SummaryCardDisclaimerText.cshtml
@@ -1,0 +1,7 @@
+﻿<div class="govuk-warning-text govuk-!-margin-bottom-0">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-visually-hidden">Warning</span>
+    Email address for internal use only
+  </strong>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
@@ -67,26 +67,35 @@
     Contacts at the trust
   </h2>
   <div class="govuk-summary-card" data-testid="accounting-officer">
-    <div class="govuk-summary-card__title-wrapper">
+    <div class="govuk-summary-card__title-wrapper contact-card-title-with-disclaimer">
       <h3 class="govuk-summary-card__title">
         Accounting officer
       </h3>
+      <div class="govuk-summary-card__actions govuk-!-margin-0">
+        @await Html.PartialAsync("Shared/_SummaryCardDisclaimerText")
+      </div>
     </div>
     @{ DisplayContact(Model.AccountingOfficer); }
   </div>
   <div class="govuk-summary-card" data-testid="chair-of-trustees">
-    <div class="govuk-summary-card__title-wrapper">
+    <div class="govuk-summary-card__title-wrapper contact-card-title-with-disclaimer">
       <h3 class="govuk-summary-card__title">
         Chair of trustees
       </h3>
+      <div class="govuk-summary-card__actions govuk-!-margin-0">
+        @await Html.PartialAsync("Shared/_SummaryCardDisclaimerText")
+      </div>
     </div>
     @{ DisplayContact(Model.ChairOfTrustees); }
   </div>
   <div class="govuk-summary-card" data-testid="chief-financial-officer">
-    <div class="govuk-summary-card__title-wrapper">
+    <div class="govuk-summary-card__title-wrapper contact-card-title-with-disclaimer">
       <h3 class="govuk-summary-card__title">
         Chief financial officer
       </h3>
+      <div class="govuk-summary-card__actions govuk-!-margin-0">
+        @await Html.PartialAsync("Shared/_SummaryCardDisclaimerText")
+      </div>
     </div>
     @{ DisplayContact(Model.ChiefFinancialOfficer); }
   </div>
@@ -129,5 +138,5 @@
       </dl>
     </div>
   }
-
+  
 }

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
@@ -5,6 +5,7 @@
 @import "components/header-search";
 @import "components/export-button";
 @import "components/sourceList";
+@import "components/contactsSummaryCard";
 
 .app-banner {
   @include govuk-responsive-padding(5, "top");

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_contactsSummaryCard.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_contactsSummaryCard.scss
@@ -1,0 +1,16 @@
+.contact-card-title-with-disclaimer {
+  align-items: center;
+  padding: 10px 20px;
+  background-color: #000000;
+
+  .govuk-summary-card__title,
+  .govuk-warning-text__text {
+    color: #ffffff;
+  }
+
+  .govuk-warning-text__icon {
+    background-color: #ffffff;
+    border-color: #ffffff;
+    color: #000000;
+  }
+}


### PR DESCRIPTION
[User Story 178354](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/178354): Build: iterate 'Trust contacts' disclaimer text
Add disclaimer text to the contacts page. These are added to the Trust contacts to inform users that the emails are for internal use only.

## Changes

- Created styling for the contacts summary page
- Update the contacts page to add the new disclaimer text

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/cb538d16-eba8-457c-a737-6ad32957b01a)

### After
![image](https://github.com/user-attachments/assets/ef99bba7-5f80-40bd-91a7-5ef57f4c15ae)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
