### PR TITLE
Update index page to add wording that links open in new tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improved performance of academies data export
 - Updated the landing page to add more information and links to other services
 - Renamed the anti forgery cookie to a static name
+- Updated wording for links on the landing page to tell users they open in new tabs
 
 ## [Release-11][release-11] (production-2024-10-17.3654)
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Index.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Index.cshtml
@@ -40,7 +40,7 @@
   </div>
   <div class="dfe-width-container govuk-!-padding-top-6">
     <h2 class="govuk-heading-l">
-      Other tools and products
+      Other tools and products (links open in a new tab)
     </h2>
     <div class="dfe-grid-container">
       @foreach (var serviceLink in ViewConstants.ExternalServiceLinks)


### PR DESCRIPTION
[Task 186303](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/186303): Update wording for service links to add "(links open in new tab)"

Small change that updates the wording in the heading of the links section on the index page to tell users the links will open in new tabs.

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/d1a228d5-739d-47fc-a062-47c588e387f4)

### After
![image](https://github.com/user-attachments/assets/31af4b5f-6767-49a1-9e96-c3a1491e2b82)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
