### PR TITLE
Added governance turnover to governance page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Added Governance turnover to governance page
+
 ### Changed
 
 - Updated the contacts page to include disclaimer text for the trust contacts

--- a/DfE.FindInformationAcademiesTrusts.Data/DateTimeProvider.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/DateTimeProvider.cs
@@ -3,10 +3,12 @@
     public interface IDateTimeProvider
     {
         DateTime Now { get; }
+        DateTime Today { get; }
     }
     public class DateTimeProvider : IDateTimeProvider
     {
         public DateTime Now => DateTime.Now;
+        public DateTime Today => DateTime.Today;
     }
 
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
@@ -11,7 +11,7 @@
     </div>
     <div class="govuk-summary-card__content">
         <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-top-2 govuk-!-margin-bottom-2">
-            @Model.TrustGovernance.GovernanceTurnover.ToString("0")% within the last 12 months
+            @Model.TrustGovernance.TurnoverRate.ToString("0")% within the last 12 months
         </p>
         <p class="govuk-body">Number of trustees appointed or resigned as a proportion of the number of trustees on the board.</p>
     </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
@@ -5,7 +5,17 @@
 @{
   Layout = "_TrustLayout";
 }
-
+<div class="govuk-summary-card govuk-!-margin-top-9">
+    <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">Governance turnover</h2>
+    </div>
+    <div class="govuk-summary-card__content">
+        <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-top-2 govuk-!-margin-bottom-2">
+            @Model.TurnoverRate.ToString("0")% within the last 12 months
+        </p>
+        <p class="govuk-body">Number of trustees appointed or resigned as a proportion of the number of trustees on the board.</p>
+    </div>
+</div>
 <section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container" data-testid="trust-leadership">
   @if (Model.TrustGovernance.TrustLeadership.Length > 0)
   {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml
@@ -11,7 +11,7 @@
     </div>
     <div class="govuk-summary-card__content">
         <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-top-2 govuk-!-margin-bottom-2">
-            @Model.TurnoverRate.ToString("0")% within the last 12 months
+            @Model.TrustGovernance.GovernanceTurnover.ToString("0")% within the last 12 months
         </p>
         <p class="govuk-body">Number of trustees appointed or resigned as a proportion of the number of trustees on the board.</p>
     </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
@@ -11,7 +11,6 @@ public class GovernanceModel(
     : TrustsAreaModel(dataSourceService, trustService, logger, "Governance")
 {
     public TrustGovernanceServiceModel TrustGovernance { get; private set; } = default!;
-    public decimal TurnoverRate { get; private set; }
 
     public override async Task<IActionResult> OnGetAsync()
     {
@@ -24,45 +23,7 @@ public class GovernanceModel(
             await DataSourceService.GetAsync(Source.Gias),
             new List<string> { "Governance" }));
 
-        CalculateTurnoverRate();
-
         return pageResult;
-    }
-
-    public void CalculateTurnoverRate()
-    {
-        var today = DateTime.Today;
-
-        // Past 12 Months 
-        var past12MonthsStart = today.AddYears(-1);
-        var past12MonthsEnd = today;
-
-        // Get all governors (Trustees and Members)
-        var allGovernors = TrustGovernance.Trustees
-            .Concat(TrustGovernance.Members)
-            .ToList();
-
-        // Total number of governor positions 
-        int totalCurrentGovernors = allGovernors.Count;
-
-        // Appointments in the past 12 months
-        int appointmentsInPast12Months = allGovernors
-            .Count(g => g.DateOfAppointment != null &&
-                        g.DateOfAppointment >= past12MonthsStart &&
-                        g.DateOfAppointment <= past12MonthsEnd);
-
-        // Resignations in the past 12 months
-        int resignationsInPast12Months = allGovernors
-            .Count(g => g.DateOfTermEnd != null &&
-                        g.DateOfTermEnd >= past12MonthsStart &&
-                        g.DateOfTermEnd <= past12MonthsEnd);
-
-        int totalEvents = appointmentsInPast12Months + resignationsInPast12Months;
-
-        // Calculate turnover rate and round to 1 decimal point
-        TurnoverRate = totalCurrentGovernors > 0
-            ? Math.Round((decimal)totalEvents / totalCurrentGovernors * 100m, 1)
-            : 0m;
     }
 
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance.cshtml.cs
@@ -4,26 +4,65 @@ using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
-
 public class GovernanceModel(
     IDataSourceService dataSourceService,
     ILogger<GovernanceModel> logger,
     ITrustService trustService)
     : TrustsAreaModel(dataSourceService, trustService, logger, "Governance")
 {
-    public TrustGovernanceServiceModel TrustGovernance { get; set; } = default!;
+    public TrustGovernanceServiceModel TrustGovernance { get; private set; } = default!;
+    public decimal TurnoverRate { get; private set; }
 
     public override async Task<IActionResult> OnGetAsync()
     {
         var pageResult = await base.OnGetAsync();
-
-        if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
+        if (pageResult is NotFoundResult) return pageResult;
 
         TrustGovernance = await TrustService.GetTrustGovernanceAsync(Uid);
 
-        DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.Gias),
+        DataSources.Add(new DataSourceListEntry(
+            await DataSourceService.GetAsync(Source.Gias),
             new List<string> { "Governance" }));
+
+        CalculateTurnoverRate();
 
         return pageResult;
     }
+
+    public void CalculateTurnoverRate()
+    {
+        var today = DateTime.Today;
+
+        // Past 12 Months 
+        var past12MonthsStart = today.AddYears(-1);
+        var past12MonthsEnd = today;
+
+        // Get all governors (Trustees and Members)
+        var allGovernors = TrustGovernance.Trustees
+            .Concat(TrustGovernance.Members)
+            .ToList();
+
+        // Total number of governor positions 
+        int totalCurrentGovernors = allGovernors.Count;
+
+        // Appointments in the past 12 months
+        int appointmentsInPast12Months = allGovernors
+            .Count(g => g.DateOfAppointment != null &&
+                        g.DateOfAppointment >= past12MonthsStart &&
+                        g.DateOfAppointment <= past12MonthsEnd);
+
+        // Resignations in the past 12 months
+        int resignationsInPast12Months = allGovernors
+            .Count(g => g.DateOfTermEnd != null &&
+                        g.DateOfTermEnd >= past12MonthsStart &&
+                        g.DateOfTermEnd <= past12MonthsEnd);
+
+        int totalEvents = appointmentsInPast12Months + resignationsInPast12Months;
+
+        // Calculate turnover rate and round to 1 decimal point
+        TurnoverRate = totalCurrentGovernors > 0
+            ? Math.Round((decimal)totalEvents / totalCurrentGovernors * 100m, 1)
+            : 0m;
+    }
+
 }

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustGovernanceServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustGovernanceServiceModel.cs
@@ -6,4 +6,5 @@ public record TrustGovernanceServiceModel(
     Governor[] TrustLeadership,
     Governor[] Members,
     Governor[] Trustees,
-    Governor[] HistoricMembers);
+    Governor[] HistoricMembers,
+    decimal GovernanceTurnover);

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustGovernanceServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustGovernanceServiceModel.cs
@@ -7,4 +7,4 @@ public record TrustGovernanceServiceModel(
     Governor[] Members,
     Governor[] Trustees,
     Governor[] HistoricMembers,
-    decimal GovernanceTurnover);
+    decimal TurnoverRate);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
@@ -114,4 +114,57 @@ public class GovernanceModelTests
         _mockTrustRepository.Verify(e => e.GetTrustGovernanceAsync(TestUid), Times.Once);
         _sut.TrustGovernance.Should().BeEquivalentTo(DummyTrustGovernanceServiceModel);
     }
