### PR TITLE
feature/193582-financial-docs - Create financial documents service and use it to make rows

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data/Enums/FinancialDocumentStatus.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Enums/FinancialDocumentStatus.cs
@@ -1,0 +1,29 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Enums;
+
+public enum FinancialDocumentStatus
+{
+    /// <summary>
+    /// There is a link to financial document
+    /// </summary>
+    Submitted,
+
+    /// <summary>
+    /// There is no link present to the relevant financial document in the latest (current) financial year
+    /// </summary>
+    NotYetSubmitted,
+
+    /// <summary>
+    /// There is no link present to the relevant financial document in a previous financial year.
+    /// </summary>
+    NotSubmitted,
+
+    /// <summary>
+    /// The trust did not open in the financial year and therefore financial documents were not expected.
+    /// </summary>
+    NotExpected,
+
+    /// <summary>
+    /// There was an issue retrieving information about this financial document
+    /// </summary>
+    Error
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/Enums/FinancialDocumentType.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Enums/FinancialDocumentType.cs
@@ -1,0 +1,9 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Enums;
+
+public enum FinancialDocumentType
+{
+    FinancialStatement,
+    ManagementLetter,
+    InternalScrutinyReport,
+    SelfAssessmentChecklist
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialStatements.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialStatements.cshtml.cs
@@ -1,4 +1,6 @@
-﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
@@ -6,11 +8,14 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
 public class FinancialStatementsModel(
     IDataSourceService dataSourceService,
     ILogger<FinancialStatementsModel> logger,
-    ITrustService trustService)
-    : FinancialDocumentsAreaModel(dataSourceService, trustService, logger)
+    ITrustService trustService,
+    IFinancialDocumentService financialDocumentService)
+    : FinancialDocumentsAreaModel(dataSourceService, trustService, logger, financialDocumentService)
 {
     public override TrustPageMetadata TrustPageMetadata =>
         base.TrustPageMetadata with { SubPageName = ViewConstants.FinancialDocumentsFinancialStatementsSubPageName };
 
     public override bool InternalUseOnly => false;
+    protected override FinancialDocumentType FinancialDocumentType => FinancialDocumentType.FinancialStatement;
+    public override string FinancialDocumentDisplayName => "financial statement";
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/InternalScrutinyReports.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/InternalScrutinyReports.cshtml.cs
@@ -1,4 +1,6 @@
-﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
@@ -6,11 +8,15 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
 public class InternalScrutinyReportsModel(
     IDataSourceService dataSourceService,
     ILogger<InternalScrutinyReportsModel> logger,
-    ITrustService trustService)
-    : FinancialDocumentsAreaModel(dataSourceService, trustService, logger)
+    ITrustService trustService,
+    IFinancialDocumentService financialDocumentService)
+    : FinancialDocumentsAreaModel(dataSourceService, trustService, logger, financialDocumentService)
 {
     public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with
     {
         SubPageName = ViewConstants.FinancialDocumentsInternalScrutinyReportsSubPageName
     };
+
+    protected override FinancialDocumentType FinancialDocumentType => FinancialDocumentType.InternalScrutinyReport;
+    public override string FinancialDocumentDisplayName => "scrutiny report";
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/ManagementLetters.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/ManagementLetters.cshtml.cs
@@ -1,4 +1,6 @@
-﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
@@ -6,9 +8,13 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
 public class ManagementLettersModel(
     IDataSourceService dataSourceService,
     ILogger<ManagementLettersModel> logger,
-    ITrustService trustService)
-    : FinancialDocumentsAreaModel(dataSourceService, trustService, logger)
+    ITrustService trustService,
+    IFinancialDocumentService financialDocumentService)
+    : FinancialDocumentsAreaModel(dataSourceService, trustService, logger, financialDocumentService)
 {
     public override TrustPageMetadata TrustPageMetadata =>
         base.TrustPageMetadata with { SubPageName = ViewConstants.FinancialDocumentsManagementLettersSubPageName };
+
+    protected override FinancialDocumentType FinancialDocumentType => FinancialDocumentType.ManagementLetter;
+    public override string FinancialDocumentDisplayName => "management letter";
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklists.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklists.cshtml.cs
@@ -1,4 +1,6 @@
-﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
@@ -6,11 +8,15 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
 public class SelfAssessmentChecklistsModel(
     IDataSourceService dataSourceService,
     ILogger<SelfAssessmentChecklistsModel> logger,
-    ITrustService trustService)
-    : FinancialDocumentsAreaModel(dataSourceService, trustService, logger)
+    ITrustService trustService,
+    IFinancialDocumentService financialDocumentService)
+    : FinancialDocumentsAreaModel(dataSourceService, trustService, logger, financialDocumentService)
 {
     public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with
     {
         SubPageName = ViewConstants.FinancialDocumentsSelfAssessmentChecklistsSubPageName
     };
+
+    protected override FinancialDocumentType FinancialDocumentType => FinancialDocumentType.SelfAssessmentChecklist;
+    public override string FinancialDocumentDisplayName => "self-assessment checklist";
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/_FinancialDocumentsLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/_FinancialDocumentsLayout.cshtml
@@ -1,3 +1,4 @@
+@using DfE.FindInformationAcademiesTrusts.Data.Enums
 @model FinancialDocumentsAreaModel
 @{
   Layout = "_TrustLayout";
@@ -18,10 +19,31 @@
       {
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            @doc year
+            @doc.YearFrom to @doc.YearTo
           </dt>
           <dd class="govuk-summary-list__value">
-            @doc link
+            @switch (doc)
+            {
+              case { Status: FinancialDocumentStatus.Submitted, Link: not null }:
+                <a href="@doc.Link" class="govuk-link" rel="noreferrer noopener" target="_blank">
+                  View
+                  <span class="govuk-visually-hidden">@doc.YearFrom to @doc.YearTo</span>
+                  @Model.FinancialDocumentDisplayName (opens in a new tab)
+                </a>
+                break;
+              case { Status: FinancialDocumentStatus.NotYetSubmitted }:
+                <strong class="govuk-tag govuk-tag--yellow">Not yet submitted</strong>
+                break;
+              case { Status: FinancialDocumentStatus.NotSubmitted }:
+                <span>Not submitted</span>
+                break;
+              case { Status: FinancialDocumentStatus.NotExpected }:
+                <span>Not expected</span>
+                break;
+              default:
+                <span>There is a problem displaying this document</span>
+                break;
+            }
           </dd>
         </div>
       }

--- a/DfE.FindInformationAcademiesTrusts/Services/FinancialDocument/FinancialDocumentService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/FinancialDocument/FinancialDocumentService.cs
@@ -1,0 +1,23 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+
+namespace DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
+
+public interface IFinancialDocumentService
+{
+    Task<FinancialDocumentServiceModel[]> GetFinancialDocumentsAsync(FinancialDocumentType financialDocumentType);
+}
+
+public class FinancialDocumentService : IFinancialDocumentService
+{
+    public Task<FinancialDocumentServiceModel[]> GetFinancialDocumentsAsync(FinancialDocumentType financialDocumentType)
+    {
+        FinancialDocumentServiceModel[] documents =
+        [
+            new(2022, 2023, FinancialDocumentStatus.NotExpected, null),
+            new(2023, 2024, FinancialDocumentStatus.NotYetSubmitted, null),
+            new(2024, 2025, FinancialDocumentStatus.Submitted, "https://www.google.com")
+        ];
+
+        return Task.FromResult(documents);
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Services/FinancialDocument/FinancialDocumentServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/FinancialDocument/FinancialDocumentServiceModel.cs
@@ -1,0 +1,5 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+
+namespace DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
+
+public record FinancialDocumentServiceModel(int YearFrom, int YearTo, FinancialDocumentStatus Status, string? Link);

--- a/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
@@ -1,4 +1,5 @@
-﻿using DfE.FindInformationAcademiesTrusts.Data;
+﻿using System.Diagnostics.CodeAnalysis;
+using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
@@ -13,9 +14,9 @@ using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
+using DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.EntityFrameworkCore;
-using System.Diagnostics.CodeAnalysis;
 
 namespace DfE.FindInformationAcademiesTrusts.Setup;
 
@@ -56,6 +57,7 @@ public static class Dependencies
         builder.Services.AddScoped<ITrustService, TrustService>();
         builder.Services.AddScoped<IAcademyService, AcademyService>();
         builder.Services.AddScoped<IExportService, ExportService>();
+        builder.Services.AddScoped<IFinancialDocumentService, FinancialDocumentService>();
 
         builder.Services.AddScoped<IOtherServicesLinkBuilder, OtherServicesLinkBuilder>();
         builder.Services.AddScoped<IFreeSchoolMealsAverageProvider, FreeSchoolMealsAverageProvider>();

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/BaseFinancialDocumentsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/BaseFinancialDocumentsAreaModelTests.cs
@@ -1,14 +1,40 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
+using DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.FinancialDocuments;
 
 public abstract class BaseFinancialDocumentsAreaModelTests<T> : BaseTrustPageTests<T>, ITestSubpages
     where T : FinancialDocumentsAreaModel
 {
+    protected readonly Mock<IFinancialDocumentService> MockFinancialDocumentService = new();
+
+    private readonly FinancialDocumentServiceModel[] _unsortedFinancialDocs =
+    [
+        new(2023, 2024, FinancialDocumentStatus.NotYetSubmitted, null),
+        new(2022, 2023, FinancialDocumentStatus.NotExpected, null),
+        new(2024, 2025, FinancialDocumentStatus.Submitted, "https://www.google.com")
+    ];
+
+    protected BaseFinancialDocumentsAreaModelTests(FinancialDocumentType financialDocumentType)
+    {
+        MockFinancialDocumentService.Setup(d => d.GetFinancialDocumentsAsync(financialDocumentType))
+            .ReturnsAsync(_unsortedFinancialDocs);
+    }
+
     [Fact(Skip = "Data source not implemented yet")]
     public override Task OnGetAsync_sets_correct_data_source_list()
     {
         throw new NotImplementedException();
+    }
+
+    [Fact]
+    public async Task OnGetAsync_sets_FinancialDocuments_in_descending_order_for_page()
+    {
+        _ = await Sut.OnGetAsync();
+
+        Sut.FinancialDocuments.Should().BeEquivalentTo(_unsortedFinancialDocs);
+        Sut.FinancialDocuments.Should().BeInDescendingOrder(d => d.YearTo);
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/FinancialStatementModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/FinancialStatementModelTests.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
@@ -5,12 +6,10 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.FinancialDoc
 
 public class FinancialStatementModelTests : BaseFinancialDocumentsAreaModelTests<FinancialStatementsModel>
 {
-    public FinancialStatementModelTests()
+    public FinancialStatementModelTests() : base(FinancialDocumentType.FinancialStatement)
     {
-        Sut = new FinancialStatementsModel(MockDataSourceService,
-                new MockLogger<FinancialStatementsModel>().Object,
-                MockTrustService.Object
-            )
+        Sut = new FinancialStatementsModel(MockDataSourceService, new MockLogger<FinancialStatementsModel>().Object,
+                MockTrustService.Object, MockFinancialDocumentService.Object)
             { Uid = TrustUid };
     }
 
@@ -35,5 +34,11 @@ public class FinancialStatementModelTests : BaseFinancialDocumentsAreaModelTests
     public void InternalUseOnly_should_be_false()
     {
         Sut.InternalUseOnly.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FinancialDocumentDisplayName_should_be_financial_statement()
+    {
+        Sut.FinancialDocumentDisplayName.Should().Be("financial statement");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/InternalScrutinyReportsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/InternalScrutinyReportsModelTests.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
@@ -5,12 +6,11 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.FinancialDoc
 
 public class InternalScrutinyReportsModelTests : BaseFinancialDocumentsAreaModelTests<InternalScrutinyReportsModel>
 {
-    public InternalScrutinyReportsModelTests()
+    public InternalScrutinyReportsModelTests() : base(FinancialDocumentType.InternalScrutinyReport)
     {
         Sut = new InternalScrutinyReportsModel(MockDataSourceService,
-                new MockLogger<InternalScrutinyReportsModel>().Object,
-                MockTrustService.Object
-            )
+                new MockLogger<InternalScrutinyReportsModel>().Object, MockTrustService.Object,
+                MockFinancialDocumentService.Object)
             { Uid = TrustUid };
     }
 
@@ -35,5 +35,11 @@ public class InternalScrutinyReportsModelTests : BaseFinancialDocumentsAreaModel
     public void InternalUseOnly_should_be_true()
     {
         Sut.InternalUseOnly.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FinancialDocumentDisplayName_should_be_scrutiny_report()
+    {
+        Sut.FinancialDocumentDisplayName.Should().Be("scrutiny report");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/ManagementLettersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/ManagementLettersModelTests.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
@@ -5,12 +6,10 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.FinancialDoc
 
 public class ManagementLettersModelTests : BaseFinancialDocumentsAreaModelTests<ManagementLettersModel>
 {
-    public ManagementLettersModelTests()
+    public ManagementLettersModelTests() : base(FinancialDocumentType.ManagementLetter)
     {
-        Sut = new ManagementLettersModel(MockDataSourceService,
-                new MockLogger<ManagementLettersModel>().Object,
-                MockTrustService.Object
-            )
+        Sut = new ManagementLettersModel(MockDataSourceService, new MockLogger<ManagementLettersModel>().Object,
+                MockTrustService.Object, MockFinancialDocumentService.Object)
             { Uid = TrustUid };
     }
 
@@ -35,5 +34,11 @@ public class ManagementLettersModelTests : BaseFinancialDocumentsAreaModelTests<
     public void InternalUseOnly_should_be_true()
     {
         Sut.InternalUseOnly.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FinancialDocumentDisplayName_should_be_management_letter()
+    {
+        Sut.FinancialDocumentDisplayName.Should().Be("management letter");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklistsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklistsModelTests.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Trusts.FinancialDocuments;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
@@ -5,12 +6,11 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.FinancialDoc
 
 public class SelfAssessmentChecklistsModelTests : BaseFinancialDocumentsAreaModelTests<SelfAssessmentChecklistsModel>
 {
-    public SelfAssessmentChecklistsModelTests()
+    public SelfAssessmentChecklistsModelTests() : base(FinancialDocumentType.SelfAssessmentChecklist)
     {
         Sut = new SelfAssessmentChecklistsModel(MockDataSourceService,
-                new MockLogger<SelfAssessmentChecklistsModel>().Object,
-                MockTrustService.Object
-            )
+                new MockLogger<SelfAssessmentChecklistsModel>().Object, MockTrustService.Object,
+                MockFinancialDocumentService.Object)
             { Uid = TrustUid };
     }
 
@@ -35,5 +35,11 @@ public class SelfAssessmentChecklistsModelTests : BaseFinancialDocumentsAreaMode
     public void InternalUseOnly_should_be_true()
     {
         Sut.InternalUseOnly.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FinancialDocumentDisplayName_should_be_self_assessment_checklist()
+    {
+        Sut.FinancialDocumentDisplayName.Should().Be("self-assessment checklist");
     }
 }


### PR DESCRIPTION
[User Story 193582](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/193582): Build: Front-end Links to trust financial docs

## Changes

- Added simple service which returns dummy values
- Added enums for `FinancialDocumentStatus` and `FinancialDocumentType` (which can be used in data layer too)
- Made each page request financial docs from the service with the appropriate `FinancialDocumentType` for that page
- Made financial docs rows display data from the service (including different behaviour for different statuses)

### Not included

- Data sources