### PR TITLE
Fix ofsted cypress errors

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml
@@ -52,7 +52,7 @@
           <td class="govuk-table__cell govuk-body" data-sort-value="@academy.CurrentOfstedRating.SafeguardingIsEffective.ToDataSortValue()" data-testid="ofsted-safeguarding-and-concerns-effective-safeguarding">
             @academy.CurrentOfstedRating.SafeguardingIsEffective.ToDisplayString()
           </td>
-          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.CurrentOfstedRating.CategoryOfConcern.ToDataSortValue()" data-testid="category-of-concern" data-testid="ofsted-safeguarding-and-concerns-category-of-concern">
+          <td class="govuk-table__cell govuk-body" data-sort-value="@academy.CurrentOfstedRating.CategoryOfConcern.ToDataSortValue()" data-testid="ofsted-safeguarding-and-concerns-category-of-concern">
             @academy.CurrentOfstedRating.CategoryOfConcern.ToDisplayString()
           </td>
           <td class="govuk-table__cell govuk-body" data-sort-value="@academy.WhenDidCurrentInspectionHappen" data-testid="ofsted-safeguarding-before-or-after-joining">

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/ofsted-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/ofsted-page.cy.ts
@@ -34,7 +34,7 @@ describe("Testing the Ofsted page and its subpages ", () => {
             ofstedPage
                 .checkCurrentRatingsQualityOfEducationJudgementsPresent()
                 .checkCurrentRatingsBehaviourAndAttitudesJudgementsPresent()
-                .checkCurrentRatingsPesronalDevelopmentJudgementsPresent()
+                .checkCurrentRatingsPersonalDevelopmentJudgementsPresent()
                 .checkCurrentRatingsLeadershipAndManagementJudgementsPresent()
                 .checkCurrentRatingsEarlyYearsProvisionJudgementsPresent()
                 .checkCurrentRatingsSixthFormProvisionJudgementsPresent()
@@ -46,7 +46,7 @@ describe("Testing the Ofsted page and its subpages ", () => {
             ofstedPage
                 .checkCurrentRatingsQualityOfEducationJudgementsPresent()
                 .checkCurrentRatingsBehaviourAndAttitudesJudgementsPresent()
-                .checkCurrentRatingsPesronalDevelopmentJudgementsPresent()
+                .checkCurrentRatingsPersonalDevelopmentJudgementsPresent()
                 .checkCurrentRatingsLeadershipAndManagementJudgementsPresent()
                 .checkCurrentRatingsEarlyYearsProvisionJudgementsPresent()
                 .checkCurrentRatingsSixthFormProvisionJudgementsPresent()
@@ -94,7 +94,7 @@ describe("Testing the Ofsted page and its subpages ", () => {
             ofstedPage
                 .checkPreviousRatingsQualityOfEducationJudgementsPresent()
                 .checkPreviousRatingsBehaviourAndAttitudesJudgementsPresent()
-                .checkPreviousRatingsPesronalDevelopmentJudgementsPresent()
+                .checkPreviousRatingsPersonalDevelopmentJudgementsPresent()
                 .checkPreviousRatingsLeadershipAndManagementJudgementsPresent()
                 .checkPreviousRatingsEarlyYearsProvisionJudgementsPresent()
                 .checkPreviousRatingsSixthFormProvisionJudgementsPresent()
@@ -106,7 +106,7 @@ describe("Testing the Ofsted page and its subpages ", () => {
             ofstedPage
                 .checkPreviousRatingsQualityOfEducationJudgementsPresent()
                 .checkPreviousRatingsBehaviourAndAttitudesJudgementsPresent()
-                .checkPreviousRatingsPesronalDevelopmentJudgementsPresent()
+                .checkPreviousRatingsPersonalDevelopmentJudgementsPresent()
                 .checkPreviousRatingsLeadershipAndManagementJudgementsPresent()
                 .checkPreviousRatingsEarlyYearsProvisionJudgementsPresent()
                 .checkPreviousRatingsSixthFormProvisionJudgementsPresent()
@@ -154,7 +154,6 @@ describe("Testing the Ofsted page and its subpages ", () => {
             ofstedPage
                 .checkSafeguardingConcernsEffectiveSafeguardingJudgementsPresent()
                 .checkSafeguardingConcernsCategoryOfConcernJudgementsPresent()
-                .checkSafeguardingConcernsCategoryOfConcernJudgementsPresent()
                 .checkSafeguardingConcernsBeforeOrAfterJoiningJudgementsPresent();
         });
 
@@ -162,7 +161,6 @@ describe("Testing the Ofsted page and its subpages ", () => {
             cy.visit('/trusts/ofsted/safeguarding-and-concerns?uid=5712');
             ofstedPage
                 .checkSafeguardingConcernsEffectiveSafeguardingJudgementsPresent()
-                .checkSafeguardingConcernsCategoryOfConcernJudgementsPresent()
                 .checkSafeguardingConcernsCategoryOfConcernJudgementsPresent()
                 .checkSafeguardingConcernsBeforeOrAfterJoiningJudgementsPresent();
         });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
@@ -51,7 +51,7 @@ class OfstedPage {
             effectiveSafeguardingHeader: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-and-concerns-effective-safeguarding-header"]'),
             effectiveSafeguarding: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-and-concerns-effective-safeguarding"]'),
             categoryOfConcernHeader: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-and-concerns-category-of-concern-header"]'),
-            categoryOfConcern: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="category-of-concern"]'),
+            categoryOfConcern: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-and-concerns-category-of-concern"]'),
             beforeOrAfterJoiningHeader: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-and-concerns-before-or-after-joining-header"]'),
             beforeOrAfterJoining: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-before-or-after-joining"]'),
         },

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
@@ -1,10 +1,6 @@
 import { TableUtility } from "../tableUtility";
 
 class OfstedPage {
-    // Resolves to a date ({2 digits} {month} {4 digits}) or "No data" string
-    // Tech debt - We are allowing Sep and Sept due to different cultures set on remote vs local builds
-    dateRegex = /^\d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec) \d{4}$|^No data$/;
-    previousAndCurrentRatingsMatch = /Good|No judgement|Outstanding|Requires improvement|Inadequate|Not yet inspected|Insufficient evidence/;
 
     elements = {
         subpageHeader: () => cy.get('[data-testid="subpage-header"]'),
@@ -72,8 +68,25 @@ class OfstedPage {
         }
     };
 
-    ///Current ratings///
+    private readonly checkValueIsValidOfstedRating = (element: JQuery<HTMLElement>) => {
+        const text = element.text().trim();
+        expect(text).to.match(/Good|No judgement|Outstanding|Requires improvement|Inadequate|Not yet inspected|Insufficient evidence/);
+    };
 
+    private readonly checkValueIsValidDate = (element: JQuery<HTMLElement>) => {
+        const text = element.text().trim();
+
+        // Resolves to a date ({2 digits} {month} {4 digits}) or "No data" string
+        // Tech debt - We are allowing Sep and Sept due to different cultures set on remote vs local builds
+        expect(text).to.match(/^\d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec) \d{4}$|^No data$/);
+    };
+
+    private readonly checkValueIsValidBeforeOrAfterJoiningTag = (element: JQuery<HTMLElement>) => {
+        const text = element.text().trim();
+        expect(text).to.match(/Before|After|Not yet inspected/);
+    };
+
+    ///Current ratings///
 
     public checkOfstedCurrentRatingsPageHeaderPresent(): this {
         this.elements.subpageHeader().should('contain', 'Current ratings');
@@ -130,58 +143,37 @@ class OfstedPage {
     }
 
     public checkCurrentRatingsQualityOfEducationJudgementsPresent(): this {
-        this.elements.currentRatings.qualityOfEducation().each((element) => {
-            const text = element.text();
-            expect(text).to.match(this.previousAndCurrentRatingsMatch);
-        });
+        this.elements.currentRatings.qualityOfEducation().each(this.checkValueIsValidOfstedRating);
         return this;
     }
 
     public checkCurrentRatingsBehaviourAndAttitudesJudgementsPresent(): this {
-        this.elements.currentRatings.behaviourAndAttitudes().each((element) => {
-            const text = element.text();
-            expect(text).to.match(this.previousAndCurrentRatingsMatch);
-        });
+        this.elements.currentRatings.behaviourAndAttitudes().each(this.checkValueIsValidOfstedRating);
         return this;
     }
 
     public checkCurrentRatingsPesronalDevelopmentJudgementsPresent(): this {
-        this.elements.currentRatings.personalDevelopment().each((element) => {
-            const text = element.text();
-            expect(text).to.match(this.previousAndCurrentRatingsMatch);
-        });
+        this.elements.currentRatings.personalDevelopment().each(this.checkValueIsValidOfstedRating);
         return this;
     }
 
     public checkCurrentRatingsLeadershipAndManagementJudgementsPresent(): this {
-        this.elements.currentRatings.leadershipAndManagement().each((element) => {
-            const text = element.text();
-            expect(text).to.match(this.previousAndCurrentRatingsMatch);
-        });
+        this.elements.currentRatings.leadershipAndManagement().each(this.checkValueIsValidOfstedRating);
         return this;
     }
 
     public checkCurrentRatingsEarlyYearsProvisionJudgementsPresent(): this {
-        this.elements.currentRatings.earlyYearsProvision().each((element) => {
-            const text = element.text();
-            expect(text).to.match(this.previousAndCurrentRatingsMatch);
-        });
+        this.elements.currentRatings.earlyYearsProvision().each(this.checkValueIsValidOfstedRating);
         return this;
     }
 
     public checkCurrentRatingsSixthFormProvisionJudgementsPresent(): this {
-        this.elements.currentRatings.sixthFormProvision().each((element) => {
-            const text = element.text();
-            expect(text).to.match(this.previousAndCurrentRatingsMatch);
-        });
+        this.elements.currentRatings.sixthFormProvision().each(this.checkValueIsValidOfstedRating);
         return this;
     }
 
     public checkCurrentRatingsBeforeOrAfterJoiningJudgementsPresent(): this {
-        this.elements.currentRatings.beforeOrAfterJoining().each((element) => {
-            const text = element.text();
-            expect(text).to.match(/Before|After|Not yet inspected/);
-        });
+        this.elements.currentRatings.beforeOrAfterJoining().each(this.checkValueIsValidBeforeOrAfterJoiningTag);
         return this;
     }
 
@@ -245,59 +237,39 @@ class OfstedPage {
         );
         return this;
     }
+
     public checkPreviousRatingsQualityOfEducationJudgementsPresent(): this {
-        this.elements.previousRatings.qualityOfEducation().each((element) => {
-            const text = element.text();
-            expect(text).to.match(this.previousAndCurrentRatingsMatch);
-        });
+        this.elements.previousRatings.qualityOfEducation().each(this.checkValueIsValidOfstedRating);
         return this;
     }
 
     public checkPreviousRatingsBehaviourAndAttitudesJudgementsPresent(): this {
-        this.elements.previousRatings.behaviourAndAttitudes().each((element) => {
-            const text = element.text();
-            expect(text).to.match(this.previousAndCurrentRatingsMatch);
-        });
+        this.elements.previousRatings.behaviourAndAttitudes().each(this.checkValueIsValidOfstedRating);
         return this;
     }
 
     public checkPreviousRatingsPesronalDevelopmentJudgementsPresent(): this {
-        this.elements.previousRatings.personalDevelopment().each((element) => {
-            const text = element.text();
-            expect(text).to.match(this.previousAndCurrentRatingsMatch);
-        });
+        this.elements.previousRatings.personalDevelopment().each(this.checkValueIsValidOfstedRating);
         return this;
     }
 
     public checkPreviousRatingsLeadershipAndManagementJudgementsPresent(): this {
-        this.elements.previousRatings.leadershipAndManagement().each((element) => {
-            const text = element.text();
-            expect(text).to.match(this.previousAndCurrentRatingsMatch);
-        });
+        this.elements.previousRatings.leadershipAndManagement().each(this.checkValueIsValidOfstedRating);
         return this;
     }
 
     public checkPreviousRatingsEarlyYearsProvisionJudgementsPresent(): this {
-        this.elements.previousRatings.earlyYearsProvision().each((element) => {
-            const text = element.text();
-            expect(text).to.match(this.previousAndCurrentRatingsMatch);
-        });
+        this.elements.previousRatings.earlyYearsProvision().each(this.checkValueIsValidOfstedRating);
         return this;
     }
 
     public checkPreviousRatingsSixthFormProvisionJudgementsPresent(): this {
-        this.elements.previousRatings.sixthFormProvision().each((element) => {
-            const text = element.text();
-            expect(text).to.match(this.previousAndCurrentRatingsMatch);
-        });
+        this.elements.previousRatings.sixthFormProvision().each(this.checkValueIsValidOfstedRating);
         return this;
     }
 
     public checkPreviousRatingsBeforeOrAfterJoiningJudgementsPresent(): this {
-        this.elements.previousRatings.beforeOrAfterJoining().each((element) => {
-            const text = element.text();
-            expect(text).to.match(/Before|After|Not yet inspected/);
-        });
+        this.elements.previousRatings.beforeOrAfterJoining().each(this.checkValueIsValidBeforeOrAfterJoiningTag);
         return this;
     }
 
@@ -353,10 +325,7 @@ class OfstedPage {
     }
 
     public checkSafeguardingConcernsBeforeOrAfterJoiningJudgementsPresent(): this {
-        this.elements.safeguardingAndConcerns.beforeOrAfterJoining().each((element) => {
-            const text = element.text();
-            expect(text).to.match(/Before|After|Not yet inspected/);
-        });
+        this.elements.safeguardingAndConcerns.beforeOrAfterJoining().each(this.checkValueIsValidBeforeOrAfterJoiningTag);
         return this;
     }
 
@@ -397,27 +366,18 @@ class OfstedPage {
 
 
     public checkDateJoinedPresent(): this {
-        this.elements.importantDates.DateJoined().each((element) => {
-            const text = element.text().trim();
-            expect(text).to.match(this.dateRegex);
-        });
+        this.elements.importantDates.DateJoined().each(this.checkValueIsValidDate);
         return this;
     }
 
     public checkDateOfCurrentInspectionPresent(): this {
-        this.elements.importantDates.DateOfCurrentInspection().each((element) => {
-            const text = element.text().trim();
-            expect(text).to.match(this.dateRegex);
-        });
+        this.elements.importantDates.DateOfCurrentInspection().each(this.checkValueIsValidDate);
         return this;
     }
 
 
     public checkDateOfPreviousInspectionPresent(): this {
-        this.elements.importantDates.DateOfPreviousInspection().each((element) => {
-            const text = element.text().trim();
-            expect(text).to.match(this.dateRegex);
-        });
+        this.elements.importantDates.DateOfPreviousInspection().each(this.checkValueIsValidDate);
         return this;
     }
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
@@ -6,65 +6,65 @@ class OfstedPage {
         subpageHeader: () => cy.get('[data-testid="subpage-header"]'),
         downloadButton: () => cy.get('[data-testid="download-all-ofsted-data-button"]'),
         currentRatings: {
-            Section: () => cy.get('[data-testid="ofsted-current-ratings-table"]'),
-            SchoolName: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-school-name"]'),
-            SchoolNameHeader: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-school-name-header"]'),
-            NoDataMessage: () => this.elements.currentRatings.Section().contains('No data available'),
-            qualityOfEducationHeader: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-quality-of-education-header"]'),
-            qualityOfEducation: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-quality-of-education"]'),
-            behaviourAndAttitudesHeader: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-behaviour-and-attitudes-header"]'),
-            behaviourAndAttitudes: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-behaviour-and-attitudes"]'),
-            personalDevelopmentHeader: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-personal-development-header"]'),
-            personalDevelopment: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-personal-development"]'),
-            leadershipAndManagementHeader: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-leadership-and-management-header"]'),
-            leadershipAndManagement: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-leadership-and-management"]'),
-            earlyYearsProvisionHeader: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-early-years-provision-header"]'),
-            earlyYearsProvision: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-early-years-provision"]'),
-            sixthFormProvisionHeader: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-sixth-form-provision-header"]'),
-            sixthFormProvision: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-sixth-form-provision"]'),
-            beforeOrAfterJoiningHeader: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-before-or-after-joining-header"]'),
-            beforeOrAfterJoining: () => this.elements.currentRatings.Section().find('[data-testid="ofsted-current-ratings-before-or-after-joining"]'),
+            section: () => cy.get('[data-testid="ofsted-current-ratings-table"]'),
+            schoolName: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-school-name"]'),
+            schoolNameHeader: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-school-name-header"]'),
+            noDataMessage: () => this.elements.currentRatings.section().contains('No data available'),
+            qualityOfEducationHeader: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-quality-of-education-header"]'),
+            qualityOfEducation: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-quality-of-education"]'),
+            behaviourAndAttitudesHeader: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-behaviour-and-attitudes-header"]'),
+            behaviourAndAttitudes: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-behaviour-and-attitudes"]'),
+            personalDevelopmentHeader: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-personal-development-header"]'),
+            personalDevelopment: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-personal-development"]'),
+            leadershipAndManagementHeader: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-leadership-and-management-header"]'),
+            leadershipAndManagement: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-leadership-and-management"]'),
+            earlyYearsProvisionHeader: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-early-years-provision-header"]'),
+            earlyYearsProvision: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-early-years-provision"]'),
+            sixthFormProvisionHeader: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-sixth-form-provision-header"]'),
+            sixthFormProvision: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-sixth-form-provision"]'),
+            beforeOrAfterJoiningHeader: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-before-or-after-joining-header"]'),
+            beforeOrAfterJoining: () => this.elements.currentRatings.section().find('[data-testid="ofsted-current-ratings-before-or-after-joining"]'),
         },
         previousRatings: {
-            Section: () => cy.get('[data-testid="ofsted-previous-ratings-table"]'),
-            SchoolName: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-school-name"]'),
-            SchoolNameHeader: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-school-name-header"]'),
-            qualityOfEducationHeader: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-quality-of-education-header"]'),
-            qualityOfEducation: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-quality-of-education"]'),
-            behaviourAndAttitudesHeader: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-behaviour-and-attitudes-header"]'),
-            behaviourAndAttitudes: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-behaviour-and-attitudes"]'),
-            personalDevelopmentHeader: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-personal-development-header"]'),
-            personalDevelopment: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-personal-development"]'),
-            leadershipAndManagementHeader: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-leadership-and-management-header"]'),
-            leadershipAndManagement: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-leadership-and-management"]'),
-            earlyYearsProvisionHeader: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-early-years-provision-header"]'),
-            earlyYearsProvision: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-early-years-provision"]'),
-            sixthFormProvisionHeader: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-sixth-form-provision-header"]'),
-            sixthFormProvision: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-sixth-form-provision"]'),
-            beforeOrAfterJoiningHeader: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-before-or-after-joining-header"]'),
-            beforeOrAfterJoining: () => this.elements.previousRatings.Section().find('[data-testid="ofsted-previous-ratings-before-or-after-joining"]'),
+            section: () => cy.get('[data-testid="ofsted-previous-ratings-table"]'),
+            schoolName: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-school-name"]'),
+            schoolNameHeader: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-school-name-header"]'),
+            qualityOfEducationHeader: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-quality-of-education-header"]'),
+            qualityOfEducation: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-quality-of-education"]'),
+            behaviourAndAttitudesHeader: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-behaviour-and-attitudes-header"]'),
+            behaviourAndAttitudes: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-behaviour-and-attitudes"]'),
+            personalDevelopmentHeader: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-personal-development-header"]'),
+            personalDevelopment: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-personal-development"]'),
+            leadershipAndManagementHeader: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-leadership-and-management-header"]'),
+            leadershipAndManagement: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-leadership-and-management"]'),
+            earlyYearsProvisionHeader: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-early-years-provision-header"]'),
+            earlyYearsProvision: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-early-years-provision"]'),
+            sixthFormProvisionHeader: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-sixth-form-provision-header"]'),
+            sixthFormProvision: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-sixth-form-provision"]'),
+            beforeOrAfterJoiningHeader: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-before-or-after-joining-header"]'),
+            beforeOrAfterJoining: () => this.elements.previousRatings.section().find('[data-testid="ofsted-previous-ratings-before-or-after-joining"]'),
         },
         safeguardingAndConcerns: {
-            Section: () => cy.get('[data-testid="ofsted-safeguarding-and-concerns-name-table"]'),
-            SchoolNameHeader: () => this.elements.safeguardingAndConcerns.Section().find('[data-testid="ofsted-safeguarding-and-concerns-name-header"]'),
-            SchoolName: () => this.elements.safeguardingAndConcerns.Section().find('[data-testid="ofsted-safeguarding-and-concerns-school-name"]'),
-            effectiveSafeguardingHeader: () => this.elements.safeguardingAndConcerns.Section().find('[data-testid="ofsted-safeguarding-and-concerns-effective-safeguarding-header"]'),
-            effectiveSafeguarding: () => this.elements.safeguardingAndConcerns.Section().find('[data-testid="ofsted-safeguarding-and-concerns-effective-safeguarding"]'),
-            categoryOfConcernHeader: () => this.elements.safeguardingAndConcerns.Section().find('[data-testid="ofsted-safeguarding-and-concerns-category-of-concern-header"]'),
-            categoryOfConcern: () => this.elements.safeguardingAndConcerns.Section().find('[data-testid="category-of-concern"]'),
-            beforeOrAfterJoiningHeader: () => this.elements.safeguardingAndConcerns.Section().find('[data-testid="ofsted-safeguarding-and-concerns-before-or-after-joining-header"]'),
-            beforeOrAfterJoining: () => this.elements.safeguardingAndConcerns.Section().find('[data-testid="ofsted-safeguarding-before-or-after-joining"]'),
+            section: () => cy.get('[data-testid="ofsted-safeguarding-and-concerns-name-table"]'),
+            schoolNameHeader: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-and-concerns-name-header"]'),
+            schoolName: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-and-concerns-school-name"]'),
+            effectiveSafeguardingHeader: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-and-concerns-effective-safeguarding-header"]'),
+            effectiveSafeguarding: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-and-concerns-effective-safeguarding"]'),
+            categoryOfConcernHeader: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-and-concerns-category-of-concern-header"]'),
+            categoryOfConcern: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="category-of-concern"]'),
+            beforeOrAfterJoiningHeader: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-and-concerns-before-or-after-joining-header"]'),
+            beforeOrAfterJoining: () => this.elements.safeguardingAndConcerns.section().find('[data-testid="ofsted-safeguarding-before-or-after-joining"]'),
         },
         importantDates: {
-            Section: () => cy.get('[data-testid="ofsted-important-dates-school-name-table"]'),
-            SchoolName: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-school-name"]'),
-            SchoolNameHeader: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-school-name-header"]'),
-            DateJoined: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-date-joined"]'),
-            DateJoinedHeader: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-date-joined-header"]'),
-            DateOfCurrentInspection: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-date-of-current-inspection"]'),
-            DateOfCurrentInspectionHeader: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-date-of-current-inspection-header"]'),
-            DateOfPreviousInspection: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-date-of-previous-inspection"]'),
-            DateOfPreviousInspectionHeader: () => this.elements.importantDates.Section().find('[data-testid="ofsted-important-dates-date-of-previous-inspection-header"]'),
+            section: () => cy.get('[data-testid="ofsted-important-dates-school-name-table"]'),
+            schoolName: () => this.elements.importantDates.section().find('[data-testid="ofsted-important-dates-school-name"]'),
+            schoolNameHeader: () => this.elements.importantDates.section().find('[data-testid="ofsted-important-dates-school-name-header"]'),
+            dateJoined: () => this.elements.importantDates.section().find('[data-testid="ofsted-important-dates-date-joined"]'),
+            dateJoinedHeader: () => this.elements.importantDates.section().find('[data-testid="ofsted-important-dates-date-joined-header"]'),
+            dateOfCurrentInspection: () => this.elements.importantDates.section().find('[data-testid="ofsted-important-dates-date-of-current-inspection"]'),
+            dateOfCurrentInspectionHeader: () => this.elements.importantDates.section().find('[data-testid="ofsted-important-dates-date-of-current-inspection-header"]'),
+            dateOfPreviousInspection: () => this.elements.importantDates.section().find('[data-testid="ofsted-important-dates-date-of-previous-inspection"]'),
+            dateOfPreviousInspectionHeader: () => this.elements.importantDates.section().find('[data-testid="ofsted-important-dates-date-of-previous-inspection-header"]'),
         }
     };
 
@@ -94,7 +94,7 @@ class OfstedPage {
     }
 
     public checkOfstedCurrentRatingsTableHeadersPresent(): this {
-        this.elements.currentRatings.SchoolNameHeader().should('be.visible');
+        this.elements.currentRatings.schoolNameHeader().should('be.visible');
         this.elements.currentRatings.qualityOfEducationHeader().should('be.visible');
         this.elements.currentRatings.behaviourAndAttitudesHeader().should('be.visible');
         this.elements.currentRatings.personalDevelopmentHeader().should('be.visible');
@@ -108,8 +108,8 @@ class OfstedPage {
 
     public checkOfstedCurrentRatingsSorting(): this {
         TableUtility.checkStringSorting(
-            this.elements.currentRatings.SchoolName,
-            this.elements.currentRatings.SchoolNameHeader
+            this.elements.currentRatings.schoolName,
+            this.elements.currentRatings.schoolNameHeader
         );
         TableUtility.checkStringSorting(
             this.elements.currentRatings.qualityOfEducation,
@@ -152,7 +152,7 @@ class OfstedPage {
         return this;
     }
 
-    public checkCurrentRatingsPesronalDevelopmentJudgementsPresent(): this {
+    public checkCurrentRatingsPersonalDevelopmentJudgementsPresent(): this {
         this.elements.currentRatings.personalDevelopment().each(this.checkValueIsValidOfstedRating);
         return this;
     }
@@ -178,7 +178,7 @@ class OfstedPage {
     }
 
     public checkNoDataMessageIsVisible(): this {
-        this.elements.currentRatings.NoDataMessage().should('be.visible');
+        this.elements.currentRatings.noDataMessage().should('be.visible');
         return this;
     }
 
@@ -190,7 +190,7 @@ class OfstedPage {
     }
 
     public checkOfstedPreviousRatingsTableHeadersPresent(): this {
-        this.elements.previousRatings.SchoolNameHeader().should('be.visible');
+        this.elements.previousRatings.schoolNameHeader().should('be.visible');
         this.elements.previousRatings.qualityOfEducationHeader().should('be.visible');
         this.elements.previousRatings.behaviourAndAttitudesHeader().should('be.visible');
         this.elements.previousRatings.personalDevelopmentHeader().should('be.visible');
@@ -204,8 +204,8 @@ class OfstedPage {
 
     public checkOfstedPreviousRatingsSorting(): this {
         TableUtility.checkStringSorting(
-            this.elements.previousRatings.SchoolName,
-            this.elements.previousRatings.SchoolNameHeader
+            this.elements.previousRatings.schoolName,
+            this.elements.previousRatings.schoolNameHeader
         );
         TableUtility.checkStringSorting(
             this.elements.previousRatings.qualityOfEducation,
@@ -248,7 +248,7 @@ class OfstedPage {
         return this;
     }
 
-    public checkPreviousRatingsPesronalDevelopmentJudgementsPresent(): this {
+    public checkPreviousRatingsPersonalDevelopmentJudgementsPresent(): this {
         this.elements.previousRatings.personalDevelopment().each(this.checkValueIsValidOfstedRating);
         return this;
     }
@@ -281,7 +281,7 @@ class OfstedPage {
     }
 
     public checkOfstedSafeguardingConcernsTableHeadersPresent(): this {
-        this.elements.safeguardingAndConcerns.SchoolNameHeader().should('be.visible');
+        this.elements.safeguardingAndConcerns.schoolNameHeader().should('be.visible');
         this.elements.safeguardingAndConcerns.effectiveSafeguardingHeader().should('be.visible');
         this.elements.safeguardingAndConcerns.categoryOfConcern().should('be.visible');
         this.elements.safeguardingAndConcerns.beforeOrAfterJoining().should('be.visible');
@@ -290,8 +290,8 @@ class OfstedPage {
 
     public checkOfstedSafeguardingConcernsSorting(): this {
         TableUtility.checkStringSorting(
-            this.elements.safeguardingAndConcerns.SchoolName,
-            this.elements.safeguardingAndConcerns.SchoolNameHeader
+            this.elements.safeguardingAndConcerns.schoolName,
+            this.elements.safeguardingAndConcerns.schoolNameHeader
         );
         TableUtility.checkStringSorting(
             this.elements.safeguardingAndConcerns.effectiveSafeguarding,
@@ -337,47 +337,47 @@ class OfstedPage {
     }
 
     public checkOfstedImportantDatesTableHeadersPresent(): this {
-        this.elements.importantDates.SchoolNameHeader().should('be.visible');
-        this.elements.importantDates.DateJoinedHeader().should('be.visible');
-        this.elements.importantDates.DateOfCurrentInspectionHeader().should('be.visible');
-        this.elements.importantDates.DateOfPreviousInspectionHeader().should('be.visible');
+        this.elements.importantDates.schoolNameHeader().should('be.visible');
+        this.elements.importantDates.dateJoinedHeader().should('be.visible');
+        this.elements.importantDates.dateOfCurrentInspectionHeader().should('be.visible');
+        this.elements.importantDates.dateOfPreviousInspectionHeader().should('be.visible');
         return this;
     }
 
     public checkOfstedImportantDatesSorting(): this {
         TableUtility.checkStringSorting(
-            this.elements.importantDates.SchoolName,
-            this.elements.importantDates.SchoolNameHeader
+            this.elements.importantDates.schoolName,
+            this.elements.importantDates.schoolNameHeader
         );
         TableUtility.checkStringSorting(
-            this.elements.importantDates.DateJoined,
-            this.elements.importantDates.DateJoinedHeader
+            this.elements.importantDates.dateJoined,
+            this.elements.importantDates.dateJoinedHeader
         );
         TableUtility.checkStringSorting(
-            this.elements.importantDates.DateOfCurrentInspection,
-            this.elements.importantDates.DateOfCurrentInspectionHeader
+            this.elements.importantDates.dateOfCurrentInspection,
+            this.elements.importantDates.dateOfCurrentInspectionHeader
         );
         TableUtility.checkStringSorting(
-            this.elements.importantDates.DateOfPreviousInspection,
-            this.elements.importantDates.DateOfPreviousInspectionHeader
+            this.elements.importantDates.dateOfPreviousInspection,
+            this.elements.importantDates.dateOfPreviousInspectionHeader
         );
         return this;
     }
 
 
     public checkDateJoinedPresent(): this {
-        this.elements.importantDates.DateJoined().each(this.checkValueIsValidDate);
+        this.elements.importantDates.dateJoined().each(this.checkValueIsValidDate);
         return this;
     }
 
     public checkDateOfCurrentInspectionPresent(): this {
-        this.elements.importantDates.DateOfCurrentInspection().each(this.checkValueIsValidDate);
+        this.elements.importantDates.dateOfCurrentInspection().each(this.checkValueIsValidDate);
         return this;
     }
 
 
     public checkDateOfPreviousInspectionPresent(): this {
-        this.elements.importantDates.DateOfPreviousInspection().each(this.checkValueIsValidDate);
+        this.elements.importantDates.dateOfPreviousInspection().each(this.checkValueIsValidDate);
         return this;
     }
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
@@ -70,7 +70,7 @@ class OfstedPage {
 
     private readonly checkValueIsValidOfstedRating = (element: JQuery<HTMLElement>) => {
         const text = element.text().trim();
-        expect(text).to.match(/Good|No judgement|Outstanding|Requires improvement|Inadequate|Not yet inspected|Insufficient evidence/);
+        expect(text).to.match(/^(Good|No judgement|Outstanding|Requires improvement|Inadequate|Not yet inspected|Insufficient evidence|Does not apply)$/);
     };
 
     private readonly checkValueIsValidDate = (element: JQuery<HTMLElement>) => {
@@ -83,7 +83,7 @@ class OfstedPage {
 
     private readonly checkValueIsValidBeforeOrAfterJoiningTag = (element: JQuery<HTMLElement>) => {
         const text = element.text().trim();
-        expect(text).to.match(/Before|After|Not yet inspected/);
+        expect(text).to.match(/^(Before|After|Not yet inspected)$/);
     };
 
     ///Current ratings///
@@ -310,16 +310,16 @@ class OfstedPage {
 
     public checkSafeguardingConcernsEffectiveSafeguardingJudgementsPresent(): this {
         this.elements.safeguardingAndConcerns.effectiveSafeguarding().each((element) => {
-            const text = element.text();
-            expect(text).to.match(/Yes|No|Not recorded/);
+            const text = element.text().trim();
+            expect(text).to.match(/^(Yes|No|Not recorded|Not yet inspected)$/);
         });
         return this;
     }
 
     public checkSafeguardingConcernsCategoryOfConcernJudgementsPresent(): this {
         this.elements.safeguardingAndConcerns.categoryOfConcern().each((element) => {
-            const text = element.text();
-            expect(text).to.match(/Not yet inspected|Special measures|Serious weakness|Notice to improve|Not yet inspected|Does not apply/);
+            const text = element.text().trim();
+            expect(text).to.match(/^(None|Special measures|Serious weakness|Notice to improve|Not yet inspected|Does not apply)$/);
         });
         return this;
     }


### PR DESCRIPTION
Fix currently failing Cypress tests for Ofsted and some minor cleanup

## Changes

- Change regexes to target whole string and check for currently allowed values
- Trim whitespace
- Reuse whole mechanism for checking value of a cell
- Fix typos and casing
- Remove redundant `data-testid` from element

## Checklist

~~Pull request attached to the appropriate user story in Azure DevOps~~ - No associated story
~~ADR decision log updated (if needed)~~
~~Release notes added to CHANGELOG.md~~
- [x] Testing complete - all manual and automated tests pass
