### PR TITLE
Add sub page/tab to browser title and standardise browser title construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added download for Ofsted specific data to Ofsted pages
 
+### Changed
+
+- Fixed browser titles so they include the name of the sub page and are all formatted in a consistent way
+
 ## [Release-16][release-16] (production-2024-12-13.4477)
 
 ### Changed

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/AcademiesPageModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/AcademiesPageModel.cs
@@ -12,7 +12,7 @@ public abstract class AcademiesPageModel(
     IExportService exportService,
     ILogger<AcademiesPageModel> logger,
     IDateTimeProvider dateTimeProvider
-) : TrustsAreaModel(dataSourceService, trustService, logger, "Academies")
+) : TrustsAreaModel(dataSourceService, trustService, logger)
 {
     public override TrustPageMetadata TrustPageMetadata =>
         base.TrustPageMetadata with { PageName = "Academies" };

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/AcademiesPageModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/AcademiesPageModel.cs
@@ -14,12 +14,9 @@ public abstract class AcademiesPageModel(
     IDateTimeProvider dateTimeProvider
 ) : TrustsAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { PageName = "Academies" };
-
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = "Academies" };
     protected IExportService ExportService { get; } = exportService;
     public IDateTimeProvider DateTimeProvider { get; } = dateTimeProvider;
-    public string? TabName { get; init; }
 
     public virtual async Task<IActionResult> OnGetExportAsync(string uid)
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/AcademiesPageModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/AcademiesPageModel.cs
@@ -4,38 +4,40 @@ using DfE.FindInformationAcademiesTrusts.Services.Export;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
 
-namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
+
+public abstract class AcademiesPageModel(
+    IDataSourceService dataSourceService,
+    ITrustService trustService,
+    IExportService exportService,
+    ILogger<AcademiesPageModel> logger,
+    IDateTimeProvider dateTimeProvider
+) : TrustsAreaModel(dataSourceService, trustService, logger, "Academies")
 {
-    public abstract class AcademiesPageModel(
-        IDataSourceService dataSourceService,
-        ITrustService trustService,
-        IExportService exportService,
-        ILogger<AcademiesPageModel> logger,
-        IDateTimeProvider dateTimeProvider
-    ) : TrustsAreaModel(dataSourceService, trustService, logger, "Academies")
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { PageName = "Academies" };
+
+    protected IExportService ExportService { get; } = exportService;
+    public IDateTimeProvider DateTimeProvider { get; } = dateTimeProvider;
+    public string? TabName { get; init; }
+
+    public virtual async Task<IActionResult> OnGetExportAsync(string uid)
     {
-        protected IExportService ExportService { get; } = exportService;
-        public IDateTimeProvider DateTimeProvider { get; } = dateTimeProvider;
-        public string? TabName { get; init; }
-        public virtual async Task<IActionResult> OnGetExportAsync(string uid)
+        var trustSummary = await TrustService.GetTrustSummaryAsync(uid);
+
+        if (trustSummary == null)
         {
-            TrustSummaryServiceModel? trustSummary = await TrustService.GetTrustSummaryAsync(uid);
-
-            if (trustSummary == null)
-            {
-                return new NotFoundResult();
-            }
-
-            // Sanitize the trust name to remove any illegal characters
-            string sanitizedTrustName = string.Concat(trustSummary.Name.Where(c => !Path.GetInvalidFileNameChars().Contains(c)));
-
-            var fileContents = await ExportService.ExportAcademiesToSpreadsheetAsync(uid);
-            string fileName = $"{sanitizedTrustName}-{DateTimeProvider.Now:yyyy-MM-dd}.xlsx";
-            string contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-
-            return File(fileContents, contentType, fileName);
+            return new NotFoundResult();
         }
 
+        // Sanitize the trust name to remove any illegal characters
+        var sanitizedTrustName =
+            string.Concat(trustSummary.Name.Where(c => !Path.GetInvalidFileNameChars().Contains(c)));
 
+        var fileContents = await ExportService.ExportAcademiesToSpreadsheetAsync(uid);
+        var fileName = $"{sanitizedTrustName}-{DateTimeProvider.Now:yyyy-MM-dd}.xlsx";
+        var contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+        return File(fileContents, contentType, fileName);
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml.cs
@@ -23,7 +23,6 @@ public class AcademiesDetailsModel : AcademiesPageModel
         IDateTimeProvider dateTimeProvider) : base(dataSourceService, trustService, exportService, logger,
         dateTimeProvider)
     {
-        PageTitle = "Academies details";
         TabName = "Details";
         LinkBuilder = linkBuilder;
         AcademyService = academyService;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml.cs
@@ -10,13 +10,18 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
 public class AcademiesDetailsModel : AcademiesPageModel
 {
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { TabName = "Details" };
+
     public AcademyDetailsServiceModel[] Academies { get; set; } = default!;
     public IOtherServicesLinkBuilder LinkBuilder { get; }
     private IAcademyService AcademyService { get; }
 
     public AcademiesDetailsModel(IDataSourceService dataSourceService,
         IOtherServicesLinkBuilder linkBuilder, ILogger<AcademiesDetailsModel> logger,
-        ITrustService trustService, IAcademyService academyService, IExportService exportService, IDateTimeProvider dateTimeProvider) : base(dataSourceService, trustService, exportService, logger, dateTimeProvider)
+        ITrustService trustService, IAcademyService academyService, IExportService exportService,
+        IDateTimeProvider dateTimeProvider) : base(dataSourceService, trustService, exportService, logger,
+        dateTimeProvider)
     {
         PageTitle = "Academies details";
         TabName = "Details";
@@ -37,5 +42,4 @@ public class AcademiesDetailsModel : AcademiesPageModel
 
         return pageResult;
     }
-
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Details.cshtml.cs
@@ -8,25 +8,20 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
-public class AcademiesDetailsModel : AcademiesPageModel
-{
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { TabName = "Details" };
-
-    public AcademyDetailsServiceModel[] Academies { get; set; } = default!;
-    public IOtherServicesLinkBuilder LinkBuilder { get; }
-    private IAcademyService AcademyService { get; }
-
-    public AcademiesDetailsModel(IDataSourceService dataSourceService,
-        IOtherServicesLinkBuilder linkBuilder, ILogger<AcademiesDetailsModel> logger,
-        ITrustService trustService, IAcademyService academyService, IExportService exportService,
-        IDateTimeProvider dateTimeProvider) : base(dataSourceService, trustService, exportService, logger,
+public class AcademiesDetailsModel(
+    IDataSourceService dataSourceService,
+    IOtherServicesLinkBuilder linkBuilder,
+    ILogger<AcademiesDetailsModel> logger,
+    ITrustService trustService,
+    IAcademyService academyService,
+    IExportService exportService,
+    IDateTimeProvider dateTimeProvider)
+    : AcademiesPageModel(dataSourceService, trustService, exportService, logger,
         dateTimeProvider)
-    {
-        TabName = "Details";
-        LinkBuilder = linkBuilder;
-        AcademyService = academyService;
-    }
+{
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = "Details" };
+    public AcademyDetailsServiceModel[] Academies { get; set; } = default!;
+    public IOtherServicesLinkBuilder LinkBuilder { get; } = linkBuilder;
 
     public override async Task<IActionResult> OnGetAsync()
     {
@@ -34,10 +29,9 @@ public class AcademiesDetailsModel : AcademiesPageModel
 
         if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
 
-        Academies = await AcademyService.GetAcademiesInTrustDetailsAsync(Uid);
+        Academies = await academyService.GetAcademiesInTrustDetailsAsync(Uid);
 
-        DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.Gias),
-            new List<string> { "Details" }));
+        DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.Gias), ["Details"]));
 
         return pageResult;
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
@@ -21,7 +21,6 @@ public class FreeSchoolMealsModel : AcademiesPageModel
         IExportService exportService, IDateTimeProvider dateTimeProvider) :
         base(dataSourceService, trustService, exportService, logger, dateTimeProvider)
     {
-        PageTitle = "Academies free school meals";
         TabName = "Free school meals";
         AcademyService = academyService;
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
@@ -8,22 +8,19 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
-public class FreeSchoolMealsModel : AcademiesPageModel
+public class FreeSchoolMealsModel(
+    IDataSourceService dataSourceService,
+    ILogger<FreeSchoolMealsModel> logger,
+    ITrustService trustService,
+    IAcademyService academyService,
+    IExportService exportService,
+    IDateTimeProvider dateTimeProvider)
+    : AcademiesPageModel(dataSourceService, trustService, exportService, logger, dateTimeProvider)
 {
     public override TrustPageMetadata TrustPageMetadata =>
         base.TrustPageMetadata with { TabName = "Free school meals" };
 
-    public IAcademyService AcademyService { get; }
     public AcademyFreeSchoolMealsServiceModel[] Academies { get; set; } = default!;
-
-    public FreeSchoolMealsModel(IDataSourceService dataSourceService,
-        ILogger<FreeSchoolMealsModel> logger, ITrustService trustService, IAcademyService academyService,
-        IExportService exportService, IDateTimeProvider dateTimeProvider) :
-        base(dataSourceService, trustService, exportService, logger, dateTimeProvider)
-    {
-        TabName = "Free school meals";
-        AcademyService = academyService;
-    }
 
     public override async Task<IActionResult> OnGetAsync()
     {
@@ -31,19 +28,13 @@ public class FreeSchoolMealsModel : AcademiesPageModel
 
         if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
 
-        Academies = await AcademyService.GetAcademiesInTrustFreeSchoolMealsAsync(Uid);
+        Academies = await academyService.GetAcademiesInTrustFreeSchoolMealsAsync(Uid);
 
         DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.Gias),
-            new[]
-            {
-                "Pupils eligible for free school meals"
-            }));
+            ["Pupils eligible for free school meals"]));
 
         DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.ExploreEducationStatistics),
-            new[]
-            {
-                "Local authority average 2023/24", "National average 2023/24"
-            }));
+            ["Local authority average 2023/24", "National average 2023/24"]));
 
         return pageResult;
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/FreeSchoolMeals.cshtml.cs
@@ -10,6 +10,9 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
 public class FreeSchoolMealsModel : AcademiesPageModel
 {
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { TabName = "Free school meals" };
+
     public IAcademyService AcademyService { get; }
     public AcademyFreeSchoolMealsServiceModel[] Academies { get; set; } = default!;
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml.cs
@@ -10,11 +10,15 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
 public class PupilNumbersModel : AcademiesPageModel
 {
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { TabName = "Pupil numbers" };
+
     public IAcademyService AcademyService { get; }
     public AcademyPupilNumbersServiceModel[] Academies { get; set; } = default!;
 
     public PupilNumbersModel(IDataSourceService dataSourceService,
-        ILogger<PupilNumbersModel> logger, ITrustService trustService, IAcademyService academyService, IExportService exportService, IDateTimeProvider dateTimeProvider)
+        ILogger<PupilNumbersModel> logger, ITrustService trustService, IAcademyService academyService,
+        IExportService exportService, IDateTimeProvider dateTimeProvider)
         : base(dataSourceService, trustService, exportService, logger, dateTimeProvider)
     {
         AcademyService = academyService;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml.cs
@@ -8,22 +8,17 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 
-public class PupilNumbersModel : AcademiesPageModel
+public class PupilNumbersModel(
+    IDataSourceService dataSourceService,
+    ILogger<PupilNumbersModel> logger,
+    ITrustService trustService,
+    IAcademyService academyService,
+    IExportService exportService,
+    IDateTimeProvider dateTimeProvider)
+    : AcademiesPageModel(dataSourceService, trustService, exportService, logger, dateTimeProvider)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { TabName = "Pupil numbers" };
-
-    public IAcademyService AcademyService { get; }
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = "Pupil numbers" };
     public AcademyPupilNumbersServiceModel[] Academies { get; set; } = default!;
-
-    public PupilNumbersModel(IDataSourceService dataSourceService,
-        ILogger<PupilNumbersModel> logger, ITrustService trustService, IAcademyService academyService,
-        IExportService exportService, IDateTimeProvider dateTimeProvider)
-        : base(dataSourceService, trustService, exportService, logger, dateTimeProvider)
-    {
-        AcademyService = academyService;
-        TabName = "Pupil numbers";
-    }
 
     public override async Task<IActionResult> OnGetAsync()
     {
@@ -31,10 +26,9 @@ public class PupilNumbersModel : AcademiesPageModel
 
         if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
 
-        Academies = await AcademyService.GetAcademiesInTrustPupilNumbersAsync(Uid);
+        Academies = await academyService.GetAcademiesInTrustPupilNumbersAsync(Uid);
 
-        DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.Gias),
-            new List<string> { "Pupil numbers" }));
+        DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.Gias), ["Pupil numbers"]));
 
         return pageResult;
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/PupilNumbers.cshtml.cs
@@ -22,7 +22,6 @@ public class PupilNumbersModel : AcademiesPageModel
         : base(dataSourceService, trustService, exportService, logger, dateTimeProvider)
     {
         AcademyService = academyService;
-        PageTitle = "Academies pupil numbers";
         TabName = "Pupil numbers";
     }
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_AcademiesLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_AcademiesLayout.cshtml
@@ -9,7 +9,7 @@
   private string GetCurrentlySelectedClassIf(string linkName)
   {
     var selectedClass = "govuk-tabs__list-item--selected";
-    return Model.TabName == linkName ? selectedClass : string.Empty;
+    return Model.TrustPageMetadata.TabName == linkName ? selectedClass : string.Empty;
   }
 
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/ContactsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/ContactsAreaModel.cs
@@ -7,13 +7,14 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Contacts;
 
