### PR TITLE
Replace moq nsubstitute

### DIFF
--- a/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/BaseFiatDbTest.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/BaseFiatDbTest.cs
@@ -10,15 +10,16 @@ namespace DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests;
 public abstract class BaseFiatDbTest : IDisposable
 {
     protected FiatDbContext FiatDbContext { get; }
-    protected Mock<IUserDetailsProvider> MockUserDetailsProvider { get; } = new();
+    protected IUserDetailsProvider MockUserDetailsProvider { get; }
 
     protected BaseFiatDbTest(FiatDbContainerFixture fiatDbContainerFixture)
     {
-        MockUserDetailsProvider.Setup(a => a.GetUserDetails()).Returns(("Default TestUser", "user@defaulttest"));
+        MockUserDetailsProvider = Substitute.For<IUserDetailsProvider>();
+        MockUserDetailsProvider.GetUserDetails().Returns(("Default TestUser", "user@defaulttest"));
 
         FiatDbContext = new FiatDbContext(
             new DbContextOptionsBuilder<FiatDbContext>().UseSqlServer(fiatDbContainerFixture.ConnectionString).Options,
-            new SetChangedByInterceptor(MockUserDetailsProvider.Object));
+            new SetChangedByInterceptor(MockUserDetailsProvider));
 
         FiatDbContext.Database.EnsureDeleted();
         FiatDbContext.Database.EnsureCreated();

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/Contexts/SetChangedByInterceptorTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/Contexts/SetChangedByInterceptorTests.cs
@@ -12,7 +12,7 @@ public class SetChangedByInterceptorTests(FiatDbContainerFixture fiatDbContainer
     public async Task SetChangedByInterceptor_should_set_lastmodified_from_userdetailsprovider_on_SaveChangesAsync(
         string username, string email)
     {
-        MockUserDetailsProvider.Setup(a => a.GetUserDetails()).Returns((username, email));
+        MockUserDetailsProvider.GetUserDetails().Returns((username, email));
 
         var entry = FiatDbContext.Contacts.Add(new Contact
         {
@@ -34,8 +34,8 @@ public class SetChangedByInterceptorTests(FiatDbContainerFixture fiatDbContainer
     public void SetChangedByInterceptor_should_set_lastmodified_from_userdetailsprovider_on_SaveChanges(string username,
         string email)
     {
-        MockUserDetailsProvider.Setup(a => a.GetUserDetails()).Returns((username, email));
-
+        MockUserDetailsProvider.GetUserDetails().Returns((username, email));
+        
         var entry = FiatDbContext.Contacts.Add(new Contact
         {
             Name = "My TrustRelationshipManager",

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests.csproj
@@ -12,6 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -22,7 +23,6 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="7.0.0"/>
-        <PackageReference Include="Moq" Version="4.20.72"/>
         <PackageReference Include="Testcontainers" Version="4.1.0"/>
         <PackageReference Include="Testcontainers.MsSql" Version="4.1.0"/>
     </ItemGroup>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/GlobalUsings.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/GlobalUsings.cs
@@ -1,4 +1,4 @@
 global using DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests.TestContainer;
 global using FluentAssertions;
-global using Moq;
+global using NSubstitute;
 global using Xunit;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="FluentAssertions" Version="7.0.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageReference Include="Moq" Version="4.20.72"/>
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockDataSourceService.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockDataSourceService.cs
@@ -1,6 +1,5 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
-using Microsoft.EntityFrameworkCore.Storage;
 using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockDataSourceService.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockDataSourceService.cs
@@ -1,17 +1,14 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using Microsoft.EntityFrameworkCore.Storage;
+using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
-public class MockDataSourceService : Mock<IDataSourceService>
+public class MockDataSourceService: IDataSourceService
 {
     private static readonly DateTime StaticTime = new(2023, 11, 9);
-
-    public MockDataSourceService()
-    {
-        Setup(f => f.GetAsync(It.IsAny<Source>())).ReturnsAsync((Source source) => GetDummyDataSource(source));
-    }
-
+    
     public static DataSourceServiceModel GetDummyDataSource(Source source)
     {
         return new DataSourceServiceModel(source, StaticTime, source switch
@@ -27,7 +24,16 @@ public class MockDataSourceService : Mock<IDataSourceService>
             _ => throw new ArgumentOutOfRangeException(nameof(source), source, null)
         });
     }
+    
+    public Task<DataSourceServiceModel> GetAsync(Source source)
+    {
 
+         var mockDataSourceService = Substitute.For<IDataSourceService>();
+         mockDataSourceService.GetAsync(source)
+            .Returns(Task.FromResult(GetDummyDataSource(source)));
+         return mockDataSourceService.GetAsync(source);
+    }
+    
     public DataSourceServiceModel Prepare { get; } = GetDummyDataSource(Source.Prepare);
     public DataSourceServiceModel Complete { get; } = GetDummyDataSource(Source.Complete);
     public DataSourceServiceModel ManageFreeSchool { get; } = GetDummyDataSource(Source.ManageFreeSchoolProjects);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/BaseAcademiesInTrustAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/BaseAcademiesInTrustAreaModelTests.cs
@@ -4,7 +4,9 @@ using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies.InTrust;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies.InTrust;
 
@@ -83,8 +85,8 @@ public abstract class AcademiesInTrustAreaModelTests<T> : BaseAcademiesAreaModel
     public override async Task OnGetAsync_sets_correct_data_source_list()
     {
         await Sut.OnGetAsync();
-        MockDataSourceService.Verify(e => e.GetAsync(Source.Gias), Times.Once);
-
+        await MockDataSourceService.Received(1).GetAsync(Source.Gias);
+        
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
             new DataSourcePageListEntry(ViewConstants.AcademiesInTrustDetailsPageName,
                 [new DataSourceListEntry(GiasDataSource)]),

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/DetailsModelTests.cs
@@ -11,7 +11,7 @@ public class AcademiesDetailsModelTests : AcademiesInTrustAreaModelTests<Academi
 
     public AcademiesDetailsModelTests()
     {
-        Sut = new AcademiesInTrustDetailsModel(MockDataSourceService.Object,
+        Sut = new AcademiesInTrustDetailsModel(MockDataSourceService,
                 _mockLinkBuilder.Object,
                 new MockLogger<AcademiesInTrustDetailsModel>().Object,
                 MockTrustService.Object,

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/FreeSchoolMealsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/FreeSchoolMealsModelTests.cs
@@ -8,7 +8,7 @@ public class FreeSchoolMealsModelTests : AcademiesInTrustAreaModelTests<FreeScho
 {
     public FreeSchoolMealsModelTests()
     {
-        Sut = new FreeSchoolMealsModel(MockDataSourceService.Object,
+        Sut = new FreeSchoolMealsModel(MockDataSourceService,
                 new MockLogger<FreeSchoolMealsModel>().Object,
                 MockTrustService.Object,
                 MockAcademyService.Object,

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/PupilNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/PupilNumbersModelTests.cs
@@ -9,7 +9,7 @@ public class PupilNumbersModelTests : AcademiesInTrustAreaModelTests<PupilNumber
 {
     public PupilNumbersModelTests()
     {
-        Sut = new PupilNumbersModel(MockDataSourceService.Object,
+        Sut = new PupilNumbersModel(MockDataSourceService,
                 new MockLogger<PupilNumbersModel>().Object,
                 MockTrustService.Object,
                 MockAcademyService.Object,

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/BaseTrustPageTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/BaseTrustPageTests.cs
@@ -6,6 +6,7 @@ using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
 
@@ -13,17 +14,17 @@ public abstract class BaseTrustPageTests<T> where T : TrustsAreaModel
 {
     protected T Sut = default!;
     protected readonly Mock<ITrustService> MockTrustService = new();
-    protected readonly MockDataSourceService MockDataSourceService = new();
+    protected IDataSourceService MockDataSourceService { get; }
 
     protected readonly DataSourceServiceModel GiasDataSource =
         new(Source.Gias, new DateTime(2025, 1, 1), UpdateFrequency.Daily);
-
+    
     protected readonly DataSourceServiceModel MstrDataSource =
         new(Source.Mstr, new DateTime(2025, 1, 1), UpdateFrequency.Monthly);
-
+    
     protected readonly DataSourceServiceModel MisDataSource =
         new(Source.Mis, new DateTime(2025, 1, 1), UpdateFrequency.Daily);
-
+    
     protected readonly DataSourceServiceModel EesDataSource = new(Source.ExploreEducationStatistics,
         new DateTime(2025, 1, 1), UpdateFrequency.Annually);
 
@@ -34,10 +35,13 @@ public abstract class BaseTrustPageTests<T> where T : TrustsAreaModel
     {
         MockTrustService.Setup(t => t.GetTrustSummaryAsync(TrustUid)).ReturnsAsync(DummyTrustSummary);
 
-        MockDataSourceService.Setup(s => s.GetAsync(Source.Gias)).ReturnsAsync(GiasDataSource);
-        MockDataSourceService.Setup(s => s.GetAsync(Source.Mstr)).ReturnsAsync(MstrDataSource);
-        MockDataSourceService.Setup(s => s.GetAsync(Source.Mis)).ReturnsAsync(MisDataSource);
-        MockDataSourceService.Setup(s => s.GetAsync(Source.ExploreEducationStatistics)).ReturnsAsync(EesDataSource);
+        MockDataSourceService = Substitute.For<IDataSourceService>();
+
+        MockDataSourceService.GetAsync(Source.Gias).Returns(Task.FromResult(GiasDataSource));
+        MockDataSourceService.GetAsync(Source.Mstr).Returns(Task.FromResult(MstrDataSource));
+        MockDataSourceService.GetAsync(Source.Mis).Returns(Task.FromResult(MisDataSource));
+        MockDataSourceService.GetAsync(Source.ExploreEducationStatistics).Returns(Task.FromResult(EesDataSource));
+
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/BaseContactsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/BaseContactsAreaModelTests.cs
@@ -4,6 +4,7 @@ using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Contacts;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Contacts;
 
@@ -118,9 +119,9 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     public override async Task OnGetAsync_sets_correct_data_source_list()
     {
         await Sut.OnGetAsync();
-
-        MockDataSourceService.Verify(e => e.GetAsync(Source.Gias), Times.Once);
-        MockDataSourceService.Verify(e => e.GetAsync(Source.Mstr), Times.Once);
+        
+        await MockDataSourceService.Received(1).GetAsync(Source.Gias);
+        await MockDataSourceService.Received(1).GetAsync(Source.Mstr);
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
             new DataSourcePageListEntry(ViewConstants.ContactsInDfePageName, [

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditContactModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditContactModelTests.cs
@@ -19,7 +19,7 @@ public class EditContactModelTests
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync(_fakeTrust.Uid))
             .ReturnsAsync(_fakeTrust);
 
-        _sut = new EditSfsoLeadModel(_mockDataSourceService.Object,
+        _sut = new EditSfsoLeadModel(_mockDataSourceService,
                 new MockLogger<EditSfsoLeadModel>().Object, _mockTrustService.Object)
             { Uid = "1234" };
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditSfsoLeadModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditSfsoLeadModelTests.cs
@@ -28,7 +28,7 @@ public class EditSfsoLeadModelTests
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync(_fakeTrust.Uid))
             .ReturnsAsync(_fakeTrust);
 
-        _sut = new EditSfsoLeadModel(_mockDataSourceService.Object,
+        _sut = new EditSfsoLeadModel(_mockDataSourceService,
                 new MockLogger<EditSfsoLeadModel>().Object, _mockTrustService.Object)
             { Uid = "1234" };
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
@@ -29,7 +29,7 @@ public class EditTrustRelationshipManagerModelTests
         _mockTrustService.Setup(t => t.GetTrustSummaryAsync(_fakeTrust.Uid))
             .ReturnsAsync(_fakeTrust);
 
-        _sut = new EditTrustRelationshipManagerModel(_mockDataSourceService.Object,
+        _sut = new EditTrustRelationshipManagerModel(_mockDataSourceService,
                 new MockLogger<EditTrustRelationshipManagerModel>().Object, _mockTrustService.Object)
             { Uid = "1234" };
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InDfeModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InDfeModelTests.cs
@@ -7,7 +7,7 @@ public class InDfeModelTests : BaseContactsAreaModelTests<InDfeModel>
 {
     public InDfeModelTests()
     {
-        Sut = new InDfeModel(MockDataSourceService.Object,
+        Sut = new InDfeModel(MockDataSourceService,
                 MockTrustService.Object,
                 new MockLogger<InDfeModel>().Object)
             { Uid = TrustUid };

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InTrustModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InTrustModelTests.cs
@@ -7,7 +7,7 @@ public class InTrustModelTests : BaseContactsAreaModelTests<InTrustModel>
 {
     public InTrustModelTests()
     {
-        Sut = new InTrustModel(MockDataSourceService.Object,
+        Sut = new InTrustModel(MockDataSourceService,
                 MockTrustService.Object,
                 new MockLogger<InTrustModel>().Object)
         { Uid = TrustUid };

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/BaseGovernanceAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/BaseGovernanceAreaModelTests.cs
@@ -4,6 +4,7 @@ using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Governance;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Governance;
 
@@ -34,7 +35,7 @@ public abstract class BaseGovernanceAreaModelTests<T> : BaseTrustPageTests<T>, I
     public override async Task OnGetAsync_sets_correct_data_source_list()
     {
         await Sut.OnGetAsync();
-        MockDataSourceService.Verify(e => e.GetAsync(Source.Gias), Times.Once);
+        await MockDataSourceService.Received(1).GetAsync(Source.Gias);
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
             new DataSourcePageListEntry(ViewConstants.GovernanceTrustLeadershipPageName,

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/HistoricMembersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/HistoricMembersModelTests.cs
@@ -7,7 +7,7 @@ public class HistoricMembersModelTests : BaseGovernanceAreaModelTests<HistoricMe
 {
     public HistoricMembersModelTests()
     {
-        Sut = new HistoricMembersModel(MockDataSourceService.Object,
+        Sut = new HistoricMembersModel(MockDataSourceService,
                 new MockLogger<HistoricMembersModel>().Object, MockTrustService.Object)
             { Uid = TrustUid };
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/MembersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/MembersModelTests.cs
@@ -7,7 +7,7 @@ public class MembersModelTests : BaseGovernanceAreaModelTests<MembersModel>
 {
     public MembersModelTests()
     {
-        Sut = new MembersModel(MockDataSourceService.Object,
+        Sut = new MembersModel(MockDataSourceService,
                 new MockLogger<MembersModel>().Object, MockTrustService.Object)
             { Uid = TrustUid };
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrustLeadershipModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrustLeadershipModelTests.cs
@@ -7,7 +7,7 @@ public class TrustLeadershipModelTests : BaseGovernanceAreaModelTests<TrustLeade
 {
     public TrustLeadershipModelTests()
     {
-        Sut = new TrustLeadershipModel(MockDataSourceService.Object,
+        Sut = new TrustLeadershipModel(MockDataSourceService,
                 new MockLogger<TrustLeadershipModel>().Object, MockTrustService.Object)
             { Uid = TrustUid };
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrusteesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrusteesModelTests.cs
@@ -7,7 +7,7 @@ public class TrusteesModelTests : BaseGovernanceAreaModelTests<TrusteesModel>
 {
     public TrusteesModelTests()
     {
-        Sut = new TrusteesModel(MockDataSourceService.Object,
+        Sut = new TrusteesModel(MockDataSourceService,
                 new MockLogger<TrusteesModel>().Object, MockTrustService.Object)
             { Uid = TrustUid };
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/BaseOfstedAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/BaseOfstedAreaModelTests.cs
@@ -7,6 +7,7 @@ using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Ofsted;
 
@@ -21,9 +22,9 @@ public abstract class BaseOfstedAreaModelTests<T> : BaseTrustPageTests<T>, ITest
     public override async Task OnGetAsync_sets_correct_data_source_list()
     {
         await Sut.OnGetAsync();
-
-        MockDataSourceService.Verify(e => e.GetAsync(Source.Gias), Times.Once);
-        MockDataSourceService.Verify(e => e.GetAsync(Source.Mis), Times.Once);
+        
+        await MockDataSourceService.Received(1).GetAsync(Source.Gias);
+        await MockDataSourceService.Received(1).GetAsync(Source.Mis);
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
             new DataSourcePageListEntry(ViewConstants.OfstedSingleHeadlineGradesPageName, [

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/CurrentRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/CurrentRatingsModelTests.cs
@@ -7,7 +7,7 @@ public class CurrentRatingsModelTests : BaseOfstedAreaModelTests<CurrentRatingsM
 {
     public CurrentRatingsModelTests()
     {
-        Sut = new CurrentRatingsModel(MockDataSourceService.Object,
+        Sut = new CurrentRatingsModel(MockDataSourceService,
                 MockTrustService.Object,
                 MockAcademyService.Object,
                 MockExportService.Object,

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/PreviousRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/PreviousRatingsModelTests.cs
@@ -7,7 +7,7 @@ public class PreviousRatingsModelTests : BaseOfstedAreaModelTests<PreviousRating
 {
     public PreviousRatingsModelTests()
     {
-        Sut = new PreviousRatingsModel(MockDataSourceService.Object,
+        Sut = new PreviousRatingsModel(MockDataSourceService,
                 MockTrustService.Object,
                 MockAcademyService.Object,
                 MockExportService.Object,

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SafeguardingAndConcernsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SafeguardingAndConcernsModelTests.cs
@@ -7,7 +7,7 @@ public class SafeguardingAndConcernsModelTests : BaseOfstedAreaModelTests<Safegu
 {
     public SafeguardingAndConcernsModelTests()
     {
-        Sut = new SafeguardingAndConcernsModel(MockDataSourceService.Object,
+        Sut = new SafeguardingAndConcernsModel(MockDataSourceService,
                 MockTrustService.Object,
                 MockAcademyService.Object,
                 MockExportService.Object,

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SingleHeadlineGradesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SingleHeadlineGradesModelTests.cs
@@ -7,7 +7,7 @@ public class SingleHeadlineGradesModelTests : BaseOfstedAreaModelTests<SingleHea
 {
     public SingleHeadlineGradesModelTests()
     {
-        Sut = new SingleHeadlineGradesModel(MockDataSourceService.Object,
+        Sut = new SingleHeadlineGradesModel(MockDataSourceService,
                 MockTrustService.Object,
                 MockAcademyService.Object,
                 MockExportService.Object,

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/BaseOverviewAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/BaseOverviewAreaModelTests.cs
@@ -3,6 +3,7 @@ using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Overview;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Overview;
 
@@ -28,7 +29,7 @@ public abstract class BaseOverviewAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     public override async Task OnGetAsync_sets_correct_data_source_list()
     {
         _ = await Sut.OnGetAsync();
-        MockDataSourceService.Verify(e => e.GetAsync(Source.Gias), Times.Once);
+        await MockDataSourceService.Received(1).GetAsync(Source.Gias);
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
             new DataSourcePageListEntry(ViewConstants.OverviewTrustDetailsPageName,

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/ReferenceNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/ReferenceNumbersModelTests.cs
@@ -9,7 +9,7 @@ public class ReferenceNumbersModelTests : BaseOverviewAreaModelTests<ReferenceNu
     public ReferenceNumbersModelTests()
     {
         Sut = new ReferenceNumbersModel(
-                MockDataSourceService.Object,
+                MockDataSourceService,
                 new MockLogger<ReferenceNumbersModel>().Object,
                 MockTrustService.Object)
             { Uid = TrustUid };

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustDetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustDetailsModelTests.cs
@@ -11,7 +11,7 @@ public class TrustDetailsModelTests : BaseOverviewAreaModelTests<TrustDetailsMod
     public TrustDetailsModelTests()
     {
         Sut = new TrustDetailsModel(
-                MockDataSourceService.Object,
+                MockDataSourceService,
                 new MockLogger<TrustDetailsModel>().Object,
                 MockTrustService.Object,
                 _mockLinksToOtherServices.Object)

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustSummaryModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustSummaryModelTests.cs
@@ -9,7 +9,7 @@ public class TrustSummaryModelTests : BaseOverviewAreaModelTests<TrustSummaryMod
     public TrustSummaryModelTests()
     {
         Sut = new TrustSummaryModel(
-                MockDataSourceService.Object,
+                MockDataSourceService,
                 new MockLogger<TrustSummaryModel>().Object,
                 MockTrustService.Object)
             { Uid = TrustUid };

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
@@ -18,14 +18,14 @@ public class TrustsAreaModelTests : BaseTrustPageTests<TrustsAreaModel>
 
     public TrustsAreaModelTests()
     {
-        Sut = new TrustsAreaModelImpl(MockDataSourceService.Object, MockTrustService.Object, _logger.Object)
+        Sut = new TrustsAreaModelImpl(MockDataSourceService, MockTrustService.Object, _logger.Object)
         { Uid = TrustUid };
     }
 
     [Fact]
     public void GroupUid_should_be_empty_string_by_default()
     {
-        Sut = new TrustsAreaModelImpl(MockDataSourceService.Object, MockTrustService.Object, _logger.Object);
+        Sut = new TrustsAreaModelImpl(MockDataSourceService, MockTrustService.Object, _logger.Object);
         Sut.Uid.Should().BeEquivalentTo(string.Empty);
     }
 


### PR DESCRIPTION
_Replace Moq with NSubstitute_

[User Story 200994](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/200994): Build: Moq to NSubstitute

<!-- Do you need to add any environment variables? -->

## Changes

- _Completed replacement in FiatDb tests_
- _Replaced data source mock in AcademiesTrusts tests_

## Screenshots of UI changes

### Before

### After

## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