+
+    [Fact]
+    public async Task CalculateTurnoverRate_Should_Calculate_Correctly_For_ExampleAsync()
+    {
+        // Arrange
+        var today = new DateTime(2024, 11, 4);
+        var past12MonthsStart = today.AddYears(-1).AddDays(1);
+
+        // Create 30 governors with default dates
+        var governors = Enumerable.Range(1, 30)
+            .Select(i => new Governor(
+                GID: "9999",
+                UID: "1234",
+                FullName: $"Governor {i}",
+                Role: "Trustee",
+                AppointingBody: "Body",
+                DateOfAppointment: new DateTime(2022, 1, 1),
+                DateOfTermEnd: null,
+                Email: null
+            ))
+            .ToList();
+
+        // Update 10 governors with appointments in the past 12 months
+        for (int i = 0; i < 10; i++)
+        {
+            governors[i] = governors[i] with { DateOfAppointment = past12MonthsStart.AddDays(i) };
+        }
+
+        // Update 3 governors with resignations in the past 12 months
+        for (int i = 0; i < 3; i++)
+        {
+            governors[29 - i] = governors[29 - i] with { DateOfTermEnd = past12MonthsStart.AddDays(i) };
+        }
+
+        var trustGovernance = new TrustGovernanceServiceModel(
+            [],
+            [],
+            [.. governors],
+            []
+        );
+
+        _mockTrustRepository.Setup(t => t.GetTrustGovernanceAsync(TestUid))
+            .ReturnsAsync(trustGovernance);
+
+        await _sut.OnGetAsync();
+
+
+        // Act
+        _sut.CalculateTurnoverRate();
+
+        // Assert
+        _sut.TurnoverRate.Should().Be(43.3m);
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
@@ -59,7 +59,7 @@ public class GovernanceModelTests
     );
 
     private static readonly TrustGovernanceServiceModel DummyTrustGovernanceServiceModel =
