### PR TITLE
add cookie tests

### DIFF
--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/cookies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/cookies.cy.ts
@@ -33,7 +33,7 @@ describe('Cookie page and consent tests', () => {
 
     });
 
-    it('should check that mandatory cookies exist but otional cookies do not after rejecting optional cookies', () => {
+    it('should check that mandatory cookies exist but optional cookies do not after rejecting optional cookies', () => {
         cookiesPage
             .rejectCookies()
             .clickSaveChangesButton()
@@ -43,13 +43,13 @@ describe('Cookie page and consent tests', () => {
 
         cy.visit('/trusts/details?uid=5712')
 
-        //check optional cookies exist
+        //check optional cookies do not  exist
         cy.getCookie('ai_user').should('not.exist')
         cy.getCookie('ai_session').should('not.exist')
         cy.getCookie('ai_authUser').should('not.exist')
         cy.getCookie('_ga').should('not.exist')
 
-        //check mandatory cookies exist after saving
+        //check mandatory cookies do not exist after saving
         cy.getCookie('.FindInformationAcademiesTrust.CookieConsent').should('exist')
         cy.getCookie('ASLBSA').should('exist')
         cy.getCookie('ASLBSACORS').should('exist')
@@ -86,5 +86,47 @@ describe('Cookie page and consent tests', () => {
 
         navigation
             .checkCurrentURLIsCorrect('/trusts/contacts?uid=5712')
+    });
+
+    it('should check that both cookie accept and reject radio buttons are in their empty state when coming in from scratch', () => {
+        cookiesPage
+            .checkCookiesAcceptIsUninteracted()
+            .checkCookiesRejectIsUninteracted()
+    });
+
+    it('should check that the accept cookies button stays checked after enabling it', () => {
+        cookiesPage
+            .acceptCookies()
+            .clickSaveChangesButton()
+
+        commonPage
+            .checkSuccessPopup('You’ve set your cookie preferences')
+
+        cy.visit('/trusts/details?uid=5712')
+
+        navigation
+            .clickCookiesLink()
+            .checkCurrentURLIsCorrect('/cookies')
+
+        cookiesPage
+            .checkCookiesAcceptIsInteracted()
+    });
+
+    it('should check that the accept cookies button stays checked after enabling it', () => {
+        cookiesPage
+            .rejectCookies()
+            .clickSaveChangesButton()
+
+        commonPage
+            .checkSuccessPopup('You’ve set your cookie preferences')
+
+        cy.visit('/trusts/details?uid=5712')
+
+        navigation
+            .clickCookiesLink()
+            .checkCurrentURLIsCorrect('/cookies')
+
+        cookiesPage
+            .checkCookiesRejectIsInteracted()
     });
 });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/cookies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/cookies.cy.ts
@@ -1,14 +1,90 @@
+import commonPage from "../../pages/commonPage";
 import cookiesPage from "../../pages/cookiesPage";
-describe("Testing the Cookie page and its options", () => {
+import navigation from "../../pages/navigation";
+
+describe('Cookie page and consent tests', () => {
 
     beforeEach(() => {
-        cy.login();
+        cy.login()
+        cy.visit('/cookies')
     });
 
-    it("Should test that the user can accept cookies at the cookies page", () => {
+    it('should check that both mandatory and optional cookies both exist after accepting optional cookies', () => {
         cookiesPage
-            .navigateToCookiesPage()
-            .acceptCookies();
+            .acceptCookies()
+            .clickSaveChangesButton()
+
+        commonPage
+            .checkSuccessPopup('You’ve set your cookie preferences')
+
+        cy.visit('/trusts/details?uid=5712')
+
+        //check optional cookies exist
+        cy.getCookie('ai_user').should('exist')
+        cy.getCookie('ai_session').should('exist')
+        cy.getCookie('ai_authUser').should('exist')
+        cy.getCookie('_ga').should('exist')
+
+        //check mandatory cookies exist after saving
+        cy.getCookie('.FindInformationAcademiesTrust.CookieConsent').should('exist')
+        cy.getCookie('ASLBSA').should('exist')
+        cy.getCookie('ASLBSACORS').should('exist')
+        cy.getCookie('.AspNetCore.Antiforgery.VyLW6ORzMgk').should('exist')
+
     });
 
-})
+    it('should check that mandatory cookies exist but otional cookies do not after rejecting optional cookies', () => {
+        cookiesPage
+            .rejectCookies()
+            .clickSaveChangesButton()
+
+        commonPage
+            .checkSuccessPopup('You’ve set your cookie preferences')
+
+        cy.visit('/trusts/details?uid=5712')
+
+        //check optional cookies exist
+        cy.getCookie('ai_user').should('not.exist')
+        cy.getCookie('ai_session').should('not.exist')
+        cy.getCookie('ai_authUser').should('not.exist')
+        cy.getCookie('_ga').should('not.exist')
+
+        //check mandatory cookies exist after saving
+        cy.getCookie('.FindInformationAcademiesTrust.CookieConsent').should('exist')
+        cy.getCookie('ASLBSA').should('exist')
+        cy.getCookie('ASLBSACORS').should('exist')
+        cy.getCookie('.AspNetCore.Antiforgery.VyLW6ORzMgk').should('exist')
+    });
+
+    it('should check that the return to previous page button actually takes me to my previous page after accept cookies', () => {
+        cy.visit('/search')
+
+        navigation
+            .clickCookiesLink()
+            .checkCurrentURLIsCorrect('/cookies')
+
+        cookiesPage
+            .acceptCookies()
+            .clickSaveChangesButton()
+            .clickReturnToPreviousPageButton()
+
+        navigation
+            .checkCurrentURLIsCorrect('/search')
+    });
+
+    it('should check that the return to previous page button actually takes me to my previous page after reject cookies', () => {
+        cy.visit('/trusts/contacts?uid=5712')
+
+        navigation
+            .clickCookiesLink()
+            .checkCurrentURLIsCorrect('/cookies')
+
+        cookiesPage
+            .rejectCookies()
+            .clickSaveChangesButton()
+            .clickReturnToPreviousPageButton()
+
+        navigation
+            .checkCurrentURLIsCorrect('/trusts/contacts?uid=5712')
+    });
+});

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/cookiesPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/cookiesPage.ts
@@ -16,7 +16,6 @@ export class CookiesPage {
 
     public acceptCookies(): this {
         this.elements.buttons.accept().click();
-        this.elements.buttons.saveChangesButton().click();
         return this;
     }
 
@@ -27,6 +26,26 @@ export class CookiesPage {
 
     public clickReturnToPreviousPageButton(): this {
         this.elements.buttons.returnToPreviousPageButton().click();
+        return this;
+    }
+
+    public checkCookiesAcceptIsUninteracted(): this {
+        this.elements.buttons.accept().should('not.be.checked')
+        return this;
+    }
+
+    public checkCookiesAcceptIsInteracted(): this {
+        this.elements.buttons.accept().should('be.checked')
+        return this;
+    }
+
+    public checkCookiesRejectIsUninteracted(): this {
+        this.elements.buttons.reject().should('not.be.checked')
+        return this;
+    }
+
+    public checkCookiesRejectIsInteracted(): this {
+        this.elements.buttons.reject().should('be.checked')
         return this;
     }
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/cookiesPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/cookiesPage.ts
@@ -1,22 +1,36 @@
-class CookiesPage {
+export class CookiesPage {
 
+    elements = {
+        buttons: {
+            accept: () => cy.get('#cookies-accept'),
+            reject: () => cy.get('#cookies-reject'),
+            saveChangesButton: () => cy.get('[data-testid="save-cookie-preferences-button"]'),
+            returnToPreviousPageButton: () => cy.get('[data-testid="return-to-previous-page"]'),
+        },
+    };
 
-    public navigateToCookiesPage(): this {
-        cy.visit('/cookies')
-
+    public clickSaveChangesButton(): this {
+        this.elements.buttons.saveChangesButton().click();
         return this;
     }
 
     public acceptCookies(): this {
-        const acceptCookiesYesButton = () => cy.get('.govuk-radios').contains('Yes');
+        this.elements.buttons.accept().click();
+        this.elements.buttons.saveChangesButton().click();
+        return this;
+    }
 
-        acceptCookiesYesButton().click();
+    public rejectCookies(): this {
+        this.elements.buttons.reject().click();
+        return this;
+    }
 
+    public clickReturnToPreviousPageButton(): this {
+        this.elements.buttons.returnToPreviousPageButton().click();
         return this;
     }
 
 }
 
 const cookiesPage = new CookiesPage();
-
 export default cookiesPage;


### PR DESCRIPTION
_Adding Cookies cypress automation tests to cover both the cookies page itself and the actually acceptance/rejection of cookies_

<!--(https://dev.azure.com/dfe-gov-uk/Academies-and-Free-Schools-SIP/_workitems/edit/185336) -->

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] Testing complete - all manual and automated tests pass
