### PR TITLE
Remove edit contact feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Renamed the anti forgery cookie to a static name
 - Updated wording for links on the landing page to tell users they open in new tabs
 - Updated the ofsted ratings to collect information about the ofsted subgrades
+- Remove the edit contact feature flag
 
 ## [Release-11][release-11] (production-2024-10-17.3654)
 

--- a/DfE.FindInformationAcademiesTrusts/Configuration/FeatureFlags.cs
+++ b/DfE.FindInformationAcademiesTrusts/Configuration/FeatureFlags.cs
@@ -3,6 +3,5 @@
 public static class FeatureFlags
 {
     public const string TestFlag = "TestFlag";
-    public const string EditContactsUI = "EditContactsUI";
     public const string UpdatedFooterHelpLink = "UpdatedFooterHelpLink";
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts.cshtml
@@ -1,5 +1,4 @@
 @page
-@using DfE.FindInformationAcademiesTrusts.Configuration
 @using DfE.FindInformationAcademiesTrusts.Data
 @using DfE.FindInformationAcademiesTrusts.Data.Enums
 @using DfE.FindInformationAcademiesTrusts.Extensions
@@ -11,23 +10,21 @@
 
 @section TrustPageMessage
 {
-  <feature name="@FeatureFlags.EditContactsUI">
-    @if (!string.IsNullOrWhiteSpace(TempData["ContactUpdatedMessage"] as string))
-    {
-      <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-            Success
-          </h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-          <h3 class="govuk-notification-banner__heading">
-            @TempData["ContactUpdatedMessage"]
-          </h3>
-        </div>
+  @if (!string.IsNullOrWhiteSpace(TempData["ContactUpdatedMessage"] as string))
+  {
+    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          Success
+        </h2>
       </div>
-    }
-  </feature>
+      <div class="govuk-notification-banner__content">
+        <h3 class="govuk-notification-banner__heading">
+          @TempData["ContactUpdatedMessage"]
+        </h3>
+      </div>
+    </div>
+  }
 }
 
 <section class="govuk-!-margin-bottom-9">
@@ -39,11 +36,9 @@
       <h3 class="govuk-summary-card__title">
         @ContactRole.TrustRelationshipManager.MapRoleToViewString()
       </h3>
-      <feature name="@FeatureFlags.EditContactsUI">
-        <div class="govuk-summary-card__actions">
-          <a class="govuk-link" asp-page="/Trusts/Contacts/EditTrustRelationshipManager" asp-route-uid="@Model.Uid">Change<span class="govuk-visually-hidden"> details of this contact (@ContactRole.TrustRelationshipManager.MapRoleToViewString())</span></a>
-        </div>
-      </feature>
+      <div class="govuk-summary-card__actions">
+        <a class="govuk-link" asp-page="/Trusts/Contacts/EditTrustRelationshipManager" asp-route-uid="@Model.Uid">Change<span class="govuk-visually-hidden"> details of this contact (@ContactRole.TrustRelationshipManager.MapRoleToViewString())</span></a>
+      </div>
     </div>
     @{ DisplayContact(Model.TrustRelationshipManager); }
   </div>
@@ -52,11 +47,9 @@
       <h3 class="govuk-summary-card__title">
         @ContactRole.SfsoLead.MapRoleToViewString()
       </h3>
-      <feature name="@FeatureFlags.EditContactsUI">
-        <div class="govuk-summary-card__actions">
-          <a class="govuk-link" asp-page="/Trusts/Contacts/EditSfsoLead" asp-route-uid="@Model.Uid">Change<span class="govuk-visually-hidden"> details of this contact (@ContactRole.SfsoLead.MapRoleToViewString())</span></a>
-        </div>
-      </feature>
+      <div class="govuk-summary-card__actions">
+        <a class="govuk-link" asp-page="/Trusts/Contacts/EditSfsoLead" asp-route-uid="@Model.Uid">Change<span class="govuk-visually-hidden"> details of this contact (@ContactRole.SfsoLead.MapRoleToViewString())</span></a>
+      </div>
     </div>
     @{ DisplayContact(Model.SfsoLead); }
   </div>
@@ -138,5 +131,5 @@
       </dl>
     </div>
   }
-  
+
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditSfsoLead.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditSfsoLead.cshtml.cs
@@ -1,13 +1,10 @@
-using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
-using Microsoft.FeatureManagement.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Contacts;
 
-[FeatureGate(FeatureFlags.EditContactsUI)]
 public class EditSfsoLeadModel(
     IDataSourceService dataSourceService,
     ILogger<EditSfsoLeadModel> logger,

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditTrustRelationshipManager.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditTrustRelationshipManager.cshtml.cs
@@ -1,13 +1,10 @@
-using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
-using Microsoft.FeatureManagement.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Contacts;
 
-[FeatureGate(FeatureFlags.EditContactsUI)]
 public class EditTrustRelationshipManagerModel(
     IDataSourceService dataSourceService,
     ILogger<EditTrustRelationshipManagerModel> logger,

--- a/DfE.FindInformationAcademiesTrusts/appsettings.json
+++ b/DfE.FindInformationAcademiesTrusts/appsettings.json
@@ -40,7 +40,6 @@
   },
   "FeatureManagement": {
     "TestFlag": false,
-    "EditContactsUI": false,
     "UpdatedFooterHelpLink": true
   },
   "DataProtection": {

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -5,7 +5,6 @@ Feature flags can be used to programatically turn features on and off. We can us
 ## List of current flags
 
 - `TestFlag` (Default: false): Flag added to test the functionality of feature flags. Adds a line to the layout that shows flags are working when set to true.
-- `EditContactsUI` (Default: false): Flag added to control who can see the edit contacts UI on the Trust contacts page while that is still in development.
 - `UpdatedFooterHelpLink` (Default: true): Flag added to control when we release the updated help link in the footer.
 
 ## Implementation


### PR DESCRIPTION
[User Story 184647](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/184647): Tech debt: Remove the Edit Contact UI feature flag

Remove the edit contact feature flag.
This flag is now redundant since the feature has been tested and released to production.

## Changes

Remove the feature gates and documentation relating to the edit contacts feature flag

## Screenshots of UI changes

No UI changeds

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
