### PR TITLE
Stop overview page querying db for Ofsted data

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
@@ -178,45 +178,21 @@ public class AcademyRepository(IAcademiesDbContext academiesDbContext, ILogger<A
 
     public async Task<AcademyOverview[]> GetAcademiesInTrustOverviewAsync(string uid)
     {
-        var academiesData = await academiesDbContext.GiasGroupLinks
+        return await academiesDbContext.GiasGroupLinks
             .Where(gl => gl.GroupUid == uid)
             .Join(
                 academiesDbContext.GiasEstablishments,
                 gl => gl.Urn!,
                 e => e.Urn.ToString(),
-                (gl, e) => new
-                {
-                    Urn = e.Urn.ToString(),
-                    LocalAuthority = e.LaName,
-                    NumberOfPupils = e.NumberOfPupils.ParseAsNullableInt(),
-                    SchoolCapacity = e.SchoolCapacity.ParseAsNullableInt()
-                })
-            .ToListAsync();
-
-        // Get URNs as ints
-        var urns = academiesData.Select(a => int.Parse(a.Urn)).ToArray();
-
-        // Fetch Ofsted ratings
-        var ofstedRatingsDict = await GetOfstedRatings(urns);
-
-        var academiesOverview = academiesData.Select(a =>
-        {
-            var currentOfstedRating = OfstedRatingScore.None;
-            if (ofstedRatingsDict.TryGetValue(a.Urn, out var ofstedRatings))
-            {
-                currentOfstedRating = ofstedRatings.Current?.OverallEffectiveness ?? OfstedRatingScore.None;
-            }
-
-            return new AcademyOverview(
-                a.Urn,
-                a.LocalAuthority ?? string.Empty,
-                a.NumberOfPupils,
-                a.SchoolCapacity,
-                currentOfstedRating
-            );
-        }).ToArray();
-
-        return academiesOverview;
+                (gl, e) =>
+                    new AcademyOverview
+                    (
+                        e.Urn.ToString(),
+                        e.LaName ?? string.Empty,
+                        e.NumberOfPupils.ParseAsNullableInt(),
+                        e.SchoolCapacity.ParseAsNullableInt()
+                    ))
+            .ToArrayAsync();
     }
 
     private sealed record AcademyOfstedRatings(int Urn, OfstedRating Current, OfstedRating Previous);

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
@@ -176,7 +176,7 @@ public class AcademyRepository(IAcademiesDbContext academiesDbContext, ILogger<A
             .FirstOrDefaultAsync();
     }
 
-    public async Task<AcademyOverview[]> GetAcademiesInTrustOverviewAsync(string uid)
+    public async Task<AcademyOverview[]> GetOverviewOfAcademiesInTrustAsync(string uid)
     {
         return await academiesDbContext.GiasGroupLinks
             .Where(gl => gl.GroupUid == uid)

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/AcademyOverview.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/AcademyOverview.cs
@@ -4,6 +4,5 @@ public record AcademyOverview(
     string Urn,
     string LocalAuthority,
     int? NumberOfPupils,
-    int? SchoolCapacity,
-    OfstedRatingScore CurrentOfstedRating
+    int? SchoolCapacity
 );

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/IAcademyRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/IAcademyRepository.cs
@@ -8,5 +8,5 @@ public interface IAcademyRepository
     Task<AcademyOfsted[]> GetAcademiesInTrustOfstedAsync(string uid);
     Task<AcademyPupilNumbers[]> GetAcademiesInTrustPupilNumbersAsync(string uid);
     Task<AcademyFreeSchoolMeals[]> GetAcademiesInTrustFreeSchoolMealsAsync(string uid);
-    Task<AcademyOverview[]> GetAcademiesInTrustOverviewAsync(string uid);
+    Task<AcademyOverview[]> GetOverviewOfAcademiesInTrustAsync(string uid);
 }

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
@@ -102,7 +102,7 @@ public class TrustService(
             ? await academyRepository.GetSingleAcademyTrustAcademyUrnAsync(uid)
             : null;
 
-        var academiesOverview = await academyRepository.GetAcademiesInTrustOverviewAsync(uid);
+        var academiesOverview = await academyRepository.GetOverviewOfAcademiesInTrustAsync(uid);
 
         var totalAcademies = academiesOverview.Length;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
@@ -430,61 +430,6 @@ public class AcademyRepositoryTests
         );
     }
 
