### PR TITLE
Move Trust Primary nav from side to top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated wording for links on the landing page to tell users they open in new tabs
 - Updated the ofsted ratings to collect information about the ofsted subgrades
 - Remove the edit contact feature flag
+- Change Trust Navigation from side nav to top nav (service navigation component)
 
 ## [Release-11][release-11] (production-2024-10-17.3654)
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
@@ -26,4 +26,6 @@ public interface ITrustsAreaModel
 
     string MapDataSourceToName(DataSourceServiceModel dataSource);
     string MapDataSourceToTestId(DataSourceListEntry source);
+
+    TrustNavigationLinkModel[] NavigationLinks { get; }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustNavigationLinkModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustNavigationLinkModel.cs
@@ -1,0 +1,3 @@
+﻿namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+
+public record TrustNavigationLinkModel(string LinkText, string Page, string Uid, bool LinkIsActive, string DataTestId);

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -1,9 +1,9 @@
+using System.Text.RegularExpressions;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
-using System.Text.RegularExpressions;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 
@@ -52,6 +52,8 @@ public class TrustsAreaModel(
             $@"data-source-{source.DataSource.Source.ToString().ToLowerInvariant()}-{string.Join("-", source.Fields.Select(s => Regex.Replace(s.ToLowerInvariant().Trim(), @"\s+", "-", RegexOptions.Compiled, TimeSpan.FromMilliseconds(500))))}";
     }
 
