### PR TITLE
Ofsted data from other subgrades is now part of the Ofsted Rating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated the landing page to add more information and links to other services
 - Renamed the anti forgery cookie to a static name
 - Updated wording for links on the landing page to tell users they open in new tabs
+- Updated the ofsted ratings to collect information about the ofsted subgrades
 
 ## [Release-11][release-11] (production-2024-10-17.3654)
 

--- a/DfE.FindInformationAcademiesTrusts.Data/OfstedRating.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/OfstedRating.cs
@@ -1,15 +1,107 @@
 namespace DfE.FindInformationAcademiesTrusts.Data;
 
-public record OfstedRating(OfstedRatingScore OfstedRatingScore, DateTime? InspectionDate)
+public record OfstedRating(
+    OfstedRatingScore OverallEffectiveness,
+    OfstedRatingScore QualityOfEducation,
+    OfstedRatingScore BehaviourAndAttitudues,
+    OfstedRatingScore PersonalDevelopment,
+    OfstedRatingScore EffectivenessOfLeadershipAndManagement,
+    OfstedRatingScore EarlyYearsProvision,
+    OfstedRatingScore SixthFormProvision,
+    CategoriesOfConcern CategoryOfConcern,
+    SafeguardingScore SafeguradingIsEffective,
+    DateTime? InspectionDate)
 {
-    public static readonly OfstedRating None = new(OfstedRatingScore.None, null);
+    public static readonly OfstedRating None = new(OfstedRatingScore.None, OfstedRatingScore.None,
+        OfstedRatingScore.None, OfstedRatingScore.None,
+        OfstedRatingScore.None, OfstedRatingScore.None, OfstedRatingScore.None, CategoriesOfConcern.None,
+        SafeguardingScore.None, null);
+
+    public OfstedRating(int? overallEffectiveness, DateTime? inspectionDate)
+        : this(
+            (OfstedRatingScore?)overallEffectiveness ?? OfstedRatingScore.None,
+            OfstedRatingScore.None,
+            OfstedRatingScore.None,
+            OfstedRatingScore.None,
+            OfstedRatingScore.None,
+            OfstedRatingScore.None,
+            OfstedRatingScore.None,
+            CategoriesOfConcern.None,
+            SafeguardingScore.None,
+            inspectionDate
+        )
+    {
+    }
+
+    public static SafeguardingScore ConvertStringToSafeguardingScore(string? input)
+    {
+        switch (input)
+        {
+            case SafeguardingScoreString.Yes:
+                return SafeguardingScore.Yes;
+            case SafeguardingScoreString.No:
+                return SafeguardingScore.No;
+            case SafeguardingScoreString.Nine:
+                return SafeguardingScore.NotRecorded;
+            default:
+                return SafeguardingScore.None;
+        }
+    }
+
+    public static CategoriesOfConcern ConvertStringToCategoriesOfConcern(string? input)
+    {
+        switch (input)
+        {
+            case CategoriesOfConcernString.SpecialMeasures:
+                return CategoriesOfConcern.SpecialMeasures;
+            case CategoriesOfConcernString.SeriousWeakness:
+                return CategoriesOfConcern.SeriousWeakness;
+            case CategoriesOfConcernString.NoticeToImprove:
+                return CategoriesOfConcern.NoticeToImprove;
+            default:
+                return CategoriesOfConcern.None;
+        }
+    }
+}
+
+public static class SafeguardingScoreString
+{
+    public const string Yes = "Yes";
+    public const string No = "No";
+    public const string Nine = "9";
+}
+
+public static class CategoriesOfConcernString
+{
+    public const string SpecialMeasures = "SM";
+    public const string SeriousWeakness = "SWK";
+    public const string NoticeToImprove = "NTI";
 }
 
 public enum OfstedRatingScore
 {
     None = -1,
+    InsufficientEvidence = 0,
     Outstanding = 1,
     Good = 2,
     RequiresImprovement = 3,
-    Inadequate = 4
+    Inadequate = 4,
+    DoesNotApply = 8,
+    NoJudgement = 9
+}
+
+public enum SafeguardingScore
+{
+    None = -1,
+    Yes,
+    No,
+    NotRecorded = 9
+}
+
+public enum CategoriesOfConcern
+{
+    None = -1,
+    SpecialMeasures,
+    SeriousWeakness,
+    NoticeToImprove
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_OfstedRatingCell.cshtml.cs
@@ -12,7 +12,7 @@ public class OfstedRatingCellModel
 
     public bool IsAfterJoining => OfstedRating.InspectionDate >= AcademyJoinedDate;
 
-    public string? OfstedRatingDescription => OfstedRating.OfstedRatingScore switch
+    public string? OfstedRatingDescription => OfstedRating.OverallEffectiveness switch
     {
         OfstedRatingScore.None => "Not yet inspected",
         OfstedRatingScore.Outstanding => "Outstanding",
@@ -21,12 +21,13 @@ public class OfstedRatingCellModel
         OfstedRatingScore.Inadequate => "Inadequate",
         _ => string.Empty
     };
+
     public int OfstedRatingSortValue
     {
         get
         {
-            if (OfstedRating.OfstedRatingScore == OfstedRatingScore.None) return 5;
-            return (int)OfstedRating.OfstedRatingScore;
+            if (OfstedRating.OverallEffectiveness == OfstedRatingScore.None) return 5;
+            return (int)OfstedRating.OverallEffectiveness;
         }
     }
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview.cshtml
@@ -83,12 +83,15 @@
               <tbody class="govuk-table__body">
                 @foreach (var rating in Enum.GetValues(typeof(OfstedRatingScore)).Cast<OfstedRatingScore>())
                 {
-                  <tr class="govuk-table__row">
-                    <td class="govuk-body govuk-table__cell" data-sort-value="@rating.ToDataSortValue()">@rating.ToDisplayString()</td>
-                    <td class="govuk-body govuk-table__cell govuk-table__cell--numeric" data-test-id="ofsted-rating-@rating.ToString()">
-                      @Model.GetNumberOfAcademiesWithOfstedRating(rating)
-                    </td>
-                  </tr>
+                  if (rating is not OfstedRatingScore.InsufficientEvidence && rating is not OfstedRatingScore.NoJudgement && rating is not OfstedRatingScore.DoesNotApply)
+                  {
+                    <tr class="govuk-table__row">
+                      <td class="govuk-body govuk-table__cell" data-sort-value="@rating.ToDataSortValue()">@rating.ToDisplayString()</td>
+                      <td class="govuk-body govuk-table__cell govuk-table__cell--numeric" data-test-id="ofsted-rating-@rating.ToString()">
+                        @Model.GetNumberOfAcademiesWithOfstedRating(rating)
+                      </td>
+                    </tr>
+                  }
                 }
               </tbody>
             </table>

--- a/DfE.FindInformationAcademiesTrusts/Services/Export/ExportService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Export/ExportService.cs
@@ -5,126 +5,137 @@ using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 using DfE.FindInformationAcademiesTrusts.Extensions;
 using DfE.FindInformationAcademiesTrusts.Pages;
 
-namespace DfE.FindInformationAcademiesTrusts.Services.Export
+namespace DfE.FindInformationAcademiesTrusts.Services.Export;
+
+public interface IExportService
 {
-    public interface IExportService
+    Task<byte[]> ExportAcademiesToSpreadsheetAsync(string uid);
+}
+
+public class ExportService(IAcademyRepository academyRepository, ITrustRepository trustRepository) : IExportService
+{
+    public async Task<byte[]> ExportAcademiesToSpreadsheetAsync(string uid)
     {
-        Task<byte[]> ExportAcademiesToSpreadsheetAsync(string uid);
+        var headers = new List<string>
+        {
+            "School Name", "URN", "Local Authority", "Type", "Rural or Urban", "Date joined",
+            "Previous Ofsted Rating", "Before/After Joining", "Date of Previous Ofsted",
+            "Current Ofsted Rating", "Before/After Joining", "Date of Current Ofsted",
+            "Phase of Education", "Age Range", "Pupil Numbers", "Capacity", "% Full",
+            "Pupils eligible for Free School Meals"
+        };
+
+        var trustSummary = await trustRepository.GetTrustSummaryAsync(uid);
+        var academiesDetails = await academyRepository.GetAcademiesInTrustDetailsAsync(uid);
+        var academiesOfstedRatings = await academyRepository.GetAcademiesInTrustOfstedAsync(uid);
+        var academiesPupilNumbers = await academyRepository.GetAcademiesInTrustPupilNumbersAsync(uid);
+        var academiesFreeSchoolMeals = await academyRepository.GetAcademiesInTrustFreeSchoolMealsAsync(uid);
+
+        return GenerateSpreadsheet(trustSummary, academiesDetails, headers, academiesOfstedRatings,
+            academiesPupilNumbers, academiesFreeSchoolMeals);
     }
 
-    public class ExportService(IAcademyRepository academyRepository, ITrustRepository trustRepository) : IExportService
+    public static float CalculatePercentageFull(int? numberOfPupils, int? schoolCapacity)
     {
-        public async Task<byte[]> ExportAcademiesToSpreadsheetAsync(string uid)
+        if (numberOfPupils.HasValue && schoolCapacity.HasValue && schoolCapacity != 0)
         {
-            var headers = new List<string>
+            return (float)Math.Round((double)numberOfPupils.Value / schoolCapacity.Value * 100);
+        }
+
+        return 0;
+    }
+
+    public static string IsOfstedRatingBeforeOrAfterJoining(OfstedRatingScore ofstedRatingScore,
+        DateTime dateAcademyJoinedTrust, DateTime? inspectionEndDate)
+    {
+        if (ofstedRatingScore == OfstedRatingScore.None || !inspectionEndDate.HasValue)
+        {
+            return string.Empty;
+        }
+
+        return inspectionEndDate < dateAcademyJoinedTrust ? "Before Joining" : "After Joining";
+    }
+
+    private static byte[] GenerateSpreadsheet(
+        TrustSummary? trustSummary,
+        AcademyDetails[] academies,
+        List<string> headers,
+        AcademyOfsted[] academiesOfstedRatings,
+        AcademyPupilNumbers[] academiesPupilNumbers,
+        AcademyFreeSchoolMeals[] academiesFreeSchoolMeals)
+    {
+        using var workbook = new XLWorkbook();
+        var worksheet = workbook.Worksheets.Add("Academies");
+
+        // Adding Trust name and type 
+        worksheet.Cell(1, 1).Value = trustSummary?.Name ?? string.Empty;
+        worksheet.Row(1).Style.Font.Bold = true;
+        worksheet.Cell(2, 1).Value = trustSummary?.Type ?? string.Empty;
+
+        // Adding Excel headers for the data points for academies
+        for (var i = 0; i < headers.Count; i++)
+        {
+            worksheet.Cell(3, i + 1).Value = headers[i];
+        }
+
+        worksheet.Row(3).Style.Font.Bold = true;
+
+        // Adding Excel data beneath relevant headers
+        for (var i = 0; i < academies.Length; i++)
+        {
+            var academyDetails = academies[i];
+            var urn = academyDetails.Urn;
+
+            var ofstedData = academiesOfstedRatings.SingleOrDefault(x => x.Urn == urn);
+            var previousRating = ofstedData?.PreviousOfstedRating ?? OfstedRating.None;
+            var currentRating = ofstedData?.CurrentOfstedRating ?? OfstedRating.None;
+
+            var pupilNumbersData = academiesPupilNumbers.SingleOrDefault(x => x.Urn == urn);
+            var freeSchoolMealsData = academiesFreeSchoolMeals.SingleOrDefault(x => x.Urn == urn);
+
+            var percentageFull =
+                CalculatePercentageFull(pupilNumbersData?.NumberOfPupils, pupilNumbersData?.SchoolCapacity);
+
+            var rowData = new[]
             {
-                "School Name", "URN", "Local Authority", "Type", "Rural or Urban", "Date joined",
-                "Previous Ofsted Rating", "Before/After Joining","Date of Previous Ofsted",
-                "Current Ofsted Rating", "Before/After Joining", "Date of Current Ofsted",
-                "Phase of Education", "Age Range", "Pupil Numbers", "Capacity", "% Full", "Pupils eligible for Free School Meals"
+                academyDetails.EstablishmentName ?? string.Empty,
+                urn,
+                academyDetails.LocalAuthority ?? string.Empty,
+                academyDetails.TypeOfEstablishment ?? string.Empty,
+                academyDetails.UrbanRural ?? string.Empty,
+                ofstedData?.DateAcademyJoinedTrust.ToString(StringFormatConstants.ViewDate) ?? string.Empty,
+                previousRating.OverallEffectiveness.ToDisplayString() ?? string.Empty,
+                IsOfstedRatingBeforeOrAfterJoining(previousRating.OverallEffectiveness,
+                    ofstedData?.DateAcademyJoinedTrust ?? DateTime.MinValue, previousRating.InspectionDate),
+                previousRating.InspectionDate?.ToString(StringFormatConstants.ViewDate) ?? string.Empty,
+                currentRating.OverallEffectiveness.ToDisplayString() ?? string.Empty,
+                IsOfstedRatingBeforeOrAfterJoining(currentRating.OverallEffectiveness,
+                    ofstedData?.DateAcademyJoinedTrust ?? DateTime.MinValue, currentRating.InspectionDate),
+                currentRating.InspectionDate?.ToString(StringFormatConstants.ViewDate) ?? string.Empty,
+                pupilNumbersData?.PhaseOfEducation ?? string.Empty,
+                pupilNumbersData != null
+                    ? $"{pupilNumbersData.AgeRange.Minimum} - {pupilNumbersData.AgeRange.Maximum}"
+                    : string.Empty,
+                pupilNumbersData?.NumberOfPupils?.ToString() ?? string.Empty,
+                pupilNumbersData?.SchoolCapacity?.ToString() ?? string.Empty,
+                percentageFull > 0 ? $"{percentageFull}%" : string.Empty,
+                freeSchoolMealsData?.PercentageFreeSchoolMeals.HasValue == true
+                    ? $"{freeSchoolMealsData.PercentageFreeSchoolMeals}%"
+                    : string.Empty
             };
 
-            TrustSummary? trustSummary = await trustRepository.GetTrustSummaryAsync(uid);
-            AcademyDetails[] academiesDetails = await academyRepository.GetAcademiesInTrustDetailsAsync(uid);
-            AcademyOfsted[] academiesOfstedRatings = await academyRepository.GetAcademiesInTrustOfstedAsync(uid);
-            AcademyPupilNumbers[] academiesPupilNumbers = await academyRepository.GetAcademiesInTrustPupilNumbersAsync(uid);
-            AcademyFreeSchoolMeals[] academiesFreeSchoolMeals = await academyRepository.GetAcademiesInTrustFreeSchoolMealsAsync(uid);
-
-            return GenerateSpreadsheet(trustSummary, academiesDetails, headers, academiesOfstedRatings, academiesPupilNumbers, academiesFreeSchoolMeals);
+            for (var j = 0; j < rowData.Length; j++)
+            {
+                worksheet.Cell(i + 4, j + 1).SetValue(rowData[j]);
+            }
         }
 
-        public static float CalculatePercentageFull(int? numberOfPupils, int? schoolCapacity)
-        {
-            if (numberOfPupils.HasValue && schoolCapacity.HasValue && schoolCapacity != 0)
-            {
-                return (float)Math.Round((double)numberOfPupils.Value / schoolCapacity.Value * 100);
-            }
-            return 0;
-        }
+        // Auto-size columns based on content
+        worksheet.Columns().AdjustToContents();
 
-        public static string IsOfstedRatingBeforeOrAfterJoining(OfstedRatingScore ofstedRatingScore, DateTime dateAcademyJoinedTrust, DateTime? inspectionEndDate)
-        {
-            if (ofstedRatingScore == OfstedRatingScore.None || !inspectionEndDate.HasValue)
-            {
-                return string.Empty;
-            }
-
-            return inspectionEndDate < dateAcademyJoinedTrust ? "Before Joining" : "After Joining";
-        }
-
-        private static byte[] GenerateSpreadsheet(
-            TrustSummary? trustSummary,
-            AcademyDetails[] academies,
-            List<string> headers,
-            AcademyOfsted[] academiesOfstedRatings,
-            AcademyPupilNumbers[] academiesPupilNumbers,
-            AcademyFreeSchoolMeals[] academiesFreeSchoolMeals)
-        {
-            using var workbook = new XLWorkbook();
-            var worksheet = workbook.Worksheets.Add("Academies");
-
-            // Adding Trust name and type 
-            worksheet.Cell(1, 1).Value = trustSummary?.Name ?? string.Empty;
-            worksheet.Row(1).Style.Font.Bold = true;
-            worksheet.Cell(2, 1).Value = trustSummary?.Type ?? string.Empty;
-
-            // Adding Excel headers for the data points for academies
-            for (int i = 0; i < headers.Count; i++)
-            {
-                worksheet.Cell(3, i + 1).Value = headers[i];
-            }
-            worksheet.Row(3).Style.Font.Bold = true;
-
-            // Adding Excel data beneath relevant headers
-            for (int i = 0; i < academies.Length; i++)
-            {
-                var academyDetails = academies[i];
-                var urn = academyDetails.Urn.ToString();
-
-                var ofstedData = academiesOfstedRatings.SingleOrDefault(x => x.Urn == urn);
-                var previousRating = ofstedData?.PreviousOfstedRating ?? OfstedRating.None;
-                var currentRating = ofstedData?.CurrentOfstedRating ?? OfstedRating.None;
-
-                var pupilNumbersData = academiesPupilNumbers.SingleOrDefault(x => x.Urn == urn);
-                var freeSchoolMealsData = academiesFreeSchoolMeals.SingleOrDefault(x => x.Urn == urn);
-
-                var percentageFull = CalculatePercentageFull(pupilNumbersData?.NumberOfPupils, pupilNumbersData?.SchoolCapacity);
-
-                var rowData = new[]
-                {
-                    academyDetails.EstablishmentName ?? string.Empty,
-                    urn,
-                    academyDetails.LocalAuthority ?? string.Empty,
-                    academyDetails.TypeOfEstablishment ?? string.Empty,
-                    academyDetails.UrbanRural ?? string.Empty,
-                    ofstedData?.DateAcademyJoinedTrust.ToString(StringFormatConstants.ViewDate) ?? string.Empty,
-                    previousRating.OfstedRatingScore.ToDisplayString() ?? string.Empty,
-                    IsOfstedRatingBeforeOrAfterJoining(previousRating.OfstedRatingScore, ofstedData?.DateAcademyJoinedTrust ?? DateTime.MinValue, previousRating.InspectionDate),
-                    previousRating.InspectionDate?.ToString(StringFormatConstants.ViewDate) ?? string.Empty,
-                    currentRating.OfstedRatingScore.ToDisplayString() ?? string.Empty,
-                    IsOfstedRatingBeforeOrAfterJoining(currentRating.OfstedRatingScore, ofstedData?.DateAcademyJoinedTrust ?? DateTime.MinValue, currentRating.InspectionDate),
-                    currentRating.InspectionDate?.ToString(StringFormatConstants.ViewDate) ?? string.Empty,
-                    pupilNumbersData?.PhaseOfEducation ?? string.Empty,
-                    pupilNumbersData != null ? $"{pupilNumbersData.AgeRange.Minimum} - {pupilNumbersData.AgeRange.Maximum}" : string.Empty,
-                    pupilNumbersData?.NumberOfPupils?.ToString() ?? string.Empty,
-                    pupilNumbersData?.SchoolCapacity?.ToString() ?? string.Empty,
-                    percentageFull > 0 ? $"{percentageFull}%" : string.Empty,
-                    freeSchoolMealsData?.PercentageFreeSchoolMeals.HasValue == true ? $"{freeSchoolMealsData.PercentageFreeSchoolMeals}%" : string.Empty,
-                };
-
-                for (int j = 0; j < rowData.Length; j++)
-                {
-                    worksheet.Cell(i + 4, j + 1).SetValue(rowData[j]);
-                }
-            }
-
-            // Auto-size columns based on content
-            worksheet.Columns().AdjustToContents();
-
-            // Save to a memory stream and return as byte array
-            using var stream = new MemoryStream();
-            workbook.SaveAs(stream);
-            return stream.ToArray();
-        }
+        // Save to a memory stream and return as byte array
+        using var stream = new MemoryStream();
+        workbook.SaveAs(stream);
+        return stream.ToArray();
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factory/MisEstablishmentFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factory/MisEstablishmentFactory.cs
@@ -1,0 +1,34 @@
+﻿using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Factory;
+
+public static class MisEstablishmentFactory
+{
+    public static MisEstablishment CreateMisEstablishment(int urn, int? grade, string? categoriesOfConcern,
+        string? safeguarding, string? dateString, bool usePreviousScores = false)
+
+    {
+        if (usePreviousScores)
+        {
+            return new MisEstablishment
+            {
+                Urn = urn, PreviousFullInspectionOverallEffectiveness = grade.ToString(),
+                PreviousQualityOfEducation = grade, PreviousBehaviourAndAttitudes = grade,
+                PreviousPersonalDevelopment = grade, PreviousEffectivenessOfLeadershipAndManagement = grade,
+                PreviousEarlyYearsProvisionWhereApplicable = grade,
+                PreviousSixthFormProvisionWhereApplicable = grade.ToString(),
+                PreviousCategoryOfConcern = categoriesOfConcern, PreviousSafeguardingIsEffective = safeguarding,
+                PreviousInspectionStartDate = dateString
+            };
+        }
+
+        return new MisEstablishment
+        {
+            Urn = urn, OverallEffectiveness = grade, QualityOfEducation = grade, BehaviourAndAttitudes = grade,
+            PersonalDevelopment = grade, EffectivenessOfLeadershipAndManagement = grade,
+            EarlyYearsProvisionWhereApplicable = grade,
+            SixthFormProvisionWhereApplicable = grade, CategoryOfConcern = categoriesOfConcern,
+            SafeguardingIsEffective = safeguarding, InspectionStartDate = dateString
+        };
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factory/MisFurtherEstablishmentFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factory/MisFurtherEstablishmentFactory.cs
@@ -1,0 +1,30 @@
+﻿using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Factory;
+
+public static class MisFurtherEstablishmentFactory
+{
+    public static MisFurtherEducationEstablishment CreateMisFurtherEducationEstablishment(int urn, int? grade,
+        string? safeguarding, string? dateString, bool usePreviousScores = false)
+
+    {
+        if (usePreviousScores)
+        {
+            return new MisFurtherEducationEstablishment
+            {
+                ProviderUrn = urn, PreviousOverallEffectiveness = grade,
+                PreviousQualityOfEducation = grade, PreviousBehaviourAndAttitudes = grade,
+                PreviousPersonalDevelopment = grade, PreviousEffectivenessOfLeadershipAndManagement = grade,
+                PreviousSafeguarding = safeguarding,
+                PreviousLastDayOfInspection = dateString
+            };
+        }
+
+        return new MisFurtherEducationEstablishment
+        {
+            ProviderUrn = urn, OverallEffectiveness = grade, QualityOfEducation = grade, BehaviourAndAttitudes = grade,
+            PersonalDevelopment = grade, EffectivenessOfLeadershipAndManagement = grade,
+            IsSafeguardingEffective = safeguarding, LastDayOfInspection = dateString
+        };
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factory/OfstedResultFactory.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Factory/OfstedResultFactory.cs
@@ -1,0 +1,83 @@
+﻿namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Factory;
+
+public static class OfstedResultFactory
+{
+    public static OfstedRating OutstandingEstablishmentOfstedRating(DateTime inspectionDate)
+    {
+        return new OfstedRating(
+            OfstedRatingScore.Outstanding, OfstedRatingScore.Outstanding, OfstedRatingScore.Outstanding,
+            OfstedRatingScore.Outstanding, OfstedRatingScore.Outstanding, OfstedRatingScore.Outstanding,
+            OfstedRatingScore.Outstanding, CategoriesOfConcern.None, SafeguardingScore.Yes, inspectionDate);
+    }
+
+    public static OfstedRating GoodEstablishmentOfstedRating(DateTime inspectionDate)
+    {
+        return new OfstedRating(
+            OfstedRatingScore.Good, OfstedRatingScore.Good, OfstedRatingScore.Good,
+            OfstedRatingScore.Good, OfstedRatingScore.Good, OfstedRatingScore.Good,
+            OfstedRatingScore.Good, CategoriesOfConcern.NoticeToImprove, SafeguardingScore.None, inspectionDate);
+    }
+
+    public static OfstedRating RequiresImprovementEstablishmentOfstedRating(DateTime inspectionDate)
+    {
+        return new OfstedRating(
+            OfstedRatingScore.RequiresImprovement, OfstedRatingScore.RequiresImprovement,
+            OfstedRatingScore.RequiresImprovement,
+            OfstedRatingScore.RequiresImprovement, OfstedRatingScore.RequiresImprovement,
+            OfstedRatingScore.RequiresImprovement,
+            OfstedRatingScore.RequiresImprovement, CategoriesOfConcern.SpecialMeasures, SafeguardingScore.NotRecorded,
+            inspectionDate);
+    }
+
+    public static OfstedRating InadequateEstablishmentOfstedRating(DateTime inspectionDate)
+    {
+        return new OfstedRating(
+            OfstedRatingScore.Inadequate, OfstedRatingScore.Inadequate, OfstedRatingScore.Inadequate,
+            OfstedRatingScore.Inadequate, OfstedRatingScore.Inadequate, OfstedRatingScore.Inadequate,
+            OfstedRatingScore.Inadequate, CategoriesOfConcern.SeriousWeakness, SafeguardingScore.No, inspectionDate);
+    }
+
+    public static OfstedRating NoneEstablishmentOfstedRating(DateTime? inspectionDate)
+    {
+        return new OfstedRating(-1, inspectionDate);
+    }
+
+    public static OfstedRating OutstandingFurtherEstablishmentOfstedRating(DateTime inspectionDate)
+    {
+        return new OfstedRating(
+            OfstedRatingScore.Outstanding, OfstedRatingScore.Outstanding, OfstedRatingScore.Outstanding,
+            OfstedRatingScore.Outstanding, OfstedRatingScore.Outstanding, OfstedRatingScore.None,
+            OfstedRatingScore.None, CategoriesOfConcern.None, SafeguardingScore.Yes, inspectionDate);
+    }
+
+    public static OfstedRating GoodFurtherEstablishmentOfstedRating(DateTime inspectionDate)
+    {
+        return new OfstedRating(
+            OfstedRatingScore.Good, OfstedRatingScore.Good, OfstedRatingScore.Good,
+            OfstedRatingScore.Good, OfstedRatingScore.Good, OfstedRatingScore.None,
+            OfstedRatingScore.None, CategoriesOfConcern.None, SafeguardingScore.None, inspectionDate);
+    }
+
+    public static OfstedRating RequiresFurtherImprovementEstablishmentOfstedRating(DateTime inspectionDate)
+    {
+        return new OfstedRating(
+            OfstedRatingScore.RequiresImprovement, OfstedRatingScore.RequiresImprovement,
+            OfstedRatingScore.RequiresImprovement,
+            OfstedRatingScore.RequiresImprovement, OfstedRatingScore.RequiresImprovement,
+            OfstedRatingScore.None,
+            OfstedRatingScore.None, CategoriesOfConcern.None, SafeguardingScore.NotRecorded, inspectionDate);
+    }
+
+    public static OfstedRating InadequateFurtherEstablishmentOfstedRating(DateTime inspectionDate)
+    {
+        return new OfstedRating(
+            OfstedRatingScore.Inadequate, OfstedRatingScore.Inadequate, OfstedRatingScore.Inadequate,
+            OfstedRatingScore.Inadequate, OfstedRatingScore.Inadequate, OfstedRatingScore.None,
+            OfstedRatingScore.None, CategoriesOfConcern.None, SafeguardingScore.No, inspectionDate);
+    }
+
+    public static OfstedRating NoneFurtherEstablishmentOfstedRating(DateTime? inspectionDate)
+    {
+        return new OfstedRating(-1, inspectionDate);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
@@ -2,6 +2,7 @@ using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Extensions;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Factory;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
@@ -118,19 +119,19 @@ public class AcademyRepositoryTests
 
         _mockAcademiesDbContext.AddMisEstablishments(new[]
         {
-            new MisEstablishment { Urn = urnsAsInt[0], OverallEffectiveness = 1, InspectionStartDate = "01/01/2022" },
-            new MisEstablishment { Urn = urnsAsInt[1], OverallEffectiveness = 2, InspectionStartDate = "29/02/2024" },
-            new MisEstablishment { Urn = urnsAsInt[2], OverallEffectiveness = 3, InspectionStartDate = "31/12/2022" },
-            new MisEstablishment { Urn = urnsAsInt[3], OverallEffectiveness = 4, InspectionStartDate = "15/10/2023" },
-            new MisEstablishment { Urn = urnsAsInt[4], OverallEffectiveness = null, InspectionStartDate = null }
+            MisEstablishmentFactory.CreateMisEstablishment(urnsAsInt[0], 1, null, SafeguardingScoreString.Yes, "01/01/2022"),
+            MisEstablishmentFactory.CreateMisEstablishment(urnsAsInt[1], 2, CategoriesOfConcernString.NoticeToImprove, null, "29/02/2024"),
+            MisEstablishmentFactory.CreateMisEstablishment(urnsAsInt[2], 3, CategoriesOfConcernString.SpecialMeasures, SafeguardingScoreString.Nine, "31/12/2022"),
+            MisEstablishmentFactory.CreateMisEstablishment(urnsAsInt[3], 4, CategoriesOfConcernString.SeriousWeakness, SafeguardingScoreString.No, "15/10/2023"),
+            MisEstablishmentFactory.CreateMisEstablishment(urnsAsInt[4], null, null, null, null)
         });
         _mockAcademiesDbContext.AddMisFurtherEducationEstablishments(new[]
         {
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[5], OverallEffectiveness = 1, LastDayOfInspection = "01/01/2022" },
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[6], OverallEffectiveness = 2, LastDayOfInspection = "29/02/2024" },
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[7], OverallEffectiveness = 3, LastDayOfInspection = "31/12/2022" },
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[8], OverallEffectiveness = 4, LastDayOfInspection = "15/10/2023" },
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[9], OverallEffectiveness = null, LastDayOfInspection = null }
+            MisFurtherEstablishmentFactory.CreateMisFurtherEducationEstablishment(urnsAsInt[5], 1, SafeguardingScoreString.Yes, "01/01/2022"),
+            MisFurtherEstablishmentFactory.CreateMisFurtherEducationEstablishment(urnsAsInt[6], 2, null, "29/02/2024"),
+            MisFurtherEstablishmentFactory.CreateMisFurtherEducationEstablishment(urnsAsInt[7], 3, SafeguardingScoreString.Nine, "31/12/2022"),
+            MisFurtherEstablishmentFactory.CreateMisFurtherEducationEstablishment(urnsAsInt[8], 4, SafeguardingScoreString.No, "15/10/2023"),
+            MisFurtherEstablishmentFactory.CreateMisFurtherEducationEstablishment(urnsAsInt[9], null, null, null)
         });
 
         var result = await _sut.GetAcademiesInTrustOfstedAsync("1234");
@@ -139,16 +140,16 @@ public class AcademyRepositoryTests
 
         result.Should().BeEquivalentTo(new[]
             {
-                dummyAcademyOfsted with { Urn = urns[0], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.Outstanding, new DateTime(2022, 01, 01)) },
-                dummyAcademyOfsted with { Urn = urns[1], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime(2024, 02, 29)) },
-                dummyAcademyOfsted with { Urn = urns[2], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2022, 12, 31)) },
-                dummyAcademyOfsted with { Urn = urns[3], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.Inadequate, new DateTime(2023, 10, 15)) },
-                dummyAcademyOfsted with { Urn = urns[4], CurrentOfstedRating = OfstedRating.None },
-                dummyAcademyOfsted with { Urn = urns[5], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.Outstanding, new DateTime(2022, 01, 01)) },
-                dummyAcademyOfsted with { Urn = urns[6], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime(2024, 02, 29)) },
-                dummyAcademyOfsted with { Urn = urns[7], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2022, 12, 31)) },
-                dummyAcademyOfsted with { Urn = urns[8], CurrentOfstedRating = new OfstedRating(OfstedRatingScore.Inadequate, new DateTime(2023, 10, 15)) },
-                dummyAcademyOfsted with { Urn = urns[9], CurrentOfstedRating = OfstedRating.None }
+                dummyAcademyOfsted with { Urn = urns[0], CurrentOfstedRating = OfstedResultFactory.OutstandingEstablishmentOfstedRating(new DateTime(2022, 01, 01)) },
+                dummyAcademyOfsted with { Urn = urns[1], CurrentOfstedRating = OfstedResultFactory.GoodEstablishmentOfstedRating(new DateTime(2024, 02, 29)) },
+                dummyAcademyOfsted with { Urn = urns[2], CurrentOfstedRating = OfstedResultFactory.RequiresImprovementEstablishmentOfstedRating(new DateTime(2022, 12, 31)) },
+                dummyAcademyOfsted with { Urn = urns[3], CurrentOfstedRating = OfstedResultFactory.InadequateEstablishmentOfstedRating(new DateTime(2023, 10, 15)) },
+                dummyAcademyOfsted with { Urn = urns[4], CurrentOfstedRating = OfstedResultFactory.NoneEstablishmentOfstedRating(null) },
+                dummyAcademyOfsted with { Urn = urns[5], CurrentOfstedRating = OfstedResultFactory.OutstandingFurtherEstablishmentOfstedRating(new DateTime(2022, 01, 01)) },
+                dummyAcademyOfsted with { Urn = urns[6], CurrentOfstedRating = OfstedResultFactory.GoodFurtherEstablishmentOfstedRating(new DateTime(2024, 02, 29)) },
+                dummyAcademyOfsted with { Urn = urns[7], CurrentOfstedRating = OfstedResultFactory.RequiresFurtherImprovementEstablishmentOfstedRating(new DateTime(2022, 12, 31)) },
+                dummyAcademyOfsted with { Urn = urns[8], CurrentOfstedRating = OfstedResultFactory.InadequateFurtherEstablishmentOfstedRating(new DateTime(2023, 10, 15)) },
+                dummyAcademyOfsted with { Urn = urns[9], CurrentOfstedRating = OfstedResultFactory.NoneFurtherEstablishmentOfstedRating(null) }
             },
             options => options
                 .Including(a => a.Urn)
