### PR TITLE
Academies page change from sub nav to tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Acadmies pages are now tabs instead of using sub nav
+
 ## [Release-15][release-15] (production-2024-12-02.4279)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Acadmies pages are now tabs instead of using sub nav
+- Academies pages are now tabs instead of using sub nav
 
 ## [Release-15][release-15] (production-2024-12-02.4279)
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml
@@ -5,12 +5,14 @@
   Layout = "Academies/_AcademiesLayout";
 }
 
-<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
+<section class="app-table-container">
+  <h3 class="govuk-heading-m">Details</h3>
   <p class="govuk-body-s">The following links open in a new tab</p>
   <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="academies-details-link">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">School name</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">URN</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Local authority</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Type</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Rural or urban</th>
@@ -21,9 +23,10 @@
       @foreach (var academy in Model.Academies)
       {
         <tr class="govuk-table__row" data-testid="academy-row">
-          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
-            @academy.EstablishmentName<br/><span class="govuk-!-font-weight-regular" data-testid="urn">URN: @academy.Urn</span>
-          </th>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
+            @academy.EstablishmentName
+          </td>
+          <td class="govuk-body govuk-table__cell" data-testid="urn">@academy.Urn</td>
           <td class="govuk-body govuk-table__cell" data-testid="local-authority">@academy.LocalAuthority</td>
           <td class="govuk-body govuk-table__cell" data-testid="type-of-establishment">@academy.TypeOfEstablishment</td>
           <td class="govuk-body govuk-table__cell" data-testid="urban-or-rural">@academy.UrbanRural</td>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml
@@ -6,9 +6,12 @@
 }
 
 <section class="app-table-container">
-  <h3 class="govuk-heading-m">Details</h3>
-  <p class="govuk-body-s">The following links open in a new tab</p>
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="academies-details-link">
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="details-caption">
+    <caption class="govuk-table__caption govuk-table__caption--m" id="details-caption" data-testid="subpage-header">
+      Details <br/>
+      <span class="govuk-body-s">The following links open in a new tab</span>
+    </caption>
+
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">School name</th>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml
@@ -6,8 +6,8 @@
 }
 
 <section class="app-table-container">
-  <h3 class="govuk-heading-m">Free school meals</h3>
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="free-school-meals-link">
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="free-school-meals-caption">
+    <caption class="govuk-table__caption govuk-table__caption--m" id="free-school-meals-caption" data-testid="subpage-header">Free school meals</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">School name</th>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml
@@ -5,11 +5,13 @@
   Layout = "Academies/_AcademiesLayout";
 }
 
-<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
+<section class="app-table-container">
+  <h3 class="govuk-heading-m">Free school meals</h3>
   <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="free-school-meals-link">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">School name</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">URN</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Pupils eligible for free school meals</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Local authority average 2023/24</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">National average 2023/24</th>
