### PR TITLE
203528 Bug fix - Don't show conversions which are dao revoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased][unreleased]
 
+### Changed
+
+- Pipeline academies pages no longer show conversion projects which are "dAO revoked"
+
 ## [Release-22][release-22] (production-2025-02-27.5055)
 
 ### Added

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Contexts/AcademiesDbContext.MstrAcademyConversions.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Contexts/AcademiesDbContext.MstrAcademyConversions.cs
@@ -4,6 +4,7 @@ using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
 using Microsoft.EntityFrameworkCore;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
+
 public partial class AcademiesDbContext
 {
     public DbSet<MstrAcademyConversion> MstrAcademyConversions { get; set; }
@@ -29,6 +30,9 @@ public partial class AcademiesDbContext
 
             entity.Property(e => e.ProjectStatus)
                 .HasColumnName("Project Status");
+
+            entity.Property(e => e.DaoProgress)
+                .HasColumnName("dAO Progress");
 
             entity.Property(e => e.StatutoryLowestAge)
                 .HasColumnName("Statutory Lowest Age");
@@ -56,6 +60,5 @@ public partial class AcademiesDbContext
                 .HasColumnName("InComplete")
                 .HasConversion<YesNoValueToBooleanConverter>();
         });
-
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Mstr/MstrAcademyConversion.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Mstr/MstrAcademyConversion.cs
@@ -15,6 +15,7 @@ public class MstrAcademyConversion : IInComplete, IInPrepare
     public string? ProjectApplicationType { get; set; } = "Conversion";
     public required string ProjectStatus { get; set; }
     public required string RouteOfProject { get; set; }
+    public string? DaoProgress { get; set; }
     public string? EstablishmentName { get; set; }
     public DateTime? ExpectedOpeningDate { get; set; }
     public string? TrustID { get; set; }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Mstr/MstrAcademyConversion.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Models/Mstr/MstrAcademyConversion.cs
@@ -12,9 +12,9 @@ public class MstrAcademyConversion : IInComplete, IInPrepare
     public int? StatutoryLowestAge { get; set; }
     public int? StatutoryHighestAge { get; set; }
     public string? LocalAuthority { get; set; }
-    public string? ProjectApplicationType { get; set; } = "Conversion";
-    public required string ProjectStatus { get; set; }
-    public required string RouteOfProject { get; set; }
+    public string? ProjectApplicationType { get; set; }
+    public string? ProjectStatus { get; set; }
+    public string? RouteOfProject { get; set; }
     public string? DaoProgress { get; set; }
     public string? EstablishmentName { get; set; }
     public DateTime? ExpectedOpeningDate { get; set; }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/PipelineEstablishmentRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/PipelineEstablishmentRepository.cs
@@ -60,9 +60,7 @@ public class PipelineEstablishmentRepository(IAcademiesDbContext academiesDbCont
         AdvisoryType advisoryType)
     {
         // Base query
-        var query = academiesDbContext.MstrAcademyConversions
-            .Where(project => project.TrustID == trustReferenceNumber)
-            .Where(project => ConversionStatuses.Contains(project.ProjectStatus));
+        var query = ConversionsBaseQuery(trustReferenceNumber);
 
         // Advisory filter
         query = advisoryType == AdvisoryType.PreAdvisory
@@ -153,7 +151,8 @@ public class PipelineEstablishmentRepository(IAcademiesDbContext academiesDbCont
     {
         return academiesDbContext.MstrAcademyConversions
             .Where(conv => conv.TrustID == trustReferenceNumber)
-            .Where(conv => ConversionStatuses.Contains(conv.ProjectStatus));
+            .Where(conv => ConversionStatuses.Contains(conv.ProjectStatus))
+            .Where(conv => conv.DaoProgress != "dAO revoked");
     }
 
     private IQueryable<MstrAcademyTransfer> TransfersBaseQuery(string trustReferenceNumber)

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -289,6 +289,15 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
         });
     }
 