@@ -165,19 +166,19 @@ public class AcademyRepositoryTests
 
         _mockAcademiesDbContext.AddMisEstablishments(new[]
         {
-            new MisEstablishment { Urn = urnsAsInt[0], PreviousFullInspectionOverallEffectiveness = "1", PreviousInspectionStartDate = "01/01/2022" },
-            new MisEstablishment { Urn = urnsAsInt[1], PreviousFullInspectionOverallEffectiveness = "2", PreviousInspectionStartDate = "29/02/2024" },
-            new MisEstablishment { Urn = urnsAsInt[2], PreviousFullInspectionOverallEffectiveness = "3", PreviousInspectionStartDate = "31/12/2022" },
-            new MisEstablishment { Urn = urnsAsInt[3], PreviousFullInspectionOverallEffectiveness = "4", PreviousInspectionStartDate = "15/10/2023" },
-            new MisEstablishment { Urn = urnsAsInt[4], PreviousFullInspectionOverallEffectiveness = null, PreviousInspectionStartDate = null }
+            MisEstablishmentFactory.CreateMisEstablishment(urnsAsInt[0], 1, null, SafeguardingScoreString.Yes, "01/01/2022", true),
+            MisEstablishmentFactory.CreateMisEstablishment(urnsAsInt[1], 2, CategoriesOfConcernString.NoticeToImprove, null, "29/02/2024", true),
+            MisEstablishmentFactory.CreateMisEstablishment(urnsAsInt[2], 3, CategoriesOfConcernString.SpecialMeasures, SafeguardingScoreString.Nine, "31/12/2022", true),
+            MisEstablishmentFactory.CreateMisEstablishment(urnsAsInt[3], 4, CategoriesOfConcernString.SeriousWeakness, SafeguardingScoreString.No, "15/10/2023", true),
+            MisEstablishmentFactory.CreateMisEstablishment(urnsAsInt[4], null, null, null, null, true)
         });
         _mockAcademiesDbContext.AddMisFurtherEducationEstablishments(new[]
         {
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[5], PreviousOverallEffectiveness = 1, PreviousLastDayOfInspection = "01/01/2022" },
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[6], PreviousOverallEffectiveness = 2, PreviousLastDayOfInspection = "29/02/2024" },
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[7], PreviousOverallEffectiveness = 3, PreviousLastDayOfInspection = "31/12/2022" },
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[8], PreviousOverallEffectiveness = 4, PreviousLastDayOfInspection = "15/10/2023" },
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[9], PreviousOverallEffectiveness = null, PreviousLastDayOfInspection = null }
+            MisFurtherEstablishmentFactory.CreateMisFurtherEducationEstablishment(urnsAsInt[5], 1, SafeguardingScoreString.Yes, "01/01/2022", true),
+            MisFurtherEstablishmentFactory.CreateMisFurtherEducationEstablishment(urnsAsInt[6], 2, null, "29/02/2024", true),
+            MisFurtherEstablishmentFactory.CreateMisFurtherEducationEstablishment(urnsAsInt[7], 3, SafeguardingScoreString.Nine, "31/12/2022", true),
+            MisFurtherEstablishmentFactory.CreateMisFurtherEducationEstablishment(urnsAsInt[8], 4, SafeguardingScoreString.No, "15/10/2023", true),
+            MisFurtherEstablishmentFactory.CreateMisFurtherEducationEstablishment(urnsAsInt[9], null, null, null, true)
         });
 
         var result = await _sut.GetAcademiesInTrustOfstedAsync("1234");