-    // @formatter:max_line_length 500 - these tests are very difficult to read after line wrapping is enforced so increase max line length
-    [Fact]
-    public async Task GetAcademiesInTrustOverviewAsync_should_set_current_ofsted()
-    {
-        // Arrange
-        var giasGroup = _mockAcademiesDbContext.AddGiasGroup("1234");
-        var giasEstablishments = _mockAcademiesDbContext.AddGiasEstablishments(10);
-        _mockAcademiesDbContext.AddGiasGroupLinksForGiasEstablishmentsToGiasGroup(giasEstablishments, giasGroup);
-
-        var urnsAsInt = giasEstablishments.Select(gl => gl.Urn).ToArray();
-        var urns = urnsAsInt.Select(u => u.ToString()).ToArray();
-
-        _mockAcademiesDbContext.AddMisEstablishments(new[]
-        {
-            new MisEstablishment { Urn = urnsAsInt[0], OverallEffectiveness = 1, InspectionStartDate = "01/01/2022" },
-            new MisEstablishment { Urn = urnsAsInt[1], OverallEffectiveness = 2, InspectionStartDate = "29/02/2024" },
-            new MisEstablishment { Urn = urnsAsInt[2], OverallEffectiveness = 3, InspectionStartDate = "31/12/2022" },
-            new MisEstablishment { Urn = urnsAsInt[3], OverallEffectiveness = 4, InspectionStartDate = "15/10/2023" },
-            new MisEstablishment { Urn = urnsAsInt[4], OverallEffectiveness = null, InspectionStartDate = null }
-        });
-        _mockAcademiesDbContext.AddMisFurtherEducationEstablishments(new[]
-        {
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[5], OverallEffectiveness = 1, LastDayOfInspection = "01/01/2022" },
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[6], OverallEffectiveness = 2, LastDayOfInspection = "29/02/2024" },
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[7], OverallEffectiveness = 3, LastDayOfInspection = "31/12/2022" },
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[8], OverallEffectiveness = 4, LastDayOfInspection = "15/10/2023" },
-            new MisFurtherEducationEstablishment { ProviderUrn = urnsAsInt[9], OverallEffectiveness = null, LastDayOfInspection = null }
-        });
-
-        // Act
-        var result = await _sut.GetAcademiesInTrustOverviewAsync("1234");
-
-        // Assert
-        var dummyAcademyOverview = new AcademyOverview(string.Empty, string.Empty, null, null, OfstedRatingScore.None);
-
-        result.Should().BeEquivalentTo(new[]
-            {
-                dummyAcademyOverview with { Urn = urns[0], CurrentOfstedRating = OfstedRatingScore.Outstanding },
-                dummyAcademyOverview with { Urn = urns[1], CurrentOfstedRating = OfstedRatingScore.Good },
-                dummyAcademyOverview with { Urn = urns[2], CurrentOfstedRating = OfstedRatingScore.RequiresImprovement },
-                dummyAcademyOverview with { Urn = urns[3], CurrentOfstedRating = OfstedRatingScore.Inadequate },
-                dummyAcademyOverview with { Urn = urns[4], CurrentOfstedRating = OfstedRatingScore.None },
-                dummyAcademyOverview with { Urn = urns[5], CurrentOfstedRating = OfstedRatingScore.Outstanding },
-                dummyAcademyOverview with { Urn = urns[6], CurrentOfstedRating = OfstedRatingScore.Good },
-                dummyAcademyOverview with { Urn = urns[7], CurrentOfstedRating = OfstedRatingScore.RequiresImprovement },
-                dummyAcademyOverview with { Urn = urns[8], CurrentOfstedRating = OfstedRatingScore.Inadequate },
-                dummyAcademyOverview with { Urn = urns[9], CurrentOfstedRating = OfstedRatingScore.None }
-            },
-            options => options
-                .Including(a => a.Urn)
-                .Including(a => a.CurrentOfstedRating)
-        );
-    }
-    // @formatter:max_line_length restore
-
     [Fact]
     public async Task GetAcademiesInTrustOverviewAsync_should_handle_academies_with_missing_data()
     {

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
@@ -402,7 +402,7 @@ public class AcademyRepositoryTests
     }
 
     [Fact]
-    public async Task GetAcademiesInTrustOverviewAsync_should_return_academies_linked_to_trust()
+    public async Task GetOverviewOfAcademiesInTrustAsync_should_return_academies_linked_to_trust()
     {
         // Arrange
         var giasGroup = _mockAcademiesDbContext.AddGiasGroup("1234");
@@ -419,7 +419,7 @@ public class AcademyRepositoryTests
         _mockAcademiesDbContext.AddGiasGroupLinksForGiasEstablishmentsToGiasGroup(giasEstablishments, giasGroup);
 
         // Act
-        var result = await _sut.GetAcademiesInTrustOverviewAsync("1234");
+        var result = await _sut.GetOverviewOfAcademiesInTrustAsync("1234");
 
         // Assert
         result.Should().BeEquivalentTo(giasEstablishments,
@@ -431,7 +431,7 @@ public class AcademyRepositoryTests
     }
 
     [Fact]
-    public async Task GetAcademiesInTrustOverviewAsync_should_handle_academies_with_missing_data()
+    public async Task GetOverviewOfAcademiesInTrustAsync_should_handle_academies_with_missing_data()
     {
         var giasGroup = _mockAcademiesDbContext.AddGiasGroup("1234");
         var giasEstablishment = new GiasEstablishment
@@ -449,7 +449,7 @@ public class AcademyRepositoryTests
             Urn = giasEstablishment.Urn.ToString()
         });
 
