### PR TITLE
Move phase banner from header to footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Academies pages are now tabs instead of using sub nav
+- Move phase banner from header to footer
 
 ## [Release-15][release-15] (production-2024-12-02.4279)
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Index.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Index.cshtml
@@ -11,7 +11,7 @@
     <div class="dfe-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half">
-          <form class="govuk-form-group app-search" asp-page="Search" method="post" role="search" aria-label="sitewide">
+          <form class="govuk-form-group app-search govuk-!-margin-bottom-0" asp-page="Search" method="post" role="search" aria-label="sitewide">
             <h1 class="govuk-label-wrapper">
               <label class="govuk-label govuk-label--xl app-banner--heading govuk-!-margin-bottom-8" for="@Model.PageSearchFormInputId">
                 Find information about academies and trusts

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Footer.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Footer.cshtml
@@ -25,6 +25,16 @@
       </div>
       <div class="govuk-footer__section govuk-grid-column-one-half">
         <h2 class="govuk-footer__heading govuk-heading-m">Give feedback</h2>
+        <div class="govuk-phase-banner rsd-footer-phase govuk-!-padding-top-0 govuk-!-padding-bottom-4">
+          <p class="govuk-phase-banner__content">
+            <strong class="govuk-tag govuk-phase-banner__content__tag">
+              Beta
+            </strong>
+            <span class="govuk-phase-banner__text">
+              This is a new product – your feedback will help us to improve it.
+            </span>
+          </p>
+        </div>
         <ul class="govuk-footer__list">
           <li class="govuk-footer__list-item">
             <a class="govuk-footer__link" href="@ViewConstants.FeedbackFormLink" target="_blank" rel="noopener noreferrer">Give feedback (opens in a new tab)</a>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Header.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_Header.cshtml
@@ -21,18 +21,3 @@
     </div>
   </div>
 </header>
-
-<div class="app-banner app-banner--s">
-  <div class="dfe-width-container">
-    <div class="govuk-phase-banner">
-      <p class="govuk-phase-banner__content">
-        <strong class="govuk-tag govuk-phase-banner__content__tag">
-          Beta
-        </strong>
-        <span class="govuk-phase-banner__text">
-          This is a new product – your <a class="govuk-link" href="@ViewConstants.FeedbackFormLink" target="_blank">feedback (opens in a new tab)</a> will help us to improve it.
-        </span>
-      </p>
-    </div>
-  </div>
-</div>

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
@@ -5,6 +5,7 @@
 @import "components/export-button";
 @import "components/sourceList";
 @import "components/contactsSummaryCard";
+@import "components/footer";
 
 .app-banner {
   @include govuk-responsive-padding(3, "top");
@@ -20,8 +21,8 @@
   }
 
   &.app-banner--l {
-    @include govuk-responsive-padding(9, "top");
-    @include govuk-responsive-padding(8, "bottom");
+    @include govuk-responsive-padding(7, "top");
+    @include govuk-responsive-padding(5, "bottom");
   }
 
   &.app-banner--s {

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_footer.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_footer.scss
@@ -1,0 +1,20 @@
+.rsd-footer-phase {
+  border-bottom: 0;
+}
+
+.rsd-footer-phase .govuk-phase-banner__content {
+  font-size: 1rem;
+  line-height: 1.25;
+}
+@media (min-width: 40.0625em) {
+  .rsd-footer-phase .govuk-phase-banner__content {
+    font-size: 1.1875rem;
+    line-height: 1.3158;
+  }
+}
+@media print {
+  .rsd-footer-phase .govuk-phase-banner__content {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}


### PR DESCRIPTION
[User Story 188853](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/188853): Build: Reposition the phase banner and tweak the footer to ask for feedback more appropriately - Nav iteration 2

Moves the phase banner from the header to the footer.
Also tweaks the size of the app banner on the landing page to account for the missing phase banner.

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/ee204a47-e770-4910-878b-46a075239820)
![image](https://github.com/user-attachments/assets/5919772b-90d3-462d-89a0-df4b7e7d809e)

### After
![image](https://github.com/user-attachments/assets/90398efc-83db-4339-97b8-b648f65152be)
![image](https://github.com/user-attachments/assets/65422fa7-8093-42a1-a21b-8f3e0e10a4b5)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
