### PR TITLE
Update urls in non-trust specific tests

### DIFF
--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/cookies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/cookies.cy.ts
@@ -5,128 +5,128 @@ import navigation from "../../pages/navigation";
 describe('Cookie page and consent tests', () => {
 
     beforeEach(() => {
-        cy.login()
-        cy.visit('/cookies')
+        cy.login();
+        cy.visit('/cookies');
     });
 
     it('should check that both mandatory and optional cookies both exist after accepting optional cookies', () => {
         cookiesPage
             .acceptCookies()
-            .clickSaveChangesButton()
+            .clickSaveChangesButton();
 
         commonPage
-            .checkSuccessPopup('You’ve set your cookie preferences')
+            .checkSuccessPopup('You’ve set your cookie preferences');
 
-        cy.visit('/trusts/overview?uid=5712')
+        cy.visit('/trusts/overview/trust-details?uid=5712');
 
         //check optional cookies exist
-        cy.getCookie('ai_user').should('exist')
-        cy.getCookie('ai_session').should('exist')
-        cy.getCookie('ai_authUser').should('exist')
-        cy.getCookie('_ga').should('exist')
+        cy.getCookie('ai_user').should('exist');
+        cy.getCookie('ai_session').should('exist');
+        cy.getCookie('ai_authUser').should('exist');
+        cy.getCookie('_ga').should('exist');
 
         //check mandatory cookies exist after saving
-        cy.getCookie('.FindInformationAcademiesTrust.CookieConsent').should('exist')
-        cy.getCookie('ASLBSA').should('exist')
-        cy.getCookie('ASLBSACORS').should('exist')
-        cy.getCookie('.FindInformationAcademiesTrusts.Antiforgery').should('exist')
+        cy.getCookie('.FindInformationAcademiesTrust.CookieConsent').should('exist');
+        cy.getCookie('ASLBSA').should('exist');
+        cy.getCookie('ASLBSACORS').should('exist');
+        cy.getCookie('.FindInformationAcademiesTrusts.Antiforgery').should('exist');
 
     });
 
     it('should check that mandatory cookies exist but optional cookies do not after rejecting optional cookies', () => {
         cookiesPage
             .rejectCookies()
-            .clickSaveChangesButton()
+            .clickSaveChangesButton();
 
         commonPage
-            .checkSuccessPopup('You’ve set your cookie preferences')
+            .checkSuccessPopup('You’ve set your cookie preferences');
 
-        cy.visit('/trusts/overview?uid=5712')
+        cy.visit('/trusts/overview/trust-details?uid=5712');
 
         //check optional cookies do not  exist
-        cy.getCookie('ai_user').should('not.exist')
-        cy.getCookie('ai_session').should('not.exist')
-        cy.getCookie('ai_authUser').should('not.exist')
-        cy.getCookie('_ga').should('not.exist')
+        cy.getCookie('ai_user').should('not.exist');
+        cy.getCookie('ai_session').should('not.exist');
+        cy.getCookie('ai_authUser').should('not.exist');
+        cy.getCookie('_ga').should('not.exist');
 
         //check mandatory cookies do not exist after saving
-        cy.getCookie('.FindInformationAcademiesTrust.CookieConsent').should('exist')
-        cy.getCookie('ASLBSA').should('exist')
-        cy.getCookie('ASLBSACORS').should('exist')
-        cy.getCookie('.FindInformationAcademiesTrusts.Antiforgery').should('exist')
+        cy.getCookie('.FindInformationAcademiesTrust.CookieConsent').should('exist');
+        cy.getCookie('ASLBSA').should('exist');
+        cy.getCookie('ASLBSACORS').should('exist');
+        cy.getCookie('.FindInformationAcademiesTrusts.Antiforgery').should('exist');
     });
 
     it('should check that the return to previous page button actually takes me to my previous page after accept cookies', () => {
-        cy.visit('/search')
+        cy.visit('/search');
 
         navigation
             .clickCookiesLink()
-            .checkCurrentURLIsCorrect('/cookies')
+            .checkCurrentURLIsCorrect('/cookies');
 
         cookiesPage
             .acceptCookies()
             .clickSaveChangesButton()
-            .clickReturnToPreviousPageButton()
+            .clickReturnToPreviousPageButton();
 
         navigation
-            .checkCurrentURLIsCorrect('/search')
+            .checkCurrentURLIsCorrect('/search');
     });
 
     it('should check that the return to previous page button actually takes me to my previous page after reject cookies', () => {
-        cy.visit('/trusts/contacts?uid=5712')
+        cy.visit('/trusts/contacts/in-dfe?uid=5712');
 
         navigation
             .clickCookiesLink()
-            .checkCurrentURLIsCorrect('/cookies')
+            .checkCurrentURLIsCorrect('/cookies');
 
         cookiesPage
             .rejectCookies()
             .clickSaveChangesButton()
-            .clickReturnToPreviousPageButton()
+            .clickReturnToPreviousPageButton();
 
         navigation
-            .checkCurrentURLIsCorrect('/trusts/contacts?uid=5712')
+            .checkCurrentURLIsCorrect('/trusts/contacts/in-dfe?uid=5712');
     });
 
     it('should check that both cookie accept and reject radio buttons are in their empty state when coming in from scratch', () => {
         cookiesPage
             .checkCookiesAcceptIsUninteracted()
-            .checkCookiesRejectIsUninteracted()
+            .checkCookiesRejectIsUninteracted();
     });
 
     it('should check that the accept cookies button stays checked after enabling it', () => {
         cookiesPage
             .acceptCookies()
-            .clickSaveChangesButton()
+            .clickSaveChangesButton();
 
         commonPage
-            .checkSuccessPopup('You’ve set your cookie preferences')
+            .checkSuccessPopup('You’ve set your cookie preferences');
 
-        cy.visit('/trusts/overview?uid=5712')
+        cy.visit('/trusts/overview/trust-details?uid=5712');
 
         navigation
             .clickCookiesLink()
-            .checkCurrentURLIsCorrect('/cookies')
+            .checkCurrentURLIsCorrect('/cookies');
 
         cookiesPage
-            .checkCookiesAcceptIsInteracted()
+            .checkCookiesAcceptIsInteracted();
     });
 
     it('should check that the accept cookies button stays checked after enabling it', () => {
         cookiesPage
             .rejectCookies()
-            .clickSaveChangesButton()
+            .clickSaveChangesButton();
 
         commonPage
-            .checkSuccessPopup('You’ve set your cookie preferences')
+            .checkSuccessPopup('You’ve set your cookie preferences');
 
-        cy.visit('/trusts/overview?uid=5712')
+        cy.visit('/trusts/overview/trust-details?uid=5712');
 
         navigation
             .clickCookiesLink()
-            .checkCurrentURLIsCorrect('/cookies')
+            .checkCurrentURLIsCorrect('/cookies');
 
         cookiesPage
-            .checkCookiesRejectIsInteracted()
+            .checkCookiesRejectIsInteracted();
     });
 });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/header-search-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/header-search-page.cy.ts
