### PR TITLE
Security: Migrate away from MS base layer

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,18 +43,7 @@ RUN ["dotnet", "publish", "DfE.FindInformationAcademiesTrusts", "--no-build", "-
 
 ### Entity Framework: Migration Runner ###
 FROM ubuntu:22.04 AS initcontainer
-RUN apt-get update && apt-get install gnupg ca-certificates wget -y
-
-# - Copy and configure sql migration script
-WORKDIR /app
-COPY ./DfE.FindInformationAcademiesTrusts.Data.FiatDb/Migrations/FiatDbMigrationScript.sql /app/sql/FiatDbMigrationScript.sql
-COPY ./docker/init-docker-entrypoint.sh /app/migratedb
-
-# - Set permissions, create user, and change ownership
-RUN chmod +x /app/migratedb && \
-    touch /app/sql/FiatDbMigrationScriptOutput.txt && \
-    useradd -r -m -U app && \
-    chown -R app:app /app
+RUN apt-get update && apt-get install ca-certificates -y
 
 # - Install upstream requirements
 ADD https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb /usr/share/microsoft.deb
@@ -66,6 +55,17 @@ RUN apt-get update && \
   msodbcsql18 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+# - Copy and configure sql migration script
+WORKDIR /app
+COPY ./DfE.FindInformationAcademiesTrusts.Data.FiatDb/Migrations/FiatDbMigrationScript.sql /app/sql/FiatDbMigrationScript.sql
+COPY ./docker/init-docker-entrypoint.sh /app/migratedb
+
+# - Set permissions, create user, and change ownership
+RUN chmod +x /app/migratedb && \
+    touch /app/sql/FiatDbMigrationScriptOutput.txt && \
+    useradd -r -m -U app && \
+    chown -R app:app /app
 
 USER app
 ENV PATH="$PATH:/opt/mssql-tools18/bin"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,11 +48,27 @@ RUN apt-get update && apt-get install gnupg ca-certificates wget -y
 # - Copy and configure sql migration script
 WORKDIR /app
 COPY ./DfE.FindInformationAcademiesTrusts.Data.FiatDb/Migrations/FiatDbMigrationScript.sql /app/sql/FiatDbMigrationScript.sql
-RUN ["touch", "/app/sql/FiatDbMigrationScriptOutput.txt"]
-
-# - Copy and configure docker entrypoint script
 COPY ./docker/init-docker-entrypoint.sh /app/migratedb
-RUN ["chmod", "+x", "/app/migratedb"]
+
+# - Set permissions, create user, and change ownership
+RUN chmod +x /app/migratedb && \
+    touch /app/sql/FiatDbMigrationScriptOutput.txt && \
+    useradd -r -m -U app && \
+    chown -R app:app /app
+
+# - Install upstream requirements
+ADD https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb /usr/share/microsoft.deb
+RUN dpkg -i /usr/share/microsoft.deb && rm /usr/share/microsoft.deb
+RUN apt-get update && \
+  apt-get upgrade -y && \
+  ACCEPT_EULA=Y apt-get install -y \
+  mssql-tools18 \
+  msodbcsql18 && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+USER app
+ENV PATH="$PATH:/opt/mssql-tools18/bin"
 
 ### Build a runtime environment ###
 FROM "mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0" AS final

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,8 @@ RUN ["dotnet", "build", "DfE.FindInformationAcademiesTrusts", "--no-restore", "-
 RUN ["dotnet", "publish", "DfE.FindInformationAcademiesTrusts", "--no-build", "-o", "/app"]
 
 ### Entity Framework: Migration Runner ###
-FROM "mcr.microsoft.com/mssql-tools" AS initcontainer
+FROM ubuntu:22.04 AS initcontainer
+RUN apt-get update && apt-get install gnupg ca-certificates wget -y
 
 # - Copy and configure sql migration script
 WORKDIR /app

--- a/docker/init-docker-entrypoint.sh
+++ b/docker/init-docker-entrypoint.sh
@@ -16,7 +16,7 @@ do
 done
 
 echo "Running FIAT database migrations ..."
-until /opt/mssql-tools/bin/sqlcmd -S "${mssqlconn[Server]}" -U "${mssqlconn[UserId]}" -P "${mssqlconn[Password]}" -d "${mssqlconn[Database]}" -C -I -i /app/sql/FiatDbMigrationScript.sql -o /app/sql/FiatDbMigrationScriptOutput.txt
+until /opt/mssql-tools18/bin/sqlcmd -S "${mssqlconn[Server]}" -U "${mssqlconn[UserId]}" -P "${mssqlconn[Password]}" -d "${mssqlconn[Database]}" -C -I -i /app/sql/FiatDbMigrationScript.sql -o /app/sql/FiatDbMigrationScriptOutput.txt
 do
   cat /app/sql/FiatDbMigrationScriptOutput.txt
   echo "Retrying FIAT database migrations ..."


### PR DESCRIPTION
There are a number of High severity GitHub Security warnings as a result of using the base mssql-tools Docker image provided by Microsoft. It would seem that this has been deprecated (it was running Ubuntu 16!) 

This Pull Request will update the initContainer layers to use the base ubuntu 22.04 LTS image which includes upstream vendor security updates and then we simply install mssql-tools over the top.

I've also added a nice feature of dropping permissions and running the migration script as a standard non-root user.