### PR TITLE
Fix governance tests and add check for governor count in subnav link label

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Extensions/StringExtensions.cs
+++ b/DfE.FindInformationAcademiesTrusts/Extensions/StringExtensions.cs
@@ -1,0 +1,29 @@
+using System.Text.RegularExpressions;
+
+namespace DfE.FindInformationAcademiesTrusts.Extensions;
+
+public static partial class StringExtensions
+{
+    [GeneratedRegex(@" *\([^)]*\) *", RegexOptions.Compiled)]
+    private static partial Regex BracketedDigitsRegex();
+
+    [GeneratedRegex(" +", RegexOptions.Compiled)]
+    private static partial Regex SpacesRegex();
+
+    [GeneratedRegex("-+", RegexOptions.Compiled)]
+    private static partial Regex DashesRegex();
+
+    public static string Kebabify(this string text)
+    {
+        var transformedText = text.Trim();
+
+        transformedText = BracketedDigitsRegex().Replace(transformedText, "-");
+        transformedText = SpacesRegex().Replace(transformedText, "-");
+        transformedText = DashesRegex().Replace(transformedText, "-");
+
+        transformedText = transformedText.Trim('-');
+        transformedText = transformedText.ToLowerInvariant();
+
+        return transformedText;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/HistoricMembers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/HistoricMembers.cshtml
@@ -52,7 +52,7 @@
       }
       else
       {
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-3">Historic members</h3>
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-3" data-testid="subpage-header">Historic members</h3>
         <p class="govuk-body govuk-!-margin-bottom-0">No Historic members</p>
       }
     </section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Members.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Members.cshtml
@@ -48,7 +48,7 @@
       }
       else
       {
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-3">Members</h3>
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-3" data-testid="subpage-header">Members</h3>
         <p class="govuk-body govuk-!-margin-bottom-0">No Members</p>
       }
     </section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/TrustLeadership.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/TrustLeadership.cshtml
@@ -48,7 +48,7 @@
       }
       else
       {
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-3">Trust Leadership</h3>
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-3" data-testid="subpage-header">Trust Leadership</h3>
         <p class="govuk-body govuk-!-margin-bottom-0">No Trust Leadership</p>
       }
     </section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Trustees.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Trustees.cshtml
@@ -48,7 +48,7 @@
       }
       else
       {
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-3">Trustees</h3>
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-3" data-testid="subpage-header">Trustees</h3>
         <p class="govuk-body govuk-!-margin-bottom-0">No Trustees</p>
       }
     </section>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustSubNavigationLinkModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustSubNavigationLinkModel.cs
