### PR TITLE
Feature/193582 financial docs/frontend

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialDocumentsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialDocumentsAreaModel.cs
@@ -13,6 +13,8 @@ public class FinancialDocumentsAreaModel(
     public override TrustPageMetadata TrustPageMetadata =>
         base.TrustPageMetadata with { PageName = ViewConstants.FinancialDocumentsPageName };
 
+    public virtual bool InternalUseOnly => true;
+
     public string[] FinancialDocuments { get; set; } = ["Doc 1", "Doc 2", "Doc 3"];
 
     public override async Task<IActionResult> OnGetAsync()

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialDocumentsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialDocumentsAreaModel.cs
@@ -1,0 +1,37 @@
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
+
+public class FinancialDocumentsAreaModel(
+    IDataSourceService dataSourceService,
+    ITrustService trustService,
+    ILogger<FinancialDocumentsAreaModel> logger)
+    : TrustsAreaModel(dataSourceService, trustService, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { PageName = ViewConstants.FinancialDocumentsPageName };
+
+    public string[] FinancialDocuments { get; set; } = ["Doc 1", "Doc 2", "Doc 3"];
+
+    public override async Task<IActionResult> OnGetAsync()
+    {
+        var pageResult = await base.OnGetAsync();
+        if (pageResult is NotFoundResult) return pageResult;
+
+        SubNavigationLinks =
+        [
+            GetSubPageLink<FinancialStatementsModel>
+                (ViewConstants.FinancialDocumentsFinancialStatementsSubPageName, "./FinancialStatements"),
+            GetSubPageLink<ManagementLettersModel>
+                (ViewConstants.FinancialDocumentsManagementLettersSubPageName, "./ManagementLetters"),
+            GetSubPageLink<InternalScrutinyReportsModel>
+                (ViewConstants.FinancialDocumentsInternalScrutinyReportsSubPageName, "./InternalScrutinyReports"),
+            GetSubPageLink<SelfAssessmentChecklistsModel>
+                (ViewConstants.FinancialDocumentsSelfAssessmentChecklistsSubPageName, "./SelfAssessmentChecklists")
+        ];
+
+        return Page();
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialStatements.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialStatements.cshtml
@@ -1,0 +1,6 @@
+﻿@page "/trusts/financial-documents/financial-statements"
+@model FinancialStatementsModel
+
+@{
+  Layout = "FinancialDocuments/_FinancialDocumentsLayout";
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialStatements.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialStatements.cshtml.cs
@@ -1,0 +1,14 @@
+﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
+
+public class FinancialStatementsModel(
+    IDataSourceService dataSourceService,
+    ILogger<FinancialStatementsModel> logger,
+    ITrustService trustService)
+    : FinancialDocumentsAreaModel(dataSourceService, trustService, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = ViewConstants.FinancialDocumentsFinancialStatementsSubPageName };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialStatements.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialStatements.cshtml.cs
@@ -11,4 +11,6 @@ public class FinancialStatementsModel(
 {
     public override TrustPageMetadata TrustPageMetadata =>
         base.TrustPageMetadata with { SubPageName = ViewConstants.FinancialDocumentsFinancialStatementsSubPageName };
+
+    public override bool InternalUseOnly => false;
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/InternalScrutinyReports.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/InternalScrutinyReports.cshtml
@@ -1,0 +1,6 @@
+﻿@page "/trusts/financial-documents/internal-scrutiny-reports"
+@model InternalScrutinyReportsModel
+
+@{
+  Layout = "FinancialDocuments/_FinancialDocumentsLayout";
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/InternalScrutinyReports.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/InternalScrutinyReports.cshtml.cs
@@ -1,0 +1,16 @@
+﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
+
+public class InternalScrutinyReportsModel(
+    IDataSourceService dataSourceService,
+    ILogger<InternalScrutinyReportsModel> logger,
+    ITrustService trustService)
+    : FinancialDocumentsAreaModel(dataSourceService, trustService, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with
+    {
+        SubPageName = ViewConstants.FinancialDocumentsInternalScrutinyReportsSubPageName
+    };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/ManagementLetters.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/ManagementLetters.cshtml
@@ -1,0 +1,6 @@
+﻿@page "/trusts/financial-documents/management-letters"
+@model ManagementLettersModel
+
+@{
+  Layout = "FinancialDocuments/_FinancialDocumentsLayout";
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/ManagementLetters.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/ManagementLetters.cshtml.cs
@@ -1,0 +1,14 @@
+﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
+
+public class ManagementLettersModel(
+    IDataSourceService dataSourceService,
+    ILogger<ManagementLettersModel> logger,
+    ITrustService trustService)
+    : FinancialDocumentsAreaModel(dataSourceService, trustService, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata =>
+        base.TrustPageMetadata with { SubPageName = ViewConstants.FinancialDocumentsManagementLettersSubPageName };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklists.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklists.cshtml
@@ -1,0 +1,6 @@
+﻿@page "/trusts/financial-documents/self-assessment-checklists"
+@model SelfAssessmentChecklistsModel
+
+@{
+  Layout = "FinancialDocuments/_FinancialDocumentsLayout";
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklists.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklists.cshtml.cs
@@ -1,0 +1,16 @@
+﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
+
+public class SelfAssessmentChecklistsModel(
+    IDataSourceService dataSourceService,
+    ILogger<SelfAssessmentChecklistsModel> logger,
+    ITrustService trustService)
+    : FinancialDocumentsAreaModel(dataSourceService, trustService, logger)
+{
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with
+    {
+        SubPageName = ViewConstants.FinancialDocumentsSelfAssessmentChecklistsSubPageName
+    };
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/_FinancialDocumentsLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/_FinancialDocumentsLayout.cshtml
@@ -1,0 +1,29 @@
+@model FinancialDocumentsAreaModel
+@{
+  Layout = "_TrustLayout";
+}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m" data-testid="subpage-header">
+      @Model.TrustPageMetadata.SubPageName
+    </h2>
+
+    <dl class="govuk-summary-list">
+      @foreach (var doc in Model.FinancialDocuments)
+      {
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            @doc year
+          </dt>
+          <dd class="govuk-summary-list__value">
+            @doc link
+          </dd>
+        </div>
+      }
+    </dl>
+
+    @RenderBody()
+
+  </div>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/_FinancialDocumentsLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/_FinancialDocumentsLayout.cshtml
@@ -8,7 +8,11 @@
     <h2 class="govuk-heading-m" data-testid="subpage-header">
       @Model.TrustPageMetadata.SubPageName
     </h2>
-
+    <p class="govuk-body">You must have permission to view these documents.</p>
+    @if (Model.InternalUseOnly)
+    {
+      <partial name="Shared/_InternalUseOnlyWarning" model="@Model.TrustPageMetadata.SubPageName" />
+    }
     <dl class="govuk-summary-list">
       @foreach (var doc in Model.FinancialDocuments)
       {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -99,4 +99,16 @@ public abstract class TrustsAreaModel(
     }
 
     public TrustSubNavigationLinkModel[] SubNavigationLinks { get; set; } = [];
+
+    public TrustSubNavigationLinkModel GetSubPageLink<TTo>(string linkText, string aspPage) where TTo : TrustsAreaModel
+    {
+        return new TrustSubNavigationLinkModel
+        (
+            linkText,
+            aspPage,
+            Uid,
+            TrustPageMetadata.PageName!,
+            this is TTo
+        );
+    }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -3,6 +3,7 @@ using DfE.FindInformationAcademiesTrusts.Extensions;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Academies;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Contacts;
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Governance;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Ofsted;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.Overview;
@@ -82,17 +83,16 @@ public abstract class TrustsAreaModel(
         NavigationLinks =
         [
             new TrustNavigationLinkModel(ViewConstants.OverviewPageName, "/Trusts/Overview/TrustDetails", Uid,
-                this is OverviewAreaModel,
-                "overview-nav"),
+                this is OverviewAreaModel, "overview-nav"),
             new TrustNavigationLinkModel(ViewConstants.ContactsPageName, "/Trusts/Contacts/InDfe", Uid,
-                this is ContactsAreaModel,
-                "contacts-nav"),
+                this is ContactsAreaModel, "contacts-nav"),
             new TrustNavigationLinkModel($"{ViewConstants.AcademiesPageName} ({TrustSummary.NumberOfAcademies})",
-                "/Trusts/Academies/InTrust/Details",
-                Uid, this is AcademiesAreaModel, "academies-nav"),
+                "/Trusts/Academies/InTrust/Details", Uid, this is AcademiesAreaModel, "academies-nav"),
             new TrustNavigationLinkModel(ViewConstants.OfstedPageName, "/Trusts/Ofsted/SingleHeadlineGrades", Uid,
-                this is OfstedAreaModel,
-                "ofsted-nav"),
+                this is OfstedAreaModel, "ofsted-nav"),
+            new TrustNavigationLinkModel(ViewConstants.FinancialDocumentsPageName,
+                "/Trusts/FinancialDocuments/FinancialStatements", Uid, this is FinancialDocumentsAreaModel,
+                "financial-documents-nav"),
             new TrustNavigationLinkModel(ViewConstants.GovernancePageName, "/Trusts/Governance/TrustLeadership", Uid,
                 this is GovernanceAreaModel, "governance-nav")
         ];

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_SourceList.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_SourceList.cshtml
@@ -1,31 +1,36 @@
 ﻿@model ITrustsAreaModel
-<details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details" data-testid="data-source-and-updates">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      <span>Where this information came from</span>
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    @foreach (var pageSource in Model.DataSourcesPerPage)
-    {
-      <p class="govuk-heading-s">
-        @pageSource.PageName
-      </p>
-      <ul class="govuk-list govuk-list--bullet">
-        @foreach (var source in pageSource.DataSources)
-        {
-          <li data-testid="@Model.MapDataSourceToTestId(source)">
-            @if (source.DataSource.UpdatedBy is not null)
-            {
-              <span>@source.DataField was updated by @source.UpdatedByText on @source.LastUpdatedText</span>
-            }
-            else
-            {
-              <span>@source.DataField taken from @Model.MapDataSourceToName(source.DataSource) on @source.LastUpdatedText</span>
-            }
-          </li>
-        }
-      </ul>
-    }
-  </div>
-</details>
+
+@if (Model.DataSourcesPerPage.Any())
+{
+  <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details"
+           data-testid="data-source-and-updates">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        <span>Where this information came from</span>
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      @foreach (var pageSource in Model.DataSourcesPerPage)
+      {
+        <p class="govuk-heading-s">
+          @pageSource.PageName
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          @foreach (var source in pageSource.DataSources)
+          {
+            <li data-testid="@Model.MapDataSourceToTestId(source)">
+              @if (source.DataSource.UpdatedBy is not null)
+              {
+                <span>@source.DataField was updated by @source.UpdatedByText on @source.LastUpdatedText</span>
+              }
+              else
+              {
+                <span>@source.DataField taken from @Model.MapDataSourceToName(source.DataSource) on @source.LastUpdatedText</span>
+              }
+            </li>
+          }
+        </ul>
+      }
+    </div>
+  </details>
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/ViewConstants.cs
@@ -1,5 +1,5 @@
-using DfE.FindInformationAcademiesTrusts.Data;
 using System.Diagnostics.CodeAnalysis;
+using DfE.FindInformationAcademiesTrusts.Data;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages;
 
@@ -67,6 +67,12 @@ public static class ViewConstants
     public const string OfstedCurrentRatingsPageName = "Current ratings";
     public const string OfstedPreviousRatingsPageName = "Previous ratings";
     public const string OfstedSafeguardingAndConcernsPageName = "Safeguarding and concerns";
+
+    public const string FinancialDocumentsPageName = "Financial documents";
+    public const string FinancialDocumentsFinancialStatementsSubPageName = "Financial statements";
+    public const string FinancialDocumentsManagementLettersSubPageName = "Management letters";
+    public const string FinancialDocumentsInternalScrutinyReportsSubPageName = "Internal scrutiny reports";
+    public const string FinancialDocumentsSelfAssessmentChecklistsSubPageName = "Self-assessment checklists";
 
     public const string GovernancePageName = "Governance";
     public const string GovernanceTrustLeadershipPageName = "Trust leadership";

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/BaseTrustPageTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/BaseTrustPageTests.cs
@@ -111,6 +111,12 @@ public abstract class BaseTrustPageTests<T> where T : TrustsAreaModel
                 },
                 l =>
                 {
+                    l.LinkText.Should().Be(ViewConstants.FinancialDocumentsPageName);
+                    l.Page.Should().Be("/Trusts/FinancialDocuments/FinancialStatements");
+                    l.DataTestId.Should().Be("financial-documents-nav");
+                },
+                l =>
+                {
                     l.LinkText.Should().Be(ViewConstants.GovernancePageName);
                     l.Page.Should().Be("/Trusts/Governance/TrustLeadership");
                     l.DataTestId.Should().Be("governance-nav");

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/BaseFinancialDocumentsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/BaseFinancialDocumentsAreaModelTests.cs
@@ -1,0 +1,69 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.FinancialDocuments;
+
+public abstract class BaseFinancialDocumentsAreaModelTests<T> : BaseTrustPageTests<T>, ITestSubpages
+    where T : FinancialDocumentsAreaModel
+{
+    [Fact(Skip = "Data source not implemented yet")]
+    public override Task OnGetAsync_sets_correct_data_source_list()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_set_active_NavigationLink_to_current_page()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.NavigationLinks.Should().ContainSingle(l => l.LinkIsActive)
+            .Which.LinkText.Should().Be("Financial documents");
+    }
+
+    [Fact]
+    public abstract Task OnGetAsync_should_set_active_SubNavigationLink_to_current_subpage();
+
+    [Fact]
+    public async Task OnGetAsync_should_populate_SubNavigationLinks_to_subpages()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.SubNavigationLinks.Should()
+            .SatisfyRespectively(
+                l =>
+                {
+                    l.LinkText.Should().Be("Financial statements");
+                    l.SubPageLink.Should().Be("./FinancialStatements");
+                    l.ServiceName.Should().Be("Financial documents");
+                },
+                l =>
+                {
+                    l.LinkText.Should().Be("Management letters");
+                    l.SubPageLink.Should().Be("./ManagementLetters");
+                    l.ServiceName.Should().Be("Financial documents");
+                },
+                l =>
+                {
+                    l.LinkText.Should().Be("Internal scrutiny reports");
+                    l.SubPageLink.Should().Be("./InternalScrutinyReports");
+                    l.ServiceName.Should().Be("Financial documents");
+                },
+                l =>
+                {
+                    l.LinkText.Should().Be("Self-assessment checklists");
+                    l.SubPageLink.Should().Be("./SelfAssessmentChecklists");
+                    l.ServiceName.Should().Be("Financial documents");
+                });
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_configure_TrustPageMetadata_PageName()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.TrustPageMetadata.PageName.Should().Be("Financial documents");
+    }
+
+    [Fact]
+    public abstract Task OnGetAsync_should_configure_TrustPageMetadata_SubPageName();
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/FinancialStatementModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/FinancialStatementModelTests.cs
@@ -1,0 +1,33 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.FinancialDocuments;
+
+public class FinancialStatementModelTests : BaseFinancialDocumentsAreaModelTests<FinancialStatementsModel>
+{
+    public FinancialStatementModelTests()
+    {
+        Sut = new FinancialStatementsModel(MockDataSourceService,
+                new MockLogger<FinancialStatementsModel>().Object,
+                MockTrustService.Object
+            )
+            { Uid = TrustUid };
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_set_active_SubNavigationLink_to_current_subpage()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.SubNavigationLinks.Should().ContainSingle(l => l.LinkIsActive)
+            .Which.SubPageLink.Should().Be("./FinancialStatements");
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_configure_TrustPageMetadata_SubPageName()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.TrustPageMetadata.SubPageName.Should().Be("Financial statements");
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/FinancialStatementModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/FinancialStatementModelTests.cs
@@ -30,4 +30,10 @@ public class FinancialStatementModelTests : BaseFinancialDocumentsAreaModelTests
 
         Sut.TrustPageMetadata.SubPageName.Should().Be("Financial statements");
     }
+
+    [Fact]
+    public void InternalUseOnly_should_be_false()
+    {
+        Sut.InternalUseOnly.Should().BeFalse();
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/InternalScrutinyReportsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/InternalScrutinyReportsModelTests.cs
@@ -1,0 +1,33 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.FinancialDocuments;
+
+public class InternalScrutinyReportsModelTests : BaseFinancialDocumentsAreaModelTests<InternalScrutinyReportsModel>
+{
+    public InternalScrutinyReportsModelTests()
+    {
+        Sut = new InternalScrutinyReportsModel(MockDataSourceService,
+                new MockLogger<InternalScrutinyReportsModel>().Object,
+                MockTrustService.Object
+            )
+            { Uid = TrustUid };
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_set_active_SubNavigationLink_to_current_subpage()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.SubNavigationLinks.Should().ContainSingle(l => l.LinkIsActive)
+            .Which.SubPageLink.Should().Be("./InternalScrutinyReports");
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_configure_TrustPageMetadata_SubPageName()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.TrustPageMetadata.SubPageName.Should().Be("Internal scrutiny reports");
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/InternalScrutinyReportsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/InternalScrutinyReportsModelTests.cs
@@ -30,4 +30,10 @@ public class InternalScrutinyReportsModelTests : BaseFinancialDocumentsAreaModel
 
         Sut.TrustPageMetadata.SubPageName.Should().Be("Internal scrutiny reports");
     }
+
+    [Fact]
+    public void InternalUseOnly_should_be_true()
+    {
+        Sut.InternalUseOnly.Should().BeTrue();
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/ManagementLettersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/ManagementLettersModelTests.cs
@@ -1,0 +1,33 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.FinancialDocuments;
+
+public class ManagementLettersModelTests : BaseFinancialDocumentsAreaModelTests<ManagementLettersModel>
+{
+    public ManagementLettersModelTests()
+    {
+        Sut = new ManagementLettersModel(MockDataSourceService,
+                new MockLogger<ManagementLettersModel>().Object,
+                MockTrustService.Object
+            )
+            { Uid = TrustUid };
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_set_active_SubNavigationLink_to_current_subpage()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.SubNavigationLinks.Should().ContainSingle(l => l.LinkIsActive)
+            .Which.SubPageLink.Should().Be("./ManagementLetters");
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_configure_TrustPageMetadata_SubPageName()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.TrustPageMetadata.SubPageName.Should().Be("Management letters");
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/ManagementLettersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/ManagementLettersModelTests.cs
@@ -30,4 +30,10 @@ public class ManagementLettersModelTests : BaseFinancialDocumentsAreaModelTests<
 
         Sut.TrustPageMetadata.SubPageName.Should().Be("Management letters");
     }
+
+    [Fact]
+    public void InternalUseOnly_should_be_true()
+    {
+        Sut.InternalUseOnly.Should().BeTrue();
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklistsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklistsModelTests.cs
@@ -30,4 +30,10 @@ public class SelfAssessmentChecklistsModelTests : BaseFinancialDocumentsAreaMode
 
         Sut.TrustPageMetadata.SubPageName.Should().Be("Self-assessment checklists");
     }
+
+    [Fact]
+    public void InternalUseOnly_should_be_true()
+    {
+        Sut.InternalUseOnly.Should().BeTrue();
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklistsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklistsModelTests.cs
@@ -1,0 +1,33 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.FinancialDocuments;
+
+public class SelfAssessmentChecklistsModelTests : BaseFinancialDocumentsAreaModelTests<SelfAssessmentChecklistsModel>
+{
+    public SelfAssessmentChecklistsModelTests()
+    {
+        Sut = new SelfAssessmentChecklistsModel(MockDataSourceService,
+                new MockLogger<SelfAssessmentChecklistsModel>().Object,
+                MockTrustService.Object
+            )
+            { Uid = TrustUid };
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_set_active_SubNavigationLink_to_current_subpage()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.SubNavigationLinks.Should().ContainSingle(l => l.LinkIsActive)
+            .Which.SubPageLink.Should().Be("./SelfAssessmentChecklists");
+    }
+
+    [Fact]
+    public override async Task OnGetAsync_should_configure_TrustPageMetadata_SubPageName()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.TrustPageMetadata.SubPageName.Should().Be("Self-assessment checklists");
+    }
+}


### PR DESCRIPTION
[User Story 193582](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/193582): Build: Front-end Links to trust financial docs


## Changes

- [Add financial docs pages](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/pull/750/commits/a8b9fcad2779f09375beef79ac5221acf47e94ab)
- [Only show datasources component if there are any](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/pull/750/commits/9ef56acb0b268163b54f6875fcfa386d0820ad53)
- [Add main nav link to financial documents page](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/pull/750/commits/1b29b662a12d487c2cfd39f2d9b4a7e7b1315e04)
- [Show InternalUseOnlyWarning on financial docs (other than statements)](https://github.com/DFE-Digital/find-information-about-academies-and-trusts/pull/750/commits/309b0c6962f28f598bcca4bd011f01b755670aeb)

### Not included

- Data sources
- Service
- Status tags
