### PR TITLE
Add visually hidden "trust" label to trust nav links

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_AcademiesLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_AcademiesLayout.cshtml
@@ -27,19 +27,19 @@
 
   <ul class="moj-sub-navigation__list">
     <li class="moj-sub-navigation__item">
-      <a id="academies-details-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Details")" asp-page="./Details" asp-route-uid="@Model.TrustSummary.Uid"><span class="visually-hidden">Academies</span>Details</a>
+      <a id="academies-details-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Details")" asp-page="./Details" asp-route-uid="@Model.TrustSummary.Uid"><span class="visually-hidden">Academies </span>Details</a>
     </li>
 
     <li class="moj-sub-navigation__item">
-      <a id="ofsted-ratings-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Ofsted ratings")" asp-page="./OfstedRatings" asp-route-uid="@Model.TrustSummary.Uid"><span class="visually-hidden">Academies</span>Ofsted ratings</a>
+      <a id="ofsted-ratings-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Ofsted ratings")" asp-page="./OfstedRatings" asp-route-uid="@Model.TrustSummary.Uid"><span class="visually-hidden">Academies </span>Ofsted ratings</a>
     </li>
 
     <li class="moj-sub-navigation__item">
-      <a id="academies-pupil-numbers-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Pupil numbers")" asp-page="./PupilNumbers" asp-route-uid="@Model.TrustSummary.Uid"><span class="visually-hidden">Academies</span>Pupil numbers</a>
+      <a id="academies-pupil-numbers-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Pupil numbers")" asp-page="./PupilNumbers" asp-route-uid="@Model.TrustSummary.Uid"><span class="visually-hidden">Academies </span>Pupil numbers</a>
     </li>
 
     <li class="moj-sub-navigation__item">
-      <a id="free-school-meals-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Free school meals")" asp-page="./FreeSchoolMeals" asp-route-uid="@Model.TrustSummary.Uid"><span class="visually-hidden">Academies</span>Free school meals</a>
+      <a id="free-school-meals-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Free school meals")" asp-page="./FreeSchoolMeals" asp-route-uid="@Model.TrustSummary.Uid"><span class="visually-hidden">Academies </span>Free school meals</a>
     </li>
   </ul>
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigationLink.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustNavigationLink.cshtml
@@ -3,7 +3,7 @@
 {
   <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
     <a class="govuk-service-navigation__link" asp-page="@Model.Page" asp-route-uid="@Model.Uid" data-testid="@Model.DataTestId">
-      <strong class="govuk-service-navigation__active-fallback govuk-!-font-weight-bold">@Model.LinkText</strong>
+      <span class="visually-hidden">Trust </span><strong class="govuk-service-navigation__active-fallback govuk-!-font-weight-bold">@Model.LinkText</strong>
     </a>
   </li>
 }
@@ -11,7 +11,7 @@ else
 {
   <li class="govuk-service-navigation__item">
     <a class="govuk-service-navigation__link govuk-!-font-weight-bold" asp-page="@Model.Page" asp-route-uid="@Model.Uid" data-testid="@Model.DataTestId">
-      @Model.LinkText
+      <span class="visually-hidden">Trust </span>@Model.LinkText
     </a>
   </li>
 }


### PR DESCRIPTION
[Task 188246](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/188246): Bug: Visually hidden "Trust" is missing from new nav

Add trust labels back to the nav links.
Add spaces to the hidden labels on the academies tabs.

## Screenshots of UI changes
Screenshots have accessible names set to visible
### Before
![image](https://github.com/user-attachments/assets/06df86bb-ce8a-4d99-9af0-daec5a22f8ca)

### After
![image](https://github.com/user-attachments/assets/42d3b547-cf91-4849-bc0f-27d61cd0a6e6)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
~~ADR decision log updated (if needed)~~
~~Release notes added to CHANGELOG.md~~
- [ ] Testing complete - all manual and automated tests pass
