### PR TITLE
Create sharepoint folder links on the details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added download for Ofsted specific data to Ofsted pages
+- Added SharePoint folder link to details page
 
 ### Changed
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/OtherServicesLinkBuilder.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/OtherServicesLinkBuilder.cs
@@ -8,6 +8,7 @@ public interface IOtherServicesLinkBuilder
     string? FindSchoolPerformanceDataListingLink(string uid, TrustType trustType, string? satAcademyUrn);
     string GetInformationAboutSchoolsListingLinkForTrust(string trustUid);
     string GetInformationAboutSchoolsListingLinkForAcademy(string urn);
+    string? SharepointFolderLink(string groupId);
 
     string? FinancialBenchmarkingInsightsToolListingLink(string? companiesHouseNumber);
 }
@@ -24,6 +25,8 @@ public class OtherServicesLinkBuilder : IOtherServicesLinkBuilder
 
     private const string FindSchoolPerformanceDataBaseUrl =
         "https://www.find-school-performance-data.service.gov.uk";
+
+    private const string SharepointBaseUrl = "https://educationgovuk.sharepoint.com";
 
     public string GetInformationAboutSchoolsListingLinkForTrust(string trustUid)
     {
@@ -58,5 +61,12 @@ public class OtherServicesLinkBuilder : IOtherServicesLinkBuilder
                 $"{FindSchoolPerformanceDataBaseUrl}/school/{satAcademyUrn}",
             _ => null
         };
+    }
+
+    public string? SharepointFolderLink(string groupId)
+    {
+        if (string.IsNullOrEmpty(groupId)) return null;
+        return
+            $"{SharepointBaseUrl}/_layouts/15/sharepoint.aspx?oobRefiners=%7B%22FileType%22%3A%5B%22other%22%5D%7D&q={groupId}&v=%2Fsearch";
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/OtherServicesLinkBuilder.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/OtherServicesLinkBuilder.cs
@@ -63,9 +63,8 @@ public class OtherServicesLinkBuilder : IOtherServicesLinkBuilder
         };
     }
 
