### PR TITLE
Fix Ofsted SHG column width

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml
@@ -28,26 +28,32 @@
   <table class="govuk-table" data-module="moj-sortable-table">
     <caption class="govuk-table__caption govuk-table__caption--m" data-testid="subpage-header">Single headline grades</caption>
     <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header govuk-body" aria-sort="ascending" data-testid="ofsted-single-headline-grades-school-name-header">
-          School name
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-date" aria-sort="none" data-testid="ofsted-single-headline-grades-date-joined-header">
-          Date joined
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body" aria-sort="none" data-testid="ofsted-single-headline-grades-current-single-headline-grade-header">
-          Current single headline grade
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-date" aria-sort="none" data-testid="ofsted-single-headline-grades-date-of-current-inspection-header">
-          Date of current inspection
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body" aria-sort="none" data-testid="ofsted-single-headline-grades-previous-single-headline-grade-header">
-          Previous single headline grade
-        </th>
-        <th scope="col" class="govuk-table__header govuk-body column-header-date" aria-sort="none" data-testid="ofsted-single-headline-grades-date-of-previous-inspection-header">
-          Date of previous inspection
-        </th>
-      </tr>
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-body" aria-sort="ascending"
+          data-testid="ofsted-single-headline-grades-school-name-header">
+        School name
+      </th>
+      <th scope="col" class="govuk-table__header govuk-body column-header-date" aria-sort="none"
+          data-testid="ofsted-single-headline-grades-date-joined-header">
+        Date joined
+      </th>
+      <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-single-headline-grade" aria-sort="none"
+          data-testid="ofsted-single-headline-grades-current-single-headline-grade-header">
+        Current single headline grade
+      </th>
+      <th scope="col" class="govuk-table__header govuk-body column-header-date" aria-sort="none"
+          data-testid="ofsted-single-headline-grades-date-of-current-inspection-header">
+        Date of current inspection
+      </th>
+      <th scope="col" class="govuk-table__header govuk-body column-header-ofsted-single-headline-grade" aria-sort="none"
+          data-testid="ofsted-single-headline-grades-previous-single-headline-grade-header">
+        Previous single headline grade
+      </th>
+      <th scope="col" class="govuk-table__header govuk-body column-header-date" aria-sort="none"
+          data-testid="ofsted-single-headline-grades-date-of-previous-inspection-header">
+        Date of previous inspection
+      </th>
+    </tr>
     </thead>
     <tbody class="govuk-table__body">
       @foreach (var academy in Model.Academies)

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss
@@ -19,17 +19,20 @@
     }
   }
 
+  .column-header-ofsted-rating {
+    width: 10%;
+  }
+
   .column-header-date {
     width: 15%;
   }
 
-  .column-header-ofsted-concern,
-  .column-header-ofsted-date {
-    width: 18%;
+  .column-header-ofsted-single-headline-grade {
+    width: 17%;
   }
 
-  .column-header-ofsted-rating {
-    width: 10%;
+  .column-header-ofsted-concern {
+    width: 18%;
   }
 
   .cell-ofsted-single-headline-grade {


### PR DESCRIPTION
On some trusts the before joining tag was breaking over two lines. Setting the column width to 17% mitigates this when 100% zoom.

[User Story 193769](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/193769): Build: Ofsted single headline grades

## Changes

- Set SHG columns to 17%
- Clean up `DfE.FindInformationAcademiesTrusts/assets/sass/components/_table.scss` to remove unused class

## Screenshots of UI changes

### Before

![image](https://github.com/user-attachments/assets/8d178077-9db7-445c-b947-cb784fd898fc)

### After

![image](https://github.com/user-attachments/assets/645ec23f-dfae-4ef0-a406-e9f8b39b1e47)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
~ADR decision log updated (if needed)~
~Release notes added to CHANGELOG.md~ - covered by existing release notes which add the page
- [ ] Testing complete - all manual and automated tests pass