-public class ContactAreaModel(
+public class ContactsAreaModel(
     IDataSourceService dataSourceService,
     ITrustService trustService,
-    ILogger<ContactAreaModel> logger
+    ILogger<ContactsAreaModel> logger
 )
     : TrustsAreaModel(dataSourceService, trustService, logger, "Contacts")
 {
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = "Contacts" };
     public Person? ChairOfTrustees { get; set; }
     public Person? AccountingOfficer { get; set; }
     public Person? ChiefFinancialOfficer { get; set; }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/ContactsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/ContactsAreaModel.cs
@@ -12,7 +12,7 @@ public class ContactsAreaModel(
     ITrustService trustService,
     ILogger<ContactsAreaModel> logger
 )
-    : TrustsAreaModel(dataSourceService, trustService, logger, "Contacts")
+    : TrustsAreaModel(dataSourceService, trustService, logger)
 {
     public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = "Contacts" };
     public Person? ChairOfTrustees { get; set; }
@@ -29,8 +29,9 @@ public class ContactsAreaModel(
 
         SubNavigationLinks =
         [
-            new TrustSubNavigationLinkModel("In DfE", "./InDfE", Uid, PageName, this is InDfeModel),
-            new TrustSubNavigationLinkModel("In the trust", "./InTrust", Uid, PageName, this is InTrustModel)
+            new TrustSubNavigationLinkModel("In DfE", "./InDfE", Uid, TrustPageMetadata.PageName!, this is InDfeModel),
+            new TrustSubNavigationLinkModel("In the trust", "./InTrust", Uid, TrustPageMetadata.PageName!,
+                this is InTrustModel)
         ];
 
         (TrustRelationshipManager, SfsoLead, AccountingOfficer, ChairOfTrustees, ChiefFinancialOfficer) =

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditContactModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditContactModel.cs
@@ -17,6 +17,12 @@ public abstract class EditContactModel(
     : TrustsAreaModel(dataSourceService, trustService,
         logger, $"Edit {role.MapRoleToViewString()} details")
 {
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with
+    {
+        SubPageName = $"Edit {role.MapRoleToViewString()} details",
+        PageName = "Contacts"
+    };
+
     public const string NameField = "Name";
     public const string EmailField = "Email";
 
@@ -93,10 +99,5 @@ public abstract class EditContactModel(
         }
 
         return [];
-    }
-
-    public string GeneratePageTitle()
-    {
-        return $"{(ModelState.IsValid ? string.Empty : "Error: ")}{PageTitle ?? PageName} - {TrustSummary.Name}";
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditContactModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditContactModel.cs
@@ -15,7 +15,7 @@ public abstract class EditContactModel(
     ILogger<EditContactModel> logger,
     ContactRole role)
     : TrustsAreaModel(dataSourceService, trustService,
-        logger, $"Edit {role.MapRoleToViewString()} details")
+        logger)
 {
     public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditSfsoLead.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditSfsoLead.cshtml
@@ -3,7 +3,7 @@
 
 @{
   Layout = "_Layout";
-  ViewData["Title"] = Model.GeneratePageTitle();
+  ViewData["Title"] = Model.TrustPageMetadata.BrowserTitle;
 }
 
 <partial name="_EditContactsForm" model="@Model"/>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditTrustRelationshipManager.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditTrustRelationshipManager.cshtml
@@ -3,7 +3,7 @@
 
 @{
   Layout = "_Layout";
-  ViewData["Title"] = Model.GeneratePageTitle();
+  ViewData["Title"] = Model.TrustPageMetadata.BrowserTitle;
 }
 
 <partial name="_EditContactsForm" model="@Model"/>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/InDfe.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/InDfe.cshtml.cs
@@ -7,4 +7,8 @@ public class InDfeModel(
     IDataSourceService dataSourceService,
     ITrustService trustService,
     ILogger<InDfeModel> logger)
-    : ContactAreaModel(dataSourceService, trustService, logger);
+    : ContactsAreaModel(dataSourceService, trustService, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "In DfE" };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/InTrust.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/InTrust.cshtml.cs
@@ -7,4 +7,8 @@ public class InTrustModel(
     IDataSourceService dataSourceService,
     ITrustService trustService,
     ILogger<InTrustModel> logger)
-    : ContactAreaModel(dataSourceService, trustService, logger);
+    : ContactsAreaModel(dataSourceService, trustService, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "In the trust" };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/_EditContactsForm.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/_EditContactsForm.cshtml
@@ -11,7 +11,7 @@
             <fieldset class="govuk-fieldset">
               <div>
                 <legend class="govuk-!-padding-0">
-                  <h1 class="govuk-heading-l">@Model.PageName</h1>
+                  <h1 class="govuk-heading-l">@Model.TrustPageMetadata.PageName</h1>
                 </legend>
               </div>
               <partial name="Shared/_ErrorSummary" model="@Model"/>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/GovernanceAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/GovernanceAreaModel.cs
@@ -11,6 +11,9 @@ public class GovernanceAreaModel(
     ILogger<GovernanceAreaModel> logger)
     : TrustsAreaModel(dataSourceService, trustService, logger, "Governance")
 {
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { PageName = "Governance" };
+
     public TrustGovernanceServiceModel TrustGovernance { get; set; } = default!;
 
     public override async Task<IActionResult> OnGetAsync()

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/GovernanceAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/GovernanceAreaModel.cs
@@ -9,7 +9,7 @@ public class GovernanceAreaModel(
     IDataSourceService dataSourceService,
     ITrustService trustService,
     ILogger<GovernanceAreaModel> logger)
-    : TrustsAreaModel(dataSourceService, trustService, logger, "Governance")
+    : TrustsAreaModel(dataSourceService, trustService, logger)
 {
     public override TrustPageMetadata TrustPageMetadata =>
         base.TrustPageMetadata with { PageName = "Governance" };
@@ -27,13 +27,13 @@ public class GovernanceAreaModel(
         SubNavigationLinks =
         [
             new TrustSubNavigationLinkModel($"Trust leadership ({TrustGovernance.CurrentTrustLeadership.Length})",
-                "./TrustLeadership", Uid, PageName, this is TrustLeadershipModel),
+                "./TrustLeadership", Uid, TrustPageMetadata.PageName!, this is TrustLeadershipModel),
             new TrustSubNavigationLinkModel($"Trustees ({TrustGovernance.CurrentTrustees.Length})", "./Trustees", Uid,
-                PageName, this is TrusteesModel),
+                TrustPageMetadata.PageName!, this is TrusteesModel),
             new TrustSubNavigationLinkModel($"Members ({TrustGovernance.CurrentMembers.Length})", "./Members", Uid,
-                PageName, this is MembersModel),
+                TrustPageMetadata.PageName!, this is MembersModel),
             new TrustSubNavigationLinkModel($"Historic members ({TrustGovernance.HistoricMembers.Length})",
-                "./HistoricMembers", Uid, PageName, this is HistoricMembersModel)
+                "./HistoricMembers", Uid, TrustPageMetadata.PageName!, this is HistoricMembersModel)
         ];
 
         DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.Gias),

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/HistoricMembers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/HistoricMembers.cshtml.cs
@@ -7,4 +7,8 @@ public class HistoricMembersModel(
     IDataSourceService dataSourceService,
     ILogger<HistoricMembersModel> logger,
     ITrustService trustService)
-    : GovernanceAreaModel(dataSourceService, trustService, logger);
+    : GovernanceAreaModel(dataSourceService, trustService, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "Historic members" };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Members.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Members.cshtml.cs
@@ -7,4 +7,8 @@ public class MembersModel(
     IDataSourceService dataSourceService,
     ILogger<MembersModel> logger,
     ITrustService trustService)
-    : GovernanceAreaModel(dataSourceService, trustService, logger);
+    : GovernanceAreaModel(dataSourceService, trustService, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "Members" };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/TrustLeadership.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/TrustLeadership.cshtml.cs
@@ -7,4 +7,8 @@ public class TrustLeadershipModel(
     IDataSourceService dataSourceService,
     ILogger<TrustLeadershipModel> logger,
     ITrustService trustService)
-    : GovernanceAreaModel(dataSourceService, trustService, logger);
+    : GovernanceAreaModel(dataSourceService, trustService, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "Trust leadership" };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Trustees.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Trustees.cshtml.cs
@@ -7,4 +7,8 @@ public class TrusteesModel(
     IDataSourceService dataSourceService,
     ILogger<TrusteesModel> logger,
     ITrustService trustService)
-    : GovernanceAreaModel(dataSourceService, trustService, logger);
+    : GovernanceAreaModel(dataSourceService, trustService, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "Trustees" };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
@@ -9,14 +9,6 @@ public interface ITrustsAreaModel
 
     List<DataSourceListEntry> DataSources { get; }
 
-    /// <summary>
-    /// The name of the page as displayed in the page h1
-    /// </summary>
-    string PageName { get; }
-
-    /// <summary>
-    /// The name of the page as displayed in the browser title
-    /// </summary>
     TrustPageMetadata TrustPageMetadata { get; }
 
     string MapDataSourceToName(DataSourceServiceModel dataSource);

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
@@ -17,6 +17,8 @@ public interface ITrustsAreaModel
     /// <summary>
     /// The name of the page as displayed in the browser title
     /// </summary>
+    TrustPageMetadata TrustPageMetadata { get; }
+
     string? PageTitle { get; set; }
 
     string MapDataSourceToName(DataSourceServiceModel dataSource);

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
@@ -19,8 +19,6 @@ public interface ITrustsAreaModel
     /// </summary>
     TrustPageMetadata TrustPageMetadata { get; }
 
-    string? PageTitle { get; set; }
-
     string MapDataSourceToName(DataSourceServiceModel dataSource);
     string MapDataSourceToTestId(DataSourceListEntry source);
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/CurrentRatings.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/CurrentRatings.cshtml.cs
@@ -13,4 +13,8 @@ public class CurrentRatingsModel(
     IExportService exportService,
     IDateTimeProvider dateTimeProvider,
     ILogger<CurrentRatingsModel> logger) : OfstedAreaModel(dataSourceService, trustService,
-    academyService, exportService, dateTimeProvider, logger);
+    academyService, exportService, dateTimeProvider, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "Current ratings" };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/ImportantDates.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/ImportantDates.cshtml.cs
@@ -13,4 +13,8 @@ public class ImportantDatesModel(
     IExportService exportService,
     IDateTimeProvider dateTimeProvider,
     ILogger<ImportantDatesModel> logger) : OfstedAreaModel(dataSourceService, trustService,
-    academyService, exportService, dateTimeProvider, logger);
+    academyService, exportService, dateTimeProvider, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "Important dates" };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/OfstedAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/OfstedAreaModel.cs
@@ -17,6 +17,7 @@ public class OfstedAreaModel(
     ILogger<OfstedAreaModel> logger)
     : TrustsAreaModel(dataSourceService, trustService, logger, "Ofsted")
 {
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = "Ofsted" };
     public AcademyOfstedServiceModel[] Academies { get; set; } = default!;
     private IAcademyService AcademyService { get; } = academyService;
     protected IExportService ExportService { get; } = exportService;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/OfstedAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/OfstedAreaModel.cs
