### PR TITLE
Move breadcrumbs to top of the banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove the edit contact feature flag
 - Change Trust Navigation from side nav to top nav (service navigation component)
 - Update the Govuk frontend package to ^5.7.1
+- Moved breadcrumbs into the trust banner
 
 ## [Release-11][release-11] (production-2024-10-17.3654)
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBanner.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBanner.cshtml
@@ -5,7 +5,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
         <partial name="_TrustBreadcrumbs" model="@Model"/>
-        <h2 class="govuk-heading-l app-banner--heading govuk-!-margin-bottom-3" data-testid="trust-name-heading">@Model.TrustSummary.Name</h2>
+        <h2 class="govuk-heading-l app-banner--heading govuk-!-margin-top-3 govuk-!-margin-bottom-3" data-testid="trust-name-heading">@Model.TrustSummary.Name</h2>
         <p class="govuk-body app-banner--body govuk-!-margin-bottom-0" data-testid="trust-type">@Model.TrustSummary.Type</p>
       </div>
     </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBanner.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBanner.cshtml
@@ -4,6 +4,7 @@
   <div class="dfe-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
+        <partial name="_TrustBreadcrumbs" model="@Model"/>
         <h2 class="govuk-heading-l app-banner--heading govuk-!-margin-bottom-3" data-testid="trust-name-heading">@Model.TrustSummary.Name</h2>
         <p class="govuk-body app-banner--body govuk-!-margin-bottom-0" data-testid="trust-type">@Model.TrustSummary.Type</p>
       </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBreadcrumbs.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBreadcrumbs.cshtml
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <nav class="govuk-breadcrumbs govuk-!-margin-top-6 govuk-!-margin-bottom-6" aria-label="Breadcrumb">
+    <nav class="govuk-breadcrumbs govuk-!-margin-0" aria-label="Breadcrumb">
       <ol class="govuk-breadcrumbs__list">
         <li class="govuk-breadcrumbs__list-item">
           <a class="govuk-breadcrumbs__link" asp-page="/Index">Home</a>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
@@ -6,11 +6,9 @@
 }
 
 <partial name="_TrustBanner" model="@Model"/>
-
 <partial name="_TrustNavigation" model="@Model"/>
-<div class="govuk-main-wrapper govuk-!-padding-top-0">
+<div class="govuk-main-wrapper govuk-!-padding-top-6">
   <div class="dfe-width-container">
-    <partial name="_TrustBreadcrumbs" model="@Model"/>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <main id="main-content">

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
@@ -8,8 +8,8 @@
 @import "components/contactsSummaryCard";
 
 .app-banner {
-  @include govuk-responsive-padding(5, "top");
-  @include govuk-responsive-padding(5, "bottom");
+  @include govuk-responsive-padding(3, "top");
+  @include govuk-responsive-padding(3, "bottom");
   background-color: $app-color-blue-light;
 
   .app-banner--heading {


### PR DESCRIPTION
[Task 187094](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/187094): Move breadcrumb to be between the phase banner and the Trust name

Moves the breadcrumbs to the top of the page inside of the banner. Some changes to spacing to match the design in the prototype.

> Note: in the final version of the navigation designs, the phase banner will be moved to the footer as shown on the prototype. This will be completed later.

## Changes

- Move the breadcrumbs into the trust banner
- Update the margin in the breadcrumbs
- Update the padding in the trust layout wrapper to account for the missing breadcrumbs
- Reduce the app banner padding to match the prototype sizing

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/ed586b2b-bae3-4a09-b2e3-3a1a9655a8be)

### After
![image](https://github.com/user-attachments/assets/c6c22ff2-4e14-47f2-8b0e-2eb3472c88eb)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
