### PR TITLE
Misc changes from archival of no access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+- Fix Privacy page having incorrect width
+- Update name of cookie consent cookie to be consistent with application name and what is displayed in the Cookie UI
+
 ## [Release-18][release-18] (production-2024-12-19.4567)
 
 ### Added

--- a/DfE.FindInformationAcademiesTrusts/Authorization/AutomationAuthorizationHandler.cs
+++ b/DfE.FindInformationAcademiesTrusts/Authorization/AutomationAuthorizationHandler.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
+using DfE.FindInformationAcademiesTrusts.Extensions;
 using DfE.FindInformationAcademiesTrusts.Options;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Infrastructure;

--- a/DfE.FindInformationAcademiesTrusts/Configuration/FiatCookies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Configuration/FiatCookies.cs
@@ -3,6 +3,6 @@ namespace DfE.FindInformationAcademiesTrusts.Configuration;
 public static class FiatCookies
 {
     public const string Antiforgery = ".FindInformationAcademiesTrusts.Antiforgery";
-    public const string CookieConsent = ".FindInformationAcademiesTrust.CookieConsent";
+    public const string CookieConsent = ".FindInformationAcademiesTrusts.CookieConsent";
     public const string Login = ".FindInformationAcademiesTrusts.Login";
 }

--- a/DfE.FindInformationAcademiesTrusts/Configuration/FiatCookies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Configuration/FiatCookies.cs
@@ -1,0 +1,8 @@
+namespace DfE.FindInformationAcademiesTrusts.Configuration;
+
+public static class FiatCookies
+{
+    public const string Antiforgery = ".FindInformationAcademiesTrusts.Antiforgery";
+    public const string CookieConsent = ".FindInformationAcademiesTrust.CookieConsent";
+    public const string Login = ".FindInformationAcademiesTrusts.Login";
+}

--- a/DfE.FindInformationAcademiesTrusts/CookiesHelper.cs
+++ b/DfE.FindInformationAcademiesTrusts/CookiesHelper.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
+﻿using DfE.FindInformationAcademiesTrusts.Configuration;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
 namespace DfE.FindInformationAcademiesTrusts;
 
 public static class CookiesHelper
 {
-    public const string ConsentCookieName = ".FindInformationAcademiesTrust.CookieConsent";
     public const string DeleteCookieTempDataName = "DeleteCookie";
     public const string CookieChangedTempDataName = "CookieResponse";
     public const string ReturnPathQuery = "returnPath";
@@ -22,8 +22,8 @@ public static class CookiesHelper
             return false;
         }
 
-        return context.Request.Cookies.ContainsKey(ConsentCookieName) &&
-               bool.Parse(context.Request.Cookies[ConsentCookieName]!);
+        return context.Request.Cookies.ContainsKey(FiatCookies.CookieConsent) &&
+               bool.Parse(context.Request.Cookies[FiatCookies.CookieConsent]!);
     }
 
     public static string ReturnPath(HttpContext context)
