### PR TITLE
Create ofsted important dates automation

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml
@@ -25,7 +25,7 @@
     </div>
   </details>
   <table class="govuk-table" data-module="moj-sortable-table">
-    <caption class="govuk-table__caption govuk-table__caption--m">Current ratings</caption>
+    <caption class="govuk-table__caption govuk-table__caption--m">Safeguarding and concerns</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header govuk-body" aria-sort="ascending" data-testid="ofsted-safeguarding-and-concerns-name-header">

--- a/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
@@ -24,7 +24,7 @@ public static class ViewConstants
     public const string SuggestChangeFormLink =
         "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-fkHK2JGo_BIpVChpLMaBFpUNUFDSzhQN0FHVklTV0JWTzFZTjNKWTNJUi4u";
 
-    public const string NoDataText = "No Data";
+    public const string NoDataText = "No data";
 
     public static readonly List<ExternalServiceLink> ExternalServiceLinks =
     [

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/ofsted-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/ofsted-page.cy.ts
@@ -93,4 +93,43 @@ describe("Testing the Ofsted page and its subpages ", () => {
         });
 
     });
+
+    describe("Testing the Ofsted important dates page ", () => {
+        beforeEach(() => {
+            cy.login();
+            cy.visit('/trusts/ofsted/important-dates?uid=5143');
+        });
+
+
+        it("Checks the correct Ofsted important dates sub page header is present", () => {
+            ofstedPage
+                .checkOfstedImportantDatesPageHeaderPresent();
+        })
+
+        it("Checks the correct Ofsted important dates table headers are present", () => {
+            ofstedPage
+                .checkOfstedImportantDatesTableHeadersPresent();
+        });
+
+        it("Checks that a trusts important dates fields are present ", () => {
+            ofstedPage
+                .checkDateJoinedPresent()
+                .checkDateOfCurrentInspectionPresent()
+                .checkDateOfPreviousInspectionPresent();
+        });
+
+        it("Checks that a trusts important dates sorting is working", () => {
+            ofstedPage
+                .checkOfstedImportantDatesSorting();
+        });
+
+        it("Checks that a different trusts important dates fields are present", () => {
+            cy.visit('/trusts/ofsted/important-dates?uid=5712');
+            ofstedPage
+                .checkDateJoinedPresent()
+                .checkDateOfCurrentInspectionPresent()
+                .checkDateOfPreviousInspectionPresent();
+        });
+
+    });
 });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/tableUtility.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/tableUtility.ts
@@ -17,7 +17,7 @@ export class TableUtility {
         }
 
         // Otherwise
