### PR TITLE
Safeguarding page - change `span` to `strong` to highlight text emphasis to screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change from schools benchmarking tool to financial benchmarking and insights tool
 - Update dependencies
 - Update breadcrumbs to add page name
+- Change `span` to `strong` to highlight text emphasis to screen readers on the Ofsted Safeguarding page
 
 ### Removed
 
@@ -194,7 +195,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Release-1][release-1] (production-2024-07-18.2517)
 
-### Changed 
+### Changed
 
 - Migrated the application to LTS .NET 8. (FIAT was on .NET 7 which Microsoft ended support for in May).
 - Updated text on "404 - Not Found" page to adhere to DfE design pattern and added the not found url to the support email template.

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml
@@ -16,10 +16,10 @@
     <div class="govuk-details__text">
 
       <p class="govuk-body">
-        <span class="govuk-!-font-weight-bold">'Effective safeguarding'</span> means that a school has been judged to have adequate safeguarding policies and processes in place. It reviews them regularly and implements them well.
+        <strong class="govuk-!-font-weight-bold">'Effective safeguarding'</strong> means that a school has been judged to have adequate safeguarding policies and processes in place. It reviews them regularly and implements them well.
       </p>
       <p class="govuk-body">
-        <span class="govuk-!-font-weight-bold">'Category of concern'</span> means that a school has been found inadequate in a key or provision judgement. The school either has ‘serious weaknesses’ or requires ‘special measures’.
+        <strong class="govuk-!-font-weight-bold">'Category of concern'</strong> means that a school has been found inadequate in a key or provision judgement. The school either has ‘serious weaknesses’ or requires ‘special measures’.
       </p>
 
     </div>


### PR DESCRIPTION
Changes `span` to `strong` to highlight text emphasis to screen readers on the Ofsted Safeguarding page.

[Bug 191398](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/191398): Bug: Safeguarding page emphasis is not accessible

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
~~ADR decision log updated (if needed)~~
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
