### PR TITLE
Update landing page to add more detail and links to other services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated the contacts page to include disclaimer text for the trust contacts
 - Removed legacy trust provider and associated code
 - Improved performance of academies data export
+- Updated the landing page to add more information and links to other services
 
 ## [Release-11][release-11] (production-2024-10-17.3654)
 

--- a/DfE.FindInformationAcademiesTrusts.Data/ExternalServiceLink.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/ExternalServiceLink.cs
@@ -1,0 +1,3 @@
+﻿namespace DfE.FindInformationAcademiesTrusts.Data;
+
+public record ExternalServiceLink(string ServiceName, string ServiceDescription, string Url);

--- a/DfE.FindInformationAcademiesTrusts.Data/ExternalServiceLink.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/ExternalServiceLink.cs
@@ -1,3 +1,6 @@
-﻿namespace DfE.FindInformationAcademiesTrusts.Data;
+﻿using System.Diagnostics.CodeAnalysis;
 
+namespace DfE.FindInformationAcademiesTrusts.Data;
+
+[ExcludeFromCodeCoverage]
 public record ExternalServiceLink(string ServiceName, string ServiceDescription, string Url);

--- a/DfE.FindInformationAcademiesTrusts/Pages/Index.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Index.cshtml
@@ -1,4 +1,6 @@
 ﻿@page
+@using DfE.FindInformationAcademiesTrusts.Data
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model IndexModel
 @{
   ViewData["Title"] = "Home page";
@@ -15,10 +17,52 @@
                 Find information about academies and trusts
               </label>
             </h1>
+            <p class="govuk-body">Use this tool to learn about a trust and the academies it is responsible for.</p>
+            <details class="govuk-details" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  <span>What you can find</span>
+                </span>
+              </summary>
+              <ul class="govuk-list govuk-details__text govuk-list--bullet">
+                <li class="govuk-!-margin-left-5">address and contact details</li>
+                <li class="govuk-!-margin-left-5">pupil numbers and capacities</li>
+                <li class="govuk-!-margin-left-5">Ofsted ratings</li>
+                <li class="govuk-!-margin-left-5">free school meal percentages</li>
+                <li class="govuk-!-margin-left-5">trust governance details</li>
+              </ul>
+            </details>
             <partial name="_PageSearchForm" model="Model"/>
           </form>
         </div>
       </div>
     </div>
   </div>
+  <div class="dfe-width-container govuk-!-padding-top-6">
+    <h2 class="govuk-heading-l">
+      Other tools and products
+    </h2>
+    <div class="dfe-grid-container">
+      @foreach (var serviceLink in ViewConstants.ExternalServiceLinks)
+      {
+        DisplayLinkInCard(serviceLink);
+      }
+    </div>
+  </div>
 </main>
+
+
+@functions
+{
+  private void DisplayLinkInCard(ExternalServiceLink serviceLink)
+  {
+    <div class="dfe-card">
+      <div class="dfe-card-container">
+        <h3 class="govuk-heading-m">
+          <a href="@serviceLink.Url" class="govuk-link govuk-link--no-visited-state dfe-card-link--header" rel="noopener" target="_blank" aria-label="@serviceLink.ServiceName (opens in a new tab)">@serviceLink.ServiceName</a>
+        </h3>
+        <p>@serviceLink.ServiceDescription</p>
+      </div>
+    </div>
+  }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
@@ -1,3 +1,5 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+
 namespace DfE.FindInformationAcademiesTrusts.Pages;
 
 public static class ViewConstants
@@ -21,4 +23,33 @@ public static class ViewConstants
         "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-fkHK2JGo_BIpVChpLMaBFpUNUFDSzhQN0FHVklTV0JWTzFZTjNKWTNJUi4u";
 
     public const string NoDataText = "No Data";
+
+    public static readonly List<ExternalServiceLink> ExternalServiceLinks =
+    [
+        new ExternalServiceLink("Prepare conversions and transfers",
+            "Create a transfer or conversion project document for an advisory board.",
+            "https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/Prepare-Conversions-and-Transfers.aspx"),
+
+        new ExternalServiceLink("Complete conversions, transfers and changes",
+            "Manage a conversion or transfer project after it has been to an advisory board.",
+            "https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/complete-conversions-transfers-and-changes.aspx"),
+
+        new ExternalServiceLink("Record concerns or support for trusts",
+            "Add cases or interactions, record risks and log support and concerns for trusts.",
+            "https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/Record-concerns-and-support-for-trusts.aspx"),
+
+        new ExternalServiceLink("Manage free school projects",
+            "Manage presumption projects in the pre-opening phase.",
+            "https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/Manage-free-school-projects.aspx?web=1"),
+
+        new ExternalServiceLink("Reporting and data tools",
+            "Tools to help you gather educational data and create reports.",
+            "https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/reportinganddata.aspx"),
+
+        new ExternalServiceLink("High quality trust framework",
+            "Process guidance and tools for making trust-related project decisions.",
+            "https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/RG%20high%20quality%20trust%20framework.aspx")
+    ];
 }
+
+

--- a/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
 using DfE.FindInformationAcademiesTrusts.Data;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages;
 
+[ExcludeFromCodeCoverage]
 public static class ViewConstants
 {
     public const string ServiceName = "Find information about academies and trusts";
@@ -51,5 +53,3 @@ public static class ViewConstants
             "https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/RG%20high%20quality%20trust%20framework.aspx")
     ];
 }
-
-


### PR DESCRIPTION
[User Story 184174](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/184174): Build: Search page iteration

Update the landing page to add more information about what users can find in FIAT and links to other services to get more related information.


## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/0e7ce6ed-350d-4770-ade0-7f63aec034e9)

### After
![image](https://github.com/user-attachments/assets/eb177b1c-9ddf-4cbc-97a9-354eb6344667)
![image](https://github.com/user-attachments/assets/7a457370-fa4b-446d-a77f-8bff90ef061e)
![image](https://github.com/user-attachments/assets/8974e37f-3c3c-4f8b-9b2e-3d2fb0a39c4c)


## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