@@ -4,8 +4,8 @@ import headerPage from "../../pages/headerPage";
 describe("Testing the components of the header search", () => {
 
     beforeEach(() => {
-        cy.login()
-        cy.visit('/trusts/overview?uid=5527')
+        cy.login();
+        cy.visit('/trusts/overview/trust-details?uid=5527');
     });
 
     it("Should check that the header search bar and autocomplete is present and functional", () => {
@@ -13,35 +13,35 @@ describe("Testing the components of the header search", () => {
             .enterHeaderSearchText("West")
             .checkHeaderAutocompleteIsPresent()
             .checkHeaderSearchButtonPresent()
-            .checkAutocompleteContainsTypedText("West")
-    })
+            .checkAutocompleteContainsTypedText("West");
+    });
 
     it("Should check that the autocomplete does not return results when entry does not exist", () => {
 
         headerPage
             .enterHeaderSearchText("KnowWhere")
             .checkHeaderAutocompleteIsPresent()
-            .checkAutocompleteContainsTypedText("No results found")
+            .checkAutocompleteContainsTypedText("No results found");
     });;
 
     it("Should check that search results are returned with a valid name entered when using the header search bar ", () => {
         headerPage
             .enterHeaderSearchText("west")
-            .clickHeaderSearchButton()
+            .clickHeaderSearchButton();
 
         searchPage
-            .checkSearchResultsReturned('west')
+            .checkSearchResultsReturned('west');
 
     });
 
     it("Should return the correct trust when searching by TRN using the header search", () => {
 
         headerPage
-            .enterHeaderSearchText("TR02343") 
-            .clickHeaderSearchButton()
+            .enterHeaderSearchText("TR02343")
+            .clickHeaderSearchButton();
 
         searchPage
-            .checkSearchResultsReturned("UNITED LEARNING TRUST") 
+            .checkSearchResultsReturned("UNITED LEARNING TRUST");
     });
 
-})
+});

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/home-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/home-page.cy.ts
@@ -11,77 +11,77 @@ describe("Testing the components of the home page", () => {
 
     it("Should check that the home pages search bar and autocomplete is present and functional", () => {
         homePage
-            .enterMainSearchText("West")
+            .enterMainSearchText("West");
         searchPage
-            .checkMainAutocompleteIsPresent()
+            .checkMainAutocompleteIsPresent();
         homePage
-            .checkMainSearchButtonPresent()
+            .checkMainSearchButtonPresent();
         searchPage
-            .checkAutocompleteContainsTypedText("West")
+            .checkAutocompleteContainsTypedText("West");
     });
 
     it("Should check that the autocomplete does not return results when entry does not exist", () => {
 
         homePage
-            .enterMainSearchText("KnowWhere")
+            .enterMainSearchText("KnowWhere");
         searchPage
             .checkMainAutocompleteIsPresent()
-            .checkAutocompleteContainsTypedText("No results found")
+            .checkAutocompleteContainsTypedText("No results found");
     });
 
     it("Should check that search results are returned with a valid name entered when using the main search bar ", () => {
         homePage
             .enterMainSearchText("west")
-            .clickMainSearchButton()
+            .clickMainSearchButton();
 
         searchPage
-            .checkSearchResultsReturned('west')
+            .checkSearchResultsReturned('west');
 
         paginationPage
-            .returnToHome()
+            .returnToHome();
 
         homePage
-            .checkMainSearchButtonPresent()
+            .checkMainSearchButtonPresent();
 
     });
 
     it("Should check that the what you can find section is collapsed when you first land on the home screen ", () => {
         homePage
             .checkWhatYouCanFindPresent()
-            .checkWhatYouCanFindListCollapsed()
+            .checkWhatYouCanFindListCollapsed();
 
     });
 
     it("Should check that the what you can find section is collapsed when you return to the home screen ", () => {
         homePage
             .checkWhatYouCanFindPresent()
-            .checkWhatYouCanFindListCollapsed()
+            .checkWhatYouCanFindListCollapsed();
 
-        cy.visit('/trusts/contacts?uid=5712')
+        cy.visit('/trusts/contacts/in-dfe?uid=5712');
 
         navigation
-            .checkCurrentURLIsCorrect('/trusts/contacts?uid=5712')
+            .checkCurrentURLIsCorrect('/trusts/contacts/in-dfe?uid=5712');
 
-        cy.visit('/')
+        cy.visit('/');
 
         homePage
             .checkWhatYouCanFindPresent()
-            .checkWhatYouCanFindListCollapsed()
+            .checkWhatYouCanFindListCollapsed();
     });
 
     it("Should check that the what you can find section is expanded when clicked on ", () => {
         homePage
             .checkWhatYouCanFindPresent()
             .clickWhatYouCanFindList()
-            .checkWhatYouCanFindListOpen()
-    })
+            .checkWhatYouCanFindListOpen();
+    });
 
     it("Should check that the expected contents of the what you can find section are all present", () => {
         homePage
             .checkWhatYouCanFindPresent()
             .clickWhatYouCanFindList()
             .checkWhatYouCanFindListOpen()
-            .checkWhatYouCanFindListItemsPresent()
-    })
+            .checkWhatYouCanFindListItemsPresent();
+    });
 