@@ -35,7 +35,7 @@ public static class CookiesHelper
 
     public static bool ShowCookieBanner(HttpContext context, ITempDataDictionary tempData)
     {
-        return !context.Request.Cookies.ContainsKey(ConsentCookieName) &&
+        return !context.Request.Cookies.ContainsKey(FiatCookies.CookieConsent) &&
                tempData[DeleteCookieTempDataName] is null;
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Extensions/EnvironmentExtensions.cs
+++ b/DfE.FindInformationAcademiesTrusts/Extensions/EnvironmentExtensions.cs
@@ -1,4 +1,4 @@
-namespace DfE.FindInformationAcademiesTrusts;
+namespace DfE.FindInformationAcademiesTrusts.Extensions;
 
 public static class EnvironmentExtensions
 {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Cookies.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Cookies.cshtml
@@ -1,157 +1,158 @@
 @page
+@using DfE.FindInformationAcademiesTrusts.Configuration
 @model CookiesModel
 
 @{
-    Layout = "_ContentLayout";
-    ViewData["Title"] = "Cookies";
+  Layout = "_ContentLayout";
+  ViewData["Title"] = "Cookies";
 }
 
 @if (Model.DisplayCookieChangedMessageOnCookiesPage)
 {
-    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Success
-            </h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">
-                You’ve set your cookie preferences. <a class="govuk-notification-banner__link" href="@Model.ReturnPath" data-testid="return-to-previous-page">Go back to the page you were looking at</a>.
-            </p>
-        </div>
+  <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+        Success
+      </h2>
     </div>
+    <div class="govuk-notification-banner__content">
+      <p class="govuk-notification-banner__heading">
+        You’ve set your cookie preferences. <a class="govuk-notification-banner__link" href="@Model.ReturnPath" data-testid="return-to-previous-page">Go back to the page you were looking at</a>.
+      </p>
+    </div>
+  </div>
 }
 
 <h1 class="govuk-heading-l">Cookie preferences</h1>
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-        <p class="govuk-body">
-            Cookies are small files saved on your phone, tablet or computer when you visit a website.
-        </p>
-        <p class="govuk-body">
-            We use cookies to make Find information about academies and trusts work and collect information about how you use our service.
-        </p>
-        <h2 class="govuk-heading-m">Essential cookies</h2>
-        <p class="govuk-body">
-            Essential cookies keep your information secure while you use this site. We do not need to ask permission to use them.
-        </p>
-        <table class="govuk-table" aria-label="Essential cookies">
-            <thead class="govuk-table__header">
-                <tr>
-                    <th class="govuk-table__header">Name</th>
-                    <th class="govuk-table__header">Purpose</th>
-                    <th class="govuk-table__header">Expires</th>
-                </tr>
-            </thead>
-            <tbody class="govuk-table__body">
-                <tr>
-                    <td class="govuk-table__cell">.FindInformationAcademiesTrusts.Login</td>
-                    <td class="govuk-table__cell">Used to keep you signed in</td>
-                    <td class="govuk-table__cell">With browser settings (Session)</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">.FindInformationAcademiesTrusts.CookieConsent </td>
-                    <td class="govuk-table__cell">Stores your consent to optional cookies </td>
-                    <td class="govuk-table__cell">1 year</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">ASLBSA </td>
-                    <td class="govuk-table__cell">Used to balance the load on our servers </td>
-                    <td class="govuk-table__cell">With browser settings (Session)</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">ASLBSACORS </td>
-                    <td class="govuk-table__cell">Used to balance the load on our servers </td>
-                    <td class="govuk-table__cell">With browser settings (Session)</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">.FindInformationAcademiesTrusts.Antiforgery </td>
-                    <td class="govuk-table__cell">Secures you and our service against Cross Site Scripting Attacks (CSRF) </td>
-                    <td class="govuk-table__cell">With browser settings (Session)</td>
-                </tr>
-            </tbody>
-        </table>
+  <div class="govuk-grid-column-three-quarters">
+    <p class="govuk-body">
+      Cookies are small files saved on your phone, tablet or computer when you visit a website.
+    </p>
+    <p class="govuk-body">
+      We use cookies to make Find information about academies and trusts work and collect information about how you use our service.
+    </p>
+    <h2 class="govuk-heading-m">Essential cookies</h2>
+    <p class="govuk-body">
+      Essential cookies keep your information secure while you use this site. We do not need to ask permission to use them.
+    </p>
+    <table class="govuk-table" aria-label="Essential cookies">
+      <thead class="govuk-table__header">
+        <tr>
+          <th class="govuk-table__header">Name</th>
+          <th class="govuk-table__header">Purpose</th>
+          <th class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr>
+          <td class="govuk-table__cell">@FiatCookies.Login</td>
+          <td class="govuk-table__cell">Used to keep you signed in</td>
+          <td class="govuk-table__cell">With browser settings (Session)</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">@FiatCookies.CookieConsent</td>
+          <td class="govuk-table__cell">Stores your consent to optional cookies </td>
+          <td class="govuk-table__cell">1 year</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">ASLBSA </td>
+          <td class="govuk-table__cell">Used to balance the load on our servers </td>
+          <td class="govuk-table__cell">With browser settings (Session)</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">ASLBSACORS </td>
+          <td class="govuk-table__cell">Used to balance the load on our servers </td>
+          <td class="govuk-table__cell">With browser settings (Session)</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">@FiatCookies.Antiforgery</td>
+          <td class="govuk-table__cell">Secures you and our service against Cross Site Scripting Attacks (CSRF) </td>
+          <td class="govuk-table__cell">With browser settings (Session)</td>
+        </tr>
+      </tbody>
+    </table>
 
-        <h2 class="govuk-heading-m">Optional analytics cookies</h2>
-        <p class="govuk-body">
-            With your permission, we use Application Insights and Google Analytics to collect data about how you use this site. This information helps us to improve our service.
-        </p>
-        <p class="govuk-body">
-            Application Insights and Google Analytics are not allowed to use or share our analytics data with anyone. Application Insights and Google Analytics store information about:
-        </p>
-        <ul class="govuk-list govuk-list--bullet">
-            <li>how you got to this site</li>
-            <li>the pages you visit on this site and how long you spend on them</li>
-            <li>any errors you see while using this site</li>
-            <li>what you click on while you are visiting the site</li>
-            <li>whether you’ve visited before</li>
-            <li>your unique user identity</li>
-        </ul>
+    <h2 class="govuk-heading-m">Optional analytics cookies</h2>
+    <p class="govuk-body">
+      With your permission, we use Application Insights and Google Analytics to collect data about how you use this site. This information helps us to improve our service.
+    </p>
+    <p class="govuk-body">
+      Application Insights and Google Analytics are not allowed to use or share our analytics data with anyone. Application Insights and Google Analytics store information about:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>how you got to this site</li>
+      <li>the pages you visit on this site and how long you spend on them</li>
+      <li>any errors you see while using this site</li>
+      <li>what you click on while you are visiting the site</li>
+      <li>whether you’ve visited before</li>
+      <li>your unique user identity</li>
+    </ul>
 
-        <table class="govuk-table" aria-label="Essential cookies">
-            <thead class="govuk-table__header">
-                <tr>
-                    <th class="govuk-table__header">Name</th>
-                    <th class="govuk-table__header">Purpose</th>
-                    <th class="govuk-table__header">Expires</th>
-                </tr>
-            </thead>
-            <tbody class="govuk-table__body">
-                <tr>
-                    <td class="govuk-table__cell">ai_user</td>
-                    <td class="govuk-table__cell">Checks if you have visited this site before. This helps us count how many people visit our site.</td>
-                    <td class="govuk-table__cell">1 year</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">ai_session</td>
-                    <td class="govuk-table__cell">Checks if you have visited this site before. This helps us count how many people visit our site.</td>
-                    <td class="govuk-table__cell">30 minutes</td>
-                </tr>
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell">ai_authUser</td>
-                    <td class="govuk-table__cell">This helps us to identify authenticated users and how they interact with the site</td>
-                    <td class="govuk-table__cell">When you close your browser</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">_ga</td>
-                    <td class="govuk-table__cell">Tracks your activity on the site. This helps us to improve our service.</td>
-                    <td class="govuk-table__cell">2 years</td>
-                </tr>
-                <tr>
-                    <td class="govuk-table__cell">_gid</td>
-                    <td class="govuk-table__cell">Tracks a number of users. This helps us determine patterns in behaviour.</td>
-                    <td class="govuk-table__cell">24 hours</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
+    <table class="govuk-table" aria-label="Essential cookies">
+      <thead class="govuk-table__header">
+        <tr>
+          <th class="govuk-table__header">Name</th>
+          <th class="govuk-table__header">Purpose</th>
+          <th class="govuk-table__header">Expires</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr>
+          <td class="govuk-table__cell">ai_user</td>
+          <td class="govuk-table__cell">Checks if you have visited this site before. This helps us count how many people visit our site.</td>
+          <td class="govuk-table__cell">1 year</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">ai_session</td>
+          <td class="govuk-table__cell">Checks if you have visited this site before. This helps us count how many people visit our site.</td>
+          <td class="govuk-table__cell">30 minutes</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">ai_authUser</td>
+          <td class="govuk-table__cell">This helps us to identify authenticated users and how they interact with the site</td>
+          <td class="govuk-table__cell">When you close your browser</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">_ga</td>
+          <td class="govuk-table__cell">Tracks your activity on the site. This helps us to improve our service.</td>
+          <td class="govuk-table__cell">2 years</td>
+        </tr>
+        <tr>
+          <td class="govuk-table__cell">_gid</td>
+          <td class="govuk-table__cell">Tracks a number of users. This helps us determine patterns in behaviour.</td>
+          <td class="govuk-table__cell">24 hours</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <form method="post" name="frmCookies">
-            <div class="govuk-form-group">
-                <input type="hidden" name="redirectPath" value="@(HttpContext.Request.Path + HttpContext.Request.QueryString)"/>
-                <fieldset class="govuk-fieldset">
-                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                        <h3 class="govuk-fieldset__heading">Do you want to accept cookies that measure your website use?</h3>
-                    </legend>
-                    <div class="govuk-radios">
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="cookies-accept" type="radio" name="consent" value="true" checked="@Model.Consent">
-                            <label class="govuk-label govuk-radios__label" for="cookies-accept">
-                                Yes
-                            </label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="cookies-reject" type="radio" name="consent" value="false" checked="@(!Model.Consent)">
-                            <label class="govuk-label govuk-radios__label" for="cookies-reject">
-                                No
-                            </label>
-                        </div>
-                    </div>
-                </fieldset>
+  <div class="govuk-grid-column-two-thirds">
+    <form method="post" name="frmCookies">
+      <div class="govuk-form-group">
+        <input type="hidden" name="redirectPath" value="@(HttpContext.Request.Path + HttpContext.Request.QueryString)"/>
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h3 class="govuk-fieldset__heading">Do you want to accept cookies that measure your website use?</h3>
+          </legend>
+          <div class="govuk-radios">
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="cookies-accept" type="radio" name="consent" value="true" checked="@Model.Consent">
+              <label class="govuk-label govuk-radios__label" for="cookies-accept">
+                Yes
+              </label>
             </div>
-            <button type="submit" class="govuk-button" data-module="govuk-button" data-testid="save-cookie-preferences-button">Save changes</button>
-        </form>
-    </div>
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="cookies-reject" type="radio" name="consent" value="false" checked="@(!Model.Consent)">
+              <label class="govuk-label govuk-radios__label" for="cookies-reject">
+                No
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <button type="submit" class="govuk-button" data-module="govuk-button" data-testid="save-cookie-preferences-button">Save changes</button>
+    </form>
+  </div>
 </div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Privacy.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Privacy.cshtml
@@ -7,7 +7,7 @@
 }
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-l">
       Privacy notice for Find information about academies and trusts
     </h1>

--- a/DfE.FindInformationAcademiesTrusts/Setup/ConfigurationVariables.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/ConfigurationVariables.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using DfE.FindInformationAcademiesTrusts.Extensions;
 using DfE.FindInformationAcademiesTrusts.Options;
 using Microsoft.FeatureManagement;
 

--- a/DfE.FindInformationAcademiesTrusts/Setup/LoggingSetup.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/LoggingSetup.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using DfE.FindInformationAcademiesTrusts.Extensions;
 using Microsoft.ApplicationInsights.Extensibility;
 using Serilog;
 using Serilog.Extensions.Hosting;

--- a/DfE.FindInformationAcademiesTrusts/Setup/PostBuildSetup.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/PostBuildSetup.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using DfE.FindInformationAcademiesTrusts.Configuration;
+using DfE.FindInformationAcademiesTrusts.Extensions;
 using Microsoft.AspNetCore.CookiePolicy;
 using Serilog;
 

--- a/DfE.FindInformationAcademiesTrusts/Setup/SecurityServicesSetup.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/SecurityServicesSetup.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Azure.Identity;
 using DfE.FindInformationAcademiesTrusts.Authorization;
+using DfE.FindInformationAcademiesTrusts.Extensions;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;

--- a/DfE.FindInformationAcademiesTrusts/Setup/SecurityServicesSetup.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/SecurityServicesSetup.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Azure.Identity;
 using DfE.FindInformationAcademiesTrusts.Authorization;
+using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Extensions;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
@@ -53,7 +54,7 @@ public static class SecurityServicesSetup
             CookieAuthenticationDefaults.AuthenticationScheme,
             options =>
             {
-                options.Cookie.Name = ".FindInformationAcademiesTrusts.Login";
+                options.Cookie.Name = FiatCookies.Login;
                 options.Cookie.HttpOnly = true;
                 options.Cookie.IsEssential = true;
                 options.Cookie.SameSite = SameSiteMode.None;
@@ -63,7 +64,7 @@ public static class SecurityServicesSetup
 
     private static void AddAntiForgeryCookies(WebApplicationBuilder builder)
     {
-        builder.Services.AddAntiforgery(opts => { opts.Cookie.Name = ".FindInformationAcademiesTrusts.Antiforgery"; });
+        builder.Services.AddAntiforgery(opts => { opts.Cookie.Name = FiatCookies.Antiforgery; });
     }
 
     private static void AddDataProtectionServices(WebApplicationBuilder builder)

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/cookies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/cookies.cy.ts
@@ -31,7 +31,7 @@ describe('Cookie page and consent tests', () => {
         cy.getCookie('_ga').should('exist');
 
         //check mandatory cookies exist after saving
-        cy.getCookie('.FindInformationAcademiesTrust.CookieConsent').should('exist');
+        cy.getCookie('.FindInformationAcademiesTrusts.CookieConsent').should('exist');
         cy.getCookie('ASLBSA').should('exist');
         cy.getCookie('ASLBSACORS').should('exist');
         cy.getCookie('.FindInformationAcademiesTrusts.Antiforgery').should('exist');
@@ -55,7 +55,7 @@ describe('Cookie page and consent tests', () => {
         cy.getCookie('_ga').should('not.exist');
 
         //check mandatory cookies do not exist after saving
-        cy.getCookie('.FindInformationAcademiesTrust.CookieConsent').should('exist');
+        cy.getCookie('.FindInformationAcademiesTrusts.CookieConsent').should('exist');
         cy.getCookie('ASLBSA').should('exist');
         cy.getCookie('ASLBSACORS').should('exist');
         cy.getCookie('.FindInformationAcademiesTrusts.Antiforgery').should('exist');

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/CookiesHelperTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/CookiesHelperTests.cs
@@ -16,7 +16,7 @@ public class CookiesHelperTests
     [Fact]
     public void OptionalCookiesAreAccepted_is_true_when_Accepted_cookie_exists()
     {
-        _mockContext.SetupAcceptedCookie();
+        _mockContext.MockRequestCookies.SetupAcceptedCookie();
         var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData.Object);
         result.Should().BeTrue();
     }
@@ -24,7 +24,7 @@ public class CookiesHelperTests
     [Fact]
     public void OptionalCookiesAreAccepted_is_false_when_Rejected_cookie_exists()
     {
-        _mockContext.SetupRejectedCookie();
+        _mockContext.MockRequestCookies.SetupRejectedCookie();
         var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData.Object);
         result.Should().BeFalse();
     }
@@ -35,7 +35,7 @@ public class CookiesHelperTests
     [InlineData(null)]
     public void OptionalCookiesAreAccepted_is_false_when_DeleteCookieTempData_exists(bool? cookieAccepted)
     {
-        _mockContext.SetupConsentCookie(cookieAccepted);
+        _mockContext.MockRequestCookies.SetupConsentCookie(cookieAccepted);
 
         SetTempDataCookieDeleted();
         var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData.Object);
@@ -81,7 +81,7 @@ public class CookiesHelperTests
     [InlineData(false)]
     public void ShowCookieBanner_is_false_when_consent_cookie_exists_and_temp_data_does_not_exist(bool cookieAccepted)
     {
-        _mockContext.SetupConsentCookie(cookieAccepted);
+        _mockContext.MockRequestCookies.SetupConsentCookie(cookieAccepted);
 
         var result = CookiesHelper.ShowCookieBanner(_mockContext.Object, _mockTempData.Object);
         result.Should().BeFalse();
@@ -100,7 +100,7 @@ public class CookiesHelperTests
     [InlineData(false)]
     public void ShowCookieBanner_is_false_when_consent_cookie_exists_and_temp_data_exists(bool cookieAccepted)
     {
-        _mockContext.SetupConsentCookie(cookieAccepted);
+        _mockContext.MockRequestCookies.SetupConsentCookie(cookieAccepted);
 
         SetTempDataCookieDeleted();
         var result = CookiesHelper.ShowCookieBanner(_mockContext.Object, _mockTempData.Object);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/EnvironmentExtensionsTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/EnvironmentExtensionsTests.cs
@@ -1,6 +1,7 @@
+using DfE.FindInformationAcademiesTrusts.Extensions;
 using Microsoft.AspNetCore.Hosting;
 
-namespace DfE.FindInformationAcademiesTrusts.UnitTests;
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Extensions;
 
 public class EnvironmentExtensionsTests
 {

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockHttpContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockHttpContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Claims;
+using DfE.FindInformationAcademiesTrusts.Configuration;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -25,8 +26,8 @@ public class MockHttpContext : Mock<HttpContext>
         _mockRequest.Setup(m => m.Query[It.IsAny<string>()]).Returns("");
 
         _mockRequestCookies.Setup(m => m[It.IsAny<string>()]).Returns("False");
-        _mockRequestCookies.Setup(m => m.ContainsKey(".FindInformationAcademiesTrusts.Login")).Returns(true);
-        _mockRequestCookies.Setup(m => m[".FindInformationAcademiesTrusts.Login"]).Returns("You are logged in");
+        _mockRequestCookies.Setup(m => m.ContainsKey(FiatCookies.Login)).Returns(true);
+        _mockRequestCookies.Setup(m => m[FiatCookies.Login]).Returns("You are logged in");
         _mockRequestCookies.Setup(m => m.Keys).Returns(new List<string>());
 
         Setup(m => m.Request).Returns(_mockRequest.Object);
@@ -54,16 +55,16 @@ public class MockHttpContext : Mock<HttpContext>
 
     public void SetupAcceptedCookie()
     {
-        _mockRequestCookies.Setup(m => m.Keys).Returns(new List<string> { CookiesHelper.ConsentCookieName });
-        _mockRequestCookies.Setup(m => m.ContainsKey(CookiesHelper.ConsentCookieName)).Returns(true);
-        _mockRequestCookies.Setup(m => m[CookiesHelper.ConsentCookieName]).Returns("True");
+        _mockRequestCookies.Setup(m => m.Keys).Returns(new List<string> { FiatCookies.CookieConsent });
+        _mockRequestCookies.Setup(m => m.ContainsKey(FiatCookies.CookieConsent)).Returns(true);
+        _mockRequestCookies.Setup(m => m[FiatCookies.CookieConsent]).Returns("True");
     }
 
     public void SetupRejectedCookie()
     {
         _mockRequestCookies.Setup(m => m.Keys).Returns(new List<string>());
-        _mockRequestCookies.Setup(m => m.ContainsKey(CookiesHelper.ConsentCookieName)).Returns(true);
-        _mockRequestCookies.Setup(m => m[CookiesHelper.ConsentCookieName]).Returns("False");
+        _mockRequestCookies.Setup(m => m.ContainsKey(FiatCookies.CookieConsent)).Returns(true);
+        _mockRequestCookies.Setup(m => m[FiatCookies.CookieConsent]).Returns("False");
     }
 
     public void SetupOptionalCookies()

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockHttpContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockHttpContext.cs
@@ -1,5 +1,4 @@
 ﻿using System.Security.Claims;
-using DfE.FindInformationAcademiesTrusts.Configuration;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -8,8 +7,8 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
 public class MockHttpContext : Mock<HttpContext>
 {
-    private readonly Mock<IResponseCookies> _mockResponseCookies = new();
-    private readonly Mock<IRequestCookieCollection> _mockRequestCookies = new();
+    public MockResponseCookies MockResponseCookies { get; } = new();
+    public MockRequestCookies MockRequestCookies { get; } = new();
     private readonly Mock<HttpRequest> _mockRequest = new();
     private readonly Mock<IFeatureCollection> _mockFeatureCollection = new();
     private readonly ClaimsIdentity _claimsIdentity = new();
@@ -17,18 +16,13 @@ public class MockHttpContext : Mock<HttpContext>
     public MockHttpContext()
     {
         Mock<HttpResponse> mockResponse = new();
-        mockResponse.Setup(m => m.Cookies).Returns(_mockResponseCookies.Object);
+        mockResponse.Setup(m => m.Cookies).Returns(MockResponseCookies.Object);
 
         ClaimsPrincipal user = new();
         user.AddIdentity(_claimsIdentity);
 
-        _mockRequest.Setup(m => m.Cookies).Returns(_mockRequestCookies.Object);
+        _mockRequest.Setup(m => m.Cookies).Returns(MockRequestCookies.Object);
         _mockRequest.Setup(m => m.Query[It.IsAny<string>()]).Returns("");
-
-        _mockRequestCookies.Setup(m => m[It.IsAny<string>()]).Returns("False");
-        _mockRequestCookies.Setup(m => m.ContainsKey(FiatCookies.Login)).Returns(true);
-        _mockRequestCookies.Setup(m => m[FiatCookies.Login]).Returns("You are logged in");
-        _mockRequestCookies.Setup(m => m.Keys).Returns(new List<string>());
 
         Setup(m => m.Request).Returns(_mockRequest.Object);
         Setup(m => m.Response).Returns(mockResponse.Object);
@@ -39,42 +33,6 @@ public class MockHttpContext : Mock<HttpContext>
     public void AddUserClaim(string type, string value)
     {
         _claimsIdentity.AddClaim(new Claim(type, value));
-    }
-
-    public void SetupConsentCookie(bool? accepted)
-    {
-        if (accepted is true)
-        {
-            SetupAcceptedCookie();
-        }
-        else if (accepted is false)
-        {
-            SetupRejectedCookie();
-        }
-    }
-
-    public void SetupAcceptedCookie()
-    {
-        _mockRequestCookies.Setup(m => m.Keys).Returns(new List<string> { FiatCookies.CookieConsent });
-        _mockRequestCookies.Setup(m => m.ContainsKey(FiatCookies.CookieConsent)).Returns(true);
-        _mockRequestCookies.Setup(m => m[FiatCookies.CookieConsent]).Returns("True");
-    }
-
-    public void SetupRejectedCookie()
-    {
-        _mockRequestCookies.Setup(m => m.Keys).Returns(new List<string>());
-        _mockRequestCookies.Setup(m => m.ContainsKey(FiatCookies.CookieConsent)).Returns(true);
-        _mockRequestCookies.Setup(m => m[FiatCookies.CookieConsent]).Returns("False");
-    }
-
-    public void SetupOptionalCookies()
-    {
-        _mockRequestCookies.Setup(m => m.Keys).Returns(new List<string> { "ai_user", "ai_session", "_gid", "_ga" });
-
-        _mockRequestCookies.Setup(m => m.ContainsKey("ai_user")).Returns(true);
-        _mockRequestCookies.Setup(m => m["ai_user"]).Returns("True");
-        _mockRequestCookies.Setup(m => m.ContainsKey("ai_session")).Returns(true);
-        _mockRequestCookies.Setup(m => m["ai_session"]).Returns("True");
     }
 
     public void SetQueryReturnPath(string path)
@@ -110,24 +68,5 @@ public class MockHttpContext : Mock<HttpContext>
                 && m.OriginalQueryString == query));
 
         _mockRequest.Setup(m => m.Host).Returns(new HostString(host));
-    }
-
-    public void VerifySecureCookieAdded(string key, string value)
-    {
-        _mockResponseCookies.Verify(
-            m => m.Append(key, value,
-                It.Is<CookieOptions>(c => c.Secure == true && c.HttpOnly == true)), Times.Once);
-    }
-
-    public void VerifyCookieDeleted(string key)
-    {
-        _mockResponseCookies.Verify(
-            m => m.Delete(key), Times.Once);
-    }
-
-    public void VerifyNoCookiesDeleted()
-    {
-        _mockResponseCookies.Verify(
-            m => m.Delete(It.IsAny<string>()), Times.Exactly(0));
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockRequestCookies.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockRequestCookies.cs
@@ -1,0 +1,46 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
+using Microsoft.AspNetCore.Http;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+
+public class MockRequestCookies : Mock<IRequestCookieCollection>
+{
+    public Dictionary<string, string> Data { get; } = new();
+
+    public MockRequestCookies()
+    {
+        Setup(m => m.Keys).Returns(Data.Keys);
+        Setup(m => m.ContainsKey(It.IsAny<string>())).Returns((string key) => Data.ContainsKey(key));
+        Setup(m => m[It.IsAny<string>()]).Returns((string key) => Data.TryGetValue(key, out var value) ? value : null);
+    }
+
+    public void SetupConsentCookie(bool? accepted)
+    {
+        if (accepted is true)
+        {
+            SetupAcceptedCookie();
+        }
+        else if (accepted is false)
+        {
+            SetupRejectedCookie();
+        }
+    }
+
+    public void SetupAcceptedCookie()
+    {
+        Data.Add(FiatCookies.CookieConsent, "True");
+    }
+
+    public void SetupRejectedCookie()
+    {
+        Data.Add(FiatCookies.CookieConsent, "False");
+    }
+
+    public void SetupOptionalCookies()
+    {
+        Data.Add("ai_user", "True");
+        Data.Add("ai_session", "True");
+        Data.Add("_gid", "True");
+        Data.Add("_ga", "True");
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockResponseCookies.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockResponseCookies.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Http;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+
+public class MockResponseCookies : Mock<IResponseCookies>
+{
+    public void VerifySecureCookieAdded(string key, string value)
+    {
+        Verify(m => m.Append(key, value,
+            It.Is<CookieOptions>(c => c.Secure == true && c.HttpOnly == true)), Times.Once);
+    }
+
+    public void VerifyCookieDeleted(string key)
+    {
+        Verify(m => m.Delete(key), Times.Once);
+    }
+
+    public void VerifyCookieDeleted(string key, CookieOptions options)
+    {
+        Verify(m => m.Delete(key, It.Is<CookieOptions>(cookieOptions =>
+                cookieOptions.HttpOnly == options.HttpOnly
+                && cookieOptions.IsEssential == options.IsEssential
+                && cookieOptions.SameSite == options.SameSite
+                && cookieOptions.Secure == options.Secure
+            )),
+            Times.Once);
+    }
+
+    public void VerifyNoCookiesDeleted()
+    {
+        Verify(m => m.Delete(It.IsAny<string>()), Times.Exactly(0));
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/CookiesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/CookiesModelTests.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Http;
@@ -183,7 +184,7 @@ public class CookiesModelTests
     {
         _sut.Consent = consent;
         _sut.OnGet();
-        _mockHttpContext.VerifySecureCookieAdded(CookiesHelper.ConsentCookieName, value);
+        _mockHttpContext.VerifySecureCookieAdded(FiatCookies.CookieConsent, value);
     }
 
     [Theory]
@@ -193,7 +194,7 @@ public class CookiesModelTests
     {
         _sut.Consent = consent;
         _sut.OnPost();
-        _mockHttpContext.VerifySecureCookieAdded(CookiesHelper.ConsentCookieName, value);
+        _mockHttpContext.VerifySecureCookieAdded(FiatCookies.CookieConsent, value);
     }
 
     // (Cookie appended Delete called if needed/TempData is not null)

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/CookiesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/CookiesModelTests.cs
@@ -93,7 +93,7 @@ public class CookiesModelTests
     [InlineData(false, false)]
     public void OnGet_should_not_change_consent_when_it_is_provided(bool consent, bool? accepted)
     {
-        _mockHttpContext.SetupConsentCookie(accepted);
+        _mockHttpContext.MockRequestCookies.SetupConsentCookie(accepted);
         _sut.Consent = consent;
         _sut.OnGet();
         _sut.Consent.Should().Be(consent);
@@ -108,7 +108,7 @@ public class CookiesModelTests
     [InlineData(false, false)]
     public void OnPost_should_not_change_consent_when_it_is_provided(bool consent, bool? accepted)
     {
-        _mockHttpContext.SetupConsentCookie(accepted);
+        _mockHttpContext.MockRequestCookies.SetupConsentCookie(accepted);
         _sut.Consent = consent;
         _sut.OnPost();
         _sut.Consent.Should().Be(consent);
@@ -119,7 +119,7 @@ public class CookiesModelTests
     [InlineData(false)]
     public void OnGet_should_set_consent_when_it_not_provided_and_the_cookie_has_been_set(bool accepted)
     {
-        _mockHttpContext.SetupConsentCookie(accepted);
+        _mockHttpContext.MockRequestCookies.SetupConsentCookie(accepted);
         _sut.OnGet();
         _sut.Consent.Should().Be(accepted);
     }
@@ -184,7 +184,7 @@ public class CookiesModelTests
     {
         _sut.Consent = consent;
         _sut.OnGet();
-        _mockHttpContext.VerifySecureCookieAdded(FiatCookies.CookieConsent, value);
+        _mockHttpContext.MockResponseCookies.VerifySecureCookieAdded(FiatCookies.CookieConsent, value);
     }
 
     [Theory]
@@ -194,7 +194,7 @@ public class CookiesModelTests
     {
         _sut.Consent = consent;
         _sut.OnPost();
-        _mockHttpContext.VerifySecureCookieAdded(FiatCookies.CookieConsent, value);
+        _mockHttpContext.MockResponseCookies.VerifySecureCookieAdded(FiatCookies.CookieConsent, value);
     }
 
     // (Cookie appended Delete called if needed/TempData is not null)
@@ -205,10 +205,10 @@ public class CookiesModelTests
     [InlineData("_gid")]
     public void OnGet_removes_optional_cookie_when_consent_is_false(string cookieName)
     {
-        _mockHttpContext.SetupOptionalCookies();
+        _mockHttpContext.MockRequestCookies.SetupOptionalCookies();
         _sut.Consent = false;
         _sut.OnGet();
-        _mockHttpContext.VerifyCookieDeleted(cookieName);
+        _mockHttpContext.MockResponseCookies.VerifyCookieDeleted(cookieName);
     }
 
     [Theory]
@@ -218,48 +218,48 @@ public class CookiesModelTests
     [InlineData("_gid")]
     public void OnPost_removes_optional_cookie_when_consent_is_false(string cookieName)
     {
-        _mockHttpContext.SetupOptionalCookies();
+        _mockHttpContext.MockRequestCookies.SetupOptionalCookies();
         _sut.Consent = false;
         _sut.OnPost();
-        _mockHttpContext.VerifyCookieDeleted(cookieName);
+        _mockHttpContext.MockResponseCookies.VerifyCookieDeleted(cookieName);
     }
 
     [Fact]
     public void OnGet_does_not_remove_cookies_when_consent_is_true()
     {
-        _mockHttpContext.SetupOptionalCookies();
-        _mockHttpContext.SetupAcceptedCookie();
+        _mockHttpContext.MockRequestCookies.SetupOptionalCookies();
+        _mockHttpContext.MockRequestCookies.SetupAcceptedCookie();
         _sut.Consent = true;
         _sut.OnGet();
-        _mockHttpContext.VerifyNoCookiesDeleted();
+        _mockHttpContext.MockResponseCookies.VerifyNoCookiesDeleted();
     }
 
     [Fact]
     public void OnPost_does_not_remove_cookies_when_consent_is_true()
     {
-        _mockHttpContext.SetupOptionalCookies();
-        _mockHttpContext.SetupAcceptedCookie();
+        _mockHttpContext.MockRequestCookies.SetupOptionalCookies();
+        _mockHttpContext.MockRequestCookies.SetupAcceptedCookie();
         _sut.Consent = true;
         _sut.OnPost();
-        _mockHttpContext.VerifyNoCookiesDeleted();
+        _mockHttpContext.MockResponseCookies.VerifyNoCookiesDeleted();
     }
 
     [Fact]
     public void OnGet_does_not_remove_cookies_when_there_are_no_optional_cookies_to_remove()
     {
-        _mockHttpContext.SetupRejectedCookie();
+        _mockHttpContext.MockRequestCookies.SetupRejectedCookie();
         _sut.Consent = false;
         _sut.OnGet();
-        _mockHttpContext.VerifyNoCookiesDeleted();
+        _mockHttpContext.MockResponseCookies.VerifyNoCookiesDeleted();
     }
 
     [Fact]
     public void OnPost_does_not_remove_cookies_when_there_are_no_optional_cookies_to_remove()
     {
-        _mockHttpContext.SetupRejectedCookie();
+        _mockHttpContext.MockRequestCookies.SetupRejectedCookie();
         _sut.Consent = false;
         _sut.OnPost();
-        _mockHttpContext.VerifyNoCookiesDeleted();
+        _mockHttpContext.MockResponseCookies.VerifyNoCookiesDeleted();
     }
 
     //TempData


### PR DESCRIPTION
These are the changes in the no access page work which aren't directly related to the current implementation of the no access page. Merging them now gives us the benefits of the work now and also reduces the complexity of the archived branch

[User Story 193195](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/193195): Tech debt: Archive No access ticket

## Changes

- Fix Privacy page width
- Move `EnvironmentExtensions.cs` into the Extensions folder
- Move cookie names to config
- Make consent cookie name consistent with other names
- Split out cookie mocks

## Screenshots of UI changes

<details>

<summary>Privacy page width change</summary>

### Before

![image](https://github.com/user-attachments/assets/0d427953-882f-4d8a-9d5d-7851768b5a38)

### After

![image](https://github.com/user-attachments/assets/8b3d2af5-401b-4a2b-bd52-e78b744dd710)

</details>

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
~ADR decision log updated (if needed)~
- [x] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