+    public TrustNavigationLinkModel[] NavigationLinks { get; set; } = [];
+
     public virtual async Task<IActionResult> OnGetAsync()
     {
         var trustSummary = await TrustService.GetTrustSummaryAsync(Uid);
@@ -62,6 +64,16 @@ public class TrustsAreaModel(
         }
 
         TrustSummary = trustSummary;
+
+        NavigationLinks =
+        [
+            new TrustNavigationLinkModel("Overview", "/Trusts/Overview", Uid, PageName == "Overview", "overview-nav"),
+            new TrustNavigationLinkModel("Contacts", "/Trusts/Contacts", Uid, PageName == "Contacts", "contacts-nav"),
+            new TrustNavigationLinkModel($"Academies ({TrustSummary.NumberOfAcademies})", "/Trusts/Academies/Details",
+                Uid, PageName == "Academies in this trust", "academies-nav"),
+            new TrustNavigationLinkModel("Governance", "/Trusts/Governance", Uid, PageName == "Governance",
+                "governance-nav")
+        ];
 
         return Page();
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -65,6 +65,13 @@ public class TrustsAreaModel(
 
         TrustSummary = trustSummary;
 
+        InitializeNavigationLinks();
+
+        return Page();
+    }
+
+    private void InitializeNavigationLinks()
+    {
         NavigationLinks =
         [
             new TrustNavigationLinkModel("Overview", "/Trusts/Overview", Uid, PageName == "Overview", "overview-nav"),
@@ -74,7 +81,5 @@ public class TrustsAreaModel(
             new TrustNavigationLinkModel("Governance", "/Trusts/Governance", Uid, PageName == "Governance",
                 "governance-nav")
         ];
-
-        return Page();
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
@@ -7,14 +7,12 @@
 
 <partial name="_TrustBanner" model="@Model"/>
 
+<partial name="_TrustNavigation" model="@Model"/>
 <div class="govuk-main-wrapper govuk-!-padding-top-0">
   <div class="dfe-width-container">
     <partial name="_TrustBreadcrumbs" model="@Model"/>
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
-        <partial name="_TrustNavigation" model="@Model"/>
-      </div>
-      <div class="govuk-grid-column-three-quarters">
+      <div class="govuk-grid-column-full">
         <main id="main-content">
           @await RenderSectionAsync("TrustPageMessage", false)
           <header>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigation.cshtml
@@ -1,49 +1,20 @@
 @model ITrustsAreaModel
 
-@functions {
-
-  private string GetCurrentLinkClassIf(string linkName)
-  {
-    var currentLinkClass = "ds_current govuk-!-font-weight-bold";
-    return Model.PageName == linkName ? currentLinkClass : string.Empty;
-  }
-
-}
-
-<nav aria-label="Sections" class="ds_side-navigation app-side-navigation" data-module="ds-side-navigation">
-  <input type="checkbox" class="fully-hidden js-toggle-side-navigation" id="show-side-navigation" aria-controls="side-navigation-root"/>
-  <label class="ds_side-navigation__expand" for="show-side-navigation"><span class="visually-hidden">Show all</span> Pages in this section <span class="ds_side-navigation__expand-indicator"></span></label>
-
-  <ul class="ds_side-navigation__list app-side-navigation__list" id="side-navigation-root">
-    <li class="ds_side-navigation__item  ds_side-navigation__item--has-children app-side-navigation__item--has-children">
-      <div class="govuk-caption-m app-side-navigation__title">@ViewConstants.AboutTheTrustSectionName</div>
-      <ul class="ds_side-navigation__list app-side-navigation__list">
-        <li class="ds_side-navigation__item app-side-navigation-highlight-item">
-          <a asp-page="/Trusts/Details" asp-route-uid="@Model.TrustSummary.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Details")" data-testid="details-nav">
-            <span class="visually-hidden">Trust</span>Details
-          </a>
-        </li>
-        <li class="ds_side-navigation__item app-side-navigation-highlight-item">
-          <a asp-page="/Trusts/Contacts" asp-route-uid="@Model.TrustSummary.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Contacts")" data-testid="contacts-nav">
-            <span class="visually-hidden">Trust</span>Contacts
-          </a>
-        </li>
-        <li class="ds_side-navigation__item app-side-navigation-highlight-item">
-          <a asp-page="/Trusts/Overview" asp-route-uid="@Model.TrustSummary.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Overview")" data-testid="overview-nav">
-            <span class="visually-hidden">Trust</span>Overview
-          </a>
-        </li>
-        <li class="ds_side-navigation__item app-side-navigation-highlight-item">
-          <a asp-page="/Trusts/Academies/Details" asp-route-uid="@Model.TrustSummary.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Academies in this trust")" data-testid="academies-nav">
-            Academies in this trust (@Model.TrustSummary.NumberOfAcademies)
-          </a>
-        </li>
-        <li class="ds_side-navigation__item app-side-navigation-highlight-item">
-          <a asp-page="/Trusts/Governance" asp-route-uid="@Model.TrustSummary.Uid" class="ds_side-navigation__link govuk-body govuk-link govuk-link--no-visited-state @GetCurrentLinkClassIf("Governance")" data-testid="governance-nav">
-            Governance
-          </a>
-        </li>
-      </ul>
-    </li>
-  </ul>
-</nav>
+<div class="govuk-service-navigation"
+     data-module="govuk-service-navigation">
+  <div class="govuk-width-container">
+    <div class="govuk-service-navigation__container">
+      <nav aria-label="Menu" class="govuk-service-navigation__wrapper">
+        <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle" aria-controls="navigation" hidden>
+          Menu
+        </button>
+        <ul class="govuk-service-navigation__list" id="navigation">
+          @foreach (var link in Model.NavigationLinks)
+          {
+            <partial name="_TrustNavigationLink" model="@link"/>
+          }
+        </ul>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigationLink.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigationLink.cshtml
@@ -1,0 +1,17 @@
+﻿@model TrustNavigationLinkModel
+@if (Model.LinkIsActive)
+{
+  <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
+    <a class="govuk-service-navigation__link" asp-page="@Model.Page" asp-route-uid="@Model.Uid" data-testid="@Model.DataTestId">
+      <strong class="govuk-service-navigation__active-fallback govuk-!-font-weight-bold">@Model.LinkText</strong>
+    </a>
+  </li>
+}
+else
+{
+  <li class="govuk-service-navigation__item">
+    <a class="govuk-service-navigation__link govuk-!-font-weight-bold" asp-page="@Model.Page" asp-route-uid="@Model.Uid" data-testid="@Model.DataTestId">
+      @Model.LinkText
+    </a>
+  </li>
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/AcademiesDetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/AcademiesDetailsModelTests.cs
@@ -1,6 +1,7 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -29,8 +30,9 @@ public class AcademiesDetailsModelTests
             .ReturnsAsync(_fakeTrust);
 
         _sut = new AcademiesDetailsModel(_mockDataSourceService.Object,
-                _mockLinkBuilder.Object, _mockLogger.Object, _mockTrustRepository.Object, _mockAcademyService.Object, _mockExportService.Object, _mockDateTimeProvider.Object)
-        { Uid = _fakeTrust.Uid };
+                _mockLinkBuilder.Object, _mockLogger.Object, _mockTrustRepository.Object, _mockAcademyService.Object,
+                _mockExportService.Object, _mockDateTimeProvider.Object)
+            { Uid = _fakeTrust.Uid };
     }
 
     [Fact]