+    public void AddMstrAcademyConversion(string trustId, AdvisoryType advisoryType, string projectStatus,
+        string projectName, string? daoProgress = null)
+    {
+        AddMstrAcademyConversion(trustId, projectStatus,
+            advisoryType == AdvisoryType.PreAdvisory,
+            advisoryType == AdvisoryType.PostAdvisory,
+            projectName: projectName, daoProgress: daoProgress);
+    }
+
     public void AddMstrAcademyConversion(
         string trustId,
         string projectStatus,
@@ -299,7 +308,8 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
         int? urn = null,
         int? statutoryLowestAge = null,
         int? statutoryHighestAge = null,
-        DateTime? expectedOpeningDate = null)
+        DateTime? expectedOpeningDate = null,
+        string? daoProgress = null)
     {
         _mstrAcademyConversions.Add(new MstrAcademyConversion
         {
@@ -313,7 +323,8 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
             URN = urn,
             StatutoryLowestAge = statutoryLowestAge,
             StatutoryHighestAge = statutoryHighestAge,
-            ExpectedOpeningDate = expectedOpeningDate
+            ExpectedOpeningDate = expectedOpeningDate,
+            DaoProgress = daoProgress
         });
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/PipelineEstablishmentRepository/GetAcademiesPipelineSummaryAsyncTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/PipelineEstablishmentRepository/GetAcademiesPipelineSummaryAsyncTests.cs
@@ -40,7 +40,6 @@ public class GetAcademiesPipelineSummaryAsyncTests
         result.PreAdvisoryCount.Should().Be(expectedCount);
     }
 
-
     [Theory]
     [InlineData(null, null, 0)]
     [InlineData(true, true, 2)]
@@ -66,6 +65,33 @@ public class GetAcademiesPipelineSummaryAsyncTests
         var result = await _sut.GetAcademiesPipelineSummaryAsync(TrustReferenceNumber);
 
         result.PostAdvisoryCount.Should().Be(expectedCount);
+    }
+
+    [Fact]
+    public async Task ForConversions_ShouldNotIncludeDaoRevoked()
+    {
+        //Pre-advisory
+        _mockContext.AddMstrAcademyConversion(TrustReferenceNumber, AdvisoryType.PreAdvisory,
+            PipelineStatuses.ConverterPreAO, "Pre-Academy convertor 1");
+        _mockContext.AddMstrAcademyConversion(TrustReferenceNumber, AdvisoryType.PreAdvisory,
+            PipelineStatuses.DirectiveAcademyOrders, "Pre-Academy revoked", "dAO revoked");
+        _mockContext.AddMstrAcademyConversion(TrustReferenceNumber, AdvisoryType.PreAdvisory,
+            PipelineStatuses.DirectiveAcademyOrders, "Pre-Academy convertor 2",
+            "Sponsor funding confirmed – progressing to conversion");
+
+        //Post-advisory
+        _mockContext.AddMstrAcademyConversion(TrustReferenceNumber, AdvisoryType.PostAdvisory,
+            PipelineStatuses.ApprovedForAO, "Post-Academy convertor 1");
+        _mockContext.AddMstrAcademyConversion(TrustReferenceNumber, AdvisoryType.PostAdvisory,
+            PipelineStatuses.DirectiveAcademyOrders, "Post-Academy revoked", "dAO revoked");
+        _mockContext.AddMstrAcademyConversion(TrustReferenceNumber, AdvisoryType.PostAdvisory,
+            PipelineStatuses.DirectiveAcademyOrders, "Post-Academy convertor 2",
+            "Sponsor funding confirmed – progressing to conversion");
+
+        var result = await _sut.GetAcademiesPipelineSummaryAsync(TrustReferenceNumber);
+
+        result.PreAdvisoryCount.Should().Be(2);
+        result.PostAdvisoryCount.Should().Be(2);
     }
 
     [Fact]


### PR DESCRIPTION
Stops dAO revoked conversions from showing in pre and post advisory pipeline academies

[Bug 203528](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/203528): dAO revoked conversion projects showing in pipeline academies

## Changes

- Filters out dAO revoked conversions from pipeline academies queries
- Fixes nullability of some entity framework columns in `MstrAcademyConversion` class for more efficient and reliable queries

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
~ADR decision log updated (if needed)~
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
