### PR TITLE
replaced moq with nsubstitute in fiatdb tests

### DIFF
--- a/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/BaseFiatDbTest.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/BaseFiatDbTest.cs
@@ -1,6 +1,7 @@
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Data.FiatDb.Contexts;
 using DfE.FindInformationAcademiesTrusts.Data.FiatDb.Models;
+using NSubstitute;
 using Microsoft.EntityFrameworkCore;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests;
@@ -10,15 +11,16 @@ namespace DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests;
 public abstract class BaseFiatDbTest : IDisposable
 {
     protected FiatDbContext FiatDbContext { get; }
-    protected Mock<IUserDetailsProvider> MockUserDetailsProvider { get; } = new();
+    protected IUserDetailsProvider MockUserDetailsProvider { get; }
 
     protected BaseFiatDbTest(FiatDbContainerFixture fiatDbContainerFixture)
     {
-        MockUserDetailsProvider.Setup(a => a.GetUserDetails()).Returns(("Default TestUser", "user@defaulttest"));
+        MockUserDetailsProvider = Substitute.For<IUserDetailsProvider>();
+        MockUserDetailsProvider.GetUserDetails().Returns(("Default TestUser", "user@defaulttest"));
 
         FiatDbContext = new FiatDbContext(
             new DbContextOptionsBuilder<FiatDbContext>().UseSqlServer(fiatDbContainerFixture.ConnectionString).Options,
-            new SetChangedByInterceptor(MockUserDetailsProvider.Object));
+            new SetChangedByInterceptor(MockUserDetailsProvider));
 
         FiatDbContext.Database.EnsureDeleted();
         FiatDbContext.Database.EnsureCreated();

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/Contexts/SetChangedByInterceptorTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/Contexts/SetChangedByInterceptorTests.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Data.FiatDb.Models;
+using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests.Contexts;
 
@@ -12,7 +13,7 @@ public class SetChangedByInterceptorTests(FiatDbContainerFixture fiatDbContainer
     public async Task SetChangedByInterceptor_should_set_lastmodified_from_userdetailsprovider_on_SaveChangesAsync(
         string username, string email)
     {
-        MockUserDetailsProvider.Setup(a => a.GetUserDetails()).Returns((username, email));
+        MockUserDetailsProvider.GetUserDetails().Returns((username, email));
 
         var entry = FiatDbContext.Contacts.Add(new Contact
         {
@@ -34,7 +35,7 @@ public class SetChangedByInterceptorTests(FiatDbContainerFixture fiatDbContainer
     public void SetChangedByInterceptor_should_set_lastmodified_from_userdetailsprovider_on_SaveChanges(string username,
         string email)
     {
-        MockUserDetailsProvider.Setup(a => a.GetUserDetails()).Returns((username, email));
+        MockUserDetailsProvider.GetUserDetails().Returns((username, email));
 
         var entry = FiatDbContext.Contacts.Add(new Contact
         {

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.FiatDb.UnitTests.csproj
@@ -12,6 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
_replaced moq with nsubstitute in fiatdb tests_

[User Story 200994](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/200994): Build: Moq to NSubstitute

<!-- Do you need to add any environment variables? -->

## Changes

_Add a summary of the changes in this pull request_

## Screenshots of UI changes

### Before

### After

## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