@@ -89,5 +91,19 @@ public class AcademiesDetailsModelTests
         _mockDataSourceService.Verify(e => e.GetAsync(Source.Gias), Times.Once);
         _sut.DataSources.Should().ContainSingle();
         _sut.DataSources[0].Fields.Should().Contain(new List<string> { "Details" });
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_correct_NavigationLinks()
+    {
+        _ = await _sut.OnGetAsync();
+        _sut.NavigationLinks.Should().BeEquivalentTo([
+            new TrustNavigationLinkModel("Overview", "/Trusts/Overview", "1234", false, "overview-nav"),
+            new TrustNavigationLinkModel("Contacts", "/Trusts/Contacts", "1234", false, "contacts-nav"),
+            new TrustNavigationLinkModel("Academies (3)", "/Trusts/Academies/Details",
+                "1234", true, "academies-nav"),
+            new TrustNavigationLinkModel("Governance", "/Trusts/Governance", "1234", false,
+                "governance-nav")
+        ]);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -32,7 +33,7 @@ public class FreeSchoolMealsModelTests
                 _mockDataSourceService.Object, new MockLogger<FreeSchoolMealsModel>().Object,
                 _mockTrustService.Object, _mockAcademyService.Object, _mockExportService.Object,
                 _mockDateTimeProvider.Object)
-        { Uid = "1234" };
+            { Uid = "1234" };
     }
 
     [Fact]
@@ -92,5 +93,19 @@ public class FreeSchoolMealsModelTests
         _ = await _sut.OnGetAsync();
 
         _sut.Academies.Should().BeEquivalentTo(academies);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_correct_NavigationLinks()
+    {
+        _ = await _sut.OnGetAsync();
+        _sut.NavigationLinks.Should().BeEquivalentTo([
+            new TrustNavigationLinkModel("Overview", "/Trusts/Overview", "1234", false, "overview-nav"),
+            new TrustNavigationLinkModel("Contacts", "/Trusts/Contacts", "1234", false, "contacts-nav"),
+            new TrustNavigationLinkModel("Academies (1)", "/Trusts/Academies/Details",
+                "1234", true, "academies-nav"),
+            new TrustNavigationLinkModel("Governance", "/Trusts/Governance", "1234", false,
+                "governance-nav")
+        ]);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/OfstedRatingsModelTests.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -95,5 +96,19 @@ public class OfstedRatingsModelTests
         _ = await _sut.OnGetAsync();
 
         _sut.Academies.Should().BeEquivalentTo(academies);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_correct_NavigationLinks()
+    {
+        _ = await _sut.OnGetAsync();
+        _sut.NavigationLinks.Should().BeEquivalentTo([
+            new TrustNavigationLinkModel("Overview", "/Trusts/Overview", "1234", false, "overview-nav"),
+            new TrustNavigationLinkModel("Contacts", "/Trusts/Contacts", "1234", false, "contacts-nav"),
+            new TrustNavigationLinkModel("Academies (3)", "/Trusts/Academies/Details",
+                "1234", true, "academies-nav"),
+            new TrustNavigationLinkModel("Governance", "/Trusts/Governance", "1234", false,
+                "governance-nav")
+        ]);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/PupilNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/PupilNumbersModelTests.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -35,9 +36,9 @@ public class PupilNumbersModelTests
             ]);
 
         _sut = new PupilNumbersModel(_mockDataSourceService.Object, logger.Object,
-               _mockTrustRepository.Object, _mockAcademyService.Object, _mockExportService.Object, _mockDateTimeProvider.Object)
-        { Uid = "1234" };
-
+                _mockTrustRepository.Object, _mockAcademyService.Object, _mockExportService.Object,
+                _mockDateTimeProvider.Object)
+            { Uid = "1234" };
     }
 
     [Fact]