@@ -186,16 +187,16 @@ public class AcademyRepositoryTests
 
         result.Should().BeEquivalentTo(new[]
             {
-                dummyAcademyOfsted with { Urn = urns[0], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.Outstanding, new DateTime(2022, 01, 01)) },
-                dummyAcademyOfsted with { Urn = urns[1], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime(2024, 02, 29)) },
-                dummyAcademyOfsted with { Urn = urns[2], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2022, 12, 31)) },
-                dummyAcademyOfsted with { Urn = urns[3], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.Inadequate, new DateTime(2023, 10, 15)) },
-                dummyAcademyOfsted with { Urn = urns[4], PreviousOfstedRating = OfstedRating.None },
-                dummyAcademyOfsted with { Urn = urns[5], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.Outstanding, new DateTime(2022, 01, 01)) },
-                dummyAcademyOfsted with { Urn = urns[6], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime(2024, 02, 29)) },
-                dummyAcademyOfsted with { Urn = urns[7], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2022, 12, 31)) },
-                dummyAcademyOfsted with { Urn = urns[8], PreviousOfstedRating = new OfstedRating(OfstedRatingScore.Inadequate, new DateTime(2023, 10, 15)) },
-                dummyAcademyOfsted with { Urn = urns[9], PreviousOfstedRating = OfstedRating.None }
+                dummyAcademyOfsted with { Urn = urns[0], PreviousOfstedRating = OfstedResultFactory.OutstandingEstablishmentOfstedRating(new DateTime(2022, 01, 01)) },
+                dummyAcademyOfsted with { Urn = urns[1], PreviousOfstedRating = OfstedResultFactory.GoodEstablishmentOfstedRating(new DateTime(2024, 02, 29)) },
+                dummyAcademyOfsted with { Urn = urns[2], PreviousOfstedRating = OfstedResultFactory.RequiresImprovementEstablishmentOfstedRating(new DateTime(2022, 12, 31)) },
+                dummyAcademyOfsted with { Urn = urns[3], PreviousOfstedRating = OfstedResultFactory.InadequateEstablishmentOfstedRating(new DateTime(2023, 10, 15)) },
+                dummyAcademyOfsted with { Urn = urns[4], PreviousOfstedRating = OfstedResultFactory.NoneEstablishmentOfstedRating(null) },
+                dummyAcademyOfsted with { Urn = urns[5], PreviousOfstedRating = OfstedResultFactory.OutstandingFurtherEstablishmentOfstedRating(new DateTime(2022, 01, 01)) },
+                dummyAcademyOfsted with { Urn = urns[6], PreviousOfstedRating = OfstedResultFactory.GoodFurtherEstablishmentOfstedRating(new DateTime(2024, 02, 29)) },
+                dummyAcademyOfsted with { Urn = urns[7], PreviousOfstedRating = OfstedResultFactory.RequiresFurtherImprovementEstablishmentOfstedRating(new DateTime(2022, 12, 31)) },
+                dummyAcademyOfsted with { Urn = urns[8], PreviousOfstedRating = OfstedResultFactory.InadequateFurtherEstablishmentOfstedRating(new DateTime(2023, 10, 15)) },
+                dummyAcademyOfsted with { Urn = urns[9], PreviousOfstedRating = OfstedResultFactory.NoneFurtherEstablishmentOfstedRating(null) }
             },
             options => options
                 .Including(a => a.Urn)

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingCellModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingCellModelTests.cs
@@ -20,7 +20,7 @@ public class OfstedRatingCellModelTests
         var sut = new OfstedRatingCellModel
         {
             AcademyJoinedDate = new DateTime(),
-            OfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime())
+            OfstedRating = new OfstedRating(2, new DateTime())
         };
 
         sut.IsAfterJoining.Should().Be(true);
