### PR TITLE
Add "About these documents"

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/_FinancialDocumentsLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/_FinancialDocumentsLayout.cshtml
@@ -49,6 +49,28 @@
       }
     </dl>
 
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          About these documents
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <p class="govuk-heading-s">Requesting access or reporting a problem</p>
+        <p class="govuk-body">Financial documents are maintained by the Data Science team.</p>
+        <p class="govuk-body"><strong>Do not</strong> contact a trust about documents that are missing or in the wrong
+          format.</p>
+        <p class="govuk-body">To report a problem with a document, or if you have a <strong>business need</strong> to be
+          granted access, email:</p>
+        <p class="govuk-body">
+          <a href="mailto:academiesfinancialmonitoring@education.gov.uk" class="govuk-link" rel="noreferrer noopener">academiesfinancialmonitoring@education.gov.uk</a>.
+        </p>
+        <p class="govuk-heading-s">Why a document might not be expected</p>
+        <p class="govuk-body">If a trust could not have submitted a document, for example because it had not formed yet,
+          we say that it was ‘not expected’.</p>
+      </div>
+    </details>
+
     @RenderBody()
 
   </div>

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/BaseFinancialDocumentsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/BaseFinancialDocumentsAreaModelTests.cs
@@ -22,10 +22,13 @@ public abstract class BaseFinancialDocumentsAreaModelTests<T> : BaseTrustPageTes
             .ReturnsAsync(_unsortedFinancialDocs);
     }
 
-    [Fact(Skip = "Data source not implemented yet")]
-    public override Task OnGetAsync_sets_correct_data_source_list()
+    [Fact]
+    public override async Task OnGetAsync_sets_correct_data_source_list()
     {
-        throw new NotImplementedException();
+        _ = await Sut.OnGetAsync();
+
+        await MockDataSourceService.DidNotReceive().GetAsync(Arg.Any<Source>());
+        Sut.DataSourcesPerPage.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
[User Story 193582](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/193582): Build: Front-end Links to trust financial docs

## Changes

- Add "About these documents" details component - This is being used in place of a data sources component