-})
+});

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation.cy.ts
@@ -70,7 +70,7 @@ describe('Testing Navigation', () => {
         });
 
         it('Should check that a trusts name breadcrumb is displayed on the trusts page', () => {
-            cy.visit('/trusts/overview?uid=5712');
+            cy.visit('/trusts/overview/trust-details?uid=5712');
 
             navigation
                 .checkTrustNameBreadcrumbPresent('ASPIRE NORTH EAST MULTI ACADEMY TRUST')
@@ -79,7 +79,7 @@ describe('Testing Navigation', () => {
         });
 
         it('Should check a different trusts name breadcrumb is displayed on the trusts page', () => {
-            cy.visit('/trusts/overview?uid=5527');
+            cy.visit('/trusts/overview/trust-details?uid=5527');
 
             navigation
                 .checkTrustNameBreadcrumbPresent('ASHTON WEST END PRIMARY ACADEMY')
@@ -88,24 +88,24 @@ describe('Testing Navigation', () => {
         });
     });
 
-    describe("Testing the service navigation", () => {
+    describe("Testing the trusts service navigation", () => {
         beforeEach(() => {
             cy.login();
-            cy.visit('/trusts/overview?uid=5527');
+            cy.visit('/trusts/overview/trust-details?uid=5527');
         });
 
-        it('Should check that the contacts navigation button takes me to the correct page', () => {
+        it('Should check that the contacts navigation button takes me to the contacts in DfE page', () => {
             navigation
                 .clickContactsServiceNavButton()
                 .checkContactsServiceNavButtonIsHighlighed()
-                .checkCurrentURLIsCorrect('/contacts?uid=5527')
+                .checkCurrentURLIsCorrect('/contacts/in-dfe?uid=5527')
                 .checkAllServiceNavItemsPresent();
             contactsPage
                 .checkChairOfTrusteesPresent()
                 .checkAccountingOfficerPresent();
         });
 
-        it('Should check that the Academies navigation button takes me to the correct page', () => {
+        it('Should check that the Academies navigation button takes me to the academies details page', () => {
             navigation
                 .clickAcademiesServiceNavButton()
                 .checkAcademiesServiceNavButtonIsHighlighted()
@@ -115,27 +115,26 @@ describe('Testing Navigation', () => {
                 .checkDetailsHeadersPresent();
         });
 
-        it('Should check that the Governance navigation button takes me to the correct page', () => {
+        it('Should check that the Governance navigation button takes me to the governance trust leadership page', () => {
             navigation
                 .clickGovernanceServiceNavButton()
                 .checkGovernanceServiceNavButtonIsHighlighted()
-                .checkCurrentURLIsCorrect('/governance?uid=5527')
+                .checkCurrentURLIsCorrect('/governance/trust-leadership?uid=5527')
                 .checkAllServiceNavItemsPresent();
             governancePage
                 .checkTrusteesTableHeadersAreVisible();
         });
 
-        it('Should check that the Overview navigation button takes me to the correct page', () => {
-            cy.visit('trusts/governance?uid=5527');
+        it('Should check that the Overview navigation button takes me to the overview trust details page', () => {
+            cy.visit('trusts/trust-leadership?uid=5527');
             navigation
                 .clickOverviewServiceNavButton()
                 .checkOverviewServiceNavButtonIsHighlighted()
-                .checkCurrentURLIsCorrect('/overview?uid=5527')
+                .checkCurrentURLIsCorrect('/overview/trust-details?uid=5527')
                 .checkAllServiceNavItemsPresent();
             overviewPage
                 .checkOverviewHeaderPresent();
         });
 
     });
-
 });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/academies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/academies.cy.ts
@@ -5,31 +5,31 @@ describe("Testing the components of the Academies page", () => {
 
     describe("Details tab", () => {
         beforeEach(() => {
-            cy.login()
-            cy.visit('/trusts/academies/details?uid=5712')
+            cy.login();
+            cy.visit('/trusts/academies/details?uid=5712');
         });
 
         it("Checks the correct details page headers are present", () => {
             academiesPage
-                .checkDetailsHeadersPresent()
-        })
+                .checkDetailsHeadersPresent();
+        });
 
         it("Checks that the correct school types are present", () => {
             academiesPage
-                .checkSchoolTypesOnDetailsTable()
-        })
+                .checkSchoolTypesOnDetailsTable();
+        });
 
         it("Checks that a different and larger trusts correct school types are present", () => {
-            cy.visit('/trusts/academies/details?uid=5143')
+            cy.visit('/trusts/academies/details?uid=5143');
             academiesPage
-                .checkSchoolTypesOnDetailsTable()
-        })
+                .checkSchoolTypesOnDetailsTable();
+        });
 
         it("Checks the detail page sorting", () => {
-            cy.visit('/trusts/academies/details?uid=5143')
+            cy.visit('/trusts/academies/details?uid=5143');
             academiesPage
-                .checkTrustDetailsSorting()
-        })
+                .checkTrustDetailsSorting();
+        });
 
         it('should match the academy count in the sidebar with the actual table row count on the Details page', () => {
             academiesPage.getAcademyCountFromSidebar().then(expectedCount => {
@@ -43,80 +43,80 @@ describe("Testing the components of the Academies page", () => {
                 academiesPage.getTableRowCountOnDetailsPage().should('eq', expectedCount);
             });
         });
-    })
+    });
 
     describe("Ofsted ratings tab", () => {
         beforeEach(() => {
-            cy.login()
-            cy.visit('/trusts/academies/ofsted-ratings?uid=5712')
+            cy.login();
+            cy.visit('/trusts/academies/ofsted-ratings?uid=5712');
         });
 
         it("Checks the correct Ofsted page headers are present", () => {
             academiesPage
-                .checkOfstedHeadersPresent()
-        })
+                .checkOfstedHeadersPresent();
+        });
 
         it("Checks that a trusts correct Current Ofsted rating types are present", () => {
             academiesPage
-                .checkCurrentOfstedTypesOnOfstedTable()
-        })
+                .checkCurrentOfstedTypesOnOfstedTable();
+        });
 
         it("Checks that a trusts correct Previous Ofsted rating types are present", () => {
             academiesPage
-                .checkPreviousOfstedTypesOnOfstedTable()
-        })
+                .checkPreviousOfstedTypesOnOfstedTable();
+        });
 
         it("Checks that a different trusts correct Current Ofsted rating types are present", () => {
-            cy.visit('/trusts/academies/ofsted-ratings?uid=5143')
+            cy.visit('/trusts/academies/ofsted-ratings?uid=5143');
             academiesPage
-                .checkCurrentOfstedTypesOnOfstedTable()
-        })
+                .checkCurrentOfstedTypesOnOfstedTable();
+        });
 
         it("Checks that a different trusts correct Previous Ofsted rating types are present", () => {
-            cy.visit('/trusts/academies/ofsted-ratings?uid=5143')
+            cy.visit('/trusts/academies/ofsted-ratings?uid=5143');
             academiesPage
-                .checkPreviousOfstedTypesOnOfstedTable()
-        })
+                .checkPreviousOfstedTypesOnOfstedTable();
+        });
 
         it("Checks the Ofsted page sorting", () => {
             academiesPage
-                .checkOfstedSorting()
-        })
+                .checkOfstedSorting();
+        });
 
