### PR TITLE
Add DbContextChecks to Health Checks

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
+++ b/DfE.FindInformationAcademiesTrusts/DfE.FindInformationAcademiesTrusts.csproj
@@ -19,6 +19,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11" />
         <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.5.0" />
         <PackageReference Include="Microsoft.Identity.Web" Version="2.21.1" />
         <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.22.0" />

--- a/DfE.FindInformationAcademiesTrusts/Program.cs
+++ b/DfE.FindInformationAcademiesTrusts/Program.cs
@@ -22,7 +22,6 @@ internal static class Program
             ConfigurationVariables.BindConfigurationVariables(builder);
 
             builder.Services.AddRazorPages();
-            builder.Services.AddHealthChecks();
             builder.Services.AddApplicationInsightsTelemetry();
             SecurityServicesSetup.AddSecurityServices(builder);
 
@@ -33,6 +32,7 @@ internal static class Program
             });
 
             Dependencies.AddDependenciesTo(builder);
+            HealthCheckSetup.AddHealthChecks(builder);
 
             var app = builder.Build();
             PostBuildSetup.ConfigureApp(app);

--- a/DfE.FindInformationAcademiesTrusts/Setup/HealthCheckSetup.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/HealthCheckSetup.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics.CodeAnalysis;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
+using DfE.FindInformationAcademiesTrusts.Data.FiatDb.Contexts;
+
+namespace DfE.FindInformationAcademiesTrusts.Setup;
+
+[ExcludeFromCodeCoverage]
+public static class HealthCheckSetup
+{
+  public static void AddHealthChecks(WebApplicationBuilder builder) {
+    builder.Services.AddHealthChecks();
+    AddDbHealthChecks(builder);
+  }
+
+  public static void AddDbHealthChecks(WebApplicationBuilder builder) {
+     builder.Services.AddHealthChecks()
+      .AddDbContextCheck<AcademiesDbContext>()
+      .AddDbContextCheck<FiatDbContext>();
+  }
+}


### PR DESCRIPTION
This will ensure that the /health endpoint correctly reports the status of the service if a database connection faults

## Changes

- New Setup file created to hold the health check configuration
- Added AcademiesDB and FiatDB contexts to health check registration

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps (CAT Board)
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