@@ -95,5 +96,19 @@ public class PupilNumbersModelTests
         _mockDataSourceService.Verify(e => e.GetAsync(Source.Gias), Times.Once);
         _sut.DataSources.Should().ContainSingle();
         _sut.DataSources[0].Fields.Should().Contain(new List<string> { "Pupil numbers" });
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_correct_NavigationLinks()
+    {
+        _ = await _sut.OnGetAsync();
+        _sut.NavigationLinks.Should().BeEquivalentTo([
+            new TrustNavigationLinkModel("Overview", "/Trusts/Overview", "1234", false, "overview-nav"),
+            new TrustNavigationLinkModel("Contacts", "/Trusts/Contacts", "1234", false, "contacts-nav"),
+            new TrustNavigationLinkModel("Academies (1)", "/Trusts/Academies/Details",
+                "1234", true, "academies-nav"),
+            new TrustNavigationLinkModel("Governance", "/Trusts/Governance", "1234", false,
+                "governance-nav")
+        ]);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/ContactsModelTests.cs
@@ -34,7 +34,7 @@ public class ContactsModelTests
 
         _sut = new ContactsModel(_mockDataSourceService.Object,
                 new MockLogger<ContactsModel>().Object, _mockTrustService.Object)
-        { Uid = "1234" };
+            { Uid = "1234" };
     }
 
     private void SetupTrustWithNoGovernors()
@@ -138,5 +138,19 @@ public class ContactsModelTests
             { "Accounting officer name", "Chief financial officer name", "Chair of trustees name" });
         _sut.DataSources[3].Fields.Should().Contain(new List<string>
             { "Accounting officer email", "Chief financial officer email", "Chair of trustees email" });
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_correct_NavigationLinks()
+    {
+        _ = await _sut.OnGetAsync();
+        _sut.NavigationLinks.Should().BeEquivalentTo([
+            new TrustNavigationLinkModel("Overview", "/Trusts/Overview", "1234", false, "overview-nav"),
+            new TrustNavigationLinkModel("Contacts", "/Trusts/Contacts", "1234", true, "contacts-nav"),
+            new TrustNavigationLinkModel("Academies (3)", "/Trusts/Academies/Details",
+                "1234", false, "academies-nav"),
+            new TrustNavigationLinkModel("Governance", "/Trusts/Governance", "1234", false,
+                "governance-nav")
+        ]);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/GovernanceModelTests.cs
@@ -75,7 +75,7 @@ public class GovernanceModelTests
 
         _sut = new GovernanceModel(_mockDataSourceService.Object,
                 new MockLogger<GovernanceModel>().Object, _mockTrustRepository.Object)
-        { Uid = TestUid };
+            { Uid = TestUid };
     }
 
     [Fact]
@@ -113,5 +113,19 @@ public class GovernanceModelTests
         await _sut.OnGetAsync();
         _mockTrustRepository.Verify(e => e.GetTrustGovernanceAsync(TestUid), Times.Once);
         _sut.TrustGovernance.Should().BeEquivalentTo(DummyTrustGovernanceServiceModel);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_correct_NavigationLinks()
+    {
+        _ = await _sut.OnGetAsync();
+        _sut.NavigationLinks.Should().BeEquivalentTo([
+            new TrustNavigationLinkModel("Overview", "/Trusts/Overview", "1234", false, "overview-nav"),
+            new TrustNavigationLinkModel("Contacts", "/Trusts/Contacts", "1234", false, "contacts-nav"),
+            new TrustNavigationLinkModel("Academies (0)", "/Trusts/Academies/Details",
+                "1234", false, "academies-nav"),
+            new TrustNavigationLinkModel("Governance", "/Trusts/Governance", "1234", true,
+                "governance-nav")
+        ]);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/OverviewModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/OverviewModelTests.cs
@@ -25,7 +25,7 @@ public class OverviewModelTests
         _sut = new OverviewModel(_mockDataSourceService.Object,
                 new MockLogger<OverviewModel>().Object,
                 _mockTrustService.Object)
-        { Uid = TrustUid };
+            { Uid = TrustUid };
     }
 
     [Fact]