-    public string? SharepointFolderLink(string groupId)
+    public string SharepointFolderLink(string groupId)
     {
-        if (string.IsNullOrEmpty(groupId)) return null;
         return
             $"{SharepointBaseUrl}/_layouts/15/sharepoint.aspx?oobRefiners=%7B%22FileType%22%3A%5B%22other%22%5D%7D&q={groupId}&v=%2Fsearch";
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/OtherServicesLinkBuilder.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/OtherServicesLinkBuilder.cs
@@ -8,7 +8,7 @@ public interface IOtherServicesLinkBuilder
     string? FindSchoolPerformanceDataListingLink(string uid, TrustType trustType, string? satAcademyUrn);
     string GetInformationAboutSchoolsListingLinkForTrust(string trustUid);
     string GetInformationAboutSchoolsListingLinkForAcademy(string urn);
-    string? SharepointFolderLink(string groupId);
+    string SharepointFolderLink(string groupId);
 
     string? FinancialBenchmarkingInsightsToolListingLink(string? companiesHouseNumber);
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml
@@ -42,6 +42,17 @@
               @Model.TrustOverview.RegionAndTerritory
             </dd>
           </div>
+          @if (Model.SharepointLink is not null)
+          {
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                SharePoint folder (opens in a new tab)
+              </dt>
+              <dd class="govuk-summary-list__value" data-testid="sharepoint-link">
+                <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.SharepointLink">Find this trust's SharePoint folder</a>
+              </dd>
+            </div>
+          }
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
               Information from other services (opens in a new tab)
@@ -49,27 +60,27 @@
             <dd class="govuk-summary-list__value">
               @if (Model.CompaniesHouseLink is not null)
               {
-                <p class="govuk-body">
-                  <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.CompaniesHouseLink">Companies House</a>
-                </p>
+                  <p class="govuk-body">
+                    <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.CompaniesHouseLink">Companies House</a>
+                  </p>
               }
               @if (Model.GetInformationAboutSchoolsLink is not null)
               {
-                <p class="govuk-body">
-                  <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.GetInformationAboutSchoolsLink">Get information about schools</a>
-                </p>
+                  <p class="govuk-body">
+                    <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.GetInformationAboutSchoolsLink">Get information about schools</a>
+                  </p>
               }
               @if (Model.FinancialBenchmarkingInsightsToolLink is not null)
               {
-                <p class="govuk-body">
-                  <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.FinancialBenchmarkingInsightsToolLink">Financial Benchmarking and Insights Tool</a>
-                </p>
+                  <p class="govuk-body">
+                    <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.FinancialBenchmarkingInsightsToolLink">Financial Benchmarking and Insights Tool</a>
+                  </p>
               }
               @if (Model.FindSchoolPerformanceLink is not null)
               {
-                <p class="govuk-body">
-                  <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.FindSchoolPerformanceLink">Find school college and performance data in England</a>
-                </p>
+                  <p class="govuk-body">
+                    <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@Model.FindSchoolPerformanceLink">Find school college and performance data in England</a>
+                  </p>
               }
             </dd>
           </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml.cs
@@ -18,6 +18,7 @@ public class TrustDetailsModel(
     public string? GetInformationAboutSchoolsLink { get; set; }
     public string? FinancialBenchmarkingInsightsToolLink { get; set; }
     public string? FindSchoolPerformanceLink { get; set; }
+    public string? SharepointLink { get; set; }
 
     public override async Task<IActionResult> OnGetAsync()
     {
@@ -33,6 +34,7 @@ public class TrustDetailsModel(
         FindSchoolPerformanceLink =
             otherServicesLinkBuilder.FindSchoolPerformanceDataListingLink(TrustOverview.Uid, TrustOverview.Type,
                 TrustOverview.SingleAcademyTrustAcademyUrn);
+        SharepointLink = otherServicesLinkBuilder.SharepointFolderLink(TrustOverview.GroupId);
 
         return Page();
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml.cs
@@ -18,7 +18,7 @@ public class TrustDetailsModel(
     public string? GetInformationAboutSchoolsLink { get; set; }
     public string? FinancialBenchmarkingInsightsToolLink { get; set; }
     public string? FindSchoolPerformanceLink { get; set; }
-    public string? SharepointLink { get; set; }
+    public string SharepointLink { get; set; } = string.Empty;
 
     public override async Task<IActionResult> OnGetAsync()
     {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
@@ -135,7 +135,7 @@ describe("Testing the components of the Governance page", () => {
     const trustsWithNoGovernanceData = [
         {
             typeOfTrust: "single academy trust with no governance data",
-            uid: 17737
+            uid: 4009
         },
         {
             typeOfTrust: "multi academy trust with no governance data",

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/OtherServicesLinkBuilderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/OtherServicesLinkBuilderTests.cs
@@ -78,4 +78,22 @@ public class OtherServicesLinkBuilderTests
             _sut.FindSchoolPerformanceDataListingLink("1234", TrustType.SingleAcademyTrust, null);
         result.Should().BeNull();
     }
+
+    [Fact]
+    public void SharepointFolderLink_should_return_url_containing_GroupId()
+    {
+        var result =
+            _sut.SharepointFolderLink("TR02345");
+
+        result.Should()
+            .Be(
+                "https://educationgovuk.sharepoint.com/_layouts/15/sharepoint.aspx?oobRefiners=%7B%22FileType%22%3A%5B%22other%22%5D%7D&q=TR02345&v=%2Fsearch");
+    }
+
+    [Fact]
+    public void SharepointFolderLink_should_return_null_if_trust_has_no_CompaniesHouseNumber()
+    {
+        var result = _sut.SharepointFolderLink("");
+        result.Should().BeNull();
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/OtherServicesLinkBuilderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/OtherServicesLinkBuilderTests.cs
@@ -79,21 +79,15 @@ public class OtherServicesLinkBuilderTests
         result.Should().BeNull();
     }
 
-    [Fact]
-    public void SharepointFolderLink_should_return_url_containing_GroupId()
+    [Theory]
+    [InlineData("TR02345", "https://educationgovuk.sharepoint.com/_layouts/15/sharepoint.aspx?oobRefiners=%7B%22FileType%22%3A%5B%22other%22%5D%7D&q=TR02345&v=%2Fsearch")]
+    [InlineData("", "https://educationgovuk.sharepoint.com/_layouts/15/sharepoint.aspx?oobRefiners=%7B%22FileType%22%3A%5B%22other%22%5D%7D&q=&v=%2Fsearch")]
+    public void SharepointFolderLink_should_return_url_containing_GroupId(string trn, string expected)
     {
         var result =
-            _sut.SharepointFolderLink("TR02345");
+            _sut.SharepointFolderLink(trn);
 
         result.Should()
-            .Be(
-                "https://educationgovuk.sharepoint.com/_layouts/15/sharepoint.aspx?oobRefiners=%7B%22FileType%22%3A%5B%22other%22%5D%7D&q=TR02345&v=%2Fsearch");
-    }
-
-    [Fact]
-    public void SharepointFolderLink_should_return_null_if_trust_has_no_CompaniesHouseNumber()
-    {
-        var result = _sut.SharepointFolderLink("");
-        result.Should().BeNull();
+            .Be(expected);
     }
 }


### PR DESCRIPTION
[User Story 184412](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/184412): Build: include link to trust SharePoint folder

Adds links to the trust SharePoint page from the details page. Uses the Group ID (TRN) to search for the correct folder in SharePoint as direct links using trust names may have been changed and not accurate.

## Changes

- Added SharePoint link builder to other service link builder
- Updated the details page with the SharePoint link

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/01c5f36f-7e9d-4d69-9da9-737164b12543)

### After
![image](https://github.com/user-attachments/assets/f8fc3d9f-e32a-42e7-ae89-5888ed732caf)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