-        new([Leader], [Member], [Trustee], [Historic]);
+        new([Leader], [Member], [Trustee], [Historic], 0);
 
     private readonly MockDataSourceService _mockDataSourceService = new();
     private readonly Mock<ITrustService> _mockTrustRepository = new();
@@ -115,56 +115,5 @@ public class GovernanceModelTests
         _sut.TrustGovernance.Should().BeEquivalentTo(DummyTrustGovernanceServiceModel);
     }
 
-    [Fact]
-    public async Task CalculateTurnoverRate_Should_Calculate_Correctly_For_ExampleAsync()
-    {
-        // Arrange
-        var today = new DateTime(2024, 11, 4);
-        var past12MonthsStart = today.AddYears(-1).AddDays(1);
 
-        // Create 30 governors with default dates
-        var governors = Enumerable.Range(1, 30)
-            .Select(i => new Governor(
-                GID: "9999",
-                UID: "1234",
-                FullName: $"Governor {i}",
-                Role: "Trustee",
-                AppointingBody: "Body",
-                DateOfAppointment: new DateTime(2022, 1, 1),
-                DateOfTermEnd: null,
-                Email: null
-            ))
-            .ToList();
-
-        // Update 10 governors with appointments in the past 12 months
-        for (int i = 0; i < 10; i++)
-        {
-            governors[i] = governors[i] with { DateOfAppointment = past12MonthsStart.AddDays(i) };
-        }
-
-        // Update 3 governors with resignations in the past 12 months
-        for (int i = 0; i < 3; i++)
-        {
-            governors[29 - i] = governors[29 - i] with { DateOfTermEnd = past12MonthsStart.AddDays(i) };
-        }
-
-        var trustGovernance = new TrustGovernanceServiceModel(
-            [],
-            [],
-            [.. governors],
-            []
-        );
-
-        _mockTrustRepository.Setup(t => t.GetTrustGovernanceAsync(TestUid))
-            .ReturnsAsync(trustGovernance);
-
-        await _sut.OnGetAsync();
-
-
-        // Act
-        _sut.CalculateTurnoverRate();
-
-        // Assert
-        _sut.TurnoverRate.Should().Be(43.3m);
-    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServiceTests.cs
@@ -3,7 +3,6 @@ using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 using DfE.FindInformationAcademiesTrusts.Pages;
-using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
@@ -59,6 +58,154 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services
             worksheet.Cell(3, 17).Value.ToString().Should().Be("% Full");
             worksheet.Cell(3, 18).Value.ToString().Should().Be("Pupils eligible for Free School Meals");
         }