-        var result = await _sut.GetAcademiesInTrustOverviewAsync("1234");
+        var result = await _sut.GetOverviewOfAcademiesInTrustAsync("1234");
 
         result.Should().NotBeNull();
         result.Length.Should().Be(1);
@@ -462,17 +462,17 @@ public class AcademyRepositoryTests
     }
 
     [Fact]
-    public async Task GetAcademiesInTrustOverviewAsync_should_return_empty_array_when_no_academies_linked_to_trust()
+    public async Task GetOverviewOfAcademiesInTrustAsync_should_return_empty_array_when_no_academies_linked_to_trust()
     {
-        var result = await _sut.GetAcademiesInTrustOverviewAsync("1234");
+        var result = await _sut.GetOverviewOfAcademiesInTrustAsync("1234");
         result.Should().NotBeNull();
         result.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task GetAcademiesInTrustOverviewAsync_should_return_empty_array_when_trust_does_not_exist()
+    public async Task GetOverviewOfAcademiesInTrustAsync_should_return_empty_array_when_trust_does_not_exist()
     {
-        var result = await _sut.GetAcademiesInTrustOverviewAsync("non-existent-uid");
+        var result = await _sut.GetOverviewOfAcademiesInTrustAsync("non-existent-uid");
         result.Should().NotBeNull();
         result.Should().BeEmpty();
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
@@ -258,9 +258,9 @@ public class TrustServiceTests
         var uid = "1234";
         var academiesOverview = new AcademyOverview[]
         {
-            new("1001", "LocalAuthorityA", 500, 600, OfstedRatingScore.Good),
-            new("1002", "LocalAuthorityB", 400, 500, OfstedRatingScore.Outstanding),
-            new("1003", "LocalAuthorityA", 300, 400, OfstedRatingScore.RequiresImprovement)
+            new("1001", "LocalAuthorityA", 500, 600),
+            new("1002", "LocalAuthorityB", 400, 500),
+            new("1003", "LocalAuthorityA", 300, 400)
         };
 
         _mockAcademyRepository.Setup(a => a.GetAcademiesInTrustOverviewAsync(uid))

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceTests.cs
@@ -263,7 +263,7 @@ public class TrustServiceTests
             new("1003", "LocalAuthorityA", 300, 400)
         };
 
-        _mockAcademyRepository.Setup(a => a.GetAcademiesInTrustOverviewAsync(uid))
+        _mockAcademyRepository.Setup(a => a.GetOverviewOfAcademiesInTrustAsync(uid))
             .ReturnsAsync(academiesOverview);
         _mockTrustRepository.Setup(t => t.GetTrustOverviewAsync(uid))
             .ReturnsAsync(BaseTrustOverview with { Uid = uid });
@@ -290,7 +290,7 @@ public class TrustServiceTests
         var uid = "1234";
         var academiesOverview = Array.Empty<AcademyOverview>();
 
-        _mockAcademyRepository.Setup(a => a.GetAcademiesInTrustOverviewAsync(uid))
+        _mockAcademyRepository.Setup(a => a.GetOverviewOfAcademiesInTrustAsync(uid))
             .ReturnsAsync(academiesOverview);
         _mockTrustRepository.Setup(t => t.GetTrustOverviewAsync(uid))
             .ReturnsAsync(BaseTrustOverview with { Uid = uid });


### PR DESCRIPTION
Stop overview page querying db for Ofsted data

[User Story 186432](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/186432): Build: Navigation iteration 1
[Task 188015](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/188015): BUG: Overview page should not query db for ofsted ratings

## Changes

- `AcademyOverview` no longer contains Ofsted data
- `GetAcademiesInTrustOverviewAsync` renamed to `GetOverviewOfAcademiesInTrustAsync` to distinguish it from the methods used by the "Academies in Trust" pages and the data export

## Screenshots of UI changes

n/a

## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
~~ADR decision log updated (if needed)~~
~~Release notes added to CHANGELOG.md~~
~~Testing complete - all manual and automated tests pass~~
