### PR TITLE
Update ofsted data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased][unreleased]
 
 - Updated accessibility statement text
+- Removed 'Date joined trust' from Ofsted data source list
 
 ## [Release-19][release-19] (production-2025-01-20.4730)
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/OfstedAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/OfstedAreaModel.cs
@@ -57,13 +57,11 @@ public class OfstedAreaModel(
 
         DataSourcesPerPage.AddRange([
             new DataSourcePageListEntry(ViewConstants.OfstedCurrentRatingsPageName, [
-                    dateJoinedTrust,
                     new DataSourceListEntry(misDataSource, "Current Ofsted rating"),
                     new DataSourceListEntry(misDataSource, "Date of current inspection")
                 ]
             ),
             new DataSourcePageListEntry(ViewConstants.OfstedPreviousRatingsPageName, [
-                    dateJoinedTrust,
                     new DataSourceListEntry(misDataSource, "Previous Ofsted rating"),
                     new DataSourceListEntry(misDataSource, "Date of previous inspection")
                 ]
@@ -75,7 +73,6 @@ public class OfstedAreaModel(
                 ]
             ),
             new DataSourcePageListEntry(ViewConstants.OfstedSafeguardingAndConcernsPageName, [
-                    dateJoinedTrust,
                     new DataSourceListEntry(misDataSource, "Effective safeguarding"),
                     new DataSourceListEntry(misDataSource, "Category of concern"),
                     new DataSourceListEntry(misDataSource, "Date of current inspection")

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/OfstedAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/OfstedAreaModelTests.cs
@@ -64,13 +64,11 @@ public class OfstedAreaModelTests
         _sut.DataSourcesPerPage.Count.Should().Be(4);
         _sut.DataSourcesPerPage.Should().BeEquivalentTo([
             new DataSourcePageListEntry(ViewConstants.OfstedCurrentRatingsPageName, [
-                    new DataSourceListEntry(_giasDataSource, "Date joined trust"),
                     new DataSourceListEntry(_misDataSource, "Current Ofsted rating"),
                     new DataSourceListEntry(_misDataSource, "Date of current inspection")
                 ]
             ),
             new DataSourcePageListEntry(ViewConstants.OfstedPreviousRatingsPageName, [
-                    new DataSourceListEntry(_giasDataSource, "Date joined trust"),
                     new DataSourceListEntry(_misDataSource, "Previous Ofsted rating"),
                     new DataSourceListEntry(_misDataSource, "Date of previous inspection")
                 ]
@@ -82,7 +80,6 @@ public class OfstedAreaModelTests
                 ]
             ),
             new DataSourcePageListEntry(ViewConstants.OfstedSafeguardingAndConcernsPageName, [
-                    new DataSourceListEntry(_giasDataSource, "Date joined trust"),
                     new DataSourceListEntry(_misDataSource, "Effective safeguarding"),
                     new DataSourceListEntry(_misDataSource, "Category of concern"),
                     new DataSourceListEntry(_misDataSource, "Date of current inspection")


### PR DESCRIPTION
_Removed the 'date joined trust' line from ofsted data sources where no longer relevant_

[User Story 196655](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/196655): Sources and updates - Ofsted - Update data returned to be clearer what its pulling it for

## Changes

_Removed the 'date joined trust' line from 'where this information came from' section for current ratings, previous ratings, and safeguarding and concerns_

## Screenshots of UI changes

### Before

![Screenshot 2025-01-22 093836](https://github.com/user-attachments/assets/c6710864-48ab-4f79-a1b1-4d7054c2bb63)

### After

![Screenshot 2025-01-22 093911](https://github.com/user-attachments/assets/efb69d00-0ab4-4aa8-87d0-4461f0920351)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