-    })
+    });
 
     describe("Pupil numbers tab", () => {
         beforeEach(() => {
-            cy.login()
-            cy.visit('/trusts/academies/pupil-numbers?uid=5712')
+            cy.login();
+            cy.visit('/trusts/academies/pupil-numbers?uid=5712');
         });
 
         it("Checks the correct Pupil numbers page headers are present", () => {
             academiesPage
-                .checkPupilNumbersHeadersPresent()
-        })
+                .checkPupilNumbersHeadersPresent();
+        });
 
         it("Checks the Ofsted page sorting", () => {
-            cy.visit('/trusts/academies/pupil-numbers?uid=5143')
+            cy.visit('/trusts/academies/pupil-numbers?uid=5143');
             academiesPage
-                .checkPupilNumbersSorting()
-        })
+                .checkPupilNumbersSorting();
+        });
 
 
-    })
+    });
 
     describe("Free school meals", () => {
         beforeEach(() => {
-            cy.login()
-            cy.visit('/trusts/academies/free-school-meals?uid=5712')
+            cy.login();
+            cy.visit('/trusts/academies/free-school-meals?uid=5712');
         });
 
         it("Checks the correct Free school meals page headers are present", () => {
             academiesPage
-                .checkFreeSchoolMealsHeadersPresent()
-        })
+                .checkFreeSchoolMealsHeadersPresent();
+        });
 
