### PR TITLE
Rename anti forgery cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed legacy trust provider and associated code
 - Improved performance of academies data export
 - Updated the landing page to add more information and links to other services
+- Renamed the anti forgery cookie to a static name
 
 ## [Release-11][release-11] (production-2024-10-17.3654)
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Cookies.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Cookies.cshtml
@@ -65,7 +65,7 @@
                     <td class="govuk-table__cell">With browser settings (Session)</td>
                 </tr>
                 <tr>
-                    <td class="govuk-table__cell">.AspNetCore.Antiforgery </td>
+                    <td class="govuk-table__cell">.FindInformationAcademiesTrusts.Antiforgery </td>
                     <td class="govuk-table__cell">Secures you and our service against Cross Site Scripting Attacks (CSRF) </td>
                     <td class="govuk-table__cell">With browser settings (Session)</td>
                 </tr>
@@ -108,7 +108,7 @@
                     <td class="govuk-table__cell">30 minutes</td>
                 </tr>
                 <tr class="govuk-table__row">
-                    <td class="govuk-table__cell">ai_authuser</td>
+                    <td class="govuk-table__cell">ai_authUser</td>
                     <td class="govuk-table__cell">This helps us to identify authenticated users and how they interact with the site</td>
                     <td class="govuk-table__cell">When you close your browser</td>
                 </tr>
@@ -130,7 +130,7 @@
     <div class="govuk-grid-column-two-thirds">
         <form method="post" name="frmCookies">
             <div class="govuk-form-group">
-                <input type="hidden" name="redirectPath" value="@(HttpContext.Request.Path + HttpContext.Request.QueryString)" />
+                <input type="hidden" name="redirectPath" value="@(HttpContext.Request.Path + HttpContext.Request.QueryString)"/>
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                         <h3 class="govuk-fieldset__heading">Do you want to accept cookies that measure your website use?</h3>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Cookies.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Cookies.cshtml.cs
@@ -72,7 +72,7 @@ public class CookiesModel : ContentPageModel
 
     private void DeleteAppInsightsCookies()
     {
-        var optionalCookiePrefixes = new[] { "ai_session", "ai_user", "ai_authuser" };
+        var optionalCookiePrefixes = new[] { "ai_session", "ai_user", "ai_authUser" };
         var cookiesToDelete = GetMatchingCookies(optionalCookiePrefixes);
 
         cookiesToDelete.ForEach(cookie => _httpContextAccessor.HttpContext!.Response.Cookies.Delete(cookie));

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -269,6 +269,8 @@ internal static class Program
                 options.Cookie.SameSite = SameSiteMode.None;
                 options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
             });
+
+        builder.Services.AddAntiforgery(opts => { opts.Cookie.Name = ".FindInformationAcademiesTrusts.Antiforgery"; });
     }
 
     private static void AddDataProtectionServices(WebApplicationBuilder builder)

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/cookies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/cookies.cy.ts
@@ -29,7 +29,7 @@ describe('Cookie page and consent tests', () => {
         cy.getCookie('.FindInformationAcademiesTrust.CookieConsent').should('exist')
         cy.getCookie('ASLBSA').should('exist')
         cy.getCookie('ASLBSACORS').should('exist')
-        cy.getCookie('.AspNetCore.Antiforgery.VyLW6ORzMgk').should('exist')
+        cy.getCookie('.FindInformationAcademiesTrusts.Antiforgery').should('exist')
 
     });
 
@@ -53,7 +53,7 @@ describe('Cookie page and consent tests', () => {
         cy.getCookie('.FindInformationAcademiesTrust.CookieConsent').should('exist')
         cy.getCookie('ASLBSA').should('exist')
         cy.getCookie('ASLBSACORS').should('exist')
-        cy.getCookie('.AspNetCore.Antiforgery.VyLW6ORzMgk').should('exist')
+        cy.getCookie('.FindInformationAcademiesTrusts.Antiforgery').should('exist')
     });
 
     it('should check that the return to previous page button actually takes me to my previous page after accept cookies', () => {


### PR DESCRIPTION
[User Story 185649](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/185649): Tech debt: make the anti forgery cookie name static

Rename the anti forgery cookie so it has a static name.

## Changes

- change the name of the anti forgery cookie on startup
- Update the automation tests to detect the correct cookie
- Update the cookie page so the correct cookie name is listed
- Update the delete method as the user auth app insights cookie name was incorrect and being persisted after declining cookies.

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/7cba3f01-db4d-4c7e-8f40-91a7712a0cee)

### After
![image](https://github.com/user-attachments/assets/d08d9ae5-0760-4bf1-ac7b-0a78f25c1d24)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
