### PR TITLE
Fix search url by removing UID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Updated the autocomplete so that searching clears the selected trust
+
 ## [Release-17][release-17] (production-2024-12-18.4551)
 
 ### Added

--- a/DfE.FindInformationAcademiesTrusts/assets/javascripts/autocomplete.js
+++ b/DfE.FindInformationAcademiesTrusts/assets/javascripts/autocomplete.js
@@ -1,7 +1,14 @@
 import accessibleAutocomplete from 'accessible-autocomplete'
 
 export class Autocomplete {
-  suggest = async (query, populateResults) => {
+  suggest = async (query, populateResults, inputId) => {
+    // Clear selected trust if we then search for new trust
+    // Avoids the uid turning up in the url
+    const searchInput = document.getElementById(`${inputId}-selected-trust`)
+    if (searchInput.hasAttribute('value')) {
+      searchInput.removeAttribute('value')
+    }
+
     if (query) {
       const response = await fetch(`/search?handler=populateautocomplete&keywords=${query}`)
       const results = await response.json()
@@ -35,7 +42,7 @@ export class Autocomplete {
       element: document.getElementById(`${inputId}-autocomplete-container`),
       id: inputId,
       name: 'keywords',
-      source: this.suggest,
+      source: async (query, populateResults) => this.suggest(query, populateResults, inputId),
       autoselect: false,
       confirmOnBlur: false,
       displayMenu: 'overlay',


### PR DESCRIPTION
[User Story 138642](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/138642): Tech Debt: Remove trustid (uid in url) from Search page url when not used

When we perform a search the UID is now removed from the input.
This then removes the UID form the URL when performing a manual search.
This applies to both the header search and the main page search.

Changes have been made to the autocomplete javascript to perform this.

### Testing

1. Type in the autocomplete input
2. Select a trust from the autocomplete
3. Type a new search term. Do not select an option from the autocomplete
4. Search for the term

Expected behaviour: UID should not appear in the URL of the search page.

Other search regression testing should be performed too.

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