-    })
+    });
 
     describe("Testing the academies sub navigation", () => {
         beforeEach(() => {
@@ -129,9 +129,9 @@ describe("Testing the components of the Academies page", () => {
                 .clickOfstedAcadmiesTrustButton()
                 .checkCurrentURLIsCorrect('/trusts/academies/ofsted-ratings?uid=5527')
                 .checkAllServiceNavItemsPresent()
-                .checkAllAcademiesNavItemsPresent()
+                .checkAllAcademiesNavItemsPresent();
             academiesPage
-                .checkOfstedHeadersPresent()
+                .checkOfstedHeadersPresent();
         });
 
         it('Should check that the academies Pupil numbers navigation button takes me to the correct page', () => {
@@ -139,9 +139,9 @@ describe("Testing the components of the Academies page", () => {
                 .clickPupilNumbersAcadmiesTrustButton()
                 .checkCurrentURLIsCorrect('/trusts/academies/pupil-numbers?uid=5527')
                 .checkAllServiceNavItemsPresent()
-                .checkAllAcademiesNavItemsPresent()
+                .checkAllAcademiesNavItemsPresent();
             academiesPage
-                .checkPupilNumbersHeadersPresent()
+                .checkPupilNumbersHeadersPresent();
         });
 
         it('Should check that the academies Free school meals navigation button takes me to the correct page', () => {
@@ -149,26 +149,26 @@ describe("Testing the components of the Academies page", () => {
                 .clickFreeSchoolMealsAcadmiesTrustButton()
                 .checkCurrentURLIsCorrect('/trusts/academies/free-school-meals?uid=5527')
                 .checkAllServiceNavItemsPresent()
-                .checkAllAcademiesNavItemsPresent()
+                .checkAllAcademiesNavItemsPresent();
             academiesPage
-                .checkFreeSchoolMealsHeadersPresent()
+                .checkFreeSchoolMealsHeadersPresent();
         });
 
         it('Should check that the academies Details navigation button takes me to the correct page', () => {
-            cy.visit('/trusts/academies/free-school-meals?uid=5527')
+            cy.visit('/trusts/academies/free-school-meals?uid=5527');
             navigation
                 .clickDetailsAcadmiesTrustButton()
                 .checkCurrentURLIsCorrect('/trusts/academies/details?uid=5527')
                 .checkAllServiceNavItemsPresent()
-                .checkAllAcademiesNavItemsPresent()
+                .checkAllAcademiesNavItemsPresent();
             academiesPage
-                .checkDetailsHeadersPresent()
+                .checkDetailsHeadersPresent();
         });
 
         it('Should check that the academies sub nav items are not present when I am not in the relevant academies page', () => {
-            cy.visit('/trusts/overview?uid=5527');
+            cy.visit('/trusts/overview/trust-details?uid=5527');
             navigation
-                .checkAcademiesSubNavNotPresent()
+                .checkAcademiesSubNavNotPresent();
         });
-    })
-})
+    });
+});


### PR DESCRIPTION
Update urls in non-trust specific tests

[Task 189941](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/189941): Refactor of automation testing - tidy urls in other tests

## Changes

- Amend urls to use new sub pages
- Run formatter

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
~~ADR decision log updated (if needed)~~
~~Release notes added to CHANGELOG.md~~
~~Testing complete - all manual and automated tests pass~~