@@ -1,4 +1,6 @@
-﻿namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+﻿using DfE.FindInformationAcademiesTrusts.Extensions;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 
 public record TrustSubNavigationLinkModel(
     string LinkText,
@@ -7,6 +9,5 @@ public record TrustSubNavigationLinkModel(
     string ServiceName,
     bool LinkIsActive)
 {
-    public string TestId =>
-        $"{ServiceName.ToLowerInvariant().Trim().Replace(" ", "-")}-{LinkText.ToLowerInvariant().Trim().Replace(" ", "-")}-subnav";
+    public string TestId => $"{ServiceName}-{LinkText}-subnav".Kebabify();
 }

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/contacts-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/contacts-page.cy.ts
@@ -13,11 +13,11 @@ function generateNameAndEmail() {
 const testTrustData = [
     {
         typeOfTrust: "single academy trust with contacts",
-        uid: 5712
+        uid: 5527
     },
     {
         typeOfTrust: "multi academy trust with contacts",
-        uid: 5527
+        uid: 5712
     }
 ];
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
@@ -3,86 +3,97 @@ import governancePage from "../../../pages/trusts/governancePage";
 
 describe("Testing the components of the Governance page", () => {
 
-    describe("On a Governance page with data", () => {
-        const trustWithFullGovernanceData = 5712;
+    beforeEach(() => {
+        cy.login();
+    });
 
-        beforeEach(() => {
-            cy.login();
-        });
+    const trustsWithGovernanceData = [
+        {
+            typeOfTrust: "single academy trust with governance data",
+            uid: 5712
+        },
+        {
+            typeOfTrust: "multi academy trust with governance data",
+            uid: 5527
+        }
+    ];
+    trustsWithGovernanceData.forEach(({ typeOfTrust, uid }) => {
+        describe(`On the Governance pages for a ${typeOfTrust}`, () => {
 
-        it("The trust leadership page loads with the correct headings and data", () => {
-            cy.visit(`/trusts/governance/trust-leadership?uid=${trustWithFullGovernanceData}`);
+            it("The trust leadership page loads with the correct headings and data", () => {
+                cy.visit(`/trusts/governance/trust-leadership?uid=${uid}`);
 
-            // Trust leadership table is visible and working
-            governancePage
-                .checkTrustLeadershipSubHeaderPresent()
-                .checkTrustLeadershipTableHeadersAreVisible()
-                .checkTrustLeadershipAppointmentDatesAreCurrent()
-                .checkOnlyTrustLeadershipRolesArePresent();
+                // Trust leadership table is visible and working
+                governancePage
+                    .checkTrustLeadershipSubHeaderPresent()
+                    .checkTrustLeadershipTableHeadersAreVisible()
+                    .checkTrustLeadershipAppointmentDatesAreCurrent()
+                    .checkOnlyTrustLeadershipRolesArePresent();
 
-            // "No Trust Leadership" message is hidden
-            governancePage
-                .checkNoTrustLeadershipMessageIsHidden();
-        });
+                // "No Trust Leadership" message is hidden
+                governancePage
+                    .checkNoTrustLeadershipMessageIsHidden();
+            });
 
-        it("The trustees page loads with the correct headings and data", () => {
-            cy.visit(`/trusts/governance/trustees?uid=${trustWithFullGovernanceData}`);
+            it("The trustees page loads with the correct headings and data", () => {
+                cy.visit(`/trusts/governance/trustees?uid=${uid}`);
 
-            // Trustee table is visible and working
-            governancePage
-                .checkTrusteesSubHeaderPresent()
-                .checkTrusteesTableHeadersAreVisible()
-                .checkTrusteesAppointmentDatesAreCurrent();
+                // Trustee table is visible and working
+                governancePage
+                    .checkTrusteesSubHeaderPresent()
+                    .checkTrusteesTableHeadersAreVisible()
+                    .checkTrusteesAppointmentDatesAreCurrent();
 
-            // "No Trustees" message is hidden
-            governancePage
-                .checkNoTrusteesMessageIsHidden();
-        });
+                // "No Trustees" message is hidden
+                governancePage
+                    .checkNoTrusteesMessageIsHidden();
+            });
 
-        it("The members page loads with the correct headings and data", () => {
-            cy.visit(`/trusts/governance/members?uid=${trustWithFullGovernanceData}`);
+            it("The members page loads with the correct headings and data", () => {
+                cy.visit(`/trusts/governance/members?uid=${uid}`);
 
-            // Members table is visible and working
-            governancePage
-                .checkMembersSubHeaderPresent()
-                .checkMembersTableHeadersAreVisible()
-                .checkMembersAppointmentDatesAreCurrent();
+                // Members table is visible and working
+                governancePage
+                    .checkMembersSubHeaderPresent()
+                    .checkMembersTableHeadersAreVisible()
+                    .checkMembersAppointmentDatesAreCurrent();
 
-            // "No Members" message is hidden
-            governancePage
-                .checkNoMembersMessageIsHidden();
-        });
+                // "No Members" message is hidden
+                governancePage
+                    .checkNoMembersMessageIsHidden();
+            });
 
-        it("The historic members page loads with the correct headings and data", () => {
-            cy.visit(`/trusts/governance/historic-members?uid=${trustWithFullGovernanceData}`);
+            it("The historic members page loads with the correct headings and data", () => {
+                cy.visit(`/trusts/governance/historic-members?uid=${uid}`);
 
-            // Historic members table is visible and working
-            governancePage
-                .checkHistoricMembersSubHeaderPresent()
-                .checkHistoricMembersTableHeadersAreVisible()
-                .checkHistoricMembersAppointmentDatesAreInThePast();
+                // Historic members table is visible and working
+                governancePage
+                    .checkHistoricMembersSubHeaderPresent()
+                    .checkHistoricMembersTableHeadersAreVisible()
+                    .checkHistoricMembersAppointmentDatesAreInThePast();
 
-            // "No Historic Members" message is hidden
-            governancePage
-                .checkNoHistoricMembersMessageIsHidden();
-        });
+                // "No Historic Members" message is hidden
+                governancePage
+                    .checkNoHistoricMembersMessageIsHidden();
+            });
 
-        it("Table sorting is working", () => {
-            cy.visit(`/trusts/governance/trust-leadership?uid=${trustWithFullGovernanceData}`);
-            governancePage.checkTrustLeadershipColumnsSortCorrectly();
+            it("Table sorting is working", () => {
+                cy.visit(`/trusts/governance/trust-leadership?uid=${uid}`);
+                governancePage.checkTrustLeadershipColumnsSortCorrectly();
 
-            cy.visit(`/trusts/governance/trustees?uid=${trustWithFullGovernanceData}`);
-            governancePage.checkTrusteesColumnsSortCorrectly();
+                cy.visit(`/trusts/governance/trustees?uid=${uid}`);
+                governancePage.checkTrusteesColumnsSortCorrectly();
 
-            cy.visit(`/trusts/governance/members?uid=${trustWithFullGovernanceData}`);
-            governancePage.checkMembersColumnsSortCorrectly();
+                cy.visit(`/trusts/governance/members?uid=${uid}`);
+                governancePage.checkMembersColumnsSortCorrectly();
 
-            cy.visit(`/trusts/governance/historic-members?uid=${trustWithFullGovernanceData}`);
-            governancePage.checkHistoricMembersColumnsSortCorrectly();
+                cy.visit(`/trusts/governance/historic-members?uid=${uid}`);
+                governancePage.checkHistoricMembersColumnsSortCorrectly();
+            });
         });
     });
 
-    [
+    const trustsWithNoGovernanceData = [
         {
             typeOfTrust: "single academy trust with no governance data",
             uid: 17737
@@ -91,14 +102,11 @@ describe("Testing the components of the Governance page", () => {
             typeOfTrust: "multi academy trust with no governance data",
             uid: 17637
         }
-    ].forEach(({ typeOfTrust, uid }) => {
-        describe.only(`On a Governance page for a ${typeOfTrust}`, () => {
-            beforeEach(() => {
-                cy.login();
-            });
+    ];
+    trustsWithNoGovernanceData.forEach(({ typeOfTrust, uid }) => {
+        describe(`On the Governance pages for a ${typeOfTrust}`, () => {
 
             it("The tables should be replaced with no data messages", () => {
-                cy.login();
                 cy.visit(`/trusts/governance/trust-leadership?uid=${uid}`);
                 governancePage.checkNoTrustLeadershipMessageIsVisible();
 
@@ -133,9 +141,6 @@ describe("Testing the components of the Governance page", () => {
     });
 
     describe("Testing the governance sub navigation", () => {
-        beforeEach(() => {
-            cy.login();
-        });
 
         it('Should check that the trust leadership navigation button takes me to the correct page', () => {
             cy.visit('/trusts/governance/historic-members?uid=5527');

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
@@ -90,6 +90,20 @@ describe("Testing the components of the Governance page", () => {
                 cy.visit(`/trusts/governance/historic-members?uid=${uid}`);
                 governancePage.checkHistoricMembersColumnsSortCorrectly();
             });
+
+            it("Sub navigation links contain correct number of governors", () => {
+                cy.visit(`/trusts/governance/trust-leadership?uid=${uid}`);
+                governancePage.checkTrustLeadershipLinkValueMatchesNumberOfTrustLeaders();
+
+                cy.visit(`/trusts/governance/trustees?uid=${uid}`);
+                governancePage.checkTrusteesLinkValueMatchesNumberOfTrustees();
+
+                cy.visit(`/trusts/governance/members?uid=${uid}`);
+                governancePage.checkMembersLinkValueMatchesNumberOfMembers();
+
+                cy.visit(`/trusts/governance/historic-members?uid=${uid}`);
+                governancePage.checkHistoricMembersLinkValueMatchesNumberOfHistoricMembers();
+            });
         });
     });
 
@@ -197,7 +211,6 @@ describe("Testing the components of the Governance page", () => {
                 .checkAllSubNavItemsPresent()
                 .checkHistoricMembersSubHeaderPresent();
         });
-
 
         it('Should check that the governance sub nav items are not present when I am not on the governance page', () => {
             cy.visit('/trusts/overview/trust-details?uid=5527');

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
@@ -82,28 +82,53 @@ describe("Testing the components of the Governance page", () => {
         });
     });
 
-    describe("On a Governance page without data", () => {
-        const trustWithNoGovernanceData = 5712;
+    [
+        {
+            typeOfTrust: "single academy trust with no governance data",
+            uid: 17737
+        },
+        {
+            typeOfTrust: "multi academy trust with no governance data",
+            uid: 17637
+        }
+    ].forEach(({ typeOfTrust, uid }) => {
+        describe.only(`On a Governance page for a ${typeOfTrust}`, () => {
+            beforeEach(() => {
+                cy.login();
+            });
 
-        beforeEach(() => {
-            cy.login();
-        });
+            it("The tables should be replaced with no data messages", () => {
+                cy.login();
+                cy.visit(`/trusts/governance/trust-leadership?uid=${uid}`);
+                governancePage.checkNoTrustLeadershipMessageIsVisible();
 
-        it("The tables should be replaced with no data messages", () => {
-            cy.visit(`/trusts/governance/trust-leadership?uid=${trustWithNoGovernanceData}`);
-            governancePage.checkNoTrustLeadershipMessageIsVisble();
+                cy.visit(`/trusts/governance/trustees?uid=${uid}`);
+                governancePage.checkNoTrusteesMessageIsVisible();
 
-            cy.visit(`/trusts/governance/trustees?uid=${trustWithNoGovernanceData}`);
-            governancePage.checkNoTrusteesMessageIsVisble();
+                cy.visit(`/trusts/governance/members?uid=${uid}`);
+                governancePage.checkNotMembersMessageIsVisible();
+            });
 
-            cy.visit(`/trusts/governance/members?uid=${trustWithNoGovernanceData}`);
-            governancePage.checkNotMembersMessageIsVisble();
-        });
+            //Skipping below test case until no data governance page issue sorted (Bug raised 179544)
+            it.skip("The historic members table should be replaced with no data message", () => {
+                cy.visit(`/trusts/governance/historic-members?uid=${uid}`);
+                governancePage.checkNoHistoricMembersMessageIsVisible();
+            });
 
-        //Skipping below test until no data governance page issue sorted (Bug raised 179544)
-        it.skip("The historic members table should be replaced with no data message", () => {
-            cy.visit(`/trusts/governance/historic-members?uid=${trustWithNoGovernanceData}`);
-            governancePage.checkNoHistoricMembersMessageIsVisble();
+            it("The number of governors in each sub nav title should be 0", () => {
+                cy.visit(`/trusts/governance/trust-leadership?uid=${uid}`);
+                governancePage.checkTrustLeadershipSubnavButtonHasZeroInBrackets();
+
+                cy.visit(`/trusts/governance/trustees?uid=${uid}`);
+                governancePage.checkTrusteesSubnavButtonHasZeroInBrackets();
+
+                cy.visit(`/trusts/governance/members?uid=${uid}`);
+                governancePage.checkMembersSubnavButtonHasZeroInBrackets();
+
+                cy.visit(`/trusts/governance/historic-members?uid=${uid}`);
+                governancePage.checkHistoricMembersSubnavButtonHasZeroInBrackets();
+            });
+
         });
     });
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
@@ -147,9 +147,8 @@ describe("Testing the components of the Governance page", () => {
                 .checkCurrentURLIsCorrect('/trusts/governance/trust-leadership?uid=5527');
 
             governancePage
-                .checkAllSubNavItemsPresent();
-
-            // Todo: Check page sub-heading "Trust leadership" is visible
+                .checkAllSubNavItemsPresent()
+                .checkTrustLeadershipSubHeaderPresent();
         });
 
         it('Should check that the trustees navigation button takes me to the correct page', () => {
@@ -162,9 +161,8 @@ describe("Testing the components of the Governance page", () => {
                 .checkCurrentURLIsCorrect('/trusts/governance/trustees?uid=5527');
 
             governancePage
-                .checkAllSubNavItemsPresent();
-
-            // Todo: Check page sub-heading "Trustees" is visible
+                .checkAllSubNavItemsPresent()
+                .checkTrusteesSubHeaderPresent();
         });
 
         it('Should check that the members navigation button takes me to the correct page', () => {
@@ -177,9 +175,8 @@ describe("Testing the components of the Governance page", () => {
                 .checkCurrentURLIsCorrect('/trusts/governance/members?uid=5527');
 
             governancePage
-                .checkAllSubNavItemsPresent();
-
-            // Todo: Check page sub-heading "Members" is visible
+                .checkAllSubNavItemsPresent()
+                .checkMembersSubHeaderPresent();
         });
 
         it('Should check that the historic members navigation button takes me to the correct page', () => {
@@ -192,9 +189,8 @@ describe("Testing the components of the Governance page", () => {
                 .checkCurrentURLIsCorrect('/trusts/governance/historic-members?uid=5527');
 
             governancePage
-                .checkAllSubNavItemsPresent();
-
-            // Todo: Check page sub-heading "Historic members" is visible
+                .checkAllSubNavItemsPresent()
+                .checkHistoricMembersSubHeaderPresent();
         });
 
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/governancePage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/governancePage.ts
@@ -238,22 +238,22 @@ class GovernancePage {
     //
     // **********************
 
-    public checkNoTrustLeadershipMessageIsVisble(): this {
+    public checkNoTrustLeadershipMessageIsVisible(): this {
         this.elements.TrustLeadership.NoDataMessage().should('be.visible');
         return this;
     }
 
-    public checkNoTrusteesMessageIsVisble(): this {
+    public checkNoTrusteesMessageIsVisible(): this {
         this.elements.Trustees.NoDataMessage().should('be.visible');
         return this;
     }
 
-    public checkNotMembersMessageIsVisble(): this {
+    public checkNotMembersMessageIsVisible(): this {
         this.elements.Members.NoDataMessage().should('be.visible');
         return this;
     }
 
-    public checkNoHistoricMembersMessageIsVisble(): this {
+    public checkNoHistoricMembersMessageIsVisible(): this {
         this.elements.HistoricMembers.NoDataMessage().should('be.visible');
         return this;
     }
@@ -359,6 +359,37 @@ class GovernancePage {
 
     public checkHistoricMembersSubnavButtonIsHighlighted(): this {
         this.elements.subNav.historicMembersSubnavButton().should('have.prop', 'aria-current', true);
+        return this;
+    }
+
+    private getCountFromSubNavButton(subNavButton: Cypress.Chainable<JQuery<HTMLElement>>): Cypress.Chainable<number> {
+        return subNavButton
+            .invoke('text')
+            .then(text => {
+                const matches = /\d+/.exec(text);
+                if (!matches)
+                    throw new Error("No count found in button text.");
+                return parseInt(matches[0]);
+            });
+    }
+
+    public checkTrustLeadershipSubnavButtonHasZeroInBrackets(): this {
+        this.getCountFromSubNavButton(this.elements.subNav.trustLeadershipSubnavButton()).should('eq', 0);
+        return this;
+    }
+
+    public checkTrusteesSubnavButtonHasZeroInBrackets(): this {
+        this.getCountFromSubNavButton(this.elements.subNav.trusteesSubnavButton()).should('eq', 0);
+        return this;
+    }
+
+    public checkMembersSubnavButtonHasZeroInBrackets(): this {
+        this.getCountFromSubNavButton(this.elements.subNav.membersSubnavButton()).should('eq', 0);
+        return this;
+    }
+
+    public checkHistoricMembersSubnavButtonHasZeroInBrackets(): this {
+        this.getCountFromSubNavButton(this.elements.subNav.historicMembersSubnavButton()).should('eq', 0);
         return this;
     }
 }

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/governancePage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/governancePage.ts
@@ -12,6 +12,7 @@ class GovernancePage {
             FromHeader: () => this.elements.TrustLeadership.section().find("th:contains('From')"),
             To: () => this.elements.TrustLeadership.section().find('[data-testid="trust-leadership-to"]'),
             ToHeader: () => this.elements.TrustLeadership.section().find("th:contains('To')"),
+            tableRows: () => this.elements.TrustLeadership.section().find('tbody tr'),
             NoDataMessage: () => this.elements.TrustLeadership.section().contains('No Trust Leadership'),
         },
         Trustees: {
@@ -24,6 +25,7 @@ class GovernancePage {
             FromHeader: () => this.elements.Trustees.section().find("th:contains('From')"),
             To: () => this.elements.Trustees.section().find('[data-testid="trustees-to"]'),
             ToHeader: () => this.elements.Trustees.section().find("th:contains('To')"),
+            tableRows: () => this.elements.Trustees.section().find('tbody tr'),
             NoDataMessage: () => this.elements.Trustees.section().contains('No Trustees'),
         },
         Members: {
@@ -36,6 +38,7 @@ class GovernancePage {
             FromHeader: () => this.elements.Members.section().find("th:contains('From')"),
             To: () => this.elements.Members.section().find('[data-testid="members-to"]'),
             ToHeader: () => this.elements.Members.section().find("th:contains('To')"),
+            tableRows: () => this.elements.Members.section().find('tbody tr'),
             NoDataMessage: () => this.elements.Members.section().contains('No Members'),
 
         },
@@ -51,6 +54,7 @@ class GovernancePage {
             FromHeader: () => this.elements.HistoricMembers.section().find("th:contains('From')"),
             To: () => this.elements.HistoricMembers.section().find('[data-testid="historic-members-to"]'),
             ToHeader: () => this.elements.HistoricMembers.section().find("th:contains('To')"),
+            tableRows: () => this.elements.HistoricMembers.section().find('tbody tr'),
             NoDataMessage: () => this.elements.HistoricMembers.section().contains('No Historic Members'),
         },
         subNav: {
@@ -390,6 +394,39 @@ class GovernancePage {
 
     public checkHistoricMembersSubnavButtonHasZeroInBrackets(): this {
         this.getCountFromSubNavButton(this.elements.subNav.historicMembersSubnavButton()).should('eq', 0);
+        return this;
+    }
+
+    private checkButtonCountMatchesActualNumberOfGovernors(subNavButton: Cypress.Chainable<JQuery<HTMLElement>>, tableRows: Cypress.Chainable<JQuery<HTMLElement>>) {
+        tableRows.its('length')
+            .then((numberOfGovernors) => {
+                //Ensure that the table has some data
+                expect(numberOfGovernors).to.be.greaterThan(0, 'Check that there are governors because this test requires a trust with full governance data');
+
+                this.getCountFromSubNavButton(subNavButton)
+                    .then((buttonCount) => {
+                        expect(buttonCount).to.eq(numberOfGovernors, 'Check that number of governors is the same as the number in the sub nav link');
+                    });
+            });
+    }
+
+    public checkTrustLeadershipLinkValueMatchesNumberOfTrustLeaders(): this {
+        this.checkButtonCountMatchesActualNumberOfGovernors(this.elements.subNav.trustLeadershipSubnavButton(), this.elements.TrustLeadership.tableRows());
+        return this;
+    }
+
+    public checkTrusteesLinkValueMatchesNumberOfTrustees(): this {
+        this.checkButtonCountMatchesActualNumberOfGovernors(this.elements.subNav.trusteesSubnavButton(), this.elements.Trustees.tableRows());
+        return this;
+    }
+
+    public checkMembersLinkValueMatchesNumberOfMembers(): this {
+        this.checkButtonCountMatchesActualNumberOfGovernors(this.elements.subNav.membersSubnavButton(), this.elements.Members.tableRows());
+        return this;
+    }
+
+    public checkHistoricMembersLinkValueMatchesNumberOfHistoricMembers(): this {
+        this.checkButtonCountMatchesActualNumberOfGovernors(this.elements.subNav.historicMembersSubnavButton(), this.elements.HistoricMembers.tableRows());
         return this;
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/StringExtensionsTest.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/StringExtensionsTest.cs
@@ -1,0 +1,65 @@
+using DfE.FindInformationAcademiesTrusts.Extensions;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Extensions;
+
+public class StringExtensionsTest
+{
+    [Theory]
+    [InlineData("UPPER", "upper")]
+    [InlineData("inPut", "input")]
+    [InlineData("lower", "lower")]
+    public void Kebabify_should_lower_text(string linkText, string expected)
+    {
+        linkText.Kebabify().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("    ", "")]
+    [InlineData("  left", "left")]
+    [InlineData("right  ", "right")]
+    [InlineData(" middlish  ", "middlish")]
+    public void Kebabify_should_trim_text(string linkText, string expected)
+    {
+        linkText.Kebabify().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("left right", "left-right")]
+    [InlineData("left middle right", "left-middle-right")]
+    [InlineData("one with extra   space", "one-with-extra-space")]
+    public void Kebabify_should_replace_spaces_with_dashes(string linkText, string expected)
+    {
+        linkText.Kebabify().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("(42)", "")]
+    [InlineData("left (middle) right", "left-right")]
+    [InlineData("left(middle)right", "left-right")]
+    [InlineData("left () right", "left-right")]
+    [InlineData("(left) middle right", "middle-right")]
+    [InlineData("left middle (right)", "left-middle")]
+    [InlineData("one with (3)   spaces", "one-with-spaces")]
+    public void Kebabify_should_remove_bracketed_text(string linkText, string expected)
+    {
+        linkText.Kebabify().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("left--right", "left-right")]
+    [InlineData("left----right", "left-right")]
+    public void Kebabify_should_dedupe_dashes(string linkText, string expected)
+    {
+        linkText.Kebabify().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("-", "")]
+    [InlineData("-left", "left")]
+    [InlineData("right-", "right")]
+    [InlineData("-middlish--", "middlish")]
+    public void Kebabify_should_not_start_or_end_with_dash(string linkText, string expected)
+    {
+        linkText.Kebabify().Should().Be(expected);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustSubNavigationLinkModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustSubNavigationLinkModelTests.cs
@@ -4,11 +4,18 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
 
 public class TrustSubNavigationLinkModelTests
 {
-    private readonly TrustSubNavigationLinkModel _sut = new("Link Text", "/page", "1234", "Service Name", true);
+    private readonly TrustSubNavigationLinkModel _baseLinkModel = new("", "", "", "", false);
 
-    [Fact]
-    public void TestId_Should_BeExpected()
+    [Theory]
+    [InlineData("Link Text", "Service Name", "service-name-link-text-subnav")]
+    [InlineData("Link", "Page", "page-link-subnav")]
+    [InlineData("Things (12)", "Page", "page-things-subnav")]
+    [InlineData("Historic things (0)", "Other Page", "other-page-historic-things-subnav")]
+    public void TestId_should_kebabify_service_name_and_link_text(string linkText, string serviceName,
+        string expected)
     {
-        _sut.TestId.Should().Be("service-name-link-text-subnav");
+        var sut = _baseLinkModel with { LinkText = linkText, ServiceName = serviceName };
+
+        sut.TestId.Should().Be(expected);
     }
 }


### PR DESCRIPTION
Fix governance tests and add check for governor count in subnav link label

[Task 190350](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/190350): Test: Governance subnav links have correct numbers

## Changes

- Make governance tests check SATs and MATs
- Make data-test-id generation for subnav links ignore brackets
- Add tests for governor count in subnav link label
- Fix contacts tests having SAT and MAT uids the wrong way round

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
~~ADR decision log updated (if needed)~~
~~Release notes added to CHANGELOG.md~~
- [x] Testing complete - all manual and automated tests pass
