### PR TITLE
Simple Cypress test checking that HTTP headers are set

### DIFF
--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/http-headers.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/http-headers.cy.ts
@@ -1,0 +1,19 @@
+describe('Testing HTTP Headers', () => {
+    describe("Testing the homepage", () => {
+        beforeEach(() => {
+            cy.login();
+        });
+
+        it("Should check that the home page serves the correct HTTP Headers in the response", () => {
+            cy.request('/').then((response) => {
+                expect(response.status).to.eq(200)
+                expect(response).to.have.property('headers')
+                expect(response.headers).to.have.property('Strict-Transport-Security')
+                expect(response.headers).to.have.property('X-Xss-Protection')
+                expect(response.headers).to.have.property('X-Frame-Options')
+                expect(response.headers).to.have.property('X-Content-Type-Options')
+                expect(response.headers).to.have.property('Content-Security-Policy')
+            })
+        });
+    })
+})


### PR DESCRIPTION
It would be good to know if any HTTP Headers (required by ITHC) get removed inadvertently. 

## Changes

Adds a new Cypress test to simply check the homepage for the minimum security HTTP Headers to be set

## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