+
+        [Fact]
+        public async Task ExportAcademiesToSpreadsheet_ShouldHandleNullTrustSummaryAsync()
+        {
+            // Arrange
+            var uid = "some-uid";
+            _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(uid))
+                .ReturnsAsync((TrustSummary?)null);
+
+            // Act
+            var result = await _sut.ExportAcademiesToSpreadsheetAsync(uid);
+            using var workbook = new XLWorkbook(new MemoryStream(result));
+            var worksheet = workbook.Worksheet("Academies");
+
+            // Assert
+            worksheet.Cell(1, 1).Value.ToString().Should().Be(string.Empty);
+            worksheet.Cell(2, 1).Value.ToString().Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public async Task ExportAcademiesToSpreadsheet_ShouldHandleMissingOfstedDataAsync()
+        {
+            // Arrange
+            var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
+            var academyUrn = "123456";
+
+            _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid))
+                .ReturnsAsync(new TrustSummary("Sample Trust", "Multi-academy trust"));
+            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid))
+                .ReturnsAsync(new AcademyDetails[]
+                {
+            new(academyUrn, "Academy 1", "Type A", "Local Authority 1", "Urban"),
+                });
+            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustOfstedAsync(trustSummary.Uid))
+                .ReturnsAsync(Array.Empty<AcademyOfsted>());
+
+            // Act
+            var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
+            using var workbook = new XLWorkbook(new MemoryStream(result));
+            var worksheet = workbook.Worksheet("Academies");
+
+            // Assert
+            worksheet.Cell(4, 7).Value.ToString().Should().Be("Not yet inspected");
+            worksheet.Cell(4, 8).Value.ToString().Should().Be(string.Empty);
+            worksheet.Cell(4, 9).Value.ToString().Should().Be(string.Empty);
+            worksheet.Cell(4, 10).Value.ToString().Should().Be("Not yet inspected");
+            worksheet.Cell(4, 11).Value.ToString().Should().Be(string.Empty);
+            worksheet.Cell(4, 12).Value.ToString().Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public async Task ExportAcademiesToSpreadsheet_ShouldHandleMissingPupilNumbersDataAsync()
+        {
+            // Arrange
+            var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
+            var academyUrn = "123456";
+
+            _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid))
+                .ReturnsAsync(new TrustSummary("Sample Trust", "Multi-academy trust"));
+            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid))
+                .ReturnsAsync(new AcademyDetails[]
+                {
+            new(academyUrn, "Academy 1", "Type A", "Local Authority 1", "Urban"),
+                });
+            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid))
+                .ReturnsAsync(Array.Empty<AcademyPupilNumbers>());
+
+            // Act
+            var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
+            using var workbook = new XLWorkbook(new MemoryStream(result));
+            var worksheet = workbook.Worksheet("Academies");
+
+            // Assert
+            worksheet.Cell(4, 15).Value.ToString().Should().Be(string.Empty);
+            worksheet.Cell(4, 16).Value.ToString().Should().Be(string.Empty);
+            worksheet.Cell(4, 17).Value.ToString().Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public async Task ExportAcademiesToSpreadsheet_ShouldHandleZeroPercentageFullAsync()
+        {
+            // Arrange
+            var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
+            var academyUrn = "123456";
+
+            _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid))
+                .ReturnsAsync(new TrustSummary("Sample Trust", "Multi-academy trust"));
+            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid))
+                .ReturnsAsync(new AcademyDetails[]
+                {
+            new(academyUrn, "Academy 1", "Type A", "Local Authority 1", "Urban"),
+                });
+            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid))
+                .ReturnsAsync(new AcademyPupilNumbers[]
+                {
+            new(academyUrn, "Academy 1", "Primary", new AgeRange(5,11), 0, 300)
+                });
+
+            // Act
+            var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
+            using var workbook = new XLWorkbook(new MemoryStream(result));
+            var worksheet = workbook.Worksheet("Academies");
+
+            // Assert
+            worksheet.Cell(4, 17).Value.ToString().Should().Be(string.Empty); // % Full should be empty
+        }
+
+        [Fact]
+        public async Task ExportAcademiesToSpreadsheet_ShouldHandleMissingFreeSchoolMealsDataAsync()
+        {
+            // Arrange
+            var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
+            var academyUrn = "123456";
+
+            _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid))
+                .ReturnsAsync(new TrustSummary("Sample Trust", "Multi-academy trust"));
+            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid))
+                .ReturnsAsync(new AcademyDetails[]
+                {
+            new(academyUrn, "Academy 1", "Type A", "Local Authority 1", "Urban"),
+                });
+            _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustFreeSchoolMealsAsync(trustSummary.Uid))
+                .ReturnsAsync(Array.Empty<AcademyFreeSchoolMeals>());
+
+            // Act
+            var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
+            using var workbook = new XLWorkbook(new MemoryStream(result));
+            var worksheet = workbook.Worksheet("Academies");
+
+            // Assert
+            worksheet.Cell(4, 18).Value.ToString().Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnAfterJoining_WhenInspectionDateIsEqualToJoiningDate()
+        {
+            // Arrange
+            var ofstedRatingScore = OfstedRatingScore.Good;
+            var dateJoinedTrust = _mockDateTimeProvider.Object.Now;
+            DateTime? inspectionEndDate = dateJoinedTrust;
+
+            // Act
+            var result = ExportService.IsOfstedRatingBeforeOrAfterJoining(ofstedRatingScore, dateJoinedTrust, inspectionEndDate);
+
+            // Assert
+            result.Should().Be("After Joining");
+        }
+
 
         [Fact]
         public async Task ExportAcademiesToSpreadsheet_ShouldCorrectlyExtractAcademyDataAsync()


### PR DESCRIPTION
<!-- Add a link to the user story -->
[User Story 144819](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/144819): Build: Governance page - turnover

## Changes

Turnover Rate % = ((Appointments in past 12 months + Resignations in past 12 months) / Total Current Governors) * 100

Past 12 months = 1 calendar year prior to date of when data is pulled from GIAS
Governors = Trustees and Members
% = 1 decimal point

Implemented the above and surfaced it on the governance page

## Screenshots of UI changes

### Before

![image](https://github.com/user-attachments/assets/6deac977-90bd-4988-952c-535d06b594ca)

### After

![image](https://github.com/user-attachments/assets/4fd87b2e-e3a7-40e8-aaf6-fe30271ea6d0)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