@@ -15,7 +15,7 @@ public class OfstedAreaModel(
     IExportService exportService,
     IDateTimeProvider dateTimeProvider,
     ILogger<OfstedAreaModel> logger)
-    : TrustsAreaModel(dataSourceService, trustService, logger, "Ofsted")
+    : TrustsAreaModel(dataSourceService, trustService, logger)
 {
     public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = "Ofsted" };
     public AcademyOfstedServiceModel[] Academies { get; set; } = default!;
@@ -33,14 +33,14 @@ public class OfstedAreaModel(
 
         SubNavigationLinks =
         [
-            new TrustSubNavigationLinkModel("Current ratings", "./CurrentRatings", Uid, PageName,
+            new TrustSubNavigationLinkModel("Current ratings", "./CurrentRatings", Uid, TrustPageMetadata.PageName!,
                 this is CurrentRatingsModel),
-            new TrustSubNavigationLinkModel("Previous ratings", "./PreviousRatings", Uid,
-                PageName, this is PreviousRatingsModel),
-            new TrustSubNavigationLinkModel("Important dates", "./ImportantDates", Uid, PageName,
+            new TrustSubNavigationLinkModel("Previous ratings", "./PreviousRatings", Uid, TrustPageMetadata.PageName!,
+                this is PreviousRatingsModel),
+            new TrustSubNavigationLinkModel("Important dates", "./ImportantDates", Uid, TrustPageMetadata.PageName!,
                 this is ImportantDatesModel),
             new TrustSubNavigationLinkModel("Safeguarding and concerns", "./SafeguardingAndConcerns", Uid,
-                PageName, this is SafeguardingAndConcernsModel)
+                TrustPageMetadata.PageName!, this is SafeguardingAndConcernsModel)
         ];
 
         DataSources.Add(new DataSourceListEntry(await DataSourceService.GetAsync(Source.Gias),

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/PreviousRatings.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/PreviousRatings.cshtml.cs
@@ -13,4 +13,8 @@ public class PreviousRatingsModel(
     IExportService exportService,
     IDateTimeProvider dateTimeProvider,
     ILogger<PreviousRatingsModel> logger) : OfstedAreaModel(dataSourceService, trustService,
-    academyService, exportService, dateTimeProvider, logger);
+    academyService, exportService, dateTimeProvider, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "Previous ratings" };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml.cs
@@ -13,4 +13,8 @@ public class SafeguardingAndConcernsModel(
     IExportService exportService,
     IDateTimeProvider dateTimeProvider,
     ILogger<SafeguardingAndConcernsModel> logger) : OfstedAreaModel(dataSourceService, trustService,
-    academyService, exportService, dateTimeProvider, logger);
+    academyService, exportService, dateTimeProvider, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "Safeguarding and concerns" };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
@@ -11,6 +11,7 @@ public class OverviewAreaModel(
     ILogger<OverviewAreaModel> logger)
     : TrustsAreaModel(dataSourceService, trustService, logger, "Overview")
 {
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = "Overview" };
     public TrustOverviewServiceModel TrustOverview { get; set; } = default!;
 
     public override async Task<IActionResult> OnGetAsync()

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
@@ -9,7 +9,7 @@ public class OverviewAreaModel(
     IDataSourceService dataSourceService,
     ITrustService trustService,
     ILogger<OverviewAreaModel> logger)
-    : TrustsAreaModel(dataSourceService, trustService, logger, "Overview")
+    : TrustsAreaModel(dataSourceService, trustService, logger)
 {
     public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = "Overview" };
     public TrustOverviewServiceModel TrustOverview { get; set; } = default!;
@@ -21,11 +21,11 @@ public class OverviewAreaModel(
 
         SubNavigationLinks =
         [
-            new TrustSubNavigationLinkModel("Trust details", "./TrustDetails", Uid, PageName,
+            new TrustSubNavigationLinkModel("Trust details", "./TrustDetails", Uid, TrustPageMetadata.PageName!,
                 this is TrustDetailsModel),
-            new TrustSubNavigationLinkModel("Trust summary", "./TrustSummary", Uid, PageName,
+            new TrustSubNavigationLinkModel("Trust summary", "./TrustSummary", Uid, TrustPageMetadata.PageName!,
                 this is TrustSummaryModel),
-            new TrustSubNavigationLinkModel("Reference numbers", "./ReferenceNumbers", Uid, PageName,
+            new TrustSubNavigationLinkModel("Reference numbers", "./ReferenceNumbers", Uid, TrustPageMetadata.PageName!,
                 this is ReferenceNumbersModel)
         ];
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/ReferenceNumbers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/ReferenceNumbers.cshtml.cs
@@ -7,4 +7,8 @@ public class ReferenceNumbersModel(
     IDataSourceService dataSourceService,
     ILogger<ReferenceNumbersModel> logger,
     ITrustService trustService)
-    : OverviewAreaModel(dataSourceService, trustService, logger);
+    : OverviewAreaModel(dataSourceService, trustService, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "Reference numbers" };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml.cs
@@ -11,6 +11,9 @@ public class TrustDetailsModel(
     IOtherServicesLinkBuilder otherServicesLinkBuilder)
     : OverviewAreaModel(dataSourceService, trustService, logger)
 {
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "Trust details" };
+
     public string? CompaniesHouseLink { get; set; }
     public string? GetInformationAboutSchoolsLink { get; set; }
     public string? FinancialBenchmarkingInsightsToolLink { get; set; }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustSummary.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustSummary.cshtml.cs
@@ -9,6 +9,9 @@ public class TrustSummaryModel(
     ITrustService trustService)
     : OverviewAreaModel(dataSourceService, trustService, logger)
 {
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = "Trust summary" };
+
     public IEnumerable<(string Authority, int Total)> AcademiesInEachLocalAuthority =>
         TrustOverview.AcademiesByLocalAuthority
             .OrderByDescending(kv => kv.Value)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustPageMetadata.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustPageMetadata.cs
@@ -1,0 +1,17 @@
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+
+public record TrustPageMetadata(
+    string TrustName,
+    string? PageName = null,
+    string? SubPageName = null,
+    string? TabName = null)
+{
+    public string BrowserTitle
+    {
+        get
+        {
+            var orderedTitleParts = new[] { TabName, SubPageName, PageName, TrustName }.Where(s => s is not null);
+            return string.Join(" - ", orderedTitleParts);
+        }
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustPageMetadata.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustPageMetadata.cs
@@ -2,6 +2,7 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 
 public record TrustPageMetadata(
     string TrustName,
+    bool ModelStateIsValid,
     string? PageName = null,
     string? SubPageName = null,
     string? TabName = null)
@@ -11,7 +12,14 @@ public record TrustPageMetadata(
         get
         {
             var orderedTitleParts = new[] { TabName, SubPageName, PageName, TrustName }.Where(s => s is not null);
-            return string.Join(" - ", orderedTitleParts);
+            var browserTitle = string.Join(" - ", orderedTitleParts);
+
+            if (!ModelStateIsValid)
+            {
+                browserTitle = $"Error: {browserTitle}";
+            }
+
+            return browserTitle;
         }
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustSubNavigationLinkModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustSubNavigationLinkModel.cs
@@ -4,7 +4,7 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 
 public record TrustSubNavigationLinkModel(
     string LinkText,
-    string Page,
+    string SubPageLink,
     string Uid,
     string ServiceName,
     bool LinkIsActive)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -1,6 +1,11 @@
 using System.Text.RegularExpressions;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Contacts;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Governance;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Ofsted;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Overview;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
@@ -10,8 +15,7 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 public class TrustsAreaModel(
     IDataSourceService dataSourceService,
     ITrustService trustService,
-    ILogger<TrustsAreaModel> logger,
-    string pageName)
+    ILogger<TrustsAreaModel> logger)
     : BasePageModel, ITrustsAreaModel
 {
     protected readonly IDataSourceService DataSourceService = dataSourceService;
@@ -20,7 +24,6 @@ public class TrustsAreaModel(
     [BindProperty(SupportsGet = true)] public string Uid { get; set; } = "";
     public TrustSummaryServiceModel TrustSummary { get; set; } = default!;
     public List<DataSourceListEntry> DataSources { get; set; } = [];
-    public string PageName { get; init; } = pageName;
     public virtual TrustPageMetadata TrustPageMetadata => new(TrustSummary.Name, ModelState.IsValid);
 
     public string MapDataSourceToName(DataSourceServiceModel dataSource)
@@ -73,17 +76,16 @@ public class TrustsAreaModel(
     {
         NavigationLinks =
         [
-            new TrustNavigationLinkModel("Overview", "/Trusts/Overview/TrustDetails", Uid, PageName == "Overview",
+            new TrustNavigationLinkModel("Overview", "/Trusts/Overview/TrustDetails", Uid, this is OverviewAreaModel,
                 "overview-nav"),
-            new TrustNavigationLinkModel("Contacts", "/Trusts/Contacts/InDfe", Uid, PageName == "Contacts",
+            new TrustNavigationLinkModel("Contacts", "/Trusts/Contacts/InDfe", Uid, this is ContactsAreaModel,
                 "contacts-nav"),
             new TrustNavigationLinkModel($"Academies ({TrustSummary.NumberOfAcademies})", "/Trusts/Academies/Details",
-                Uid, PageName == "Academies", "academies-nav"),
-            new TrustNavigationLinkModel("Ofsted", "/Trusts/Ofsted/CurrentRatings",
-                Uid, PageName == "Ofsted", "ofsted-nav"),
+                Uid, this is AcademiesPageModel, "academies-nav"),
+            new TrustNavigationLinkModel("Ofsted", "/Trusts/Ofsted/CurrentRatings", Uid, this is OfstedAreaModel,
+                "ofsted-nav"),
             new TrustNavigationLinkModel("Governance", "/Trusts/Governance/TrustLeadership", Uid,
-                PageName == "Governance",
-                "governance-nav")
+                this is GovernanceAreaModel, "governance-nav")
         ];
     }
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -21,7 +21,6 @@ public class TrustsAreaModel(
     public TrustSummaryServiceModel TrustSummary { get; set; } = default!;
     public List<DataSourceListEntry> DataSources { get; set; } = [];
     public string PageName { get; init; } = pageName;
-    public string? PageTitle { get; set; }
     public virtual TrustPageMetadata TrustPageMetadata => new(TrustSummary.Name, ModelState.IsValid);
 
     public string MapDataSourceToName(DataSourceServiceModel dataSource)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -22,7 +22,7 @@ public class TrustsAreaModel(
     public List<DataSourceListEntry> DataSources { get; set; } = [];
     public string PageName { get; init; } = pageName;
     public string? PageTitle { get; set; }
-    public virtual TrustPageMetadata TrustPageMetadata => new(TrustSummary.Name);
+    public virtual TrustPageMetadata TrustPageMetadata => new(TrustSummary.Name, ModelState.IsValid);
 
     public string MapDataSourceToName(DataSourceServiceModel dataSource)
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -22,6 +22,7 @@ public class TrustsAreaModel(
     public List<DataSourceListEntry> DataSources { get; set; } = [];
     public string PageName { get; init; } = pageName;
     public string? PageTitle { get; set; }
+    public virtual TrustPageMetadata TrustPageMetadata => new(TrustSummary.Name);
 
     public string MapDataSourceToName(DataSourceServiceModel dataSource)
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
 
-public class TrustsAreaModel(
+public abstract class TrustsAreaModel(
     IDataSourceService dataSourceService,
     ITrustService trustService,
     ILogger<TrustsAreaModel> logger)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBreadcrumbs.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBreadcrumbs.cshtml
@@ -15,7 +15,7 @@
           </a>
         </li>
         <li class="govuk-breadcrumbs__list-item" data-testid="breadcrumb-page-name">
-          @Model.PageName
+          @Model.TrustPageMetadata.PageName
         </li>
       </ol>
     </nav>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
@@ -2,7 +2,7 @@
 
 @{
   Layout = "_Layout";
-  ViewData["Title"] = $"{Model.PageTitle ?? Model.PageName} - {Model.TrustSummary.Name}";
+  ViewData["Title"] = Model.TrustPageMetadata.BrowserTitle;
 }
 
 <partial name="_TrustBanner" model="@Model"/>
@@ -14,7 +14,7 @@
         <main id="main-content">
           @await RenderSectionAsync("TrustPageMessage", false)
           <header>
-            <h1 class="govuk-heading-l" data-testid="page-name">@Model.PageName</h1>
+            <h1 class="govuk-heading-l" data-testid="page-name">@Model.TrustPageMetadata.PageName</h1>
           </header>
           <partial name="_TrustSubNavigation" model="@Model"/>
           @RenderBody()

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustSubNavigationLink.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustSubNavigationLink.cshtml
@@ -2,7 +2,7 @@
 @if (Model.LinkIsActive)
 {
   <li class="moj-sub-navigation__item">
-    <a class="moj-sub-navigation__link" aria-current="page" asp-page="@Model.Page" asp-route-uid="@Model.Uid" data-testid="@Model.TestId">
+    <a class="moj-sub-navigation__link" aria-current="page" asp-page="@Model.SubPageLink" asp-route-uid="@Model.Uid" data-testid="@Model.TestId">
       <span class="govuk-visually-hidden">@Model.ServiceName </span>@Model.LinkText
     </a>
   </li>
@@ -10,7 +10,7 @@
 else
 {
   <li class="moj-sub-navigation__item">
-    <a class="moj-sub-navigation__link" asp-page="@Model.Page" asp-route-uid="@Model.Uid" data-testid="@Model.TestId">
+    <a class="moj-sub-navigation__link" asp-page="@Model.SubPageLink" asp-route-uid="@Model.Uid" data-testid="@Model.TestId">
       <span class="govuk-visually-hidden">@Model.ServiceName </span>@Model.LinkText
     </a>
   </li>

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/cookies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/cookies.cy.ts
@@ -9,6 +9,11 @@ describe('Cookie page and consent tests', () => {
         cy.visit('/cookies');
     });
 
+    it("Checks the browser title is correct", () => {
+        commonPage
+            .checkThatBrowserTitleMatches('Cookies - Find information about academies and trusts');
+    });
+
     it('should check that both mandatory and optional cookies both exist after accepting optional cookies', () => {
         cookiesPage
             .acceptCookies()

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/home-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/home-page.cy.ts
@@ -2,11 +2,17 @@ import paginationPage from "../../pages/paginationPage";
 import homePage from "../../pages/homePage";
 import searchPage from "../../pages/searchPage";
 import navigation from "../../pages/navigation";
+import commonPage from "../../pages/commonPage";
 
 describe("Testing the components of the home page", () => {
 
     beforeEach(() => {
         cy.login();
+    });
+
+    it("Checks the browser title is correct", () => {
+        commonPage
+            .checkThatBrowserTitleMatches('Home page - Find information about academies and trusts');
     });
 
     it("Should check that the home pages search bar and autocomplete is present and functional", () => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/pagination.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/pagination.cy.ts
@@ -1,3 +1,4 @@
+import commonPage from "../../pages/commonPage";
 import navigation from "../../pages/navigation";
 import paginationPage from "../../pages/paginationPage";
 
@@ -5,8 +6,8 @@ describe('Pagination Tests', () => {
 
 
     beforeEach(() => {
-        cy.login()
-        cy.visit('/search?keywords=west')
+        cy.login();
+        cy.visit('/search?keywords=west');
     });
 
     it('Should display multiple pagination buttons', () => {
@@ -16,76 +17,82 @@ describe('Pagination Tests', () => {
 
     it('Should navigate to a specific page when a page number is clicked on a large result page', () => {
 
-        cy.visit('/search?keywords=tru')
+        cy.visit('/search?keywords=tru');
         paginationPage
-            .clickPageNumber(2)
+            .clickPageNumber(2);
         navigation
-            .checkCurrentURLIsCorrect('pagenumber=2')
-
-        paginationPage
-            .clickPageNumber(72)
-
-        navigation
-            .checkCurrentURLIsCorrect('pagenumber=72')
+            .checkCurrentURLIsCorrect('pagenumber=2');
+        commonPage
+            .checkThatBrowserTitleMatches('Search (page 2 of 72) - tru - Find information about academies and trusts');
 
         paginationPage
-            .clickPageNumber(71)
+            .clickPageNumber(72);
 
         navigation
-            .checkCurrentURLIsCorrect('pagenumber=71')
+            .checkCurrentURLIsCorrect('pagenumber=72');
+        commonPage
+            .checkThatBrowserTitleMatches('Search (page 72 of 72) - tru - Find information about academies and trusts');
+
+        paginationPage
+            .clickPageNumber(71);
+
+        navigation
+            .checkCurrentURLIsCorrect('pagenumber=71');
+        commonPage
+            .checkThatBrowserTitleMatches('Search (page 71 of 72) - tru - Find information about academies and trusts');
     });
 
     it('Should navigate to the next page on next button click', () => {
         paginationPage
-            .clickNext()
+            .clickNext();
 
         navigation
-            .checkCurrentURLIsCorrect('pagenumber=2')
+            .checkCurrentURLIsCorrect('pagenumber=2');
 
         paginationPage
-            .clickNext()
+            .clickNext();
 
         navigation
-            .checkCurrentURLIsCorrect('pagenumber=3')
+            .checkCurrentURLIsCorrect('pagenumber=3');
 
     });
 
     it('Should navigate to the previous page on previous button click', () => {
         paginationPage
-            .clickNext()
+            .clickNext();
 
         navigation
-            .checkCurrentURLIsCorrect('pagenumber=2')
+            .checkCurrentURLIsCorrect('pagenumber=2');
 
         paginationPage
-            .clickPrevious()
+            .clickPrevious();
 
         navigation
-            .checkCurrentURLIsCorrect('pagenumber=1')
+            .checkCurrentURLIsCorrect('pagenumber=1');
 
     });
 
     it('Checks that the previous page button is not present on the first page of results', () => {
         paginationPage
-            .checkPreviousButtonNotPresent()
+            .checkPreviousButtonNotPresent();
     });
 
     it('Checks that the next page button is not present on the first page of results', () => {
         paginationPage
             .clickPageNumber(3)
-            .checkNextButtonNotPresent()
+            .checkNextButtonNotPresent();
     });
 
     it('Checks that the previous and next page buttons are not present on the no results found page', () => {
-        cy.visit('/search?keywords=knowhere')
+        cy.visit('/search?keywords=knowhere');
 
         paginationPage
             .checkPreviousButtonNotPresent()
-            .checkNextButtonNotPresent()
+            .checkNextButtonNotPresent();
     });
 
     it('Checks that I see the pages I would expect mid pagination and dont see the ones that should be hidden', () => {
-        cy.visit('/search?keywords=tru&pagenumber=30')
+        cy.visit('/search?keywords=tru&pagenumber=30');
 
         paginationPage
             .checkExpectedPageNumberInPaginationBar(1)
@@ -96,37 +103,39 @@ describe('Pagination Tests', () => {
             .checkExpectedPageNumberInPaginationBar(31)
             .checkResultIsNotInPaginationBar(32)
             .checkResultIsNotInPaginationBar(71)
-            .checkExpectedPageNumberInPaginationBar(72)
+            .checkExpectedPageNumberInPaginationBar(72);
     });
 
     it('Checks that on a single result page only the page number is present', () => {
-        cy.visit('/search?keywords=henley-in-arden')
+        cy.visit('/search?keywords=henley-in-arden');
 
         paginationPage
             .checkPreviousButtonNotPresent()
             .checkNextButtonNotPresent()
-            .checkSingleResultOnlyHasOnePage(1)
+            .checkSingleResultOnlyHasOnePage(1);
+
+        commonPage
+            .checkThatBrowserTitleMatches('Search - henley-in-arden - Find information about academies and trusts');
     });
 
     it('Should navigate to the previous page on previous button click', () => {
         paginationPage
-            .clickNext()
+            .clickNext();
 
         navigation
-            .checkCurrentURLIsCorrect('pagenumber=2')
+            .checkCurrentURLIsCorrect('pagenumber=2');
 
         paginationPage.getResults().then(secondPageResults => {
             const secondPageFirstResultText = secondPageResults.first().text();
 
-            paginationPage.clickPrevious()
+            paginationPage.clickPrevious();
 
             navigation
-                .checkCurrentURLIsCorrect('pagenumber=1')
+                .checkCurrentURLIsCorrect('pagenumber=1');
 
             paginationPage.getResults().first().should('not.have.text', secondPageFirstResultText);
         });
     });
-
 
     it('Should iterate through all pagination pages and verify results are different', () => {
         paginationPage.getTotalPaginationButtons().then(totalPages => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/academies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/academies.cy.ts
@@ -10,6 +10,11 @@ describe("Testing the components of the Academies page", () => {
             cy.visit('/trusts/academies/details?uid=5712');
         });
 
+        it("Checks the browser title is correct", () => {
+            commonPage
+                .checkThatBrowserTitleForTrustPageMatches('Details - Academies - {trustName} - Find information about academies and trusts');
+        });
+
         it("Checks the correct details page headers are present", () => {
             academiesPage
                 .checkDetailsHeadersPresent();
@@ -53,6 +58,11 @@ describe("Testing the components of the Academies page", () => {
             cy.visit('/trusts/academies/pupil-numbers?uid=5712');
         });
 
+        it("Checks the browser title is correct", () => {
+            commonPage
+                .checkThatBrowserTitleForTrustPageMatches('Pupil numbers - Academies - {trustName} - Find information about academies and trusts');
+        });
+
         it("Checks the correct Pupil numbers page headers are present", () => {
             academiesPage
                 .checkPupilNumbersHeadersPresent();
@@ -88,6 +98,11 @@ describe("Testing the components of the Academies page", () => {
         beforeEach(() => {
             cy.login();
             cy.visit('/trusts/academies/free-school-meals?uid=5712');
+        });
+
+        it("Checks the browser title is correct", () => {
+            commonPage
+                .checkThatBrowserTitleForTrustPageMatches('Free school meals - Academies - {trustName} - Find information about academies and trusts');
         });
 
         it("Checks the correct Free school meals page headers are present", () => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/contacts-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/contacts-page.cy.ts
@@ -29,6 +29,11 @@ describe("Testing the components of the Trust contacts page", () => {
                 cy.visit(`/trusts/contacts/in-dfe?uid=${uid}`);
             });
 
+            it("Checks the browser title is correct", () => {
+                commonPage
+                    .checkThatBrowserTitleForTrustPageMatches('In DfE - Contacts - {trustName} - Find information about academies and trusts');
+            });
+
             it("Checks the breadcrumb shows the correct page name", () => {
                 navigation
                     .checkPageNameBreadcrumbPresent("Contacts");
@@ -61,10 +66,39 @@ describe("Testing the components of the Trust contacts page", () => {
             });
         });
 
+        describe(`On the edit Trust relationship manager contact details page for a ${typeOfTrust}`, () => {
+            beforeEach(() => {
+                cy.login();
+                cy.visit(`/trusts/contacts/edittrustrelationshipmanager?uid=${uid}`);
+            });
+
+            it("Checks the browser title is correct", () => {
+                commonPage
+                    .checkThatBrowserTitleForTrustPageMatches('Edit Trust relationship manager details - Contacts - {trustName} - Find information about academies and trusts');
+            });
+        });
+
+        describe(`On the edit SFSO lead contact details page for a ${typeOfTrust}`, () => {
+            beforeEach(() => {
+                cy.login();
+                cy.visit(`/trusts/contacts/editsfsolead?uid=${uid}`);
+            });
+
+            it("Checks the browser title is correct", () => {
+                commonPage
+                    .checkThatBrowserTitleForTrustPageMatches('Edit SFSO (Schools financial support and oversight) lead details - Contacts - {trustName} - Find information about academies and trusts');
+            });
+        });
+
         describe(`On the contacts in the trust page for a ${typeOfTrust}`, () => {
             beforeEach(() => {
                 cy.login();
                 cy.visit(`/trusts/contacts/in-the-trust?uid=${uid}`);
+            });
+
+            it("Checks the browser title is correct", () => {
+                commonPage
+                    .checkThatBrowserTitleForTrustPageMatches('In the trust - Contacts - {trustName} - Find information about academies and trusts');
             });
 
             it("Checks the breadcrumb shows the correct page name", () => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/governance-page.cy.ts
@@ -1,3 +1,4 @@
+import commonPage from "../../../pages/commonPage";
 import navigation from "../../../pages/navigation";
 import governancePage from "../../../pages/trusts/governancePage";
 
@@ -23,6 +24,9 @@ describe("Testing the components of the Governance page", () => {
             it("The trust leadership page loads with the correct headings and data", () => {
                 cy.visit(`/trusts/governance/trust-leadership?uid=${uid}`);
 
+                commonPage
+                    .checkThatBrowserTitleForTrustPageMatches('Trust leadership - Governance - {trustName} - Find information about academies and trusts');
+
                 // Trust leadership table is visible and working
                 governancePage
                     .checkTrustLeadershipSubHeaderPresent()
@@ -41,6 +45,9 @@ describe("Testing the components of the Governance page", () => {
             it("The trustees page loads with the correct headings and data", () => {
                 cy.visit(`/trusts/governance/trustees?uid=${uid}`);
 
+                commonPage
+                    .checkThatBrowserTitleForTrustPageMatches('Trustees - Governance - {trustName} - Find information about academies and trusts');
+
                 // Trustee table is visible and working
                 governancePage
                     .checkTrusteesSubHeaderPresent()
@@ -58,6 +65,9 @@ describe("Testing the components of the Governance page", () => {
             it("The members page loads with the correct headings and data", () => {
                 cy.visit(`/trusts/governance/members?uid=${uid}`);
 
+                commonPage
+                    .checkThatBrowserTitleForTrustPageMatches('Members - Governance - {trustName} - Find information about academies and trusts');
+
                 // Members table is visible and working
                 governancePage
                     .checkMembersSubHeaderPresent()
@@ -74,6 +84,9 @@ describe("Testing the components of the Governance page", () => {
 
             it("The historic members page loads with the correct headings and data", () => {
                 cy.visit(`/trusts/governance/historic-members?uid=${uid}`);
+
+                commonPage
+                    .checkThatBrowserTitleForTrustPageMatches('Historic members - Governance - {trustName} - Find information about academies and trusts');
 
                 // Historic members table is visible and working
                 governancePage

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/ofsted-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/ofsted-page.cy.ts
@@ -22,12 +22,17 @@ describe("Testing the Ofsted page and its subpages ", () => {
                 .checkOfstedCurrentRatingsPageHeaderPresent();
         });
 
+        it("Checks the browser title is correct", () => {
+            commonPage
+                .checkThatBrowserTitleForTrustPageMatches('Current ratings - Ofsted - {trustName} - Find information about academies and trusts');
+        });
+
         it("Checks the breadcrumb shows the correct page name", () => {
             navigation
                 .checkPageNameBreadcrumbPresent("Ofsted");
-        })
+        });
 
-        it("Checks the correct Ofsted current ratings headers are present", () => {
+        it("Checks the correct Ofsted current ratings table headers are present", () => {
             ofstedPage
                 .checkOfstedCurrentRatingsTableHeadersPresent();
         });
@@ -87,10 +92,15 @@ describe("Testing the Ofsted page and its subpages ", () => {
                 .checkOfstedPreviousRatingsPageHeaderPresent();
         });
 
+        it("Checks the browser title is correct", () => {
+            commonPage
+                .checkThatBrowserTitleForTrustPageMatches('Previous ratings - Ofsted - {trustName} - Find information about academies and trusts');
+        });
+
         it("Checks the breadcrumb shows the correct page name", () => {
             navigation
                 .checkPageNameBreadcrumbPresent("Ofsted");
-        })
+        });
 
         it("Checks the correct Ofsted previous ratings headers are present", () => {
             ofstedPage
@@ -152,10 +162,15 @@ describe("Testing the Ofsted page and its subpages ", () => {
                 .checkOfstedSafeguardingConcernsPageHeaderPresent();
         });
 
+        it("Checks the browser title is correct", () => {
+            commonPage
+                .checkThatBrowserTitleForTrustPageMatches('Safeguarding and concerns - Ofsted - {trustName} - Find information about academies and trusts');
+        });
+
         it("Checks the breadcrumb shows the correct page name", () => {
             navigation
                 .checkPageNameBreadcrumbPresent("Ofsted");
-        })
+        });
 
         it("Checks the correct Ofsted safeguarding and concerns headers are present", () => {
             ofstedPage
@@ -208,6 +223,16 @@ describe("Testing the Ofsted page and its subpages ", () => {
         it("Checks the correct Ofsted important dates sub page header is present", () => {
             ofstedPage
                 .checkOfstedImportantDatesPageHeaderPresent();
+        });
+
+        it("Checks the browser title is correct", () => {
+            commonPage
+                .checkThatBrowserTitleForTrustPageMatches('Important dates - Ofsted - {trustName} - Find information about academies and trusts');
+        });
+
+        it("Checks the breadcrumb shows the correct page name", () => {
+            navigation
+                .checkPageNameBreadcrumbPresent("Ofsted");
         });
 
         it("Checks the correct Ofsted important dates table headers are present", () => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/overview-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/overview-page.cy.ts
@@ -1,5 +1,6 @@
 import navigation from "../../../pages/navigation";
 import overviewPage from "../../../pages/trusts/overviewPage";
+import commonPage from "../../../pages/commonPage";
 
 describe("Testing the components of the Trust overview page", () => {
 
@@ -9,11 +10,15 @@ describe("Testing the components of the Trust overview page", () => {
             cy.visit('/trusts/overview/trust-details?uid=5712');
         });
 
-        it("The page loads with the correct headings and data in the Trust details card", () => {
+        it("The page loads with the correct headings and data", () => {
+            commonPage
+                .checkThatBrowserTitleForTrustPageMatches('Trust details - Overview - {trustName} - Find information about academies and trusts');
+
             overviewPage
                 .checkTrustDetailsSubHeaderPresent()
                 .checkTrustDetailsCardPresent()
                 .checkTrustDetailsCardItemsPresent();
+
             navigation
                 .checkPageNameBreadcrumbPresent("Overview");
         });
@@ -25,12 +30,16 @@ describe("Testing the components of the Trust overview page", () => {
             cy.visit('/trusts/overview/trust-summary?uid=5712');
         });
 
-        it("The page loads with the correct headings and data in the Trust summary card", () => {
+        it("The page loads with the correct headings and data", () => {
+            commonPage
+                .checkThatBrowserTitleForTrustPageMatches('Trust summary - Overview - {trustName} - Find information about academies and trusts');
+
             overviewPage
                 .checkTrustSummarySubHeaderPresent()
                 .checkOverviewHeaderPresent()
                 .checkTrustSummaryCardPresent()
                 .checkTrustSummaryCardItemsPresent();
+
             navigation
                 .checkPageNameBreadcrumbPresent("Overview");
         });
@@ -42,11 +51,15 @@ describe("Testing the components of the Trust overview page", () => {
             cy.visit('/trusts/overview/reference-numbers?uid=5712');
         });
 
-        it("The page loads with the correct headings and data in the reference numbers card", () => {
+        it("The page loads with the correct headings and data", () => {
+            commonPage
+                .checkThatBrowserTitleForTrustPageMatches('Reference numbers - Overview - {trustName} - Find information about academies and trusts');
+
             overviewPage
                 .checkReferenceNumbersSubHeaderPresent()
                 .checkReferenceNumbersCardPresent()
                 .checkReferenceNumbersCardItemsPresent();
+
             navigation
                 .checkPageNameBreadcrumbPresent("Overview");
         });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/overview-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/overview-page.cy.ts
@@ -44,7 +44,7 @@ describe("Testing the components of the Trust overview page", () => {
 
         it("The page loads with the correct headings and data in the reference numbers card", () => {
             overviewPage
-                .checkReferenceNumversSubHeaderPresent()
+                .checkReferenceNumbersSubHeaderPresent()
                 .checkReferenceNumbersCardPresent()
                 .checkReferenceNumbersCardItemsPresent();
             navigation

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/commonPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/commonPage.ts
@@ -11,7 +11,26 @@ class CommonPage {
             message: () => this.elements.errorPopup.section().find('[data-testid="error-summary"]')
         },
 
+        trustName: () => cy.get('[data-testid="trust-name-heading"]'),
     };
+
+    /**
+     * Checks that the browser title for a trust page is correct
+     * 
+     * @pageTitle should contain `{trustName}` which will be replaced with the name of the trust retrieved from the header
+     */
+    public checkThatBrowserTitleForTrustPageMatches(pageTitle: string): this {
+
+        this.elements.trustName()
+            .invoke('text')
+            .then(trustName => {
+                const expectedBrowserTitle = pageTitle.replace('{trustName}', trustName);
+
+                cy.title().should('equal', expectedBrowserTitle);
+            });
+
+        return this;
+    }
 
     public checkSuccessPopup(expectedMessage: string): this {
         const { successPopup } = this.elements;

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/commonPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/commonPage.ts
@@ -32,6 +32,11 @@ class CommonPage {
         return this;
     }
 
+    public checkThatBrowserTitleMatches(pageTitle: string): this {
+        cy.title().should('equal', pageTitle);
+        return this;
+    }
+
     public checkSuccessPopup(expectedMessage: string): this {
         const { successPopup } = this.elements;
         successPopup.section().should('be.visible');

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/overviewPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/overviewPage.ts
@@ -125,7 +125,7 @@ class OverviewPage {
         return this;
     }
 
-    public checkReferenceNumversSubHeaderPresent(): this {
+    public checkReferenceNumbersSubHeaderPresent(): this {
         this.elements.subHeaders.subHeader().should('be.visible');
         this.elements.subHeaders.subHeader().should('contain', 'Reference numbers');
         return this;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/DetailsModelTests.cs
@@ -42,12 +42,6 @@ public class AcademiesDetailsModelTests
     }
 
     [Fact]
-    public void PageName_should_be_AcademiesInThisTrust()
-    {
-        _sut.PageName.Should().Be("Academies");
-    }
-
-    [Fact]
     public void OtherServicesLinkBuilder_should_be_injected()
     {
         _sut.LinkBuilder.Should().Be(_mockLinkBuilder.Object);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/DetailsModelTests.cs
@@ -36,12 +36,6 @@ public class AcademiesDetailsModelTests
     }
 
     [Fact]
-    public void TabName_should_be_Details()
-    {
-        _sut.TabName.Should().Be("Details");
-    }
-
-    [Fact]
     public void OtherServicesLinkBuilder_should_be_injected()
     {
         _sut.LinkBuilder.Should().Be(_mockLinkBuilder.Object);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/DetailsModelTests.cs
@@ -15,7 +15,7 @@ public class AcademiesDetailsModelTests
 {
     private readonly AcademiesDetailsModel _sut;
     private readonly Mock<IOtherServicesLinkBuilder> _mockLinkBuilder = new();
-    private readonly Mock<ITrustService> _mockTrustRepository = new();
+    private readonly Mock<ITrustService> _mockTrustService = new();
     private readonly Mock<IAcademyService> _mockAcademyService = new();
     private readonly Mock<IExportService> _mockExportService = new();
     private readonly Mock<IDateTimeProvider> _mockDateTimeProvider = new();
@@ -26,11 +26,11 @@ public class AcademiesDetailsModelTests
 
     public AcademiesDetailsModelTests()
     {
-        _mockTrustRepository.Setup(t => t.GetTrustSummaryAsync(_fakeTrust.Uid))
+        _mockTrustService.Setup(t => t.GetTrustSummaryAsync(_fakeTrust.Uid))
             .ReturnsAsync(_fakeTrust);
 
         _sut = new AcademiesDetailsModel(_mockDataSourceService.Object,
-                _mockLinkBuilder.Object, _mockLogger.Object, _mockTrustRepository.Object, _mockAcademyService.Object,
+                _mockLinkBuilder.Object, _mockLogger.Object, _mockTrustService.Object, _mockAcademyService.Object,
                 _mockExportService.Object, _mockDateTimeProvider.Object)
             { Uid = _fakeTrust.Uid };
     }
@@ -62,7 +62,7 @@ public class AcademiesDetailsModelTests
     [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
-        _mockTrustRepository.Setup(t => t.GetTrustSummaryAsync(_sut.Uid)).ReturnsAsync((TrustSummaryServiceModel?)null);
+        _mockTrustService.Setup(t => t.GetTrustSummaryAsync(_sut.Uid)).ReturnsAsync((TrustSummaryServiceModel?)null);
         var result = await _sut.OnGetAsync();
         result.Should().BeOfType<NotFoundResult>();
     }
@@ -112,6 +112,16 @@ public class AcademiesDetailsModelTests
     public async Task OnGetAsync_sets_SubNavigationLinks_toEmptyArray()
     {
         _ = await _sut.OnGetAsync();
-        _sut.SubNavigationLinks.Should().Equal([]);
+        _sut.SubNavigationLinks.Should().Equal();
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.TabName.Should().Be("Details");
+        _sut.TrustPageMetadata.PageName.Should().Be("Academies");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/DetailsModelTests.cs
@@ -36,12 +36,6 @@ public class AcademiesDetailsModelTests
     }
 
     [Fact]
-    public void PageTitle_should_be_AcademiesDetails()
-    {
-        _sut.PageTitle.Should().Be("Academies details");
-    }
-
-    [Fact]
     public void TabName_should_be_Details()
     {
         _sut.TabName.Should().Be("Details");

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
@@ -43,12 +43,6 @@ public class FreeSchoolMealsModelTests
     }
 
     [Fact]
-    public void PageName_should_be_AcademiesInThisTrust()
-    {
-        _sut.PageName.Should().Be("Academies");
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync("1234")).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
@@ -37,12 +37,6 @@ public class FreeSchoolMealsModelTests
     }
 
     [Fact]
-    public void TabName_should_be_Details()
-    {
-        _sut.TabName.Should().Be("Free school meals");
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync("1234")).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
@@ -114,6 +114,16 @@ public class FreeSchoolMealsModelTests
     public async Task OnGetAsync_sets_SubNavigationLinks_toEmptyArray()
     {
         _ = await _sut.OnGetAsync();
-        _sut.SubNavigationLinks.Should().Equal([]);
+        _sut.SubNavigationLinks.Should().Equal();
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.TabName.Should().Be("Free school meals");
+        _sut.TrustPageMetadata.PageName.Should().Be("Academies");
+        _sut.TrustPageMetadata.TrustName.Should().Be("Test Trust");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/FreeSchoolMealsModelTests.cs
@@ -37,12 +37,6 @@ public class FreeSchoolMealsModelTests
     }
 
     [Fact]
-    public void PageTitle_should_be_AcademiesDetails()
-    {
-        _sut.PageTitle.Should().Be("Academies free school meals");
-    }
-
-    [Fact]
     public void TabName_should_be_Details()
     {
         _sut.TabName.Should().Be("Free school meals");

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/PupilNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/PupilNumbersModelTests.cs
@@ -117,6 +117,16 @@ public class PupilNumbersModelTests
     public async Task OnGetAsync_sets_SubNavigationLinks_toEmptyArray()
     {
         _ = await _sut.OnGetAsync();
-        _sut.SubNavigationLinks.Should().Equal([]);
+        _sut.SubNavigationLinks.Should().Equal();
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.TabName.Should().Be("Pupil numbers");
+        _sut.TrustPageMetadata.PageName.Should().Be("Academies");
+        _sut.TrustPageMetadata.TrustName.Should().Be("Test Trust");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/PupilNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/PupilNumbersModelTests.cs
@@ -41,12 +41,6 @@ public class PupilNumbersModelTests
             { Uid = "1234" };
     }
 
-    [Fact]
-    public void TabName_should_be_PupilNumbers()
-    {
-        _sut.TabName.Should().Be("Pupil numbers");
-    }
-
     [Theory]
     [InlineData("Primary", 5, 11, "Primary0511")]
     [InlineData("Primary", 5, 9, "Primary0509")]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/PupilNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/PupilNumbersModelTests.cs
@@ -47,12 +47,6 @@ public class PupilNumbersModelTests
         _sut.TabName.Should().Be("Pupil numbers");
     }
 
-    [Fact]
-    public void PageName_should_be_AcademiesInThisTrust()
-    {
-        _sut.PageName.Should().Be("Academies");
-    }
-
     [Theory]
     [InlineData("Primary", 5, 11, "Primary0511")]
     [InlineData("Primary", 5, 9, "Primary0509")]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/PupilNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/PupilNumbersModelTests.cs
@@ -42,13 +42,6 @@ public class PupilNumbersModelTests
     }
 
     [Fact]
-    public void PageTitle_should_be_AcademiesPupilNumbers()
-    {
-        _sut.PageTitle.Should().Be("Academies pupil numbers");
-    }
-
-
-    [Fact]
     public void TabName_should_be_PupilNumbers()
     {
         _sut.TabName.Should().Be("Pupil numbers");

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/ContactsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/ContactsAreaModelTests.cs
@@ -54,12 +54,6 @@ public class ContactsAreaModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Contacts()
-    {
-        _sut.PageName.Should().Be("Contacts");
-    }
-
-    [Fact]
     public async Task OnGetAsync_sets_chair_of_trustees_to_be_current_chair()
     {
         await _sut.OnGetAsync();

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/ContactsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/ContactsAreaModelTests.cs
@@ -8,9 +8,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Contacts;
 
-public class ContactAreaModelTests
+public class ContactsAreaModelTests
 {
-    private readonly ContactAreaModel _sut;
+    private readonly ContactsAreaModel _sut;
 
     private readonly MockDataSourceService _mockDataSourceService = new();
     private readonly Mock<ITrustService> _mockTrustService = new();
@@ -27,7 +27,7 @@ public class ContactAreaModelTests
     private readonly InternalContact _trustRelationshipManager =
         new("Trust Relationship Manager", "trm@test.com", DateTime.Today, "test@email.com");
 
-    public ContactAreaModelTests()
+    public ContactsAreaModelTests()
     {
         _mockTrustService.Setup(tp => tp.GetTrustContactsAsync(TestUid)).ReturnsAsync(
             new TrustContactsServiceModel(_trustRelationshipManager, _sfsoLead, _accountingOfficer, _chairOfTrustees,
@@ -35,8 +35,8 @@ public class ContactAreaModelTests
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync(_fakeTrust.Uid))
             .ReturnsAsync(_fakeTrust);
 
-        _sut = new ContactAreaModel(_mockDataSourceService.Object, _mockTrustService.Object,
-                new MockLogger<ContactAreaModel>().Object)
+        _sut = new ContactsAreaModel(_mockDataSourceService.Object, _mockTrustService.Object,
+                new MockLogger<ContactsAreaModel>().Object)
             { Uid = TestUid };
     }
 
@@ -166,5 +166,14 @@ public class ContactAreaModelTests
             new TrustSubNavigationLinkModel("In DfE", "./InDfE", TestUid, "Contacts", false),
             new TrustSubNavigationLinkModel("In the trust", "./InTrust", TestUid, "Contacts", false)
         ]);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditContactModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditContactModelTests.cs
@@ -6,7 +6,7 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Contacts;
 
 public class EditContactModelTests
 {
-    private EditContactModel _sut;
+    private readonly EditContactModel _sut;
     private readonly MockDataSourceService _mockDataSourceService = new();
     private readonly Mock<ITrustService> _mockTrustService = new();
 
@@ -21,7 +21,7 @@ public class EditContactModelTests
 
         _sut = new EditSfsoLeadModel(_mockDataSourceService.Object,
                 new MockLogger<EditSfsoLeadModel>().Object, _mockTrustService.Object)
-        { Uid = "1234" };
+            { Uid = "1234" };
     }
 
     [Fact]
@@ -73,39 +73,5 @@ public class EditContactModelTests
         var result = _sut.GetErrorList("Test");
         result.Should().HaveCount(0);
         result.Should().BeEquivalentTo(Array.Empty<(int, string)>());
-    }
-
-    [Theory]
-    [InlineData("title", null, null, "title - My Trust")]
-    [InlineData("title", "name", null, "title - My Trust")]
-    [InlineData(null, "name", null, "name - My Trust")]
-    [InlineData("title", null, "error", "Error: title - My Trust")]
-    [InlineData("title", "name", "error", "Error: title - My Trust")]
-    [InlineData(null, "name", "error", "Error: name - My Trust")]
-    public void GeneratePageTitle_returns_correctly_(string? pageTitle, string? pageName, string? error,
-        string expected)
-    {
-        if (pageName != null)
-        {
-            _sut = new EditSfsoLeadModel(_mockDataSourceService.Object,
-                    new MockLogger<EditSfsoLeadModel>().Object, _mockTrustService.Object)
-            { Uid = "1234", PageName = pageName, PageTitle = pageTitle };
-        }
-        else
-        {
-            _sut = new EditSfsoLeadModel(_mockDataSourceService.Object,
-                    new MockLogger<EditSfsoLeadModel>().Object, _mockTrustService.Object)
-            { Uid = "1234", PageTitle = pageTitle };
-        }
-
-        _sut.TrustSummary = _fakeTrust;
-
-        if (error is not null)
-        {
-            _sut.ModelState.AddModelError(error, error);
-        }
-
-        var result = _sut.GeneratePageTitle();
-        result.Should().Be(expected);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditSfsoLeadModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditSfsoLeadModelTests.cs
@@ -33,12 +33,6 @@ public class EditSfsoLeadModelTests
     }
 
     [Fact]
-    public void PageName_should_be_correct()
-    {
-        _sut.PageName.Should().Be("Edit SFSO (Schools financial support and oversight) lead details");
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
         _mockTrustService.Setup(r => r.GetTrustSummaryAsync("1234")).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
@@ -34,12 +34,6 @@ public class EditTrustRelationshipManagerModelTests
     }
 
     [Fact]
-    public void PageName_should_be_correct()
-    {
-        _sut.PageName.Should().Be($"Edit {TrustRelationShipManagerDisplayName} details");
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
         _mockTrustService.Setup(r => r.GetTrustSummaryAsync("1234")).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
@@ -76,20 +76,57 @@ public class EditTrustRelationshipManagerModelTests
         var result = await _sut.OnPostAsync();
 
         _sut.ContactUpdatedMessage.Should().Be(expectedMessage);
-        _sut.GeneratePageTitle().Should().NotContain("Error: ");
 
-        result.Should().BeOfType<RedirectToPageResult>();
-        var redirect = result as RedirectToPageResult;
-        redirect!.PageName.Should().Be("/Trusts/Contacts/InDfe");
+        result.Should().BeOfType<RedirectToPageResult>()
+            .Which.PageName.Should().Be("/Trusts/Contacts/InDfe");
     }
 
     [Fact]
     public async Task OnPostAsync_sets_ContactUpdated_to_false_when_validation_is_incorrect()
     {
         _sut.ModelState.AddModelError("Test", "Test");
+
         var result = await _sut.OnPostAsync();
+
         result.Should().BeOfType<PageResult>();
-        _sut.GeneratePageTitle().Should().Contain("Error: ");
         _sut.ContactUpdatedMessage.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Edit Trust relationship manager details");
+        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
+
+    [Fact]
+    public async Task OnPostAsync_should_configure_TrustPageMetadata_when_model_is_valid()
+    {
+        _sut.TrustSummary = _fakeTrust;
+        _mockTrustService
+            .Setup(r => r.UpdateContactAsync(1234, It.IsAny<string>(), It.IsAny<string>(),
+                ContactRole.TrustRelationshipManager))
+            .ReturnsAsync(new TrustContactUpdatedServiceModel(true, true));
+        _ = await _sut.OnPostAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Edit Trust relationship manager details");
+        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+        _sut.TrustPageMetadata.ModelStateIsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnPostAsync_should_configure_TrustPageMetadata_when_model_is_not_valid()
+    {
+        _sut.ModelState.AddModelError("Test", "Test");
+        _ = await _sut.OnPostAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Edit Trust relationship manager details");
+        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+        _sut.TrustPageMetadata.ModelStateIsValid.Should().BeFalse();
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InDfeModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InDfeModelTests.cs
@@ -53,12 +53,6 @@ public class InDfeModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Contacts()
-    {
-        _sut.PageName.Should().Be("Contacts");
-    }
-
-    [Fact]
     public async Task OnGetAsync_sets_chair_of_trustees_to_be_current_chair()
     {
         await _sut.OnGetAsync();

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InDfeModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InDfeModelTests.cs
@@ -166,4 +166,14 @@ public class InDfeModelTests
             new TrustSubNavigationLinkModel("In the trust", "./InTrust", "1234", "Contacts", false)
         ]);
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("In DfE");
+        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InTrustModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InTrustModelTests.cs
@@ -53,12 +53,6 @@ public class InTrustModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Contacts()
-    {
-        _sut.PageName.Should().Be("Contacts");
-    }
-
-    [Fact]
     public async Task OnGetAsync_sets_chair_of_trustees_to_be_current_chair()
     {
         await _sut.OnGetAsync();

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InTrustModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InTrustModelTests.cs
@@ -166,4 +166,14 @@ public class InTrustModelTests
             new TrustSubNavigationLinkModel("In the trust", "./InTrust", "1234", "Contacts", true)
         ]);
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("In the trust");
+        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/GovernanceAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/GovernanceAreaModelTests.cs
@@ -80,12 +80,6 @@ public class GovernanceAreaModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Governance()
-    {
-        _sut.PageName.Should().Be("Governance");
-    }
-
-    [Fact]
     public void ShowHeaderSearch_should_be_true()
     {
         _sut.ShowHeaderSearch.Should().Be(true);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/GovernanceAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/GovernanceAreaModelTests.cs
@@ -142,4 +142,13 @@ public class GovernanceAreaModelTests
             new TrustSubNavigationLinkModel("Historic members (1)", "./HistoricMembers", "1234", "Governance", false)
         ]);
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.PageName.Should().Be("Governance");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/HistoricMembersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/HistoricMembersModelTests.cs
@@ -142,4 +142,14 @@ public class HistoricMembersModelTests
             new TrustSubNavigationLinkModel("Historic members (1)", "./HistoricMembers", "1234", "Governance", true)
         ]);
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Historic members");
+        _sut.TrustPageMetadata.PageName.Should().Be("Governance");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/HistoricMembersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/HistoricMembersModelTests.cs
@@ -80,12 +80,6 @@ public class HistoricMembersModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Governance()
-    {
-        _sut.PageName.Should().Be("Governance");
-    }
-
-    [Fact]
     public void ShowHeaderSearch_should_be_true()
     {
         _sut.ShowHeaderSearch.Should().Be(true);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/MembersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/MembersModelTests.cs
@@ -80,12 +80,6 @@ public class MembersModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Governance()
-    {
-        _sut.PageName.Should().Be("Governance");
-    }
-
-    [Fact]
     public void ShowHeaderSearch_should_be_true()
     {
         _sut.ShowHeaderSearch.Should().Be(true);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/MembersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/MembersModelTests.cs
@@ -142,4 +142,14 @@ public class MembersModelTests
             new TrustSubNavigationLinkModel("Historic members (1)", "./HistoricMembers", "1234", "Governance", false)
         ]);
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Members");
+        _sut.TrustPageMetadata.PageName.Should().Be("Governance");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrustLeadershipModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrustLeadershipModelTests.cs
@@ -142,4 +142,14 @@ public class TrustLeadershipModelTests
             new TrustSubNavigationLinkModel("Historic members (1)", "./HistoricMembers", "1234", "Governance", false)
         ]);
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Trust leadership");
+        _sut.TrustPageMetadata.PageName.Should().Be("Governance");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrustLeadershipModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrustLeadershipModelTests.cs
@@ -80,12 +80,6 @@ public class TrustLeadershipModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Governance()
-    {
-        _sut.PageName.Should().Be("Governance");
-    }
-
-    [Fact]
     public void ShowHeaderSearch_should_be_true()
     {
         _sut.ShowHeaderSearch.Should().Be(true);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrusteesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrusteesModelTests.cs
@@ -142,4 +142,14 @@ public class TrusteesModelTests
             new TrustSubNavigationLinkModel("Historic members (1)", "./HistoricMembers", "1234", "Governance", false)
         ]);
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Trustees");
+        _sut.TrustPageMetadata.PageName.Should().Be("Governance");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrusteesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrusteesModelTests.cs
@@ -80,12 +80,6 @@ public class TrusteesModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Governance()
-    {
-        _sut.PageName.Should().Be("Governance");
-    }
-
-    [Fact]
     public void ShowHeaderSearch_should_be_true()
     {
         _sut.ShowHeaderSearch.Should().Be(true);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/CurrentRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/CurrentRatingsModelTests.cs
@@ -37,12 +37,6 @@ public class CurrentRatingsModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Ofsted()
-    {
-        _sut.PageName.Should().Be("Ofsted");
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync("1234")).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/CurrentRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/CurrentRatingsModelTests.cs
@@ -187,4 +187,14 @@ public class CurrentRatingsModelTests
         var containsInvalidChars = fileDownloadName.Any(c => invalidFileNameChars.Contains(c));
         containsInvalidChars.Should().BeFalse("the file name should not contain any illegal characters");
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Current ratings");
+        _sut.TrustPageMetadata.PageName.Should().Be("Ofsted");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/ImportantDatesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/ImportantDatesModelTests.cs
@@ -37,12 +37,6 @@ public class ImportantDatesModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Ofsted()
-    {
-        _sut.PageName.Should().Be("Ofsted");
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync("1234")).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/ImportantDatesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/ImportantDatesModelTests.cs
@@ -187,4 +187,14 @@ public class ImportantDatesModelTests
         var containsInvalidChars = fileDownloadName.Any(c => invalidFileNameChars.Contains(c));
         containsInvalidChars.Should().BeFalse("the file name should not contain any illegal characters");
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Important dates");
+        _sut.TrustPageMetadata.PageName.Should().Be("Ofsted");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/OfstedAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/OfstedAreaModelTests.cs
@@ -187,4 +187,13 @@ public class OfstedAreaModelTests
         var containsInvalidChars = fileDownloadName.Any(c => invalidFileNameChars.Contains(c));
         containsInvalidChars.Should().BeFalse("the file name should not contain any illegal characters");
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.PageName.Should().Be("Ofsted");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/OfstedAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/OfstedAreaModelTests.cs
@@ -37,12 +37,6 @@ public class OfstedAreaModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Ofsted()
-    {
-        _sut.PageName.Should().Be("Ofsted");
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync("1234")).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/PreviousRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/PreviousRatingsModelTests.cs
@@ -187,4 +187,14 @@ public class PreviousRatingsModelTests
         var containsInvalidChars = fileDownloadName.Any(c => invalidFileNameChars.Contains(c));
         containsInvalidChars.Should().BeFalse("the file name should not contain any illegal characters");
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Previous ratings");
+        _sut.TrustPageMetadata.PageName.Should().Be("Ofsted");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/PreviousRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/PreviousRatingsModelTests.cs
@@ -37,12 +37,6 @@ public class PreviousRatingsModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Ofsted()
-    {
-        _sut.PageName.Should().Be("Ofsted");
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync("1234")).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SafeguardingAndConcernsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SafeguardingAndConcernsModelTests.cs
@@ -187,4 +187,14 @@ public class SafeguardingAndConcernsModelTests
         var containsInvalidChars = fileDownloadName.Any(c => invalidFileNameChars.Contains(c));
         containsInvalidChars.Should().BeFalse("the file name should not contain any illegal characters");
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Safeguarding and concerns");
+        _sut.TrustPageMetadata.PageName.Should().Be("Ofsted");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SafeguardingAndConcernsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SafeguardingAndConcernsModelTests.cs
@@ -37,12 +37,6 @@ public class SafeguardingAndConcernsModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Ofsted()
-    {
-        _sut.PageName.Should().Be("Ofsted");
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync("1234")).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/OverviewAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/OverviewAreaModelTests.cs
@@ -32,12 +32,6 @@ public class OverviewAreaModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Overview()
-    {
-        _sut.PageName.Should().Be("Overview");
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync(TrustUid)).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/OverviewAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/OverviewAreaModelTests.cs
@@ -80,4 +80,13 @@ public class OverviewAreaModelTests
             new TrustSubNavigationLinkModel("Reference numbers", "./ReferenceNumbers", "1234", "Overview", false)
         ]);
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.PageName.Should().Be("Overview");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/ReferenceNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/ReferenceNumbersModelTests.cs
@@ -80,4 +80,14 @@ public class ReferenceNumbersModelTests
             new TrustSubNavigationLinkModel("Reference numbers", "./ReferenceNumbers", "1234", "Overview", true)
         ]);
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Reference numbers");
+        _sut.TrustPageMetadata.PageName.Should().Be("Overview");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/ReferenceNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/ReferenceNumbersModelTests.cs
@@ -32,12 +32,6 @@ public class ReferenceNumbersModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Overview()
-    {
-        _sut.PageName.Should().Be("Overview");
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync(TrustUid)).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustDetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustDetailsModelTests.cs
@@ -35,12 +35,6 @@ public class TrustDetailsModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Overview()
-    {
-        _sut.PageName.Should().Be("Overview");
-    }
-
-    [Fact]
     public async Task OnGetAsync_returns_NotFoundResult_if_Trust_is_not_found()
     {
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync(TrustUid)).ReturnsAsync((TrustSummaryServiceModel?)null);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustDetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustDetailsModelTests.cs
@@ -155,4 +155,14 @@ public class TrustDetailsModelTests
             new TrustSubNavigationLinkModel("Reference numbers", "./ReferenceNumbers", "1234", "Overview", false)
         ]);
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Trust details");
+        _sut.TrustPageMetadata.PageName.Should().Be("Overview");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustSummaryModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustSummaryModelTests.cs
@@ -32,12 +32,6 @@ public class TrustSummaryModelTests
     }
 
     [Fact]
-    public void PageName_should_be_Overview()
-    {
-        _sut.PageName.Should().Be("Overview");
-    }
-
-    [Fact]
     public async Task OnGetAsync_sets_list_of_local_authorities()
     {
         var overviewWithLocalAuthorities = BaseTrustOverviewServiceModel with

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustSummaryModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustSummaryModelTests.cs
@@ -112,4 +112,14 @@ public class TrustSummaryModelTests
             new TrustSubNavigationLinkModel("Reference numbers", "./ReferenceNumbers", "1234", "Overview", false)
         ]);
     }
+
+    [Fact]
+    public async Task OnGetAsync_should_configure_TrustPageMetadata()
+    {
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.SubPageName.Should().Be("Trust summary");
+        _sut.TrustPageMetadata.PageName.Should().Be("Overview");
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustPageMetadataTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustPageMetadataTests.cs
@@ -8,7 +8,7 @@ public class TrustPageMetadataTests
     public void TrustPageMetadata_can_be_composed_in_parts()
     {
         //This is similar to how it is being used in the page object models
-        var sut = new TrustPageMetadata("MY TRUST");
+        var sut = new TrustPageMetadata("MY TRUST", true);
         sut.BrowserTitle.Should().Be("MY TRUST");
 
         sut = sut with { PageName = "Page" };
@@ -22,17 +22,28 @@ public class TrustPageMetadataTests
     }
 
     [Theory]
-    [InlineData("MY TRUST", "Page", "Sub page", "The tab", "The tab - Sub page - Page - MY TRUST")]
-    [InlineData("OTHER TRUST", "Page", "Sub page", null, "Sub page - Page - OTHER TRUST")]
-    [InlineData("OTHER TRUST", "Page", null, null, "Page - OTHER TRUST")]
-    [InlineData("OTHER TRUST", null, null, null, "OTHER TRUST")]
-    [InlineData("MY TRUST", null, null, "The tab", "The tab - MY TRUST")]
-    [InlineData("MY TRUST", null, "Sub page", "The tab", "The tab - Sub page - MY TRUST")]
-    [InlineData("MY TRUST", "Page", null, "The tab", "The tab - Page - MY TRUST")]
-    public void BrowserTitle_only_uses_present_strings(string trustName, string? pageName, string? subPageName,
+    [InlineData("MY TRUST", true, "Page", "Sub page", "The tab", "The tab - Sub page - Page - MY TRUST")]
+    [InlineData("MY TRUST", false, "Page", "Sub page", "The tab", "Error: The tab - Sub page - Page - MY TRUST")]
+    [InlineData("OTHER TRUST", true, "Page", "Sub page", null, "Sub page - Page - OTHER TRUST")]
+    [InlineData("OTHER TRUST", false, "Page", "Sub page", null, "Error: Sub page - Page - OTHER TRUST")]
+    [InlineData("OTHER TRUST", true, "Page", null, null, "Page - OTHER TRUST")]
+    [InlineData("OTHER TRUST", false, "Page", null, null, "Error: Page - OTHER TRUST")]
+    [InlineData("OTHER TRUST", true, null, null, null, "OTHER TRUST")]
+    [InlineData("OTHER TRUST", false, null, null, null, "Error: OTHER TRUST")]
+    [InlineData("MY TRUST", true, null, null, "The tab", "The tab - MY TRUST")]
+    [InlineData("MY TRUST", false, null, null, "The tab", "Error: The tab - MY TRUST")]
+    [InlineData("MY TRUST", true, null, "Sub page", "The tab", "The tab - Sub page - MY TRUST")]
+    [InlineData("MY TRUST", false, null, "Sub page", "The tab", "Error: The tab - Sub page - MY TRUST")]
+    [InlineData("MY TRUST", true, "Page", null, "The tab", "The tab - Page - MY TRUST")]
+    [InlineData("MY TRUST", false, "Page", null, "The tab", "Error: The tab - Page - MY TRUST")]
+    public void BrowserTitle_should_be_constructed_from_properties_and_modelstate(
+        string trustName,
+        bool modelStateIsValid,
+        string? pageName,
+        string? subPageName,
         string? tabName, string expected)
     {
-        var sut = new TrustPageMetadata(trustName, pageName, subPageName, tabName);
+        var sut = new TrustPageMetadata(trustName, modelStateIsValid, pageName, subPageName, tabName);
 
         sut.BrowserTitle.Should().Be(expected);
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustPageMetadataTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustPageMetadataTests.cs
@@ -1,0 +1,39 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
+
+public class TrustPageMetadataTests
+{
+    [Fact]
+    public void TrustPageMetadata_can_be_composed_in_parts()
+    {
+        //This is similar to how it is being used in the page object models
+        var sut = new TrustPageMetadata("MY TRUST");
+        sut.BrowserTitle.Should().Be("MY TRUST");
+
+        sut = sut with { PageName = "Page" };
+        sut.BrowserTitle.Should().Be("Page - MY TRUST");
+
+        sut = sut with { SubPageName = "Sub page" };
+        sut.BrowserTitle.Should().Be("Sub page - Page - MY TRUST");
+
+        sut = sut with { TabName = "The tab" };
+        sut.BrowserTitle.Should().Be("The tab - Sub page - Page - MY TRUST");
+    }
+
+    [Theory]
+    [InlineData("MY TRUST", "Page", "Sub page", "The tab", "The tab - Sub page - Page - MY TRUST")]
+    [InlineData("OTHER TRUST", "Page", "Sub page", null, "Sub page - Page - OTHER TRUST")]
+    [InlineData("OTHER TRUST", "Page", null, null, "Page - OTHER TRUST")]
+    [InlineData("OTHER TRUST", null, null, null, "OTHER TRUST")]
+    [InlineData("MY TRUST", null, null, "The tab", "The tab - MY TRUST")]
+    [InlineData("MY TRUST", null, "Sub page", "The tab", "The tab - Sub page - MY TRUST")]
+    [InlineData("MY TRUST", "Page", null, "The tab", "The tab - Page - MY TRUST")]
+    public void BrowserTitle_only_uses_present_strings(string trustName, string? pageName, string? subPageName,
+        string? tabName, string expected)
+    {
+        var sut = new TrustPageMetadata(trustName, pageName, subPageName, tabName);
+
+        sut.BrowserTitle.Should().Be(expected);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
@@ -12,21 +12,17 @@ public class TrustsAreaModelTests
     private readonly Mock<IDataSourceService> _mockDataSourceProvider = new();
     private readonly TrustsAreaModel _sut;
     private readonly MockLogger<TrustsAreaModel> _logger = new();
-    private readonly Mock<ITrustService> _mockTrustRepository = new();
+    private readonly Mock<ITrustService> _mockTrustService = new();
 
     public TrustsAreaModelTests()
     {
-        _sut = new TrustsAreaModel(_mockDataSourceProvider.Object,
-            _mockTrustRepository.Object, _logger.Object, "Details");
+        _sut = new TrustsAreaModel(_mockDataSourceProvider.Object, _mockTrustService.Object, _logger.Object, "Details");
     }
 
     [Fact]
     public async Task OnGetAsync_should_fetch_a_trustsummary_by_uid()
     {
-        var dummyTrustSummary = new TrustSummaryServiceModel("1234", "My Trust", "Multi-academy trust", 3);
-        _mockTrustRepository.Setup(t => t.GetTrustSummaryAsync(dummyTrustSummary.Uid))
-            .ReturnsAsync(dummyTrustSummary);
-        _sut.Uid = dummyTrustSummary.Uid;
+        var dummyTrustSummary = SetupSutToUseDummyTrustSummary();
 
         await _sut.OnGetAsync();
         _sut.TrustSummary.Should().Be(dummyTrustSummary);
@@ -43,14 +39,14 @@ public class TrustsAreaModelTests
     public void PageName_should_be_set_at_initialisation()
     {
         var sut = new TrustsAreaModel(_mockDataSourceProvider.Object,
-            _mockTrustRepository.Object, _logger.Object, "Contacts");
+            _mockTrustService.Object, _logger.Object, "Contacts");
         sut.PageName.Should().Be("Contacts");
     }
 
     [Fact]
     public async Task OnGetAsync_should_return_not_found_result_if_trust_is_not_found()
     {
-        _mockTrustRepository.Setup(t => t.GetTrustSummaryAsync("1111"))
+        _mockTrustService.Setup(t => t.GetTrustSummaryAsync("1111"))
             .ReturnsAsync((TrustSummaryServiceModel?)null);
 
         _sut.Uid = "1111";
@@ -68,10 +64,7 @@ public class TrustsAreaModelTests
     [Fact]
     public async Task OnGetAsync_should_populate_NavigationLinks()
     {
-        var dummyTrustSummary = new TrustSummaryServiceModel("1234", "My Trust", "Multi-academy trust", 3);
-        _mockTrustRepository.Setup(t => t.GetTrustSummaryAsync(dummyTrustSummary.Uid))
-            .ReturnsAsync(dummyTrustSummary);
-        _sut.Uid = dummyTrustSummary.Uid;
+        _ = SetupSutToUseDummyTrustSummary();
 
         await _sut.OnGetAsync();
         _sut.NavigationLinks.Should().BeEquivalentTo([
@@ -83,6 +76,27 @@ public class TrustsAreaModelTests
             new TrustNavigationLinkModel("Governance", "/Trusts/Governance/TrustLeadership", "1234", false,
                 "governance-nav")
         ]);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_set_TrustPageTitle_to_trust_name()
+    {
+        _ = SetupSutToUseDummyTrustSummary(trustName: "My Trust");
+
+        _ = await _sut.OnGetAsync();
+
+        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+    }
+
+    private TrustSummaryServiceModel SetupSutToUseDummyTrustSummary(string uid = "1234", string trustName = "My Trust",
+        string trustType = "Multi-academy trust", int numberOfAcademies = 3)
+    {
+        var dummyTrustSummary = new TrustSummaryServiceModel(uid, trustName, trustType, numberOfAcademies);
+        _mockTrustService.Setup(t => t.GetTrustSummaryAsync(dummyTrustSummary.Uid))
+            .ReturnsAsync(dummyTrustSummary);
+        _sut.Uid = dummyTrustSummary.Uid;
+
+        return dummyTrustSummary;
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
@@ -16,7 +16,7 @@ public class TrustsAreaModelTests
 
     public TrustsAreaModelTests()
     {
-        _sut = new TrustsAreaModel(_mockDataSourceProvider.Object, _mockTrustService.Object, _logger.Object, "Details");
+        _sut = new TrustsAreaModel(_mockDataSourceProvider.Object, _mockTrustService.Object, _logger.Object);
     }
 
     [Fact]
@@ -33,14 +33,6 @@ public class TrustsAreaModelTests
     {
         await _sut.OnGetAsync();
         _sut.Uid.Should().BeEquivalentTo(string.Empty);
-    }
-
-    [Fact]
-    public void PageName_should_be_set_at_initialisation()
-    {
-        var sut = new TrustsAreaModel(_mockDataSourceProvider.Object,
-            _mockTrustService.Object, _logger.Object, "Contacts");
-        sut.PageName.Should().Be("Contacts");
     }
 
     [Fact]
@@ -103,7 +95,7 @@ public class TrustsAreaModelTests
     public async Task OnGetAsync_sets_SubNavigationLinks_toEmptyArray()
     {
         _ = await _sut.OnGetAsync();
-        _sut.SubNavigationLinks.Should().Equal([]);
+        _sut.SubNavigationLinks.Should().BeEmpty();
     }
 
     [Theory]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
@@ -4,6 +4,7 @@ using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
 
@@ -14,9 +15,14 @@ public class TrustsAreaModelTests
     private readonly MockLogger<TrustsAreaModel> _logger = new();
     private readonly Mock<ITrustService> _mockTrustService = new();
 
+    private class TrustsAreaModelImpl(
+        IDataSourceService dataSourceService,
+        ITrustService trustService,
+        ILogger<TrustsAreaModel> logger) : TrustsAreaModel(dataSourceService, trustService, logger);
+
     public TrustsAreaModelTests()
     {
-        _sut = new TrustsAreaModel(_mockDataSourceProvider.Object, _mockTrustService.Object, _logger.Object);
+        _sut = new TrustsAreaModelImpl(_mockDataSourceProvider.Object, _mockTrustService.Object, _logger.Object);
     }
 
     [Fact]


### PR DESCRIPTION
Add sub page/tab to browser title and standardise browser title construction

[Bug 191397](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/191397): Bug: Title should contain subpage for A11y users

## Changes

- All pages now use a `TrustPageMetadata` property to set and retrieve information about the current page's page name, sub page name, tab name, trust name and whether or not the model state is valid
- The new `TrustPageMetadata` uses all of its properties to construct a browser page title which is visible to users in their browser tabs and is read out by screen readers.
- Some refactoring of touched pages to ensure consistency
- Nav menu uses same type pattern as sub-nav menu to identify current page

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
~ADR decision log updated (if needed)~
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