@@ -82,7 +82,7 @@ public class OfstedRatingCellModelTests
     {
         var sut = new OfstedRatingCellModel
         {
-            OfstedRating = new OfstedRating(score, new DateTime()),
+            OfstedRating = new OfstedRating((int)score, new DateTime()),
             AcademyJoinedDate = new DateTime()
         };
 
@@ -111,7 +111,7 @@ public class OfstedRatingCellModelTests
     {
         var sut = new OfstedRatingCellModel
         {
-            OfstedRating = new OfstedRating(score, new DateTime()),
+            OfstedRating = new OfstedRating((int)score, new DateTime()),
             AcademyJoinedDate = new DateTime()
         };
 
@@ -123,7 +123,7 @@ public class OfstedRatingCellModelTests
         return new OfstedRatingCellModel
         {
             AcademyJoinedDate = new DateTime(2020, 11, 1),
-            OfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime(2022, 3, 2))
+            OfstedRating = new OfstedRating((int)OfstedRatingScore.Good, new DateTime(2022, 3, 2))
         };
     }
 
@@ -132,7 +132,7 @@ public class OfstedRatingCellModelTests
         return new OfstedRatingCellModel
         {
             AcademyJoinedDate = new DateTime(2022, 3, 2),
-            OfstedRating = new OfstedRating(OfstedRatingScore.Good, new DateTime(2020, 11, 1)),
+            OfstedRating = new OfstedRating((int)OfstedRatingScore.Good, new DateTime(2020, 11, 1)),
             IdPrefix = ""
         };
     }