@@ -187,5 +187,19 @@ public class OverviewModelTests
         _mockDataSourceService.Verify(e => e.GetAsync(Source.Gias), Times.Once);
         _sut.DataSources.Should().ContainSingle();
         _sut.DataSources[0].Fields.Should().Contain(new List<string> { "Trust summary", "Ofsted ratings" });
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_correct_NavigationLinks()
+    {
+        _ = await _sut.OnGetAsync();
+        _sut.NavigationLinks.Should().BeEquivalentTo([
+            new TrustNavigationLinkModel("Overview", "/Trusts/Overview", "1234", true, "overview-nav"),
+            new TrustNavigationLinkModel("Contacts", "/Trusts/Contacts", "1234", false, "contacts-nav"),
+            new TrustNavigationLinkModel("Academies (3)", "/Trusts/Academies/Details",
+                "1234", false, "academies-nav"),
+            new TrustNavigationLinkModel("Governance", "/Trusts/Governance", "1234", false,
+                "governance-nav")
+        ]);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
@@ -71,6 +71,25 @@ public class TrustsAreaModelTests
         result.Should().BeOfType<NotFoundResult>();
     }
 
+    [Fact]
+    public async Task OnGetAsync_should_populate_NavigationLinks()
+    {
+        var dummyTrustSummary = new TrustSummaryServiceModel("1234", "My Trust", "Multi-academy trust", 3);
+        _mockTrustRepository.Setup(t => t.GetTrustSummaryAsync(dummyTrustSummary.Uid))
+            .ReturnsAsync(dummyTrustSummary);
+        _sut.Uid = dummyTrustSummary.Uid;
+
+        await _sut.OnGetAsync();
+        _sut.NavigationLinks.Should().BeEquivalentTo([
+            new TrustNavigationLinkModel("Overview", "/Trusts/Overview", "1234", false, "overview-nav"),
+            new TrustNavigationLinkModel("Contacts", "/Trusts/Contacts", "1234", false, "contacts-nav"),
+            new TrustNavigationLinkModel("Academies (3)", "/Trusts/Academies/Details",
+                "1234", false, "academies-nav"),
+            new TrustNavigationLinkModel("Governance", "/Trusts/Governance", "1234", false,
+                "governance-nav")
+        ]);
+    }
+
     [Theory]
     [InlineData(Source.Gias, "Get information about schools")]
     [InlineData(Source.Mstr, "Get information about schools (internal use only, do not share outside of DfE)")]
@@ -118,7 +137,7 @@ public class TrustsAreaModelTests
         var result = _sut.MapDataSourceToTestId(new DataSourceListEntry(source, fields));
 
         // Assert
-        Assert.Equal("data-source-gias-", result);  // Fields are empty, but source should still be present
+        Assert.Equal("data-source-gias-", result); // Fields are empty, but source should still be present
     }
 
     [Fact]


### PR DESCRIPTION
[Task 187092](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/187092): Move primary navigation from side to top
Moves the primary navigation for trust pages from a side nav to a service navigation component under the trust banner.

> Note that link to the details page is missing, this is being merged into the overview page in a separate PR

## Changes

- Created TrustNavigationLinkModel and partial to render each item in the service nav
- Update the TrustAreaModel to hold the list of links
- Update the TrustNavigation Partial to switch to the new design
- Update the TrustLayout to move the TrustNavigation partial to under the banner
- Switch the width container for trust pages to full

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/972367ee-9a1d-4228-b2c6-fcddd311d4bd)

### After
![image](https://github.com/user-attachments/assets/ef30e6e0-e484-4512-b9cc-6c2e9a7eb05e)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
