### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.sh text eol=lf


### PR DESCRIPTION
This tells Git to always use LF line endings for files ending in .sh, regardless of the operating system where the file is checked out.