@@ -19,9 +21,10 @@
       @foreach (var academy in Model.Academies)
       {
         <tr class="govuk-table__row" data-testid="academy-row">
-          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
-            @academy.EstablishmentName<br/><span class="govuk-!-font-weight-regular" data-testid="urn">URN: @academy.Urn</span>
-          </th>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
+            @academy.EstablishmentName
+          </td>
+          <td class="govuk-body govuk-table__cell" data-testid="urn">@academy.Urn</td>
           <td class="govuk-body govuk-table__cell" data-sort-value="@academy.PercentageFreeSchoolMeals" data-testid="pupils-eligible">
             @if (academy.PercentageFreeSchoolMeals is not null)
             {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml
@@ -6,11 +6,13 @@
   Layout = "Academies/_AcademiesLayout";
 }
 
-<section class="govuk-!-margin-top-4 govuk-!-margin-bottom-9 app-table-container">
+<section class="app-table-container">
+  <h3 class="govuk-heading-m">Pupil numbers</h3>
   <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="academies-pupil-numbers-link">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">School name</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">URN</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Phase and age range</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Pupil numbers</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Pupil capacity</th>
@@ -21,9 +23,10 @@
       @foreach (var academy in Model.Academies)
       {
         <tr class="govuk-table__row" data-testid="academy-row">
-          <th scope="row" class="govuk-body govuk-table__header" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
-            @academy.EstablishmentName<br/><span class="govuk-!-font-weight-regular" data-testid="urn">URN: @academy.Urn</span>
-          </th>
+          <td class="govuk-body govuk-table__cell" data-sort-value="@academy.EstablishmentName" data-testid="school-name">
+            @academy.EstablishmentName
+          </td>
+          <td class="govuk-body govuk-table__cell" data-testid="urn">@academy.Urn</td>
           <td class="govuk-body govuk-table__cell" data-sort-value="@PupilNumbersModel.PhaseAndAgeRangeSortValue(academy)" data-testid="phase-and-age-range">
             @academy.PhaseOfEducation<br/>
             @academy.AgeRange.Minimum - @academy.AgeRange.Maximum

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml
@@ -7,8 +7,8 @@
 }
 
 <section class="app-table-container">
-  <h3 class="govuk-heading-m">Pupil numbers</h3>
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="academies-pupil-numbers-link">
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="pupil-numbers-caption">
+    <caption class="govuk-table__caption govuk-table__caption--m" id="pupil-numbers-caption" data-testid="subpage-header">Pupil numbers</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">School name</th>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_AcademiesLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_AcademiesLayout.cshtml
@@ -6,14 +6,39 @@
 
 @functions {
 
-  private string? GetAriaCurrentIf(string linkName)
+  private string GetCurrentlySelectedClassIf(string linkName)
   {
-    var ariaCurrentValue = "page";
-    return Model.TabName == linkName ? ariaCurrentValue : null;
+    var selectedClass = "govuk-tabs__list-item--selected";
+    return Model.TabName == linkName ? selectedClass : string.Empty;
   }
 
 }
 
+<div class="govuk-tabs">
+  <h2 class="govuk-tabs__title">
+    Contents
+  </h2>
+  <ul class="govuk-tabs__list">
+    <li class="govuk-tabs__list-item @GetCurrentlySelectedClassIf("Details")">
+      <a id="academies-details-link" class="govuk-tabs__tab" asp-page="./Details" asp-route-uid="@Model.TrustSummary.Uid">
+        <span class="govuk-visually-hidden">Academies </span>Details
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item @GetCurrentlySelectedClassIf("Pupil numbers")">
+      <a id="academies-pupil-numbers-link" class="govuk-tabs__tab" asp-page="./PupilNumbers" asp-route-uid="@Model.TrustSummary.Uid">
+        <span class="govuk-visually-hidden">Academies </span>Pupil numbers
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item @GetCurrentlySelectedClassIf("Free school meals")">
+      <a id="free-school-meals-link" class="govuk-tabs__tab" asp-page="./FreeSchoolMeals" asp-route-uid="@Model.TrustSummary.Uid">
+        <span class="govuk-visually-hidden">Academies </span>Free school meals
+      </a>
+    </li>
+  </ul>
+  <div class="govuk-tabs__panel">
+    @RenderBody()
+  </div>
+</div>
 <section class="govuk-!-margin-top-2 govuk-!-margin-bottom-2 export-container">
   <input type="hidden" name="Uid" value="@Model.TrustSummary.Uid"/>
   <a asp-page-handler="Export" asp-route-uid="@Model.TrustSummary.Uid"
@@ -24,25 +49,6 @@
     Download all academy data
   </a>
 </section>
-<nav class="moj-sub-navigation" aria-label="Academies tabs">
-
-  <ul class="moj-sub-navigation__list">
-    <li class="moj-sub-navigation__item">
-      <a id="academies-details-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Details")" asp-page="./Details" asp-route-uid="@Model.TrustSummary.Uid"><span class="govuk-visually-hidden">Academies </span>Details</a>
-    </li>
-
-    <li class="moj-sub-navigation__item">
-      <a id="academies-pupil-numbers-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Pupil numbers")" asp-page="./PupilNumbers" asp-route-uid="@Model.TrustSummary.Uid"><span class="govuk-visually-hidden">Academies </span>Pupil numbers</a>
-    </li>
-
-    <li class="moj-sub-navigation__item">
-      <a id="free-school-meals-link" class="moj-sub-navigation__link" aria-current="@GetAriaCurrentIf("Free school meals")" asp-page="./FreeSchoolMeals" asp-route-uid="@Model.TrustSummary.Uid"><span class="govuk-visually-hidden">Academies </span>Free school meals</a>
-    </li>
-  </ul>
-
-</nav>
-
-@RenderBody()
 
 @section Scripts {
   @await RenderSectionAsync("Scripts", false)

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/academies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/academies.cy.ts
@@ -57,6 +57,30 @@ describe("Testing the components of the Academies page", () => {
                 .checkPupilNumbersHeadersPresent();
         });
 
+        it("Checks the Pupil numbers page sorting", () => {
+            academiesPage
+                .checkPupilNumbersSorting();
+        });
+
+        it('should match the academy count in the sidebar with the actual table row count on the Pupil numbers page', () => {
+            academiesPage.getAcademyCountFromSidebar().then(expectedCount => {
+                academiesPage.getTableRowCountOnPupilNumbersPage().should('eq', expectedCount);
+            });
+        });
+
+        it('should match the academy count in the sidebar with the actual table row count on the Pupil numbers page after visiting', () => {
+            cy.visit('/trusts/academies/pupil-numbers?uid=5143');
+            academiesPage.getAcademyCountFromSidebar().then(expectedCount => {
+                academiesPage.getTableRowCountOnPupilNumbersPage().should('eq', expectedCount);
+            });
+        });
+
+        it("Checks the Pupil numbers page sorting on a larger trust", () => {
+            cy.visit('/trusts/academies/pupil-numbers?uid=5143');
+            academiesPage
+                .checkPupilNumbersSorting();
+        });
+
     });
 
     describe("Free school meals", () => {
@@ -68,6 +92,30 @@ describe("Testing the components of the Academies page", () => {
         it("Checks the correct Free school meals page headers are present", () => {
             academiesPage
                 .checkFreeSchoolMealsHeadersPresent();
+        });
+
+        it("Checks the Free school meals page sorting", () => {
+            academiesPage
+                .checkFreeSchoolMealsSorting();
+        });
+
+        it('should match the academy count in the sidebar with the actual table row count on the Free school meals page', () => {
+            academiesPage.getAcademyCountFromSidebar().then(expectedCount => {
+                academiesPage.getTableRowCountOnFreeSchoolMealsPage().should('eq', expectedCount);
+            });
+        });
+
+        it('should match the academy count in the sidebar with the actual table row count on the Free school meals page after visiting', () => {
+            cy.visit('/trusts/academies/free-school-meals?uid=5143');
+            academiesPage.getAcademyCountFromSidebar().then(expectedCount => {
+                academiesPage.getTableRowCountOnFreeSchoolMealsPage().should('eq', expectedCount);
+            });
+        });
+
+        it("Checks the Free school meals page sorting on a larger trust", () => {
+            cy.visit('/trusts/academies/free-school-meals?uid=5143');
+            academiesPage
+                .checkFreeSchoolMealsSorting();
         });
 
     });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesPage.ts
@@ -12,7 +12,7 @@ class AcademiesPage {
     };
 
     private createDetailsPageElements() {
-        const table = () => cy.get('[aria-describedby="academies-details-link"]');
+        const table = () => cy.get('[aria-describedby="details-caption"]');
         return {
             table,
             tableRows: () => table().find('tbody tr'),
@@ -32,7 +32,7 @@ class AcademiesPage {
 
 
     private createPupilNumbersPageElements() {
-        const table = () => cy.get('[aria-describedby="academies-pupil-numbers-link"]');
+        const table = () => cy.get('[aria-describedby="pupil-numbers-caption"]');
         return {
             table,
             tableRows: () => table().find('tbody tr'),
@@ -50,7 +50,7 @@ class AcademiesPage {
     }
 
     private createFreeSchoolMealsElements() {
-        const table = () => cy.get('[aria-describedby="free-school-meals-link"]');
+        const table = () => cy.get('[aria-describedby="free-school-meals-caption"]');
         return {
             table,
             tableRows: () => table().find('tbody tr'),

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesPage.ts
@@ -18,6 +18,8 @@ class AcademiesPage {
             tableRows: () => table().find('tbody tr'),
             schoolName: () => table().find('[data-testid="school-name"]'),
             schoolNameHeader: () => table().find("th:contains('School name')"),
+            urn: () => table().find('[data-testid="urn"]'),
+            urnHeader: () => table().find("th:contains('URN')"),
             localAuthority: () => table().find('[data-testid="local-authority"]'),
             localAuthorityHeader: () => table().find("th:contains('Local authority')"),
             schoolType: () => table().find('[data-testid="type-of-establishment"]'),
@@ -33,8 +35,11 @@ class AcademiesPage {
         const table = () => cy.get('[aria-describedby="academies-pupil-numbers-link"]');
         return {
             table,
+            tableRows: () => table().find('tbody tr'),
             schoolName: () => table().find('[data-testid="school-name"]'),
             schoolNameHeader: () => table().find("th:contains('School name')"),
+            urn: () => table().find('[data-testid="urn"]'),
+            urnHeader: () => table().find("th:contains('URN')"),
             phaseAndAge: () => table().find('[data-testid="phase-and-age-range"]'),
             phaseAndAgeHeader: () => table().find("th:contains('Phase and age range')"),
             pupilNumbers: () => table().find('[data-testid="pupil-numbers"]'),
@@ -46,9 +51,21 @@ class AcademiesPage {
 
     private createFreeSchoolMealsElements() {
         const table = () => cy.get('[aria-describedby="free-school-meals-link"]');
-        return { table };
+        return {
+            table,
+            tableRows: () => table().find('tbody tr'),
+            schoolName: () => table().find('[data-testid="school-name"]'),
+            schoolNameHeader: () => table().find("th:contains('School name')"),
+            urn: () => table().find('[data-testid="urn"]'),
+            urnHeader: () => table().find("th:contains('URN')"),
+            pupilsEligible: () => table().find('[data-testid="pupils-eligible"]'),
+            pupilsEligibleHeader: () => table().find("th:contains('Pupils eligible for free school meals')"),
+            localAuthorityAverage: () => table().find('[data-testid="local-authority-average"]'),
+            localAuthorityAverageHeader: () => table().find("th:contains('Local authority average')"),
+            nationalAverage: () => table().find('[data-testid="national-average"]'),
+            nationalAverageHeader: () => table().find("th:contains('National average')"),
+        };
     }
-
     public getAcademyCountFromSidebar(): Cypress.Chainable<number> {
         return this.elements.PageTabs.academyCountLabel()
             .invoke('text')
@@ -59,9 +76,18 @@ class AcademiesPage {
         return this.elements.DetailsPage.tableRows().its('length');
     }
 
+    public getTableRowCountOnPupilNumbersPage(): Cypress.Chainable<number> {
+        return this.elements.PupilNumbersPage.tableRows().its('length');
+    }
+
+    public getTableRowCountOnFreeSchoolMealsPage(): Cypress.Chainable<number> {
+        return this.elements.FreeSchoolMeals.tableRows().its('length');
+    }
+
     public checkDetailsHeadersPresent(): this {
         const { DetailsPage } = this.elements;
         DetailsPage.table().should('contain', 'School name')
+            .and('contain', 'URN')
             .and('contain', 'Local authority')
             .and('contain', 'Type')
             .and('contain', 'Rural or urban')
@@ -72,6 +98,7 @@ class AcademiesPage {
     public checkPupilNumbersHeadersPresent(): this {
         const { PupilNumbersPage } = this.elements;
         PupilNumbersPage.table().should('contain', 'School name')
+            .and('contain', 'URN')
             .and('contain', 'Phase and age range')
             .and('contain', 'Pupil numbers')
             .and('contain', 'Pupil capacity')
@@ -82,6 +109,7 @@ class AcademiesPage {
     public checkFreeSchoolMealsHeadersPresent(): this {
         const { FreeSchoolMeals } = this.elements;
         FreeSchoolMeals.table().should('contain', 'School name')
+            .and('contain', 'URN')
             .and('contain', 'Pupils eligible for free school meals')
             .and('contain', 'Local authority average')
             .and('contain', 'National average');
@@ -97,6 +125,7 @@ class AcademiesPage {
     public checkTrustDetailsSorting() {
         const { DetailsPage } = this.elements;
         TableUtility.checkStringSorting(DetailsPage.schoolName, DetailsPage.schoolNameHeader);
+        TableUtility.checkStringSorting(DetailsPage.urn, DetailsPage.urnHeader);
         TableUtility.checkStringSorting(DetailsPage.localAuthority, DetailsPage.localAuthorityHeader);
         TableUtility.checkStringSorting(DetailsPage.schoolType, DetailsPage.schoolTypeHeader);
         TableUtility.checkStringSorting(DetailsPage.ruralOrUrban, DetailsPage.ruralOrUrbanHeader);
@@ -105,9 +134,19 @@ class AcademiesPage {
     public checkPupilNumbersSorting() {
         const { PupilNumbersPage } = this.elements;
         TableUtility.checkStringSorting(PupilNumbersPage.schoolName, PupilNumbersPage.schoolNameHeader);
+        TableUtility.checkStringSorting(PupilNumbersPage.urn, PupilNumbersPage.urnHeader);
         TableUtility.checkStringSorting(PupilNumbersPage.phaseAndAge, PupilNumbersPage.phaseAndAgeHeader);
         TableUtility.checkNumericSorting(PupilNumbersPage.pupilNumbers, PupilNumbersPage.pupilNumbersHeader);
         TableUtility.checkNumericSorting(PupilNumbersPage.pupilCapacity, PupilNumbersPage.pupilCapacityHeader);
+    }
+
+    public checkFreeSchoolMealsSorting() {
+        const { FreeSchoolMeals } = this.elements;
+        TableUtility.checkStringSorting(FreeSchoolMeals.schoolName, FreeSchoolMeals.schoolNameHeader);
+        TableUtility.checkStringSorting(FreeSchoolMeals.urn, FreeSchoolMeals.urnHeader);
+        TableUtility.checkNumericSorting(FreeSchoolMeals.pupilsEligible, FreeSchoolMeals.pupilsEligibleHeader);
+        TableUtility.checkNumericSorting(FreeSchoolMeals.localAuthorityAverage, FreeSchoolMeals.localAuthorityAverageHeader);
+        TableUtility.checkNumericSorting(FreeSchoolMeals.nationalAverage, FreeSchoolMeals.nationalAverageHeader);
     }
 }
 


### PR DESCRIPTION
[User Story 190099](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/190099): Build: Academies page change from sub nav to tabs

Switch to using tabs instead of sub nav on the academies page.
Other UI changes include moving academy URN into its own column and moving the download button below the content on the academies page.

Overhaul to the automation in the academies pages to re add missing tests and add checking for URN column.

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/c072e07f-febb-4f9e-bd99-63fe0682d3c2)

### After
![image](https://github.com/user-attachments/assets/289249d9-8c96-45cb-a51e-9ff4b508d9bd)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
