### PR TITLE
Pipeline academies automation

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/FreeSchools.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/FreeSchools.cshtml
@@ -6,7 +6,7 @@
     Layout = "Academies/_AcademiesLayout";
 }
 
-<section class="app-table-container">
+<section class="app-table-container" data-testid="free-schools-table">
     @if (!Model.PipelineFreeSchools.Any())
     {
         <div class="govuk-body" data-testid="empty-state-message">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/FreeSchools.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/FreeSchools.cshtml
@@ -40,7 +40,7 @@
                         </td>
                         <td class="govuk-body govuk-table__cell" data-sort-value="@academy.LocalAuthority" data-testid="free-schools-local-authority">@academy.LocalAuthority.DefaultIfNullOrWhiteSpace(ViewConstants.UnconfirmedDateText)</td>
                         <td class="govuk-body govuk-table__cell" data-sort-value="@academy.ProjectType" data-testid="free-schools-project-type">@academy.ProjectType.DefaultIfNullOrWhiteSpace(ViewConstants.UnconfirmedDateText)</td>
-                        <td class="govuk-body govuk-table__cell" data-sort-value="@academy.ChangeDate" data-testid="free-schools-provisional-opening-date-header">
+                        <td class="govuk-body govuk-table__cell" data-sort-value="@academy.ChangeDate" data-testid="free-schools-provisional-opening-date">
                             @academy.ChangeDate.ShowDateStringOrReplaceWithText(ViewConstants.UnconfirmedDateText)
                         </td>
                     </tr>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoard.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoard.cshtml
@@ -6,7 +6,7 @@
     Layout = "Academies/_AcademiesLayout";
 }
 
-<section class="app-table-container">
+<section class="app-table-container" data-testid="post-advisory-board-table">
     @if (!Model.PostAdvisoryPipelineEstablishments.Any())
     {
         <div class="govuk-body" data-testid="empty-state-message">

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoard.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoard.cshtml
@@ -6,7 +6,7 @@
     Layout = "Academies/_AcademiesLayout";
 }
 
