### PR TITLE
Update ofsted download to include single headline grades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Changed Ofsted data download to include single headline grades
+
 ## [Release-20][release-20](production-2025-02-04.4852)
 
 ### Added

--- a/DfE.FindInformationAcademiesTrusts/Services/Export/ExportService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Export/ExportService.cs
@@ -177,16 +177,18 @@ public class ExportService(IAcademyRepository academyRepository, ITrustRepositor
         {
             "School Name",
             "Date Joined",
-            "Date of Current Inspection",
+            "Current single headline grade",
             BeforeOrAfterJoiningHeader,
+            "Date of Current Inspection",
+            "Previous single headline grade",
+            BeforeOrAfterJoiningHeader,
+            "Date of previous inspection",
             "Quality of Education",
             "Behaviour and Attitudes",
             "Personal Development",
             "Leadership and Management",
             "Early Years Provision",
             "Sixth Form Provision",
-            "Date of Previous Inspection",
-            BeforeOrAfterJoiningHeader,
             "Previous Quality of Education",
             "Previous Behaviour and Attitudes",
             "Previous Personal Development",
@@ -244,8 +246,8 @@ public class ExportService(IAcademyRepository academyRepository, ITrustRepositor
         // Date Joined Trust
         SetDateCell(worksheet, rowNumber, 2, ofstedData?.DateAcademyJoinedTrust);
 
-        // Current Inspection Date
-        SetDateCell(worksheet, rowNumber, 3, currentRating.InspectionDate);
+        // Current Single Headline Grade
+        SetTextCell(worksheet, rowNumber, 3, currentRating.OverallEffectiveness.ToDisplayString(true));
 
         // Before/After Joining (Current)
         SetTextCell(worksheet, rowNumber, 4,
@@ -256,20 +258,14 @@ public class ExportService(IAcademyRepository academyRepository, ITrustRepositor
             )
         );
 
-        // Current Ratings
-        SetTextCell(worksheet, rowNumber, 5, currentRating.QualityOfEducation.ToDisplayString(true));
-        SetTextCell(worksheet, rowNumber, 6, currentRating.BehaviourAndAttitudes.ToDisplayString(true));
-        SetTextCell(worksheet, rowNumber, 7, currentRating.PersonalDevelopment.ToDisplayString(true));
-        SetTextCell(worksheet, rowNumber, 8,
-            currentRating.EffectivenessOfLeadershipAndManagement.ToDisplayString(true));
-        SetTextCell(worksheet, rowNumber, 9, currentRating.EarlyYearsProvision.ToDisplayString(true));
-        SetTextCell(worksheet, rowNumber, 10, currentRating.SixthFormProvision.ToDisplayString(true));
+        // Current Inspection Date
+        SetDateCell(worksheet, rowNumber, 5, currentRating.InspectionDate);
 
-        // Previous Inspection Date
-        SetDateCell(worksheet, rowNumber, 11, previousRating.InspectionDate);
+        // Previous Single Headline Grade
+        SetTextCell(worksheet, rowNumber, 6, previousRating.OverallEffectiveness.ToDisplayString(false));
 
         // Before/After Joining (Previous)
-        SetTextCell(worksheet, rowNumber, 12,
+        SetTextCell(worksheet, rowNumber, 7,
             IsOfstedRatingBeforeOrAfterJoining(
                 previousRating.OverallEffectiveness,
                 ofstedData?.DateAcademyJoinedTrust,
@@ -277,20 +273,32 @@ public class ExportService(IAcademyRepository academyRepository, ITrustRepositor
             )
         );
 
+        // Previous Inspection Date
+        SetDateCell(worksheet, rowNumber, 8, previousRating.InspectionDate);
+
+        // Current Ratings
+        SetTextCell(worksheet, rowNumber, 9, currentRating.QualityOfEducation.ToDisplayString(true));
+        SetTextCell(worksheet, rowNumber, 10, currentRating.BehaviourAndAttitudes.ToDisplayString(true));
+        SetTextCell(worksheet, rowNumber, 11, currentRating.PersonalDevelopment.ToDisplayString(true));
+        SetTextCell(worksheet, rowNumber, 12,
+            currentRating.EffectivenessOfLeadershipAndManagement.ToDisplayString(true));
+        SetTextCell(worksheet, rowNumber, 13, currentRating.EarlyYearsProvision.ToDisplayString(true));
+        SetTextCell(worksheet, rowNumber, 14, currentRating.SixthFormProvision.ToDisplayString(true));
+
         // Previous Ratings
-        SetTextCell(worksheet, rowNumber, 13, previousRating.QualityOfEducation.ToDisplayString(false));
-        SetTextCell(worksheet, rowNumber, 14, previousRating.BehaviourAndAttitudes.ToDisplayString(false));
-        SetTextCell(worksheet, rowNumber, 15, previousRating.PersonalDevelopment.ToDisplayString(false));
-        SetTextCell(worksheet, rowNumber, 16,
+        SetTextCell(worksheet, rowNumber, 15, previousRating.QualityOfEducation.ToDisplayString(false));
+        SetTextCell(worksheet, rowNumber, 16, previousRating.BehaviourAndAttitudes.ToDisplayString(false));
+        SetTextCell(worksheet, rowNumber, 17, previousRating.PersonalDevelopment.ToDisplayString(false));
+        SetTextCell(worksheet, rowNumber, 18,
             previousRating.EffectivenessOfLeadershipAndManagement.ToDisplayString(false));
-        SetTextCell(worksheet, rowNumber, 17, previousRating.EarlyYearsProvision.ToDisplayString(false));
-        SetTextCell(worksheet, rowNumber, 18, previousRating.SixthFormProvision.ToDisplayString(false));
+        SetTextCell(worksheet, rowNumber, 19, previousRating.EarlyYearsProvision.ToDisplayString(false));
+        SetTextCell(worksheet, rowNumber, 20, previousRating.SixthFormProvision.ToDisplayString(false));
 
         // Safeguarding Effective
-        SetTextCell(worksheet, rowNumber, 19, currentRating.SafeguardingIsEffective.ToDisplayString());
+        SetTextCell(worksheet, rowNumber, 21, currentRating.SafeguardingIsEffective.ToDisplayString());
 
         // Category of Concern
-        SetTextCell(worksheet, rowNumber, 20, currentRating.CategoryOfConcern.ToDisplayString());
+        SetTextCell(worksheet, rowNumber, 22, currentRating.CategoryOfConcern.ToDisplayString());
     }
 
     private static void SetDateCell(IXLWorksheet worksheet, int row, int column, DateTime? dateValue)

--- a/docs/run-tests-locally.md
+++ b/docs/run-tests-locally.md
@@ -103,7 +103,7 @@ You will be able to find all reports in the `StrykerOutput` folder in your proje
 
     ```json
     {
-      "URL": "localhost",
+      "URL": "http://localhost",
       "AUTH_KEY": "<the TestOverride__CypressTestSecret value you set in step 2>"
     }
     ```

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServiceTests.cs
@@ -4,6 +4,7 @@ using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using DocumentFormat.OpenXml.Wordprocessing;
 using FluentAssertions.Execution;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
@@ -400,26 +401,28 @@ public class ExportServiceTests
         var worksheet = workbook.Worksheet("Ofsted");
 
         // Verify headers on row 3
-        worksheet.Cell(3, 1).Value.ToString().Should().Be("School Name");
-        worksheet.Cell(3, 2).Value.ToString().Should().Be("Date Joined");
-        worksheet.Cell(3, 3).Value.ToString().Should().Be("Date of Current Inspection");
-        worksheet.Cell(3, 4).Value.ToString().Should().Be("Before/After Joining");
-        worksheet.Cell(3, 5).Value.ToString().Should().Be("Quality of Education");
-        worksheet.Cell(3, 6).Value.ToString().Should().Be("Behaviour and Attitudes");
-        worksheet.Cell(3, 7).Value.ToString().Should().Be("Personal Development");
-        worksheet.Cell(3, 8).Value.ToString().Should().Be("Leadership and Management");
-        worksheet.Cell(3, 9).Value.ToString().Should().Be("Early Years Provision");
-        worksheet.Cell(3, 10).Value.ToString().Should().Be("Sixth Form Provision");
-        worksheet.Cell(3, 11).Value.ToString().Should().Be("Date of Previous Inspection");
-        worksheet.Cell(3, 12).Value.ToString().Should().Be("Before/After Joining");
-        worksheet.Cell(3, 13).Value.ToString().Should().Be("Previous Quality of Education");
-        worksheet.Cell(3, 14).Value.ToString().Should().Be("Previous Behaviour and Attitudes");
-        worksheet.Cell(3, 15).Value.ToString().Should().Be("Previous Personal Development");
-        worksheet.Cell(3, 16).Value.ToString().Should().Be("Previous Leadership and Management");
-        worksheet.Cell(3, 17).Value.ToString().Should().Be("Previous Early Years Provision");
-        worksheet.Cell(3, 18).Value.ToString().Should().Be("Previous Sixth Form Provision");
-        worksheet.Cell(3, 19).Value.ToString().Should().Be("Effective Safeguarding");
-        worksheet.Cell(3, 20).Value.ToString().Should().Be("Category of Concern");
+        Cell(worksheet, 3, OfstedColumns.SchoolName).Should().Be("School Name");
+        Cell(worksheet, 3, OfstedColumns.DateJoined).Should().Be("Date Joined");
+        Cell(worksheet, 3, OfstedColumns.CurrentSingleHeadlineGrade).Should().Be("Current single headline grade");
+        Cell(worksheet, 3, OfstedColumns.CurrentBeforeAfterJoining).Should().Be("Before/After Joining");
+        Cell(worksheet, 3, OfstedColumns.DateOfCurrentInspection).Should().Be("Date of Current Inspection");
+        Cell(worksheet, 3, OfstedColumns.PreviousSingleHeadlineGrade).Should().Be("Previous single headline grade");
+        Cell(worksheet, 3, OfstedColumns.PreviousBeforeAfterJoining).Should().Be("Before/After Joining");
+        Cell(worksheet, 3, OfstedColumns.DateOfPreviousInspection).Should().Be("Date of previous inspection");
+        Cell(worksheet, 3, OfstedColumns.CurrentQualityOfEducation).Should().Be("Quality of Education");
+        Cell(worksheet, 3, OfstedColumns.CurrentBehaviourAndAttitudes).Should().Be("Behaviour and Attitudes");
+        Cell(worksheet, 3, OfstedColumns.CurrentPersonalDevelopment).Should().Be("Personal Development");
+        Cell(worksheet, 3, OfstedColumns.CurrentLeadershipAndManagement).Should().Be("Leadership and Management");
+        Cell(worksheet, 3, OfstedColumns.CurrentEarlyYearsProvision).Should().Be("Early Years Provision");
+        Cell(worksheet, 3, OfstedColumns.CurrentSixthFormProvision).Should().Be("Sixth Form Provision");
+        Cell(worksheet, 3, OfstedColumns.PreviousQualityOfEducation).Should().Be("Previous Quality of Education");
+        Cell(worksheet, 3, OfstedColumns.PreviousBehaviourAndAttitudes).Should().Be("Previous Behaviour and Attitudes");
+        Cell(worksheet, 3, OfstedColumns.PreviousPersonalDevelopment).Should().Be("Previous Personal Development");
+        Cell(worksheet, 3, OfstedColumns.PreviousLeadershipAndManagement).Should().Be("Previous Leadership and Management");
+        Cell(worksheet, 3, OfstedColumns.PreviousEarlyYearsProvision).Should().Be("Previous Early Years Provision");
+        Cell(worksheet, 3, OfstedColumns.PreviousSixthFormProvision).Should().Be("Previous Sixth Form Provision");
+        Cell(worksheet, 3, OfstedColumns.EffectiveSafeguarding).Should().Be("Effective Safeguarding");
+        Cell(worksheet, 3, OfstedColumns.CategoryOfConcern).Should().Be("Category of Concern");
     }
 
     [Fact]
@@ -488,12 +491,12 @@ public class ExportServiceTests
         worksheet.Cell(4, 2).GetValue<DateTime>().Should().Be(joinedDate);
 
         // Current Inspection Date as date
-        worksheet.Cell(4, 3).DataType.Should().Be(XLDataType.DateTime);
-        worksheet.Cell(4, 3).GetValue<DateTime>().Should().Be(currentInspectionDate);
+        worksheet.Cell(4, 5).DataType.Should().Be(XLDataType.DateTime);
+        worksheet.Cell(4, 5).GetValue<DateTime>().Should().Be(currentInspectionDate);
 
         // Previous Inspection Date as date
-        worksheet.Cell(4, 11).DataType.Should().Be(XLDataType.DateTime);
-        worksheet.Cell(4, 11).GetValue<DateTime>().Should().Be(previousInspectionDate);
+        worksheet.Cell(4, 8).DataType.Should().Be(XLDataType.DateTime);
+        worksheet.Cell(4, 8).GetValue<DateTime>().Should().Be(previousInspectionDate);
     }
 
     [Fact]
@@ -563,23 +566,25 @@ public class ExportServiceTests
     {
         SchoolName = 1,
         DateJoined = 2,
-        DateOfCurrentInspection = 3,
+        CurrentSingleHeadlineGrade = 3,
         CurrentBeforeAfterJoining = 4,
-        CurrentQualityOfEducation = 5,
-        CurrentBehaviourAndAttitudes = 6,
-        CurrentPersonalDevelopment = 7,
-        CurrentLeadershipAndManagement = 8,
-        CurrentEarlyYearsProvision = 9,
-        CurrentSixthFormProvision = 10,
-        DateOfPreviousInspection = 11,
-        PreviousBeforeAfterJoining = 12,
-        PreviousQualityOfEducation = 13,
-        PreviousBehaviourAndAttitudes = 14,
-        PreviousPersonalDevelopment = 15,
-        PreviousLeadershipAndManagement = 16,
-        PreviousEarlyYearsProvision = 17,
-        PreviousSixthFormProvision = 18,
-        EffectiveSafeguarding = 19,
-        CategoryOfConcern = 20
+        DateOfCurrentInspection = 5,
+        PreviousSingleHeadlineGrade = 6,
+        PreviousBeforeAfterJoining = 7,
+        DateOfPreviousInspection = 8,
+        CurrentQualityOfEducation = 9,
+        CurrentBehaviourAndAttitudes = 10,
+        CurrentPersonalDevelopment = 11,
+        CurrentLeadershipAndManagement = 12,
+        CurrentEarlyYearsProvision = 13,
+        CurrentSixthFormProvision = 14,
+        PreviousQualityOfEducation = 15,
+        PreviousBehaviourAndAttitudes = 16,
+        PreviousPersonalDevelopment = 17,
+        PreviousLeadershipAndManagement = 18,
+        PreviousEarlyYearsProvision = 19,
+        PreviousSixthFormProvision = 20,
+        EffectiveSafeguarding = 21,
+        CategoryOfConcern = 22
     }
 }


### PR DESCRIPTION
_Updated  the Ofsted data download to reflect the addition of the single headline grades page_

[User Story 195122](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/195122): Build: Update Ofsted data download to include SHGs

<!-- Do you need to add any environment variables? -->

## Changes

_Updated Ofsted data download_

## Screenshots of UI changes

### Before

![image](https://github.com/user-attachments/assets/a984e40a-4188-41d8-a1bd-14ea56d2cf2c)

### After

![image](https://github.com/user-attachments/assets/de848a7f-6587-43eb-9c91-c88c3e100b82)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