-        expect(cellContent).to.equal("No Data", "Cell should have no data");
+        expect(cellContent).to.equal("No data", "Cell should have no data");
     }
 
     public static checkCellDateIsOnOrAfterTodayOrHasNoData(cellElement: JQuery<HTMLElement>) {
@@ -31,7 +31,7 @@ export class TableUtility {
         }
 
         // Otherwise
-        expect(cellContent).to.equal("No Data", "Cell should have no data");
+        expect(cellContent).to.equal("No data", "Cell should have no data");
     }
 
     public static checkStringSorting(

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
@@ -2,7 +2,8 @@ import { TableUtility } from "../tableUtility";
 
 class OfstedPage {
     // Resolves to a date ({2 digits} {month} {4 digits}) or "No data" string
-    dateRegex = /^\d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sept|Oct|Nov|Dec) \d{4}$|^No data$/;
+    // Tech debt - We are allowing Sep and Sept due to different cultures set on remote vs local builds
+    dateRegex = /^\d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec) \d{4}$|^No data$/;
 
     elements = {
         subpageHeader: () => cy.get('[data-testid="subpage-header"]'),

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
@@ -1,6 +1,7 @@
 import { TableUtility } from "../tableUtility";
 
 class OfstedPage {
+    // Resolves to a date ({2 digits} {month} {4 digits}) or "No data" string
     dateRegex = /^\d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sept|Oct|Nov|Dec) \d{4}$|^No data$/;
 
     elements = {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
@@ -1,6 +1,8 @@
 import { TableUtility } from "../tableUtility";
 
 class OfstedPage {
+    dateRegex = /^\d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sept|Oct|Nov|Dec) \d{4}$|^No data$/;
+
     elements = {
         subpageHeader: () => cy.get('[data-testid="subpage-header"]'),
         currentRatings: {
@@ -43,9 +45,15 @@ class OfstedPage {
             beforeOrAfterJoining: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-before-or-after-joining"]'),
         },
         importantDates: {
-            DateJoined: () => this.elements.currentRatings.Section().find('[data-testid="date-joined"]'),
-            DateJoinedHeader: () => this.elements.currentRatings.Section().find("th:contains('Date joined')"),
-
+            Section: () => cy.get('[data-testid="ofsted-important-dates-school-name-table"]'),
+            SchoolName: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-school-name"]'),
+            SchoolNameHeader: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-school-name-header"]'),
+            DateJoined: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-date-joined"]'),
+            DateJoinedHeader: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-date-joined-header"]'),
+            DateOfCurrentInspection: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-date-of-current-inspection"]'),
+            DateOfCurrentInspectionHeader: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-date-of-current-inspection-header"]'),
+            DateOfPreviousInspection: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-date-of-previous-inspection"]'),
+            DateOfPreviousInspectionHeader: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-date-of-previous-inspection-header"]'),
         }
     };
 
@@ -222,7 +230,6 @@ class OfstedPage {
         );
         return this;
     }
-
     public checkPreviousRatingsQualityOfEducationJudgementsPresent(): this {
         this.elements.previousRatings.qualityOfEducation().each((element) => {
             const text = element.text();
@@ -275,6 +282,67 @@ class OfstedPage {
         this.elements.previousRatings.beforeOrAfterJoining().each((element) => {
             const text = element.text();
             expect(text).to.match(/Before|After|Not yet inspected/);
+        });
+        return this;
+    }
+
+    // Important Dates
+
+    public checkOfstedImportantDatesPageHeaderPresent(): this {
+        this.elements.subpageHeader().should('contain', 'Important dates');
+        return this;
+    }
+
+    public checkOfstedImportantDatesTableHeadersPresent(): this {
+        this.elements.importantDates.SchoolNameHeader().should('be.visible');
+        this.elements.importantDates.DateJoinedHeader().should('be.visible');
+        this.elements.importantDates.DateOfCurrentInspectionHeader().should('be.visible');
+        this.elements.importantDates.DateOfPreviousInspectionHeader().should('be.visible');
+        return this;
+    }
+
+    public checkOfstedImportantDatesSorting(): this {
+        TableUtility.checkStringSorting(
+            this.elements.importantDates.SchoolName,
+            this.elements.importantDates.SchoolNameHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.importantDates.DateJoined,
+            this.elements.importantDates.DateJoinedHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.importantDates.DateOfCurrentInspection,
+            this.elements.importantDates.DateOfCurrentInspectionHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.importantDates.DateOfPreviousInspection,
+            this.elements.importantDates.DateOfPreviousInspectionHeader
+        );
+        return this;
+    }
+
+
+    public checkDateJoinedPresent(): this {
+        this.elements.importantDates.DateJoined().each((element) => {
+            const text = element.text().trim();
+            expect(text).to.match(this.dateRegex);
+        });
+        return this;
+    }
+
+    public checkDateOfCurrentInspectionPresent(): this {
+        this.elements.importantDates.DateOfCurrentInspection().each((element) => {
+            const text = element.text().trim();
+            expect(text).to.match(this.dateRegex);
+        });
+        return this;
+    }
+
+
+    public checkDateOfPreviousInspectionPresent(): this {
+        this.elements.importantDates.DateOfPreviousInspection().each((element) => {
+            const text = element.text().trim();
+            expect(text).to.match(this.dateRegex);
         });
         return this;
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/DateTimeExtensionsTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/DateTimeExtensionsTests.cs
@@ -18,6 +18,6 @@ public class DateTimeExtensionsTests
     {
         DateTime? testTime = null;
         var result = testTime.ShowDateStringOrReplaceWithText();
-        result.Should().BeEquivalentTo("No Data");
+        result.Should().Be("No data");
     }
 }


### PR DESCRIPTION
[Task 190577](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/190577): Automation - Important dates

Add automation tests for the Important dates page.

Also fix the heading on the Safeguarding and concerns page.