@@ -142,7 +142,7 @@ public class OfstedRatingCellModelTests
         return new OfstedRatingCellModel
         {
             AcademyJoinedDate = new DateTime(2022, 3, 2),
-            OfstedRating = new OfstedRating(OfstedRatingScore.None, null)
+            OfstedRating = new OfstedRating((int)OfstedRatingScore.None, null)
         };
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingsModelTests.cs
@@ -27,8 +27,9 @@ public class OfstedRatingsModelTests
 
         _sut = new OfstedRatingsModel(_mockDataSourceService.Object,
                 new MockLogger<OfstedRatingsModel>().Object,
-                _mockTrustService.Object, _mockAcademyService.Object, _mockExportService.Object, _mockDateTimeProvider.Object)
-        { Uid = "1234" };
+                _mockTrustService.Object, _mockAcademyService.Object, _mockExportService.Object,
+                _mockDateTimeProvider.Object)
+            { Uid = "1234" };
     }
 
     [Fact]
@@ -79,14 +80,14 @@ public class OfstedRatingsModelTests
         var academies = new[]
         {
             new AcademyOfstedServiceModel("1", "Academy 1", new DateTime(2022, 12, 1),
-                new OfstedRating(OfstedRatingScore.Good, new DateTime(2023, 1, 1)),
-                new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2023, 2, 1))),
+                new OfstedRating(2, new DateTime(2023, 1, 1)),
+                new OfstedRating(3, new DateTime(2023, 2, 1))),
             new AcademyOfstedServiceModel("2", "Academy 2", new DateTime(2022, 11, 2),
-                new OfstedRating(OfstedRatingScore.Good, new DateTime(2023, 1, 2)),
-                new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2023, 3, 1))),
+                new OfstedRating(2, new DateTime(2023, 1, 2)),
+                new OfstedRating(3, new DateTime(2023, 3, 1))),
             new AcademyOfstedServiceModel("3", "Academy 3", new DateTime(2022, 10, 3),
-                new OfstedRating(OfstedRatingScore.Good, new DateTime(2023, 1, 3)),
-                new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2023, 4, 1)))
+                new OfstedRating(2, new DateTime(2023, 1, 3)),
+                new OfstedRating(3, new DateTime(2023, 4, 1)))
         };
         _mockAcademyService.Setup(a => a.GetAcademiesInTrustOfstedAsync(_sut.Uid))
             .ReturnsAsync(academies);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