-<section class="app-table-container">
+<section class="app-table-container" data-testid="pre-advisory-board-table">
     @if (!Model.PreAdvisoryPipelineEstablishments.Any())
     {
         <div class="govuk-body" data-testid="empty-state-message">

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation.cy.ts
@@ -129,7 +129,7 @@ describe('Testing Navigation', () => {
             navigation
                 .clickAcademiesServiceNavButton()
                 .checkAcademiesServiceNavButtonIsHighlighted()
-                .checkCurrentURLIsCorrect('/trusts/academies/details?uid=5527')
+                .checkCurrentURLIsCorrect('/trusts/academies/in-trust/details?uid=5527')
                 .checkAllServiceNavItemsPresent();
             academiesInTrustPage
                 .checkDetailsHeadersPresent();
@@ -137,7 +137,7 @@ describe('Testing Navigation', () => {
 
         it('Should check that the Governance navigation button takes me to the governance trust leadership page', () => {
             // Academies -> Governance
-            cy.visit('/trusts/academies/details?uid=5527');
+            cy.visit('/trusts/academies/in-trust/details?uid=5527');
 
             navigation
                 .clickGovernanceServiceNavButton()
@@ -146,6 +146,43 @@ describe('Testing Navigation', () => {
                 .checkAllServiceNavItemsPresent();
             governancePage
                 .checkTrustLeadershipSubHeaderPresent();
+        });
+    });
+
+    describe("Should check that the pipeline academies navigation works", () => {
+        beforeEach(() => {
+            cy.login();
+        });
+
+        it('Navigates from In this trust to pipeline academies', () => {
+            // Academies in Trust -> Pipeline Academies
+            cy.visit('/trusts/academies/in-trust/details?uid=16002');
+
+            navigation
+                .clickPipelineAcademiesNavButton()
+                .checkCurrentURLIsCorrect('/trusts/academies/pipeline/pre-advisory-board?uid=16002');
+        });
+
+        it('Navigates from In this trust to pipeline academies', () => {
+            // Pipeline Academies -> Academies in Trust
+            cy.visit('/trusts/academies/pipeline/pre-advisory-board?uid=16002');
+
+            navigation
+                .clickAcademiesInThisTrustNavButton()
+                .checkCurrentURLIsCorrect('/trusts/academies/in-trust/details?uid=16002');
+        });
+
+        it('Navigates from In this trust to pipeline academies', () => {
+            // Pipeline Academies page nav buttons
+            cy.visit('/trusts/academies/pipeline/pre-advisory-board?uid=16002');
+
+            navigation
+                .clickPipelineAcademiesPostAdvisoryNavButton()
+                .checkCurrentURLIsCorrect('/trusts/academies/pipeline/post-advisory-board?uid=16002')
+                .clickPipelineAcademiesFreeSchoolsNavButton()
+                .checkCurrentURLIsCorrect('/trusts/academies/pipeline/free-schools?uid=16002')
+                .clickPipelineAcademiesPreAdvisoryNavButton()
+                .checkCurrentURLIsCorrect('/trusts/academies/pipeline/pre-advisory-board?uid=16002');
         });
     });
 });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation.cy.ts
@@ -1,5 +1,5 @@
 import navigation from "../../pages/navigation";
-import academiesPage from "../../pages/trusts/academiesPage";
+import academiesInTrustPage from "../../pages/trusts/academiesInTrustPage";
 import governancePage from "../../pages/trusts/governancePage";
 import contactsPage from "../../pages/trusts/contactsPage";
 import overviewPage from "../../pages/trusts/overviewPage";
@@ -131,7 +131,7 @@ describe('Testing Navigation', () => {
                 .checkAcademiesServiceNavButtonIsHighlighted()
                 .checkCurrentURLIsCorrect('/trusts/academies/details?uid=5527')
                 .checkAllServiceNavItemsPresent();
-            academiesPage
+            academiesInTrustPage
                 .checkDetailsHeadersPresent();
         });
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/academies-in-trust.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/academies-in-trust.cy.ts
@@ -1,4 +1,4 @@
-import academiesPage from "../../../pages/trusts/academiesPage";
+import academiesInTrustPage from "../../../pages/trusts/academiesInTrustPage";
 import navigation from "../../../pages/navigation";
 import commonPage from "../../../pages/commonPage";
 
@@ -27,37 +27,37 @@ describe("Testing the components of the Academies page", () => {
         });
 
         it("Checks the correct details page headers are present", () => {
-            academiesPage
+            academiesInTrustPage
                 .checkDetailsHeadersPresent();
         });
 
         it("Checks that the correct school types are present", () => {
-            academiesPage
+            academiesInTrustPage
                 .checkSchoolTypesOnDetailsTable();
         });
 
         it("Checks that a different and larger trusts correct school types are present", () => {
             cy.visit('/trusts/academies/details?uid=5143');
-            academiesPage
+            academiesInTrustPage
                 .checkSchoolTypesOnDetailsTable();
         });
 
         it("Checks the detail page sorting", () => {
             cy.visit('/trusts/academies/details?uid=5143');
-            academiesPage
+            academiesInTrustPage
                 .checkTrustDetailsSorting();
         });
 
         it('should match the academy count in the sidebar with the actual table row count on the Details page', () => {
-            academiesPage.getAcademyCountFromSidebar().then(expectedCount => {
-                academiesPage.getTableRowCountOnDetailsPage().should('eq', expectedCount);
+            academiesInTrustPage.getAcademyCountFromSidebar().then(expectedCount => {
+                academiesInTrustPage.getTableRowCountOnDetailsPage().should('eq', expectedCount);
             });
         });
 
         it('should match the academy count in the sidebar with the actual table row count on the Details page after visiting', () => {
             cy.visit('/trusts/academies/details?uid=5143');
-            academiesPage.getAcademyCountFromSidebar().then(expectedCount => {
-                academiesPage.getTableRowCountOnDetailsPage().should('eq', expectedCount);
+            academiesInTrustPage.getAcademyCountFromSidebar().then(expectedCount => {
+                academiesInTrustPage.getTableRowCountOnDetailsPage().should('eq', expectedCount);
             });
         });
     });
@@ -75,31 +75,31 @@ describe("Testing the components of the Academies page", () => {
         });
 
         it("Checks the correct Pupil numbers page headers are present", () => {
-            academiesPage
+            academiesInTrustPage
                 .checkPupilNumbersHeadersPresent();
         });
 
         it("Checks the Pupil numbers page sorting", () => {
-            academiesPage
+            academiesInTrustPage
                 .checkPupilNumbersSorting();
         });
 
         it('should match the academy count in the sidebar with the actual table row count on the Pupil numbers page', () => {
-            academiesPage.getAcademyCountFromSidebar().then(expectedCount => {
-                academiesPage.getTableRowCountOnPupilNumbersPage().should('eq', expectedCount);
+            academiesInTrustPage.getAcademyCountFromSidebar().then(expectedCount => {
+                academiesInTrustPage.getTableRowCountOnPupilNumbersPage().should('eq', expectedCount);
             });
         });
 
         it('should match the academy count in the sidebar with the actual table row count on the Pupil numbers page after visiting', () => {
             cy.visit('/trusts/academies/pupil-numbers?uid=5143');
-            academiesPage.getAcademyCountFromSidebar().then(expectedCount => {
-                academiesPage.getTableRowCountOnPupilNumbersPage().should('eq', expectedCount);
+            academiesInTrustPage.getAcademyCountFromSidebar().then(expectedCount => {
+                academiesInTrustPage.getTableRowCountOnPupilNumbersPage().should('eq', expectedCount);
             });
         });
 
         it("Checks the Pupil numbers page sorting on a larger trust", () => {
             cy.visit('/trusts/academies/pupil-numbers?uid=5143');
-            academiesPage
+            academiesInTrustPage
                 .checkPupilNumbersSorting();
         });
 
@@ -117,31 +117,31 @@ describe("Testing the components of the Academies page", () => {
         });
 
         it("Checks the correct Free school meals page headers are present", () => {
-            academiesPage
+            academiesInTrustPage
                 .checkFreeSchoolMealsHeadersPresent();
         });
 
         it("Checks the Free school meals page sorting", () => {
-            academiesPage
+            academiesInTrustPage
                 .checkFreeSchoolMealsSorting();
         });
 
         it('should match the academy count in the sidebar with the actual table row count on the Free school meals page', () => {
-            academiesPage.getAcademyCountFromSidebar().then(expectedCount => {
-                academiesPage.getTableRowCountOnFreeSchoolMealsPage().should('eq', expectedCount);
+            academiesInTrustPage.getAcademyCountFromSidebar().then(expectedCount => {
+                academiesInTrustPage.getTableRowCountOnFreeSchoolMealsPage().should('eq', expectedCount);
             });
         });
 
         it('should match the academy count in the sidebar with the actual table row count on the Free school meals page after visiting', () => {
             cy.visit('/trusts/academies/free-school-meals?uid=5143');
-            academiesPage.getAcademyCountFromSidebar().then(expectedCount => {
-                academiesPage.getTableRowCountOnFreeSchoolMealsPage().should('eq', expectedCount);
+            academiesInTrustPage.getAcademyCountFromSidebar().then(expectedCount => {
+                academiesInTrustPage.getTableRowCountOnFreeSchoolMealsPage().should('eq', expectedCount);
             });
         });
 
         it("Checks the Free school meals page sorting on a larger trust", () => {
             cy.visit('/trusts/academies/free-school-meals?uid=5143');
-            academiesPage
+            academiesInTrustPage
                 .checkFreeSchoolMealsSorting();
         });
 
@@ -159,7 +159,7 @@ describe("Testing the components of the Academies page", () => {
                 .checkCurrentURLIsCorrect('/trusts/academies/pupil-numbers?uid=5527')
                 .checkAllServiceNavItemsPresent()
                 .checkAllAcademiesNavItemsPresent();
-            academiesPage
+            academiesInTrustPage
                 .checkPupilNumbersHeadersPresent();
         });
 
@@ -169,7 +169,7 @@ describe("Testing the components of the Academies page", () => {
                 .checkCurrentURLIsCorrect('/trusts/academies/free-school-meals?uid=5527')
                 .checkAllServiceNavItemsPresent()
                 .checkAllAcademiesNavItemsPresent();
-            academiesPage
+            academiesInTrustPage
                 .checkFreeSchoolMealsHeadersPresent();
         });
 
@@ -180,7 +180,7 @@ describe("Testing the components of the Academies page", () => {
                 .checkCurrentURLIsCorrect('/trusts/academies/details?uid=5527')
                 .checkAllServiceNavItemsPresent()
                 .checkAllAcademiesNavItemsPresent();
-            academiesPage
+            academiesInTrustPage
                 .checkDetailsHeadersPresent();
         });
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/academies-in-trust.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/academies-in-trust.cy.ts
@@ -18,12 +18,12 @@ describe("Testing the components of the Academies page", () => {
     describe("Details tab", () => {
         beforeEach(() => {
             cy.login();
-            cy.visit('/trusts/academies/details?uid=5712');
+            cy.visit('/trusts/academies/in-trust/details?uid=5712');
         });
 
         it("Checks the browser title is correct", () => {
             commonPage
-                .checkThatBrowserTitleForTrustPageMatches('Details - Academies - {trustName} - Find information about academies and trusts');
+                .checkThatBrowserTitleForTrustPageMatches('Details - In this trust - Academies - {trustName} - Find information about academies and trusts');
         });
 
         it("Checks the correct details page headers are present", () => {
@@ -37,13 +37,13 @@ describe("Testing the components of the Academies page", () => {
         });
 
         it("Checks that a different and larger trusts correct school types are present", () => {
-            cy.visit('/trusts/academies/details?uid=5143');
+            cy.visit('/trusts/academies/in-trust/details?uid=5143');
             academiesInTrustPage
                 .checkSchoolTypesOnDetailsTable();
         });
 
         it("Checks the detail page sorting", () => {
-            cy.visit('/trusts/academies/details?uid=5143');
+            cy.visit('/trusts/academies/in-trust/details?uid=5143');
             academiesInTrustPage
                 .checkTrustDetailsSorting();
         });
@@ -55,7 +55,7 @@ describe("Testing the components of the Academies page", () => {
         });
 
         it('should match the academy count in the sidebar with the actual table row count on the Details page after visiting', () => {
-            cy.visit('/trusts/academies/details?uid=5143');
+            cy.visit('/trusts/academies/in-trust/details?uid=5143');
             academiesInTrustPage.getAcademyCountFromSidebar().then(expectedCount => {
                 academiesInTrustPage.getTableRowCountOnDetailsPage().should('eq', expectedCount);
             });
@@ -66,12 +66,12 @@ describe("Testing the components of the Academies page", () => {
     describe("Pupil numbers tab", () => {
         beforeEach(() => {
             cy.login();
-            cy.visit('/trusts/academies/pupil-numbers?uid=5712');
+            cy.visit('/trusts/academies/in-trust/pupil-numbers?uid=5712');
         });
 
         it("Checks the browser title is correct", () => {
             commonPage
-                .checkThatBrowserTitleForTrustPageMatches('Pupil numbers - Academies - {trustName} - Find information about academies and trusts');
+                .checkThatBrowserTitleForTrustPageMatches('Pupil numbers - In this trust - Academies - {trustName} - Find information about academies and trusts');
         });
 
         it("Checks the correct Pupil numbers page headers are present", () => {
@@ -91,14 +91,14 @@ describe("Testing the components of the Academies page", () => {
         });
 
         it('should match the academy count in the sidebar with the actual table row count on the Pupil numbers page after visiting', () => {
-            cy.visit('/trusts/academies/pupil-numbers?uid=5143');
+            cy.visit('/trusts/academies/in-trust/pupil-numbers?uid=5143');
             academiesInTrustPage.getAcademyCountFromSidebar().then(expectedCount => {
                 academiesInTrustPage.getTableRowCountOnPupilNumbersPage().should('eq', expectedCount);
             });
         });
 
         it("Checks the Pupil numbers page sorting on a larger trust", () => {
-            cy.visit('/trusts/academies/pupil-numbers?uid=5143');
+            cy.visit('/trusts/academies/in-trust/pupil-numbers?uid=5143');
             academiesInTrustPage
                 .checkPupilNumbersSorting();
         });
@@ -108,12 +108,12 @@ describe("Testing the components of the Academies page", () => {
     describe("Free school meals", () => {
         beforeEach(() => {
             cy.login();
-            cy.visit('/trusts/academies/free-school-meals?uid=5712');
+            cy.visit('/trusts/academies/in-trust/free-school-meals?uid=5143');
         });
 
         it("Checks the browser title is correct", () => {
             commonPage
-                .checkThatBrowserTitleForTrustPageMatches('Free school meals - Academies - {trustName} - Find information about academies and trusts');
+                .checkThatBrowserTitleForTrustPageMatches('Free school meals - In this trust - Academies - {trustName} - Find information about academies and trusts');
         });
 
         it("Checks the correct Free school meals page headers are present", () => {
@@ -133,30 +133,30 @@ describe("Testing the components of the Academies page", () => {
         });
 
         it('should match the academy count in the sidebar with the actual table row count on the Free school meals page after visiting', () => {
-            cy.visit('/trusts/academies/free-school-meals?uid=5143');
+            cy.visit('/trusts/academies/in-trust/free-school-meals?uid=5143');
             academiesInTrustPage.getAcademyCountFromSidebar().then(expectedCount => {
                 academiesInTrustPage.getTableRowCountOnFreeSchoolMealsPage().should('eq', expectedCount);
             });
         });
 
         it("Checks the Free school meals page sorting on a larger trust", () => {
-            cy.visit('/trusts/academies/free-school-meals?uid=5143');
+            cy.visit('/trusts/academies/in-trust/free-school-meals?uid=5143');
             academiesInTrustPage
                 .checkFreeSchoolMealsSorting();
         });
 
     });
 
-    describe("Testing the academies sub navigation", () => {
+    describe.only("Testing the academies sub navigation", () => {
         beforeEach(() => {
             cy.login();
-            cy.visit('/trusts/academies/details?uid=5527');
+            cy.visit('/trusts/academies/in-trust/details?uid=5527');
         });
 
         it('Should check that the academies Pupil numbers navigation button takes me to the correct page', () => {
             navigation
                 .clickPupilNumbersAcadmiesTrustButton()
-                .checkCurrentURLIsCorrect('/trusts/academies/pupil-numbers?uid=5527')
+                .checkCurrentURLIsCorrect('/trusts/academies/in-trust/pupil-numbers?uid=5527')
                 .checkAllServiceNavItemsPresent()
                 .checkAllAcademiesNavItemsPresent();
             academiesInTrustPage
@@ -166,7 +166,7 @@ describe("Testing the components of the Academies page", () => {
         it('Should check that the academies Free school meals navigation button takes me to the correct page', () => {
             navigation
                 .clickFreeSchoolMealsAcadmiesTrustButton()
-                .checkCurrentURLIsCorrect('/trusts/academies/free-school-meals?uid=5527')
+                .checkCurrentURLIsCorrect('/trusts/academies/in-trust/free-school-meals?uid=5527')
                 .checkAllServiceNavItemsPresent()
                 .checkAllAcademiesNavItemsPresent();
             academiesInTrustPage
@@ -174,10 +174,10 @@ describe("Testing the components of the Academies page", () => {
         });
 
         it('Should check that the academies Details navigation button takes me to the correct page', () => {
-            cy.visit('/trusts/academies/free-school-meals?uid=5527');
+            cy.visit('/trusts/academies/in-trust/free-school-meals?uid=5527');
             navigation
                 .clickDetailsAcadmiesTrustButton()
-                .checkCurrentURLIsCorrect('/trusts/academies/details?uid=5527')
+                .checkCurrentURLIsCorrect('/trusts/academies/in-trust/details?uid=5527')
                 .checkAllServiceNavItemsPresent()
                 .checkAllAcademiesNavItemsPresent();
             academiesInTrustPage
@@ -197,7 +197,7 @@ describe("Testing the components of the Academies page", () => {
             commonPage.interceptAndVerifyNo500Errors();
         });
 
-        ['/trusts/academies/details?uid=17728', '/trusts/academies/pupil-numbers?uid=17728', '/trusts/academies/free-school-meals?uid=17728'].forEach((url) => {
+        ['/trusts/academies/in-trust/details?uid=17728', '/trusts/academies/in-trust/pupil-numbers?uid=17728', '/trusts/academies/in-trust/free-school-meals?uid=17728'].forEach((url) => {
             it(`Should have no 500 error on ${url}`, () => {
                 cy.visit(url);
             });
@@ -210,7 +210,7 @@ describe("Testing the components of the Academies page", () => {
                 cy.login();
             });
 
-            [`/trusts/academies/details?uid=${uid}`, `/trusts/academies/pupil-numbers?uid=${uid}`, `/trusts/academies/free-school-meals?uid=${uid}`].forEach((url) => {
+            [`/trusts/academies/in-trust/details?uid=${uid}`, `/trusts/academies/in-trust/pupil-numbers?uid=${uid}`, `/trusts/academies/in-trust/free-school-meals?uid=${uid}`].forEach((url) => {
                 it(`Should have no unknown entries on ${url} for a ${typeOfTrust}`, () => {
                     cy.visit(url);
                     commonPage

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/contacts-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/contacts-page.cy.ts
@@ -118,7 +118,7 @@ describe("Testing the components of the Trust contacts page", () => {
 
             it("Checks the browser title is correct", () => {
                 commonPage
-                    .checkThatBrowserTitleForTrustPageMatches('In the trust - Contacts - {trustName} - Find information about academies and trusts');
+                    .checkThatBrowserTitleForTrustPageMatches('In this trust - Contacts - {trustName} - Find information about academies and trusts');
             });
 
             it("Checks the breadcrumb shows the correct page name", () => {
@@ -237,7 +237,7 @@ describe("Testing the components of the Trust contacts page", () => {
                 .checkTrustRelationshipManagerIsPresent();
         });
 
-        it('Should check that the contacts in the trust navigation button takes me to the correct page', () => {
+        it('Should check that the contacts in this trust navigation button takes me to the correct page', () => {
             cy.visit('/trusts/contacts/in-dfe?uid=5527');
 
             contactsPage

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/data-download-trust.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/data-download-trust.cy.ts
@@ -3,7 +3,7 @@ import dataDownload from "../../../pages/trusts/dataDownload";
 describe('Trust export and content verification', () => {
   beforeEach(() => {
     cy.login();
-    cy.visit('/trusts/academies/details?uid=5712');
+    cy.visit('/trusts/academies/in-trust/details?uid=5712');
 
     // Clear the downloads folder before running each test
     cy.task('checkForFiles', 'cypress/downloads').then((files) => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/ofsted-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/ofsted-page.cy.ts
@@ -17,69 +17,66 @@ const testTrustOfstedData = [
 
 describe("Testing the Ofsted page and its subpages ", () => {
 
-    testTrustOfstedData.forEach(({ typeOfTrust, uid }) => {
-        describe(`Testing the single headline grades page for a ${typeOfTrust}`, () => {
-            beforeEach(() => {
-                cy.login();
-                cy.visit(`/trusts/ofsted/single-headline-grades?uid=${uid}`);
-
-                cy.task('checkForFiles', 'cypress/downloads').then((files) => {
-                    if (files) {
-                        cy.task('clearDownloads', 'cypress/downloads');
-                    }
-                });
+    describe(`Testing the single headline grades page `, () => {
+        beforeEach(() => {
+            cy.login();
+            cy.task('checkForFiles', 'cypress/downloads').then((files) => {
+                if (files) {
+                    cy.task('clearDownloads', 'cypress/downloads');
+                }
             });
-
-            it("Checks the correct Ofsted single headline grades subpage header is present", () => {
-                ofstedPage
-                    .checkOfstedSHGPageHeaderPresent();
-            });
-
-            it("Checks the browser title is correct", () => {
-                commonPage
-                    .checkThatBrowserTitleForTrustPageMatches('Single headline grades - Ofsted - {trustName} - Find information about academies and trusts');
-            });
-
-            it("Checks the breadcrumb shows the correct page name", () => {
-                navigation
-                    .checkPageNameBreadcrumbPresent("Ofsted");
-            });
-
-            it("Checks the correct Ofsted single headline grades table headers are present", () => {
-                ofstedPage
-                    .checkOfstedSHGTableHeadersPresent();
-            });
-
-            it("Checks the Ofsted current ratings page sorting", () => {
-                ofstedPage
-                    .checkOfstedSHGSorting();
-            });
-
-            it("Checks that a trusts current and previous ratings correct judgement types are present", () => {
-                ofstedPage
-                    .checkSHGCurrentSHGJudgementsPresent()
-                    .checkSHGPreviousSHGJudgementsPresent()
-                    .checkSHGCurrentSHGBeforeOrAfterPresent()
-                    .checkSHGPreviousSHGBeforeOrAfterPresent();
-            });
-
-            it("Checks that the single headline grades dates are within the correct parameters", () => {
-                ofstedPage
-                    .checkSHGDateJoinedPresent()
-                    .checkSHGDateOfCurrentInspectionPresent()
-                    .checkSHGDateOfPreviousInspectionPresent();
-            });
-
-            it('should export academies data as an xlsx and verify it has downloaded and has content', () => {
-                ofstedPage
-                    .clickDownloadButton();
-                dataDownload
-                    .checkFileDownloaded()
-                    .checkFileHasContent()
-                    .deleteDownloadedFile();
-            });
-
         });
+
+        it("Checks the correct Ofsted single headline grades subpage header is present", () => {
+            cy.visit(`/trusts/ofsted/single-headline-grades?uid=5527`);
+            ofstedPage
+                .checkOfstedSHGPageHeaderPresent();
+        });
+
+        it("Checks the browser title is correct", () => {
+            commonPage
+                .checkThatBrowserTitleForTrustPageMatches('Single headline grades - Ofsted - {trustName} - Find information about academies and trusts');
+        });
+
+        it("Checks the breadcrumb shows the correct page name", () => {
+            navigation
+                .checkPageNameBreadcrumbPresent("Ofsted");
+        });
+
+        it("Checks the correct Ofsted single headline grades table headers are present", () => {
+            ofstedPage
+                .checkOfstedSHGTableHeadersPresent();
+        });
+
+        it("Checks the Ofsted current ratings page sorting", () => {
+            ofstedPage
+                .checkOfstedSHGSorting();
+        });
+
+        it("Checks that a trusts current and previous ratings correct judgement types are present", () => {
+            ofstedPage
+                .checkSHGCurrentSHGJudgementsPresent()
+                .checkSHGPreviousSHGJudgementsPresent()
+                .checkSHGCurrentSHGBeforeOrAfterPresent()
+                .checkSHGPreviousSHGBeforeOrAfterPresent();
+        });
+
+        it("Checks that the single headline grades dates are within the correct parameters", () => {
+            ofstedPage
+                .checkSHGDateJoinedPresent()
+                .checkSHGDateOfCurrentInspectionPresent()
+                .checkSHGDateOfPreviousInspectionPresent();
+        });
+
+        it('should export academies data as an xlsx and verify it has downloaded and has content', () => {
+            ofstedPage
+                .clickDownloadButton();
+            dataDownload
+                .checkFileDownloaded()
+                .checkFileHasContent()
+                .deleteDownloadedFile();
+        });
+
     });
 
     describe("Testing the Ofsted current ratings page ", () => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/ofsted-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/ofsted-page.cy.ts
@@ -25,10 +25,11 @@ describe("Testing the Ofsted page and its subpages ", () => {
                     cy.task('clearDownloads', 'cypress/downloads');
                 }
             });
+            cy.visit(`/trusts/ofsted/single-headline-grades?uid=5527`);
         });
 
         it("Checks the correct Ofsted single headline grades subpage header is present", () => {
-            cy.visit(`/trusts/ofsted/single-headline-grades?uid=5527`);
+
             ofstedPage
                 .checkOfstedSHGPageHeaderPresent();
         });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/pipeline-academies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/pipeline-academies.cy.ts
@@ -1,21 +1,38 @@
 import commonPage from "../../../pages/commonPage";
 import pipelineAcademiesPage from "../../../pages/trusts/pipelineAcademiesPage";
+import navigation from "../../../pages/navigation";
 
-const testTrustData = [
+const testPreAdvisoryData = [
     {
-        typeOfTrust: "single academy trust",
-        uid: 5527
+        uid: 16002
     },
     {
-        typeOfTrust: "multi academy trust",
-        uid: 5712
+        uid: 4921
+    }
+];
+
+const testPostAdvisoryData = [
+    {
+        uid: 17584
+    },
+    {
+        uid: 16857
+    }
+];
+
+const testFreeSchoolsData = [
+    {
+        uid: 17538
+    },
+    {
+        uid: 15786
     }
 ];
 
 describe("Testing the Pipeline academies pages", () => {
-    testTrustData.forEach(({ typeOfTrust, uid }) => {
 
-        describe(`On the Pre advisory board page for a ${typeOfTrust}`, () => {
+    describe(`On the Pre advisory board page for a trust`, () => {
+        testPreAdvisoryData.forEach(({ uid }) => {
             beforeEach(() => {
                 cy.login();
                 cy.visit(`/trusts/academies/pipeline/pre-advisory-board?uid=${uid}`);
@@ -26,13 +43,31 @@ describe("Testing the Pipeline academies pages", () => {
                     .checkThatBrowserTitleForTrustPageMatches('Pre advisory board - Pipeline academies - Academies - {trustName} - Find information about academies and trusts');
             });
 
-            it("Checks the correct Pipeline academies  subpage header is present", () => {
+            it("Checks the Pre advisory board Pipeline academies subpage header is present", () => {
                 pipelineAcademiesPage
-                    .checkOfstedSHGPageHeaderPresent();
+                    .checkPreAdvisoryPageHeaderPresent();
             });
-        });
 
-        describe(`On the Post advisory board page for a ${typeOfTrust}`, () => {
+            it("Checks the breadcrumb shows the correct page name", () => {
+                navigation
+                    .checkPageNameBreadcrumbPresent("Academies");
+            });
+
+            it("Checks the correct Pipeline academies Pre advisory board table headers are present", () => {
+                pipelineAcademiesPage
+                    .checkPreAdvisoryTableHeadersPresent();
+            });
+
+            it("Checks the Pipeline academies Pre advisory page sorting", () => {
+                pipelineAcademiesPage
+                    .checkPreAdvisoryTableSorting();
+            });
+
+        });
+    });
+
+    describe(`On the Post advisory board page for`, () => {
+        testPostAdvisoryData.forEach(({ uid }) => {
             beforeEach(() => {
                 cy.login();
                 cy.visit(`/trusts/academies/pipeline/post-advisory-board?uid=${uid}`);
@@ -42,9 +77,37 @@ describe("Testing the Pipeline academies pages", () => {
                 commonPage
                     .checkThatBrowserTitleForTrustPageMatches('Post advisory board - Pipeline academies - Academies - {trustName} - Find information about academies and trusts');
             });
-        });
 
-        describe(`On the Free schools page for a ${typeOfTrust}`, () => {
+            it("Checks the Post advisory board Pipeline academies subpage header is present", () => {
+                pipelineAcademiesPage
+                    .checkPostAdvisoryPageHeaderPresent();
+            });
+
+            it("Checks the breadcrumb shows the correct page name", () => {
+                navigation
+                    .checkPageNameBreadcrumbPresent("Academies");
+            });
+
+            it("Checks the correct Pipeline academies Post advisory board table headers are present", () => {
+                pipelineAcademiesPage
+                    .checkPostAdvisoryTableHeadersPresent();
+            });
+
+            it("Checks the Pipeline academies Post advisory page sorting", () => {
+                pipelineAcademiesPage
+                    .checkPostAdvisoryTableHeadersPresent();
+            });
+
+            it("Checks the Pipeline academies Post advisory page sorting", () => {
+                pipelineAcademiesPage
+                    .checkPostAdvisoryTableSorting();
+            });
+
+        });
+    });
+
+    describe(`On the Free schools page`, () => {
+        testFreeSchoolsData.forEach(({ uid }) => {
             beforeEach(() => {
                 cy.login();
                 cy.visit(`/trusts/academies/pipeline/free-schools?uid=${uid}`);
@@ -54,6 +117,58 @@ describe("Testing the Pipeline academies pages", () => {
                 commonPage
                     .checkThatBrowserTitleForTrustPageMatches('Free schools - Pipeline academies - Academies - {trustName} - Find information about academies and trusts');
             });
+
+            it("Checks the Free schools Pipeline academies subpage header is present", () => {
+                pipelineAcademiesPage
+                    .checkFreeSchoolsPageHeaderPresent();
+            });
+
+            it("Checks the breadcrumb shows the correct page name", () => {
+                navigation
+                    .checkPageNameBreadcrumbPresent("Academies");
+            });
+
+            it("Checks the correct Pipeline academies Free schools table headers are present", () => {
+                pipelineAcademiesPage
+                    .checkFreeSchoolsTableHeadersPresent();
+            });
+
+            it("Checks the Pipeline academies Free schools page sorting", () => {
+                pipelineAcademiesPage
+                    .checkFreeSchoolsTableHeadersPresent();
+            });
+
+            it("Checks the Pipeline academies Free schools page sorting", () => {
+                pipelineAcademiesPage
+                    .checkFreeSchoolsTableSorting();
+            });
+
         });
     });
+
+    describe.only(`On the pages with no pipeline academy data under them`, () => {
+
+        beforeEach(() => {
+            cy.login();
+        });
+
+        it("Checks the Pipeline academies Pre advisory page when an academy doesnt exist under it to ensure the correct message is displayed", () => {
+            cy.visit(`/trusts/academies/pipeline/pre-advisory-board?uid=5712`);
+            pipelineAcademiesPage
+                .checkPreAdvisoryNoAcademyPresent();
+        });
+
+        it("Checks the Pipeline academies Post advisory page when an academy doesnt exist under it to ensure the correct message is displayed", () => {
+            cy.visit(`/trusts/academies/pipeline/post-advisory-board?uid=5712`);
+            pipelineAcademiesPage
+                .checkPostAdvisoryNoAcademyPresent();
+        });
+
+        it("Checks the Pipeline academies Free schools page when an academy doesnt exist under it to ensure the correct message is displayed", () => {
+            cy.visit(`/trusts/academies/pipeline/free-schools?uid=5712`);
+            pipelineAcademiesPage
+                .checkFreeSchoolsNoAcademyPresent();
+        });
+    });
+
 });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/pipeline-academies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/pipeline-academies.cy.ts
@@ -1,4 +1,5 @@
 import commonPage from "../../../pages/commonPage";
+import pipelineAcademiesPage from "../../../pages/trusts/pipelineAcademiesPage";
 
 const testTrustData = [
     {
@@ -11,39 +12,47 @@ const testTrustData = [
     }
 ];
 
-describe.skip("Testing the Pipeline academies pages", () => {
+describe("Testing the Pipeline academies pages", () => {
     testTrustData.forEach(({ typeOfTrust, uid }) => {
 
         describe(`On the Pre advisory board page for a ${typeOfTrust}`, () => {
             beforeEach(() => {
                 cy.login();
-                cy.visit(`/trusts/contacts/editsfsolead?uid=${uid}`);
+                cy.visit(`/trusts/academies/pipeline/pre-advisory-board?uid=${uid}`);
             });
 
             it("Checks the browser title is correct", () => {
-                pipelineAcademiesPage;
+                commonPage
+                    .checkThatBrowserTitleForTrustPageMatches('Pre advisory board - Pipeline academies - Academies - {trustName} - Find information about academies and trusts');
+            });
+
+            it("Checks the correct Pipeline academies  subpage header is present", () => {
+                pipelineAcademiesPage
+                    .checkOfstedSHGPageHeaderPresent();
             });
         });
 
         describe(`On the Post advisory board page for a ${typeOfTrust}`, () => {
             beforeEach(() => {
                 cy.login();
-                cy.visit(`/trusts/contacts/editsfsolead?uid=${uid}`);
+                cy.visit(`/trusts/academies/pipeline/post-advisory-board?uid=${uid}`);
             });
 
             it("Checks the browser title is correct", () => {
-                pipelineAcademiesPage;
+                commonPage
+                    .checkThatBrowserTitleForTrustPageMatches('Post advisory board - Pipeline academies - Academies - {trustName} - Find information about academies and trusts');
             });
         });
 
         describe(`On the Free schools page for a ${typeOfTrust}`, () => {
             beforeEach(() => {
                 cy.login();
-                cy.visit(`/trusts/contacts/editsfsolead?uid=${uid}`);
+                cy.visit(`/trusts/academies/pipeline/free-schools?uid=${uid}`);
             });
 
             it("Checks the browser title is correct", () => {
-                pipelineAcademiesPage;
+                commonPage
+                    .checkThatBrowserTitleForTrustPageMatches('Free schools - Pipeline academies - Academies - {trustName} - Find information about academies and trusts');
             });
         });
     });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/pipeline-academies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/pipeline-academies.cy.ts
@@ -1,6 +1,7 @@
 import commonPage from "../../../pages/commonPage";
 import pipelineAcademiesPage from "../../../pages/trusts/pipelineAcademiesPage";
 import navigation from "../../../pages/navigation";
+import { TestDataStore } from "../../../support/test-data-store";
 
 const testPreAdvisoryData = [
     {
@@ -146,7 +147,7 @@ describe("Testing the Pipeline academies pages", () => {
         });
     });
 
-    describe.only(`On the pages with no pipeline academy data under them`, () => {
+    describe(`On the pages with no pipeline academy data under them`, () => {
 
         beforeEach(() => {
             cy.login();
@@ -168,6 +169,26 @@ describe("Testing the Pipeline academies pages", () => {
             cy.visit(`/trusts/academies/pipeline/free-schools?uid=5712`);
             pipelineAcademiesPage
                 .checkFreeSchoolsNoAcademyPresent();
+        });
+    });
+
+    describe("Testing a trust that has no ofsted data within it to ensure the issue of a 500 page appearing does not happen", () => {
+        beforeEach(() => {
+            cy.login();
+            commonPage
+                .interceptAndVerifyNo500Errors();
+        });
+
+        it(`Should have no 500 error on the Pre advisory page`, () => {
+            cy.visit(`/trusts/academies/pipeline/pre-advisory-board?uid=5712`);
+        });
+
+        it(`Should have no 500 error on the Post advisory page`, () => {
+            cy.visit(`/trusts/academies/pipeline/post-advisory-board?uid=5712`);
+        });
+
+        it(`Should have no 500 error on the free schools page`, () => {
+            cy.visit(`/trusts/academies/pipeline/free-schools?uid=5712`);
         });
     });
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/pipeline-academies.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/pipeline-academies.cy.ts
@@ -1,0 +1,50 @@
+import commonPage from "../../../pages/commonPage";
+
+const testTrustData = [
+    {
+        typeOfTrust: "single academy trust",
+        uid: 5527
+    },
+    {
+        typeOfTrust: "multi academy trust",
+        uid: 5712
+    }
+];
+
+describe.skip("Testing the Pipeline academies pages", () => {
+    testTrustData.forEach(({ typeOfTrust, uid }) => {
+
+        describe(`On the Pre advisory board page for a ${typeOfTrust}`, () => {
+            beforeEach(() => {
+                cy.login();
+                cy.visit(`/trusts/contacts/editsfsolead?uid=${uid}`);
+            });
+
+            it("Checks the browser title is correct", () => {
+                pipelineAcademiesPage;
+            });
+        });
+
+        describe(`On the Post advisory board page for a ${typeOfTrust}`, () => {
+            beforeEach(() => {
+                cy.login();
+                cy.visit(`/trusts/contacts/editsfsolead?uid=${uid}`);
+            });
+
+            it("Checks the browser title is correct", () => {
+                pipelineAcademiesPage;
+            });
+        });
+
+        describe(`On the Free schools page for a ${typeOfTrust}`, () => {
+            beforeEach(() => {
+                cy.login();
+                cy.visit(`/trusts/contacts/editsfsolead?uid=${uid}`);
+            });
+
+            it("Checks the browser title is correct", () => {
+                pipelineAcademiesPage;
+            });
+        });
+    });
+});

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/navigation.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/navigation.ts
@@ -4,22 +4,27 @@ class Navigation {
         privacyFooterButton: () => cy.contains('Privacy'),
         cookiesFooterButton: () => cy.get('[data-testid="cookies-footer-link"]'),
         accessibilityFooterButton: () => cy.contains('Accessibility'),
-
-
+        academyTypeNav: {
+            inThisTrustButton: () => cy.get('[data-testid="academies-in-this-trust-subnav"]'),
+            pipelineAcademiesButton: () => cy.get('[data-testid="academies-pipeline-academies-subnav"]'),
+        },
         serviceNav: {
             academiesServiceNavButton: () => cy.get('[data-testid="academies-nav"]'),
             contactsServiceNavButton: () => cy.get('[data-testid="contacts-nav"]'),
             governanceServiceNavButton: () => cy.get('[data-testid="governance-nav"]'),
             overviewServiceNavButton: () => cy.get('[data-testid="overview-nav"]'),
         },
-
         currentPageSubnavLinks: () => cy.get('.moj-sub-navigation__link'),
-
-        acadmiesSubNav: {
-            ofstedAcadmiesTrustButton: () => cy.get('[data-testid="ofsted-nav"]'),
-            pupilNumbersAcadmiesTrustButton: () => cy.get('#academies-pupil-numbers-link'),
-            freeSchoolMealsAcadmiesTrustButton: () => cy.get('#free-school-meals-link'),
-            detailsAcadmiesTrustButton: () => cy.get('#academies-details-link'),
+        acadmiesInTrustSubNav: {
+            academiesInTrustofstedButton: () => cy.get('[data-testid="ofsted-nav"]'),
+            academiesInTrustpupilNumbersButton: () => cy.get('[data-testid="in-this-trust-pupil-numbers-tab"]'),
+            academiesInTrustfreeSchoolMealsButton: () => cy.get('[data-testid="in-this-trust-free-school-meals-tab"]'),
+            academiesInTrustdetailsButton: () => cy.get('[data-testid="in-this-trust-details-tab"]'),
+        },
+        pipelineAcadmiesSubNav: {
+            pipelineAcademiesPreAdvisoryButton: () => cy.get('[data-testid="pipeline-pre-advisory-board-tab"]'),
+            pipelineAcademiesPostAdvisoryButton: () => cy.get('[data-testid="pipeline-post-advisory-board-tab"]'),
+            pipelineAcademiesFreeSchoolMealsButton: () => cy.get('[data-testid="pipeline-free-schools-tab"]'),
         },
         breadcrumbs: {
             breadcrumbParent: () => cy.get('[aria-label="Breadcrumb"]'),
@@ -151,36 +156,36 @@ class Navigation {
     }
 
     public clickOfstedAcadmiesTrustButton(): this {
-        this.elements.acadmiesSubNav.ofstedAcadmiesTrustButton().click();
+        this.elements.acadmiesInTrustSubNav.academiesInTrustofstedButton().click();
         return this;
     }
 
     public clickPupilNumbersAcadmiesTrustButton(): this {
-        this.elements.acadmiesSubNav.pupilNumbersAcadmiesTrustButton().click();
+        this.elements.acadmiesInTrustSubNav.academiesInTrustpupilNumbersButton().click();
         return this;
     }
 
     public clickFreeSchoolMealsAcadmiesTrustButton(): this {
-        this.elements.acadmiesSubNav.freeSchoolMealsAcadmiesTrustButton().click();
+        this.elements.acadmiesInTrustSubNav.academiesInTrustfreeSchoolMealsButton().click();
         return this;
     }
 
     public clickDetailsAcadmiesTrustButton(): this {
-        this.elements.acadmiesSubNav.detailsAcadmiesTrustButton().click();
+        this.elements.acadmiesInTrustSubNav.academiesInTrustdetailsButton().click();
         return this;
     }
 
     public checkAcademiesSubNavNotPresent(): this {
-        this.elements.acadmiesSubNav.detailsAcadmiesTrustButton().should('not.exist');
-        this.elements.acadmiesSubNav.pupilNumbersAcadmiesTrustButton().should('not.exist');
-        this.elements.acadmiesSubNav.freeSchoolMealsAcadmiesTrustButton().should('not.exist');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustdetailsButton().should('not.exist');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustpupilNumbersButton().should('not.exist');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustfreeSchoolMealsButton().should('not.exist');
         return this;
     }
 
     public checkAllAcademiesNavItemsPresent(): this {
-        this.elements.acadmiesSubNav.detailsAcadmiesTrustButton().should('be.visible');
-        this.elements.acadmiesSubNav.pupilNumbersAcadmiesTrustButton().should('be.visible');
-        this.elements.acadmiesSubNav.freeSchoolMealsAcadmiesTrustButton().should('be.visible');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustdetailsButton().should('be.visible');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustpupilNumbersButton().should('be.visible');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustfreeSchoolMealsButton().should('be.visible');
         return this;
     }
 
@@ -189,7 +194,32 @@ class Navigation {
         this.elements.serviceNav.contactsServiceNavButton().should('be.visible');
         this.elements.serviceNav.academiesServiceNavButton().should('be.visible');
         this.elements.serviceNav.governanceServiceNavButton().should('be.visible');
-        this.elements.acadmiesSubNav.ofstedAcadmiesTrustButton().should('be.visible');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustofstedButton().should('be.visible');
+        return this;
+    }
+
+    public clickAcademiesInThisTrustNavButton(): this {
+        this.elements.academyTypeNav.inThisTrustButton().click();
+        return this;
+    }
+
+    public clickPipelineAcademiesNavButton(): this {
+        this.elements.academyTypeNav.pipelineAcademiesButton().click();
+        return this;
+    }
+
+    public clickPipelineAcademiesPreAdvisoryNavButton(): this {
+        this.elements.pipelineAcadmiesSubNav.pipelineAcademiesPreAdvisoryButton().click();
+        return this;
+    }
+
+    public clickPipelineAcademiesPostAdvisoryNavButton(): this {
+        this.elements.pipelineAcadmiesSubNav.pipelineAcademiesPostAdvisoryButton().click();
+        return this;
+    }
+
+    public clickPipelineAcademiesFreeSchoolsNavButton(): this {
+        this.elements.pipelineAcadmiesSubNav.pipelineAcademiesFreeSchoolMealsButton().click();
         return this;
     }
 }

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/navigation.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/navigation.ts
@@ -16,12 +16,12 @@ class Navigation {
         },
         currentPageSubnavLinks: () => cy.get('.moj-sub-navigation__link'),
         acadmiesInTrustSubNav: {
-            academiesInTrustofstedButton: () => cy.get('[data-testid="ofsted-nav"]'),
-            academiesInTrustpupilNumbersButton: () => cy.get('[data-testid="in-this-trust-pupil-numbers-tab"]'),
-            academiesInTrustfreeSchoolMealsButton: () => cy.get('[data-testid="in-this-trust-free-school-meals-tab"]'),
-            academiesInTrustdetailsButton: () => cy.get('[data-testid="in-this-trust-details-tab"]'),
+            academiesInTrustOfstedButton: () => cy.get('[data-testid="ofsted-nav"]'),
+            academiesInTrustPupilNumbersButton: () => cy.get('[data-testid="in-this-trust-pupil-numbers-tab"]'),
+            academiesInTrustFreeSchoolMealsButton: () => cy.get('[data-testid="in-this-trust-free-school-meals-tab"]'),
+            academiesInTrustDetailsButton: () => cy.get('[data-testid="in-this-trust-details-tab"]'),
         },
-        pipelineAcadmiesSubNav: {
+        pipelineAcademiesSubNav: {
             pipelineAcademiesPreAdvisoryButton: () => cy.get('[data-testid="pipeline-pre-advisory-board-tab"]'),
             pipelineAcademiesPostAdvisoryButton: () => cy.get('[data-testid="pipeline-post-advisory-board-tab"]'),
             pipelineAcademiesFreeSchoolMealsButton: () => cy.get('[data-testid="pipeline-free-schools-tab"]'),
@@ -156,36 +156,36 @@ class Navigation {
     }
 
     public clickOfstedAcadmiesTrustButton(): this {
-        this.elements.acadmiesInTrustSubNav.academiesInTrustofstedButton().click();
+        this.elements.acadmiesInTrustSubNav.academiesInTrustOfstedButton().click();
         return this;
     }
 
     public clickPupilNumbersAcadmiesTrustButton(): this {
-        this.elements.acadmiesInTrustSubNav.academiesInTrustpupilNumbersButton().click();
+        this.elements.acadmiesInTrustSubNav.academiesInTrustPupilNumbersButton().click();
         return this;
     }
 
     public clickFreeSchoolMealsAcadmiesTrustButton(): this {
-        this.elements.acadmiesInTrustSubNav.academiesInTrustfreeSchoolMealsButton().click();
+        this.elements.acadmiesInTrustSubNav.academiesInTrustFreeSchoolMealsButton().click();
         return this;
     }
 
     public clickDetailsAcadmiesTrustButton(): this {
-        this.elements.acadmiesInTrustSubNav.academiesInTrustdetailsButton().click();
+        this.elements.acadmiesInTrustSubNav.academiesInTrustDetailsButton().click();
         return this;
     }
 
     public checkAcademiesSubNavNotPresent(): this {
-        this.elements.acadmiesInTrustSubNav.academiesInTrustdetailsButton().should('not.exist');
-        this.elements.acadmiesInTrustSubNav.academiesInTrustpupilNumbersButton().should('not.exist');
-        this.elements.acadmiesInTrustSubNav.academiesInTrustfreeSchoolMealsButton().should('not.exist');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustDetailsButton().should('not.exist');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustPupilNumbersButton().should('not.exist');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustFreeSchoolMealsButton().should('not.exist');
         return this;
     }
 
     public checkAllAcademiesNavItemsPresent(): this {
-        this.elements.acadmiesInTrustSubNav.academiesInTrustdetailsButton().should('be.visible');
-        this.elements.acadmiesInTrustSubNav.academiesInTrustpupilNumbersButton().should('be.visible');
-        this.elements.acadmiesInTrustSubNav.academiesInTrustfreeSchoolMealsButton().should('be.visible');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustDetailsButton().should('be.visible');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustPupilNumbersButton().should('be.visible');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustFreeSchoolMealsButton().should('be.visible');
         return this;
     }
 
@@ -194,7 +194,7 @@ class Navigation {
         this.elements.serviceNav.contactsServiceNavButton().should('be.visible');
         this.elements.serviceNav.academiesServiceNavButton().should('be.visible');
         this.elements.serviceNav.governanceServiceNavButton().should('be.visible');
-        this.elements.acadmiesInTrustSubNav.academiesInTrustofstedButton().should('be.visible');
+        this.elements.acadmiesInTrustSubNav.academiesInTrustOfstedButton().should('be.visible');
         return this;
     }
 
@@ -209,17 +209,17 @@ class Navigation {
     }
 
     public clickPipelineAcademiesPreAdvisoryNavButton(): this {
-        this.elements.pipelineAcadmiesSubNav.pipelineAcademiesPreAdvisoryButton().click();
+        this.elements.pipelineAcademiesSubNav.pipelineAcademiesPreAdvisoryButton().click();
         return this;
     }
 
     public clickPipelineAcademiesPostAdvisoryNavButton(): this {
-        this.elements.pipelineAcadmiesSubNav.pipelineAcademiesPostAdvisoryButton().click();
+        this.elements.pipelineAcademiesSubNav.pipelineAcademiesPostAdvisoryButton().click();
         return this;
     }
 
     public clickPipelineAcademiesFreeSchoolsNavButton(): this {
-        this.elements.pipelineAcadmiesSubNav.pipelineAcademiesFreeSchoolMealsButton().click();
+        this.elements.pipelineAcademiesSubNav.pipelineAcademiesFreeSchoolMealsButton().click();
         return this;
     }
 }

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesInTrustPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesInTrustPage.ts
@@ -1,6 +1,6 @@
 import { TableUtility } from "../tableUtility";
 
-class AcademiesPage {
+class AcademiesInTrustPage {
 
     elements = {
         pageTabs: {
@@ -149,5 +149,5 @@ class AcademiesPage {
     }
 }
 
-const academiesPage = new AcademiesPage();
-export default academiesPage;
+const academiesInTrustPage = new AcademiesInTrustPage();
+export default academiesInTrustPage;

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/contactsPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/contactsPage.ts
@@ -53,7 +53,7 @@ class ContactsPage {
 
         subNav: {
             contactsInDfeSubnavButton: () => cy.get('[data-testid="contacts-in-dfe-subnav"]'),
-            contactsInTheTrustSubnavButton: () => cy.get('[data-testid="contacts-in-the-trust-subnav"]'),
+            contactsInTheTrustSubnavButton: () => cy.get('[data-testid="contacts-in-this-trust-subnav"]'),
         },
         subHeaders: {
             subHeader: () => cy.get('[data-testid="subpage-header"]'),
@@ -215,7 +215,7 @@ class ContactsPage {
 
     public checkContactsInTheTrustSubHeaderPresent(): this {
         this.elements.subHeaders.subHeader().should('be.visible');
-        this.elements.subHeaders.subHeader().should('contain', 'Contacts in the trust');
+        this.elements.subHeaders.subHeader().should('contain', 'Contacts in this trust');
         return this;
     }
 }

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/pipelineAcademiesPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/pipelineAcademiesPage.ts
@@ -3,6 +3,7 @@ import { TableUtility } from "../tableUtility";
 class PipelineAcademies {
 
     elements = {
+        subpageHeader: () => cy.get('[data-testid="subpage-header"]'),
         preAdvisory: {
             section: () => cy.get('[data-testid="pre-advisory-board-table"]'),
             schoolName: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-school-name"]'),
@@ -51,6 +52,11 @@ class PipelineAcademies {
         },
 
     };
+
+    public checkOfstedSHGPageHeaderPresent(): this {
+        this.elements.subpageHeader().should('contain', 'Single headline grades');
+        return this;
+    }
 
 }
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/pipelineAcademiesPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/pipelineAcademiesPage.ts
@@ -1,0 +1,59 @@
+import { TableUtility } from "../tableUtility";
+
+class PipelineAcademies {
+
+    elements = {
+        preAdvisory: {
+            section: () => cy.get('[data-testid="pre-advisory-board-table"]'),
+            schoolName: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-school-name"]'),
+            schoolNameHeader: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-school-name-header"]'),
+            urn: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-URN"]'),
+            urnHeader: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-URN-header"]'),
+            ageRange: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-age-range"]'),
+            ageRangeHeader: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-age-range-header"]'),
+            localAuthority: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-local-authority"]'),
+            localAuthorityHeader: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-local-authority-header"]'),
+            projectType: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-project-type"]'),
+            projectTypeHeader: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-project-type-header"]'),
+            proposedConversionTransferDate: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-conversion-transfer-date"]'),
+            proposedConversionTransferDateHeader: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-conversion-transfer-date-header"]'),
+        },
+        postAdvisory: {
+            section: () => cy.get('[data-testid="post-advisory-board-table"]'),
+            schoolName: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-school-name"]'),
+            schoolNameHeader: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-school-name-header"]'),
+            urn: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-URN"]'),
+            urnHeader: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-URN-header"]'),
+            ageRange: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-age-range"]'),
+            ageRangeHeader: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-age-range-header"]'),
+            localAuthority: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-local-authority"]'),
+            localAuthorityHeader: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-local-authority-header"]'),
+            projectType: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-project-type"]'),
+            projectTypeHeader: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-project-type-header"]'),
+            proposedConversionTransferDate: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-conversion-transfer-date"]'),
+            proposedConversionTransferDateHeader: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-conversion-transfer-date-header"]'),
+
+        },
+        freeSchools: {
+            section: () => cy.get('[data-testid="free-schools-table"]'),
+            schoolName: () => this.elements.freeSchools.section().find('[data-testid="free-schools-school-name"]'),
+            schoolNameHeader: () => this.elements.freeSchools.section().find('[data-testid="free-schools-school-name-header"]'),
+            urn: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-URN"]'),
+            urnHeader: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-URN-header"]'),
+            ageRange: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-age-range"]'),
+            ageRangeHeader: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-age-range-header"]'),
+            localAuthority: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-local-authority"]'),
+            localAuthorityHeader: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-local-authority-header"]'),
+            projectType: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-project-type"]'),
+            projectTypeHeader: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-project-type-header"]'),
+            proposedConversionTransferDate: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-conversion-transfer-date"]'),
+            proposedConversionTransferDateHeader: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-conversion-transfer-date-header"]'),
+        },
+
+    };
+
+}
+
+const pipelineAcademiesPage = new PipelineAcademies();
+export default pipelineAcademiesPage;
+

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/pipelineAcademiesPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/pipelineAcademiesPage.ts
@@ -4,6 +4,7 @@ class PipelineAcademies {
 
     elements = {
         subpageHeader: () => cy.get('[data-testid="subpage-header"]'),
+        emptyStateMessage: () => cy.get('[data-testid="empty-state-message"]'),
         preAdvisory: {
             section: () => cy.get('[data-testid="pre-advisory-board-table"]'),
             schoolName: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-school-name"]'),
@@ -16,45 +17,184 @@ class PipelineAcademies {
             localAuthorityHeader: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-local-authority-header"]'),
             projectType: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-project-type"]'),
             projectTypeHeader: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-project-type-header"]'),
-            proposedConversionTransferDate: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-conversion-transfer-date"]'),
-            proposedConversionTransferDateHeader: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-conversion-transfer-date-header"]'),
+            proposedConversionTransferDate: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-date"]'),
+            proposedConversionTransferDateHeader: () => this.elements.preAdvisory.section().find('[data-testid="pre-advisory-board-proposed-conversion-transfer-date-header"]'),
         },
         postAdvisory: {
             section: () => cy.get('[data-testid="post-advisory-board-table"]'),
             schoolName: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-school-name"]'),
             schoolNameHeader: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-school-name-header"]'),
-            urn: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-URN"]'),
-            urnHeader: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-URN-header"]'),
-            ageRange: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-age-range"]'),
-            ageRangeHeader: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-age-range-header"]'),
-            localAuthority: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-local-authority"]'),
-            localAuthorityHeader: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-local-authority-header"]'),
-            projectType: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-project-type"]'),
-            projectTypeHeader: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-project-type-header"]'),
-            proposedConversionTransferDate: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-conversion-transfer-date"]'),
-            proposedConversionTransferDateHeader: () => this.elements.postAdvisory.section().find('[data-testid="pre-advisory-board-conversion-transfer-date-header"]'),
+            urn: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-URN"]'),
+            urnHeader: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-URN-header"]'),
+            ageRange: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-age-range"]'),
+            ageRangeHeader: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-age-range-header"]'),
+            localAuthority: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-local-authority"]'),
+            localAuthorityHeader: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-local-authority-header"]'),
+            projectType: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-project-type"]'),
+            projectTypeHeader: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-project-type-header"]'),
+            proposedConversionTransferDate: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-conversion-transfer-date"]'),
+            proposedConversionTransferDateHeader: () => this.elements.postAdvisory.section().find('[data-testid="post-advisory-board-proposed-conversion-transfer-date-header"]'),
 
         },
         freeSchools: {
             section: () => cy.get('[data-testid="free-schools-table"]'),
-            schoolName: () => this.elements.freeSchools.section().find('[data-testid="free-schools-school-name"]'),
+            schoolName: () => this.elements.freeSchools.section().find('[data-testid="free-schools-board-school-name"]'),
             schoolNameHeader: () => this.elements.freeSchools.section().find('[data-testid="free-schools-school-name-header"]'),
-            urn: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-URN"]'),
-            urnHeader: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-URN-header"]'),
-            ageRange: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-age-range"]'),
-            ageRangeHeader: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-age-range-header"]'),
-            localAuthority: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-local-authority"]'),
-            localAuthorityHeader: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-local-authority-header"]'),
-            projectType: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-project-type"]'),
-            projectTypeHeader: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-project-type-header"]'),
-            proposedConversionTransferDate: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-conversion-transfer-date"]'),
-            proposedConversionTransferDateHeader: () => this.elements.freeSchools.section().find('[data-testid="pre-advisory-board-conversion-transfer-date-header"]'),
+            urn: () => this.elements.freeSchools.section().find('[data-testid="free-schools-URN"]'),
+            urnHeader: () => this.elements.freeSchools.section().find('[data-testid="free-schools-URN-header"]'),
+            ageRange: () => this.elements.freeSchools.section().find('[data-testid="free-schools-age-range"]'),
+            ageRangeHeader: () => this.elements.freeSchools.section().find('[data-testid="free-schools-age-range-header"]'),
+            localAuthority: () => this.elements.freeSchools.section().find('[data-testid="free-schools-local-authority"]'),
+            localAuthorityHeader: () => this.elements.freeSchools.section().find('[data-testid="free-schools-local-authority-header"]'),
+            projectType: () => this.elements.freeSchools.section().find('[data-testid="free-schools-project-type"]'),
+            projectTypeHeader: () => this.elements.freeSchools.section().find('[data-testid="free-schools-project-type-header"]'),
+            proposedConversionTransferDate: () => this.elements.freeSchools.section().find('[data-testid="free-schools-provisional-opening-date"]'),
+            proposedConversionTransferDateHeader: () => this.elements.freeSchools.section().find('[data-testid="free-schools-provisional-opening-date-header"]'),
         },
 
     };
 
-    public checkOfstedSHGPageHeaderPresent(): this {
-        this.elements.subpageHeader().should('contain', 'Single headline grades');
+    public checkPreAdvisoryPageHeaderPresent(): this {
+        this.elements.subpageHeader().should('contain', 'Pre advisory board');
+        return this;
+    }
+
+    public checkPreAdvisoryTableHeadersPresent(): this {
+        this.elements.preAdvisory.schoolNameHeader().should('be.visible');
+        this.elements.preAdvisory.urnHeader().should('be.visible');
+        this.elements.preAdvisory.ageRangeHeader().should('be.visible');
+        this.elements.preAdvisory.localAuthorityHeader().should('be.visible');
+        this.elements.preAdvisory.projectTypeHeader().should('be.visible');
+        this.elements.preAdvisory.proposedConversionTransferDateHeader().should('be.visible');
+        return this;
+    }
+
+    public checkPreAdvisoryTableSorting(): this {
+        TableUtility.checkStringSorting(
+            this.elements.preAdvisory.schoolName,
+            this.elements.preAdvisory.schoolNameHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.preAdvisory.urn,
+            this.elements.preAdvisory.urnHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.preAdvisory.ageRange,
+            this.elements.preAdvisory.ageRangeHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.preAdvisory.localAuthority,
+            this.elements.preAdvisory.localAuthorityHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.preAdvisory.projectType,
+            this.elements.preAdvisory.projectTypeHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.preAdvisory.proposedConversionTransferDate,
+            this.elements.preAdvisory.proposedConversionTransferDateHeader
+        );
+        return this;
+    }
+
+    public checkPostAdvisoryPageHeaderPresent(): this {
+        this.elements.subpageHeader().should('contain', 'Post advisory board');
+        return this;
+    }
+
+    public checkPostAdvisoryTableHeadersPresent(): this {
+        this.elements.postAdvisory.schoolNameHeader().should('be.visible');
+        this.elements.postAdvisory.urnHeader().should('be.visible');
+        this.elements.postAdvisory.ageRangeHeader().should('be.visible');
+        this.elements.postAdvisory.localAuthorityHeader().should('be.visible');
+        this.elements.postAdvisory.projectTypeHeader().should('be.visible');
+        this.elements.postAdvisory.proposedConversionTransferDateHeader().should('be.visible');
+        return this;
+    }
+
+    public checkPostAdvisoryTableSorting(): this {
+        TableUtility.checkStringSorting(
+            this.elements.postAdvisory.schoolName,
+            this.elements.postAdvisory.schoolNameHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.postAdvisory.urn,
+            this.elements.postAdvisory.urnHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.postAdvisory.ageRange,
+            this.elements.postAdvisory.ageRangeHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.postAdvisory.localAuthority,
+            this.elements.postAdvisory.localAuthorityHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.postAdvisory.projectType,
+            this.elements.postAdvisory.projectTypeHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.postAdvisory.proposedConversionTransferDate,
+            this.elements.postAdvisory.proposedConversionTransferDateHeader
+        );
+        return this;
+    }
+
+    public checkFreeSchoolsPageHeaderPresent(): this {
+        this.elements.subpageHeader().should('contain', 'Free schools');
+        return this;
+    }
+
+    public checkFreeSchoolsTableHeadersPresent(): this {
+        this.elements.freeSchools.schoolNameHeader().should('be.visible');
+        this.elements.freeSchools.urnHeader().should('be.visible');
+        this.elements.freeSchools.ageRangeHeader().should('be.visible');
+        this.elements.freeSchools.localAuthorityHeader().should('be.visible');
+        this.elements.freeSchools.projectTypeHeader().should('be.visible');
+        this.elements.freeSchools.proposedConversionTransferDateHeader().should('be.visible');
+        return this;
+    }
+
+    public checkFreeSchoolsTableSorting(): this {
+        TableUtility.checkStringSorting(
+            this.elements.freeSchools.schoolName,
+            this.elements.freeSchools.schoolNameHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.freeSchools.urn,
+            this.elements.freeSchools.urnHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.freeSchools.ageRange,
+            this.elements.freeSchools.ageRangeHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.freeSchools.localAuthority,
+            this.elements.freeSchools.localAuthorityHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.freeSchools.projectType,
+            this.elements.freeSchools.projectTypeHeader
+        );
+        TableUtility.checkStringSorting(
+            this.elements.freeSchools.proposedConversionTransferDate,
+            this.elements.freeSchools.proposedConversionTransferDateHeader
+        );
+        return this;
+    }
+
+    public checkPreAdvisoryNoAcademyPresent(): this {
+        this.elements.emptyStateMessage().should('contain', 'There are no pre advisory board academies in the pipeline for this trust');
+        return this;
+    }
+
+    public checkPostAdvisoryNoAcademyPresent(): this {
+        this.elements.emptyStateMessage().should('contain', 'There are no post advisory board academies in the pipeline for this trust');
+        return this;
+    }
+
+    public checkFreeSchoolsNoAcademyPresent(): this {
+        this.elements.emptyStateMessage().should('contain', 'There are no free schools in the pipeline for this trust.');
         return this;
     }
 


### PR DESCRIPTION
Adding pipeline academy tests to cover:
- Navigation
- Pathways
- Table functionality
- Refactor existing tests for 'in trust'
- Fixed URLs to now contain /in-trust/ where needed
- Split academy PO into pipeline and inTrust

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] Testing complete - all manual and automated tests pass