@@ -43,14 +43,14 @@ public class AcademyServiceTests
         var academies = new[]
         {
             new AcademyOfsted("1", "Academy 1", new DateTime(2022, 12, 1),
-                new OfstedRating(OfstedRatingScore.Good, new DateTime(2023, 1, 1)),
-                new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2023, 2, 1))),
+                new OfstedRating((int)OfstedRatingScore.Good, new DateTime(2023, 1, 1)),
+                new OfstedRating((int)OfstedRatingScore.RequiresImprovement, new DateTime(2023, 2, 1))),
             new AcademyOfsted("2", "Academy 2", new DateTime(2022, 11, 2),
-                new OfstedRating(OfstedRatingScore.Good, new DateTime(2023, 1, 2)),
-                new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2023, 3, 1))),
+                new OfstedRating((int)OfstedRatingScore.Good, new DateTime(2023, 1, 2)),
+                new OfstedRating((int)OfstedRatingScore.RequiresImprovement, new DateTime(2023, 3, 1))),
             new AcademyOfsted("3", "Academy 3", new DateTime(2022, 10, 3),
-                new OfstedRating(OfstedRatingScore.Good, new DateTime(2023, 1, 3)),
-                new OfstedRating(OfstedRatingScore.RequiresImprovement, new DateTime(2023, 4, 1)))
+                new OfstedRating((int)OfstedRatingScore.Good, new DateTime(2023, 1, 3)),
+                new OfstedRating((int)OfstedRatingScore.RequiresImprovement, new DateTime(2023, 4, 1)))
         };
 
         _mockAcademyRepository.Setup(a => a.GetAcademiesInTrustOfstedAsync(uid))

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServiceTests.cs
@@ -3,275 +3,278 @@ using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 using DfE.FindInformationAcademiesTrusts.Pages;
-using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
-namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
+
+public class ExportServiceTests
 {
-    public class ExportServiceTests
+    private readonly Mock<IDateTimeProvider> _mockDateTimeProvider;
+    private readonly Mock<IAcademyRepository> _mockAcademyRepository;
+    private readonly Mock<ITrustRepository> _mockTrustRepository;
+    private readonly ExportService _sut;
+
+    public ExportServiceTests()
     {
-        private readonly Mock<IDateTimeProvider> _mockDateTimeProvider;
-        private readonly Mock<IAcademyRepository> _mockAcademyRepository;
-        private readonly Mock<ITrustRepository> _mockTrustRepository;
-        private readonly ExportService _sut;
+        _mockDateTimeProvider = new Mock<IDateTimeProvider>();
+        _mockAcademyRepository = new Mock<IAcademyRepository>();
+        _mockTrustRepository = new Mock<ITrustRepository>();
 
-        public ExportServiceTests()
-        {
-            _mockDateTimeProvider = new Mock<IDateTimeProvider>();
-            _mockAcademyRepository = new Mock<IAcademyRepository>();
-            _mockTrustRepository = new Mock<ITrustRepository>();
+        // Baseline date for testing will be the current date in this instance
+        _mockDateTimeProvider.Setup(m => m.Now).Returns(DateTime.Now);
 
-            // Baseline date for testing will be the current date in this instance
-            _mockDateTimeProvider.Setup(m => m.Now).Returns(DateTime.Now);
+        _sut = new ExportService(_mockAcademyRepository.Object, _mockTrustRepository.Object);
+    }
 
-            _sut = new(_mockAcademyRepository.Object, _mockTrustRepository.Object);
-        }
+    [Fact]
+    public async Task ExportAcademiesToSpreadsheet_ShouldGenerateCorrectHeadersAsync()
+    {
+        // Arrange            
+        var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 0);
 
-        [Fact]
-        public async Task ExportAcademiesToSpreadsheet_ShouldGenerateCorrectHeadersAsync()
-        {
-            // Arrange            
-            var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 0);
+        // Act
+        var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
+        using var workbook = new XLWorkbook(new MemoryStream(result));
+        var worksheet = workbook.Worksheet("Academies");
 
-            // Act
-            var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
-            using var workbook = new XLWorkbook(new MemoryStream(result));
-            var worksheet = workbook.Worksheet("Academies");
+        // Assert
+        worksheet.Cell(3, 1).Value.ToString().Should().Be("School Name");
+        worksheet.Cell(3, 2).Value.ToString().Should().Be("URN");
+        worksheet.Cell(3, 3).Value.ToString().Should().Be("Local Authority");
+        worksheet.Cell(3, 4).Value.ToString().Should().Be("Type");
+        worksheet.Cell(3, 5).Value.ToString().Should().Be("Rural or Urban");
+        worksheet.Cell(3, 6).Value.ToString().Should().Be("Date joined");
+        worksheet.Cell(3, 7).Value.ToString().Should().Be("Previous Ofsted Rating");
+        worksheet.Cell(3, 8).Value.ToString().Should().Be("Before/After Joining");
+        worksheet.Cell(3, 9).Value.ToString().Should().Be("Date of Previous Ofsted");
+        worksheet.Cell(3, 10).Value.ToString().Should().Be("Current Ofsted Rating");
+        worksheet.Cell(3, 11).Value.ToString().Should().Be("Before/After Joining");
+        worksheet.Cell(3, 12).Value.ToString().Should().Be("Date of Current Ofsted");
+        worksheet.Cell(3, 13).Value.ToString().Should().Be("Phase of Education");
+        worksheet.Cell(3, 14).Value.ToString().Should().Be("Age Range");
+        worksheet.Cell(3, 15).Value.ToString().Should().Be("Pupil Numbers");
+        worksheet.Cell(3, 16).Value.ToString().Should().Be("Capacity");
+        worksheet.Cell(3, 17).Value.ToString().Should().Be("% Full");
+        worksheet.Cell(3, 18).Value.ToString().Should().Be("Pupils eligible for Free School Meals");
+    }
 
-            // Assert
-            worksheet.Cell(3, 1).Value.ToString().Should().Be("School Name");
-            worksheet.Cell(3, 2).Value.ToString().Should().Be("URN");
-            worksheet.Cell(3, 3).Value.ToString().Should().Be("Local Authority");
-            worksheet.Cell(3, 4).Value.ToString().Should().Be("Type");
-            worksheet.Cell(3, 5).Value.ToString().Should().Be("Rural or Urban");
-            worksheet.Cell(3, 6).Value.ToString().Should().Be("Date joined");
-            worksheet.Cell(3, 7).Value.ToString().Should().Be("Previous Ofsted Rating");
-            worksheet.Cell(3, 8).Value.ToString().Should().Be("Before/After Joining");
-            worksheet.Cell(3, 9).Value.ToString().Should().Be("Date of Previous Ofsted");
-            worksheet.Cell(3, 10).Value.ToString().Should().Be("Current Ofsted Rating");
-            worksheet.Cell(3, 11).Value.ToString().Should().Be("Before/After Joining");
-            worksheet.Cell(3, 12).Value.ToString().Should().Be("Date of Current Ofsted");
-            worksheet.Cell(3, 13).Value.ToString().Should().Be("Phase of Education");
-            worksheet.Cell(3, 14).Value.ToString().Should().Be("Age Range");
-            worksheet.Cell(3, 15).Value.ToString().Should().Be("Pupil Numbers");
-            worksheet.Cell(3, 16).Value.ToString().Should().Be("Capacity");
-            worksheet.Cell(3, 17).Value.ToString().Should().Be("% Full");
-            worksheet.Cell(3, 18).Value.ToString().Should().Be("Pupils eligible for Free School Meals");
-        }
+    [Fact]
+    public async Task ExportAcademiesToSpreadsheet_ShouldCorrectlyExtractAcademyDataAsync()
+    {
+        // Arrange
+        var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
 
-        [Fact]
-        public async Task ExportAcademiesToSpreadsheet_ShouldCorrectlyExtractAcademyDataAsync()
-        {
-            // Arrange
-            var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
+        // Trust summary set up
+        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid)).ReturnsAsync(
+            new TrustSummary("Sample Trust", "Multi-academy trust"));
+        // Academies details set up
+        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid)).ReturnsAsync(
+            new AcademyDetails[]
+            {
+                new("123456", "Academy 1", "Type A", "Local Authority 1", "Urban")
+            });
+        // Academies ofsted set up
+        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustOfstedAsync(trustSummary.Uid)).ReturnsAsync(
+            new AcademyOfsted[]
+            {
+                new("123456", "Academy 1", DateTime.Now, new OfstedRating(-1, null), new OfstedRating(1, DateTime.Now))
+            });
+        // Academies pupil number set up
+        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid)).ReturnsAsync(
+            new AcademyPupilNumbers[]
+            {
+                new("123456", "Academy 1", "Primary", new AgeRange(5, 11), 500, 600)
+            });
+        // Academies free school meals
+        _mockAcademyRepository.Setup(m
+            => m.GetAcademiesInTrustFreeSchoolMealsAsync(trustSummary.Uid)).ReturnsAsync(
+            new AcademyFreeSchoolMeals[]
+            {
+                new("123456", "Academy 1", 20, 1, "Type A", "Primary")
+            });
 
-            // Trust summary set up
-            _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid)).ReturnsAsync(
-                new TrustSummary("Sample Trust", "Multi-academy trust"));
-            // Academies details set up
-            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid)).ReturnsAsync(
-                new AcademyDetails[]
-                {
-                    new("123456", "Academy 1", "Type A", "Local Authority 1", "Urban"),
-                });
-            // Academies ofsted set up
-            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustOfstedAsync(trustSummary.Uid)).ReturnsAsync(
-                new AcademyOfsted[]
-                {
-                    new("123456", "Academy 1", DateTime.Now, new OfstedRating(OfstedRatingScore.None, null), new OfstedRating(OfstedRatingScore.Outstanding, DateTime.Now))
-                });
-            // Academies pupil number set up
-            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid)).ReturnsAsync(
-                new AcademyPupilNumbers[]
-                {
-                    new("123456", "Academy 1", "Primary", new AgeRange(5,11), 500, 600)
-                });
-            // Academies free school meals
-            _mockAcademyRepository.Setup(m
-                => m.GetAcademiesInTrustFreeSchoolMealsAsync(trustSummary.Uid)).ReturnsAsync(
-                new AcademyFreeSchoolMeals[]
-                {
-                    new("123456", "Academy 1", 20, 1, "Type A", "Primary"),
-                });
+        // Act
+        var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
+        using var workbook = new XLWorkbook(new MemoryStream(result));
+        var worksheet = workbook.Worksheet("Academies");
 
-            // Act
-            var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
-            using var workbook = new XLWorkbook(new MemoryStream(result));
-            var worksheet = workbook.Worksheet("Academies");
+        // Assert
+        worksheet.Cell(4, 1).Value.ToString().Should().Be("Academy 1");
+        worksheet.Cell(4, 2).Value.ToString().Should().Be("123456");
+        worksheet.Cell(4, 3).Value.ToString().Should().Be("Local Authority 1");
+        worksheet.Cell(4, 4).Value.ToString().Should().Be("Type A");
+        worksheet.Cell(4, 5).Value.ToString().Should().Be("Urban");
+        worksheet.Cell(4, 6).Value.ToString().Should().Be(DateTime.Now.ToString(StringFormatConstants.ViewDate));
+        worksheet.Cell(4, 7).Value.ToString().Should().Be("Not yet inspected");
+        worksheet.Cell(4, 8).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 9).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 10).Value.ToString().Should().Be("Outstanding");
+        worksheet.Cell(4, 11).Value.ToString().Should().Be("After Joining");
+        worksheet.Cell(4, 12).Value.ToString().Should().Be(DateTime.Now.ToString(StringFormatConstants.ViewDate));
+        worksheet.Cell(4, 13).Value.ToString().Should().Be("Primary");
+        worksheet.Cell(4, 14).Value.ToString().Should().Be("5 - 11");
+        worksheet.Cell(4, 15).Value.ToString().Should().Be("500");
+        worksheet.Cell(4, 16).Value.ToString().Should().Be("600");
+        worksheet.Cell(4, 17).Value.ToString().Should().Be("83%");
+        worksheet.Cell(4, 18).Value.ToString().Should().Be("20%");
+    }
 
-            // Assert
-            worksheet.Cell(4, 1).Value.ToString().Should().Be("Academy 1");
-            worksheet.Cell(4, 2).Value.ToString().Should().Be("123456");
-            worksheet.Cell(4, 3).Value.ToString().Should().Be("Local Authority 1");
-            worksheet.Cell(4, 4).Value.ToString().Should().Be("Type A");
-            worksheet.Cell(4, 5).Value.ToString().Should().Be("Urban");
-            worksheet.Cell(4, 6).Value.ToString().Should().Be(DateTime.Now.ToString(StringFormatConstants.ViewDate));
-            worksheet.Cell(4, 7).Value.ToString().Should().Be("Not yet inspected");
-            worksheet.Cell(4, 8).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 9).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 10).Value.ToString().Should().Be("Outstanding");
-            worksheet.Cell(4, 11).Value.ToString().Should().Be("After Joining");
-            worksheet.Cell(4, 12).Value.ToString().Should().Be(DateTime.Now.ToString(StringFormatConstants.ViewDate));
-            worksheet.Cell(4, 13).Value.ToString().Should().Be("Primary");
-            worksheet.Cell(4, 14).Value.ToString().Should().Be("5 - 11");
-            worksheet.Cell(4, 15).Value.ToString().Should().Be("500");
-            worksheet.Cell(4, 16).Value.ToString().Should().Be("600");
-            worksheet.Cell(4, 17).Value.ToString().Should().Be("83%");
-            worksheet.Cell(4, 18).Value.ToString().Should().Be("20%");
-        }
+    [Fact]
+    public async Task ExportAcademiesToSpreadsheet_ShouldHandleEmptyAcademiesAsync()
+    {
+        // Arrange            
+        var trustSummary = new TrustSummaryServiceModel("1", "Empty Trust", "Multi-academy trust", 0);
 
-        [Fact]
-        public async Task ExportAcademiesToSpreadsheet_ShouldHandleEmptyAcademiesAsync()
-        {
-            // Arrange            
-            var trustSummary = new TrustSummaryServiceModel("1", "Empty Trust", "Multi-academy trust", 0);
+        // Act
+        var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
+        using var workbook = new XLWorkbook(new MemoryStream(result));
+        var worksheet = workbook.Worksheet("Academies");
 
-            // Act
-            var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
-            using var workbook = new XLWorkbook(new MemoryStream(result));
-            var worksheet = workbook.Worksheet("Academies");
+        // Assert
+        worksheet.LastRowUsed().RowNumber().Should()
+            .Be(3); // Last row should be headers as there is no data for the next row
+    }
 
-            // Assert
-            worksheet.LastRowUsed().RowNumber().Should().Be(3); // Last row should be headers as there is no data for the next row
-        }
+    [Fact]
+    public async Task ExportAcademiesToSpreadsheet_ShouldCorrectlyHandleNullValuesAsync()
+    {
+        // Arrange
 
-        [Fact]
-        public async Task ExportAcademiesToSpreadsheet_ShouldCorrectlyHandleNullValuesAsync()
-        {
-            // Arrange
+        var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
 
-            var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
+        // Trust summary set up
+        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid)).ReturnsAsync(
+            new TrustSummary("Sample Trust", "Multi-academy trust"));
+        // Academies details set up
+        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid)).ReturnsAsync(
+            new AcademyDetails[]
+            {
+                new("123456", null, null, null, null)
+            });
+        // Academies ofsted set up
+        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustOfstedAsync(trustSummary.Uid)).ReturnsAsync(
+            new AcademyOfsted[]
+            {
+                new("123456", null, DateTime.Now, new OfstedRating(-1, null), new OfstedRating(-1, null))
+            });
+        // Academies pupil number set up
+        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid)).ReturnsAsync(
+            new AcademyPupilNumbers[]
+            {
+                new("123456", null, null, new AgeRange(5, 11), null, null)
+            });
+        // Academies free school meals
+        _mockAcademyRepository.Setup(m
+            => m.GetAcademiesInTrustFreeSchoolMealsAsync(trustSummary.Uid)).ReturnsAsync(
+            new AcademyFreeSchoolMeals[]
+            {
+                new("123456", null, null, 1, null, null)
+            });
+        // Act
+        var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
+        using var workbook = new XLWorkbook(new MemoryStream(result));
+        var worksheet = workbook.Worksheet("Academies");
 
-            // Trust summary set up
-            _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid)).ReturnsAsync(
-                new TrustSummary("Sample Trust", "Multi-academy trust"));
-            // Academies details set up
-            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid)).ReturnsAsync(
-                new AcademyDetails[]
-                {
-                    new("123456", null, null, null, null),
-                });
-            // Academies ofsted set up
-            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustOfstedAsync(trustSummary.Uid)).ReturnsAsync(
-                new AcademyOfsted[]
-                {
-                    new("123456", null, DateTime.Now, new OfstedRating(OfstedRatingScore.None, null), new OfstedRating(OfstedRatingScore.None, null))
-                });
-            // Academies pupil number set up
-            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid)).ReturnsAsync(
-                new AcademyPupilNumbers[]
-                {
-                    new("123456", null, null, new AgeRange(5,11), null, null)
-                });
-            // Academies free school meals
-            _mockAcademyRepository.Setup(m
-                => m.GetAcademiesInTrustFreeSchoolMealsAsync(trustSummary.Uid)).ReturnsAsync(
-                new AcademyFreeSchoolMeals[]
-                {
-                    new("123456", null, null, 1, null, null),
-                });
-            // Act
-            var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
-            using var workbook = new XLWorkbook(new MemoryStream(result));
-            var worksheet = workbook.Worksheet("Academies");
+        // Assert
+        worksheet.Cell(4, 1).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 2).Value.ToString().Should().Be("123456");
+        worksheet.Cell(4, 3).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 4).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 5).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 6).Value.ToString().Should().Be(DateTime.Now.ToString(StringFormatConstants.ViewDate));
+        worksheet.Cell(4, 7).Value.ToString().Should().Be("Not yet inspected");
+        worksheet.Cell(4, 8).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 9).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 10).Value.ToString().Should().Be("Not yet inspected");
+        worksheet.Cell(4, 11).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 12).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 13).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 14).Value.ToString().Should().Be("5 - 11");
+        worksheet.Cell(4, 15).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 16).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 17).Value.ToString().Should().Be(string.Empty);
+        worksheet.Cell(4, 18).Value.ToString().Should().Be(string.Empty);
+    }
 
-            // Assert
-            worksheet.Cell(4, 1).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 2).Value.ToString().Should().Be("123456");
-            worksheet.Cell(4, 3).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 4).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 5).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 6).Value.ToString().Should().Be(DateTime.Now.ToString(StringFormatConstants.ViewDate));
-            worksheet.Cell(4, 7).Value.ToString().Should().Be("Not yet inspected");
-            worksheet.Cell(4, 8).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 9).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 10).Value.ToString().Should().Be("Not yet inspected");
-            worksheet.Cell(4, 11).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 12).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 13).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 14).Value.ToString().Should().Be("5 - 11");
-            worksheet.Cell(4, 15).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 16).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 17).Value.ToString().Should().Be(string.Empty);
-            worksheet.Cell(4, 18).Value.ToString().Should().Be(string.Empty);
-        }
+    [Fact]
+    public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnEmptyString_WhenOfstedRatingScoreIsNone()
+    {
+        // Arrange
+        var ofstedRatingScore = OfstedRatingScore.None;
+        var dateJoinedTrust = _mockDateTimeProvider.Object.Now;
+        DateTime? inspectionEndDate = dateJoinedTrust.AddDays(-1);
 
-        [Fact]
-        public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnEmptyString_WhenOfstedRatingScoreIsNone()
-        {
-            // Arrange
-            var ofstedRatingScore = OfstedRatingScore.None;
-            var dateJoinedTrust = _mockDateTimeProvider.Object.Now;
-            DateTime? inspectionEndDate = dateJoinedTrust.AddDays(-1);
+        // Act
+        var result =
+            ExportService.IsOfstedRatingBeforeOrAfterJoining(ofstedRatingScore, dateJoinedTrust, inspectionEndDate);
 
-            // Act
-            var result = ExportService.IsOfstedRatingBeforeOrAfterJoining(ofstedRatingScore, dateJoinedTrust, inspectionEndDate);
+        // Assert
+        result.Should().Be(string.Empty);
+    }
 
-            // Assert
-            result.Should().Be(string.Empty);
-        }
+    [Fact]
+    public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnBeforeJoining_WhenInspectionDateIsBeforeJoiningDate()
+    {
+        // Arrange
+        var ofstedRatingScore = OfstedRatingScore.Good;
+        var dateJoinedTrust = _mockDateTimeProvider.Object.Now;
+        DateTime? inspectionEndDate = dateJoinedTrust.AddDays(-10);
 
-        [Fact]
-        public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnBeforeJoining_WhenInspectionDateIsBeforeJoiningDate()
-        {
-            // Arrange
-            var ofstedRatingScore = OfstedRatingScore.Good;
-            var dateJoinedTrust = _mockDateTimeProvider.Object.Now;
-            DateTime? inspectionEndDate = dateJoinedTrust.AddDays(-10);
+        // Act
+        var result =
+            ExportService.IsOfstedRatingBeforeOrAfterJoining(ofstedRatingScore, dateJoinedTrust, inspectionEndDate);
 
-            // Act
-            var result = ExportService.IsOfstedRatingBeforeOrAfterJoining(ofstedRatingScore, dateJoinedTrust, inspectionEndDate);
+        // Assert
+        result.Should().Be("Before Joining");
+    }
 
-            // Assert
-            result.Should().Be("Before Joining");
-        }
+    [Fact]
+    public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnAfterJoining_WhenInspectionDateIsAfterJoiningDate()
+    {
+        // Arrange
+        var ofstedRatingScore = OfstedRatingScore.Good;
+        var dateJoinedTrust = _mockDateTimeProvider.Object.Now.AddDays(-10);
+        DateTime? inspectionEndDate = dateJoinedTrust.AddDays(5);
 
-        [Fact]
-        public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnAfterJoining_WhenInspectionDateIsAfterJoiningDate()
-        {
-            // Arrange
-            var ofstedRatingScore = OfstedRatingScore.Good;
-            var dateJoinedTrust = _mockDateTimeProvider.Object.Now.AddDays(-10);
-            DateTime? inspectionEndDate = dateJoinedTrust.AddDays(5);
+        // Act
+        var result =
+            ExportService.IsOfstedRatingBeforeOrAfterJoining(ofstedRatingScore, dateJoinedTrust, inspectionEndDate);
 
-            // Act
-            var result = ExportService.IsOfstedRatingBeforeOrAfterJoining(ofstedRatingScore, dateJoinedTrust, inspectionEndDate);
+        // Assert
+        result.Should().Be("After Joining");
+    }
 
-            // Assert
-            result.Should().Be("After Joining");
-        }
-
-        [Fact]
-        public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnEmptyString_WhenInspectionDateIsNull()
-        {
-            // Arrange
-            var ofstedRatingScore = OfstedRatingScore.Good;
-            var dateJoinedTrust = _mockDateTimeProvider.Object.Now;
+    [Fact]
+    public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnEmptyString_WhenInspectionDateIsNull()
+    {
+        // Arrange
+        var ofstedRatingScore = OfstedRatingScore.Good;
+        var dateJoinedTrust = _mockDateTimeProvider.Object.Now;
 
 
-            // Act
-            var result = ExportService.IsOfstedRatingBeforeOrAfterJoining(ofstedRatingScore, dateJoinedTrust, null);
+        // Act
+        var result = ExportService.IsOfstedRatingBeforeOrAfterJoining(ofstedRatingScore, dateJoinedTrust, null);
 
-            // Assert
-            result.Should().Be(string.Empty);
-        }
+        // Assert
+        result.Should().Be(string.Empty);
+    }
 
-        [Theory]
-        [InlineData(500, 600, 83)]  // Valid case
-        [InlineData(300, 300, 100)] // Edge case: full capacity
-        [InlineData(0, 300, 0)]     // Edge case: 0 pupils
-        [InlineData(300, 0, 0)]     // Edge case: zero capacity (should return 0)
-        [InlineData(null, 300, 0)]  // Edge case: null pupils
-        [InlineData(300, null, 0)]  // Edge case: null capacity
-        [InlineData(null, null, 0)] // Edge case: both null
-        public void CalculatePercentageFull_ShouldReturnExpectedResult(int? numberOfPupils, int? schoolCapacity, float expected)
-        {
-            // Act
-            var result = ExportService.CalculatePercentageFull(numberOfPupils, schoolCapacity);
+    [Theory]
+    [InlineData(500, 600, 83)] // Valid case
+    [InlineData(300, 300, 100)] // Edge case: full capacity
+    [InlineData(0, 300, 0)] // Edge case: 0 pupils
+    [InlineData(300, 0, 0)] // Edge case: zero capacity (should return 0)
+    [InlineData(null, 300, 0)] // Edge case: null pupils
+    [InlineData(300, null, 0)] // Edge case: null capacity
+    [InlineData(null, null, 0)] // Edge case: both null
+    public void CalculatePercentageFull_ShouldReturnExpectedResult(int? numberOfPupils, int? schoolCapacity,
+        float expected)
+    {
+        // Act
+        var result = ExportService.CalculatePercentageFull(numberOfPupils, schoolCapacity);
 
-            // Assert
-            Assert.Equal(expected, result);
-        }
+        // Assert
+        Assert.Equal(expected, result);
     }
 }


### PR DESCRIPTION
[User Story 184180](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/184180): Build: Spike to review Ofsted data in light of policy change

Update the Academy Repository to collect additional Ofsted data in preparation for displaying additional information to the user instead of Single headline grades. 

## Changes

- Update the Ofsted Rating to store additional ofsted information including Concern and Safeguarding ratings
- Update the Academy repository to use the new Ofsted Ratings
- Create factories for MisEstablishments, MisFurtherEstablishments and OfstedResults to be used in tests
- Update the UI to use the Ofsted overall effectiveness (the renamed fields for the SHG)
- Update the tests to use the updated ofsted ratings

## Screenshots of UI changes

No UI changes

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
