### PR TITLE
200994 moq nsubstitute academiestrusts memorycache

### DIFF
--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/CookiesHelperTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/CookiesHelperTests.cs
@@ -6,18 +6,18 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests;
 public class CookiesHelperTests
 {
     private readonly MockHttpContext _mockContext = new();
-    private readonly Mock<ITempDataDictionary> _mockTempData = new();
+    private readonly ITempDataDictionary _mockTempData = Substitute.For<ITempDataDictionary>();
 
     private void SetTempDataCookieDeleted()
     {
-        _mockTempData.Setup(m => m[CookiesHelper.DeleteCookieTempDataName]).Returns(true);
+        _mockTempData[CookiesHelper.DeleteCookieTempDataName].Returns(true);
     }
 
     [Fact]
     public void OptionalCookiesAreAccepted_is_true_when_Accepted_cookie_exists()
     {
         _mockContext.MockRequestCookies.SetupAcceptedCookie();
-        var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData.Object);
+        var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData);
         result.Should().BeTrue();
     }
 
@@ -25,7 +25,7 @@ public class CookiesHelperTests
     public void OptionalCookiesAreAccepted_is_false_when_Rejected_cookie_exists()
     {
         _mockContext.MockRequestCookies.SetupRejectedCookie();
-        var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData.Object);
+        var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData);
         result.Should().BeFalse();
     }
 
@@ -38,14 +38,14 @@ public class CookiesHelperTests
         _mockContext.MockRequestCookies.SetupConsentCookie(cookieAccepted);
 
         SetTempDataCookieDeleted();
-        var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData.Object);
+        var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData);
         result.Should().BeFalse();
     }
 
     [Fact]
     public void OptionalCookiesAreAccepted_is_false_when_neither_Cookie_or_TempData_exists()
     {
-        var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData.Object);
+        var result = CookiesHelper.OptionalCookiesAreAccepted(_mockContext.Object, _mockTempData);
         result.Should().BeFalse();
     }
 
@@ -72,7 +72,7 @@ public class CookiesHelperTests
     [Fact]
     public void ShowCookieBanner_is_true_when_consent_cookie_does_not_exist_and_temp_data_does_not_exist()
     {
-        var result = CookiesHelper.ShowCookieBanner(_mockContext.Object, _mockTempData.Object);
+        var result = CookiesHelper.ShowCookieBanner(_mockContext.Object, _mockTempData);
         result.Should().BeTrue();
     }
 
@@ -83,7 +83,7 @@ public class CookiesHelperTests
     {
         _mockContext.MockRequestCookies.SetupConsentCookie(cookieAccepted);
 
-        var result = CookiesHelper.ShowCookieBanner(_mockContext.Object, _mockTempData.Object);
+        var result = CookiesHelper.ShowCookieBanner(_mockContext.Object, _mockTempData);
         result.Should().BeFalse();
     }
 
@@ -91,7 +91,7 @@ public class CookiesHelperTests
     public void ShowCookieBanner_is_false_when_consent_cookie_does_not_exist_and_temp_data_exists()
     {
         SetTempDataCookieDeleted();
-        var result = CookiesHelper.ShowCookieBanner(_mockContext.Object, _mockTempData.Object);
+        var result = CookiesHelper.ShowCookieBanner(_mockContext.Object, _mockTempData);
         result.Should().BeFalse();
     }
 
@@ -103,7 +103,7 @@ public class CookiesHelperTests
         _mockContext.MockRequestCookies.SetupConsentCookie(cookieAccepted);
 
         SetTempDataCookieDeleted();
-        var result = CookiesHelper.ShowCookieBanner(_mockContext.Object, _mockTempData.Object);
+        var result = CookiesHelper.ShowCookieBanner(_mockContext.Object, _mockTempData);
         result.Should().BeFalse();
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/DfE.FindInformationAcademiesTrusts.UnitTests.csproj
@@ -13,7 +13,6 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="7.0.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-        <PackageReference Include="Moq" Version="4.20.72"/>
         <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/EnvironmentExtensionsTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Extensions/EnvironmentExtensionsTests.cs
@@ -10,7 +10,7 @@ public class EnvironmentExtensionsTests
     {
         var mockWebHostEnvironment = CreateMockEnvironment("LocalDevelopment");
 
-        mockWebHostEnvironment.Object.IsLocalDevelopment().Should().BeTrue();
+        mockWebHostEnvironment.IsLocalDevelopment().Should().BeTrue();
     }
 
     [Theory]
@@ -23,7 +23,7 @@ public class EnvironmentExtensionsTests
     {
         var mockWebHostEnvironment = CreateMockEnvironment(environmentName);
 
-        mockWebHostEnvironment.Object.IsLocalDevelopment().Should().BeFalse();
+        mockWebHostEnvironment.IsLocalDevelopment().Should().BeFalse();
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public class EnvironmentExtensionsTests
     {
         var mockWebHostEnvironment = CreateMockEnvironment("CI");
 
-        mockWebHostEnvironment.Object.IsContinuousIntegration().Should().BeTrue();
+        mockWebHostEnvironment.IsContinuousIntegration().Should().BeTrue();
     }
 
     [Theory]
@@ -44,7 +44,7 @@ public class EnvironmentExtensionsTests
     {
         var mockWebHostEnvironment = CreateMockEnvironment(environmentName);
 
-        mockWebHostEnvironment.Object.IsContinuousIntegration().Should().BeFalse();
+        mockWebHostEnvironment.IsContinuousIntegration().Should().BeFalse();
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class EnvironmentExtensionsTests
     {
         var mockWebHostEnvironment = CreateMockEnvironment("Test");
 
-        mockWebHostEnvironment.Object.IsTest().Should().BeTrue();
+        mockWebHostEnvironment.IsTest().Should().BeTrue();
     }
 
     [Theory]
@@ -65,7 +65,7 @@ public class EnvironmentExtensionsTests
     {
         var mockWebHostEnvironment = CreateMockEnvironment(environmentName);
 
-        mockWebHostEnvironment.Object.IsTest().Should().BeFalse();
+        mockWebHostEnvironment.IsTest().Should().BeFalse();
     }
 
     [Theory]
@@ -77,7 +77,7 @@ public class EnvironmentExtensionsTests
     {
         var mockWebHostEnvironment = CreateMockEnvironment(environmentName);
 
-        mockWebHostEnvironment.Object.IsLiveEnvironment().Should().BeFalse();
+        mockWebHostEnvironment.IsLiveEnvironment().Should().BeFalse();
     }
 
     [Theory]
@@ -89,13 +89,13 @@ public class EnvironmentExtensionsTests
     {
         var mockWebHostEnvironment = CreateMockEnvironment(environmentName);
 
-        mockWebHostEnvironment.Object.IsLiveEnvironment().Should().BeTrue();
+        mockWebHostEnvironment.IsLiveEnvironment().Should().BeTrue();
     }
 
-    private static Mock<IWebHostEnvironment> CreateMockEnvironment(string environmentName)
+    private static IWebHostEnvironment CreateMockEnvironment(string environmentName)
     {
-        var mockWebHostEnvironment = new Mock<IWebHostEnvironment>();
-        mockWebHostEnvironment.SetupGet(m => m.EnvironmentName).Returns(environmentName);
+        var mockWebHostEnvironment = Substitute.For<IWebHostEnvironment>();
+        mockWebHostEnvironment.EnvironmentName.Returns(environmentName);
         return mockWebHostEnvironment;
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/HttpContextUserDetailsProviderTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/HttpContextUserDetailsProviderTests.cs
@@ -10,16 +10,17 @@ public class HttpContextUserDetailsProviderTests
 
     public HttpContextUserDetailsProviderTests()
     {
-        Mock<IHttpContextAccessor> mockHttpAccessor = new();
-        mockHttpAccessor.Setup(m => m.HttpContext).Returns(_mockHttpContext.Object);
+        IHttpContextAccessor mockHttpAccessor = Substitute.For<IHttpContextAccessor>();
+        mockHttpAccessor.HttpContext.Returns(_mockHttpContext.Object);
 
-        _sut = new HttpContextUserDetailsProvider(mockHttpAccessor.Object);
+        _sut = new HttpContextUserDetailsProvider(mockHttpAccessor);
     }
 
     [Fact]
     public void GetUserDetails_should_throw_if_there_is_no_httpcontext()
     {
-        _sut = new HttpContextUserDetailsProvider(Mock.Of<IHttpContextAccessor>());
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        _sut = new HttpContextUserDetailsProvider(httpContextAccessor);
 
         var action = () => _sut.GetUserDetails();
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockMemoryCache.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockMemoryCache.cs
@@ -3,28 +3,30 @@ using Microsoft.Extensions.Primitives;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 
-public class MockMemoryCache : Mock<IMemoryCache>
+public class MockMemoryCache
 {
     public Dictionary<object, MockCacheEntry> MockCacheEntries { get; } = new();
+    public IMemoryCache Object { get; } = Substitute.For<IMemoryCache>();
 
     public MockMemoryCache()
     {
-        Setup(m => m.CreateEntry(It.IsAny<object>())).Returns((object key) =>
+        Object.CreateEntry(Arg.Any<object>()).Returns(args =>
         {
+            var key = args[0];
             var mockCacheEntry = new MockCacheEntry(key);
             MockCacheEntries.Add(key, mockCacheEntry);
 
             return mockCacheEntry;
         });
 
-        object? outReturn; //needed separately by Moq for out parameter
-        Setup(m => m.TryGetValue(It.IsAny<object>(), out outReturn))
-            .Returns((object key, out object? value) =>
+        Object.TryGetValue(Arg.Any<object>(), out Arg.Any<object?>()).Returns(args =>
             {
+                var key = args[0];
                 var isInCache = MockCacheEntries.TryGetValue(key, out var mockCacheEntry);
-                value = mockCacheEntry?.Value;
+                args[1] = mockCacheEntry?.Value;
                 return isInCache;
-            });
+            }
+        );
     }
 
     public void AddMockCacheEntry<TItem>(object key, TItem value)

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/CookiesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/CookiesModelTests.cs
@@ -19,12 +19,13 @@ public class CookiesModelTests
 
     public CookiesModelTests()
     {
-        Mock<IHttpContextAccessor> mockHttpAccessor = new();
+        IHttpContextAccessor mockHttpAccessor = Substitute.For<IHttpContextAccessor>();
         _mockHttpContext = new MockHttpContext();
-        mockHttpAccessor.Setup(m => m.HttpContext).Returns(_mockHttpContext.Object);
+        mockHttpAccessor.HttpContext.Returns(_mockHttpContext.Object);
         var actionContext = new ActionContext(_mockHttpContext.Object, new RouteData(), new ActionDescriptor());
-        _tempData = new TempDataDictionary(_mockHttpContext.Object, Mock.Of<ITempDataProvider>());
-        _sut = new CookiesModel(mockHttpAccessor.Object)
+        var tempDataProvider = Substitute.For<ITempDataProvider>();
+        _tempData = new TempDataDictionary(_mockHttpContext.Object, tempDataProvider);
+        _sut = new CookiesModel(mockHttpAccessor)
         {
             TempData = _tempData,
             Url = new UrlHelper(actionContext)

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/ErrorModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/ErrorModelTests.cs
@@ -11,10 +11,10 @@ public class ErrorModelTests
 
     public ErrorModelTests()
     {
-        Mock<IHttpContextAccessor> mockHttpAccessor = new();
-        mockHttpAccessor.Setup(m => m.HttpContext).Returns(_mockHttpContext.Object);
+        IHttpContextAccessor mockHttpAccessor = Substitute.For<IHttpContextAccessor>();
+        mockHttpAccessor.HttpContext.Returns(_mockHttpContext.Object);
 
-        _sut = new ErrorModel(mockHttpAccessor.Object);
+        _sut = new ErrorModel(mockHttpAccessor);
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/SearchModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/SearchModelTests.cs
@@ -1,7 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Pages;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
-using DocumentFormat.OpenXml.Office2013.Excel;
 using FluentAssertions.Execution;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/BaseAcademiesAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/BaseAcademiesAreaModelTests.cs
@@ -7,24 +7,22 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies;
 public abstract class BaseAcademiesAreaModelTests<T> : BaseTrustPageTests<T>, ITestSubpages, ITestTabPages, ITestExport
     where T : AcademiesAreaModel
 {
-    protected readonly Mock<IAcademyService> MockAcademyService = new();
-    protected readonly Mock<IExportService> MockExportService = new();
+    protected readonly IAcademyService MockAcademyService = Substitute.For<IAcademyService>();
+    protected readonly IExportService MockExportService = Substitute.For<IExportService>();
     protected const string TrustReferenceNumber = "TRN00123";
 
     public BaseAcademiesAreaModelTests()
     {
-        MockTrustService
-            .Setup(a => a.GetTrustReferenceNumberAsync(TrustUid))
-            .ReturnsAsync(TrustReferenceNumber);
+        MockTrustService.GetTrustReferenceNumberAsync(TrustUid).Returns(Task.FromResult(TrustReferenceNumber));
 
         //Set default GetAcademiesPipelineSummaryAsync to enable base tests with different UIDs
         MockAcademyService
-            .Setup(t => t.GetAcademiesPipelineSummaryAsync(It.IsAny<string>()))
-            .ReturnsAsync(new AcademyPipelineSummaryServiceModel(0, 0, 0));
+            .GetAcademiesPipelineSummaryAsync(Arg.Any<string>())
+            .Returns(Task.FromResult(new AcademyPipelineSummaryServiceModel(0, 0, 0)));
 
         MockAcademyService
-            .Setup(t => t.GetAcademiesPipelineSummaryAsync(TrustReferenceNumber))
-            .ReturnsAsync(new AcademyPipelineSummaryServiceModel(1, 2, 3));
+            .GetAcademiesPipelineSummaryAsync(TrustReferenceNumber)
+            .Returns(Task.FromResult(new AcademyPipelineSummaryServiceModel(1, 2, 3)));
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/BaseAcademiesInTrustAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/BaseAcademiesInTrustAreaModelTests.cs
@@ -12,7 +12,7 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies.In
 public abstract class AcademiesInTrustAreaModelTests<T> : BaseAcademiesAreaModelTests<T>, ITestTabPages
     where T : AcademiesInTrustAreaModel
 {
-    protected readonly Mock<IDateTimeProvider> MockDateTimeProvider = new();
+    protected readonly IDateTimeProvider MockDateTimeProvider = Substitute.For<IDateTimeProvider>();
 
     [Fact]
     public override async Task OnGetExportAsync_ShouldReturnFileResult_WhenUidIsValid()
@@ -20,8 +20,7 @@ public abstract class AcademiesInTrustAreaModelTests<T> : BaseAcademiesAreaModel
         // Arrange
         byte[] expectedBytes = [1, 2, 3];
 
-        MockExportService.Setup(x => x.ExportAcademiesToSpreadsheetAsync(TrustUid))
-            .ReturnsAsync(expectedBytes);
+        MockExportService.ExportAcademiesToSpreadsheetAsync(TrustUid).Returns(Task.FromResult(expectedBytes));
 
         // Act
         var result = await Sut.OnGetExportAsync(TrustUid);
@@ -39,8 +38,7 @@ public abstract class AcademiesInTrustAreaModelTests<T> : BaseAcademiesAreaModel
         // Arrange
         var uid = "invalid-uid";
 
-        MockTrustService.Setup(x => x.GetTrustSummaryAsync(uid))
-            .ReturnsAsync((TrustSummaryServiceModel?)null);
+        MockTrustService.GetTrustSummaryAsync(uid).Returns(Task.FromResult((TrustSummaryServiceModel?)null));
 
         // Act
         var result = await Sut.OnGetExportAsync(uid);
@@ -56,10 +54,8 @@ public abstract class AcademiesInTrustAreaModelTests<T> : BaseAcademiesAreaModel
         var uid = TrustUid;
         var expectedBytes = new byte[] { 1, 2, 3 };
 
-        MockTrustService.Setup(x => x.GetTrustSummaryAsync(uid))
-            .ReturnsAsync(DummyTrustSummary with { Name = "Sample/Trust:Name?" });
-        MockExportService.Setup(x => x.ExportAcademiesToSpreadsheetAsync(uid))
-            .ReturnsAsync(expectedBytes);
+        MockTrustService.GetTrustSummaryAsync(uid)!.Returns(Task.FromResult(DummyTrustSummary with { Name = "Sample/Trust:Name?" }));
+        MockExportService.ExportAcademiesToSpreadsheetAsync(uid).Returns(Task.FromResult(expectedBytes));
 
         // Act
         var result = await Sut.OnGetExportAsync(uid);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/DetailsModelTests.cs
@@ -7,24 +7,24 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies.In
 
 public class AcademiesDetailsModelTests : AcademiesInTrustAreaModelTests<AcademiesInTrustDetailsModel>
 {
-    private readonly Mock<IOtherServicesLinkBuilder> _mockLinkBuilder = new();
+    private readonly IOtherServicesLinkBuilder _mockLinkBuilder = Substitute.For<IOtherServicesLinkBuilder>();
 
     public AcademiesDetailsModelTests()
     {
         Sut = new AcademiesInTrustDetailsModel(MockDataSourceService,
-                _mockLinkBuilder.Object,
+                _mockLinkBuilder,
                 MockLogger.CreateLogger<AcademiesInTrustDetailsModel>(),
-                MockTrustService.Object,
-                MockAcademyService.Object,
-                MockExportService.Object,
-                MockDateTimeProvider.Object)
+                MockTrustService,
+                MockAcademyService,
+                MockExportService,
+                MockDateTimeProvider)
             { Uid = TrustUid };
     }
 
     [Fact]
     public void OtherServicesLinkBuilder_should_be_injected()
     {
-        Sut.LinkBuilder.Should().Be(_mockLinkBuilder.Object);
+        Sut.LinkBuilder.Should().Be(_mockLinkBuilder);
     }
 
     [Fact]
@@ -36,8 +36,7 @@ public class AcademiesDetailsModelTests : AcademiesInTrustAreaModelTests<Academi
             new AcademyDetailsServiceModel("2", "", "", "", ""),
             new AcademyDetailsServiceModel("3", "", "", "", "")
         };
-        MockAcademyService.Setup(a => a.GetAcademiesInTrustDetailsAsync(Sut.Uid))
-            .ReturnsAsync(academies);
+        MockAcademyService.GetAcademiesInTrustDetailsAsync(Sut.Uid).Returns(Task.FromResult(academies));
 
         _ = await Sut.OnGetAsync();
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/FreeSchoolMealsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/FreeSchoolMealsModelTests.cs
@@ -11,10 +11,10 @@ public class FreeSchoolMealsModelTests : AcademiesInTrustAreaModelTests<FreeScho
     {
         Sut = new FreeSchoolMealsModel(MockDataSourceService,
                 MockLogger.CreateLogger<FreeSchoolMealsModel>(),
-                MockTrustService.Object,
-                MockAcademyService.Object,
-                MockExportService.Object,
-                MockDateTimeProvider.Object)
+                MockTrustService,
+                MockAcademyService,
+                MockExportService,
+                MockDateTimeProvider)
             { Uid = TrustUid };
     }
 
@@ -27,8 +27,7 @@ public class FreeSchoolMealsModelTests : AcademiesInTrustAreaModelTests<FreeScho
             new AcademyFreeSchoolMealsServiceModel("2", "Academy 2", null, 70.1, 64.1),
             new AcademyFreeSchoolMealsServiceModel("3", "Academy 3", 8.2, 4, 10)
         };
-        MockAcademyService.Setup(a => a.GetAcademiesInTrustFreeSchoolMealsAsync(Sut.Uid))
-            .ReturnsAsync(academies);
+        MockAcademyService.GetAcademiesInTrustFreeSchoolMealsAsync(Sut.Uid).Returns(Task.FromResult(academies));
 
         _ = await Sut.OnGetAsync();
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/PupilNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/PupilNumbersModelTests.cs
@@ -11,10 +11,10 @@ public class PupilNumbersModelTests : AcademiesInTrustAreaModelTests<PupilNumber
     {
         Sut = new PupilNumbersModel(MockDataSourceService,
                 MockLogger.CreateLogger<PupilNumbersModel>(),
-                MockTrustService.Object,
-                MockAcademyService.Object,
-                MockExportService.Object,
-                MockDateTimeProvider.Object)
+                MockTrustService,
+                MockAcademyService,
+                MockExportService,
+                MockDateTimeProvider)
             { Uid = TrustUid };
     }
 
@@ -49,8 +49,7 @@ public class PupilNumbersModelTests : AcademiesInTrustAreaModelTests<PupilNumber
             academy with { Urn = "2" },
             academy with { Urn = "3" }
         };
-        MockAcademyService.Setup(a => a.GetAcademiesInTrustPupilNumbersAsync(TrustUid))
-            .ReturnsAsync(academies);
+        MockAcademyService.GetAcademiesInTrustPupilNumbersAsync(TrustUid).Returns(Task.FromResult(academies));
 
         _ = await Sut.OnGetAsync();
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/BasePipelineAcademiesAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/BasePipelineAcademiesAreaModelTests.cs
@@ -13,12 +13,12 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Academies.Pi
 public abstract class BasePipelineAcademiesAreaModelTests<T> : BaseAcademiesAreaModelTests<T>
     where T : PipelineAcademiesAreaModel
 {
-    protected readonly Mock<IDateTimeProvider> MockDateTimeProvider = new();
+    protected readonly IDateTimeProvider MockDateTimeProvider = Substitute.For<IDateTimeProvider>();
 
     protected BasePipelineAcademiesAreaModelTests()
     {
-        MockAcademyService.Setup(t => t.GetAcademiesPipelineSummaryAsync(TrustUid))
-            .ReturnsAsync(new AcademyPipelineSummaryServiceModel(1, 2, 3));
+        MockAcademyService.GetAcademiesPipelineSummaryAsync(TrustUid)
+            .Returns(Task.FromResult(new AcademyPipelineSummaryServiceModel(1, 2, 3)));
     }
 
     [Fact]
@@ -27,7 +27,7 @@ public abstract class BasePipelineAcademiesAreaModelTests<T> : BaseAcademiesArea
         // Arrange
         byte[] expectedBytes = [1, 2, 3];
 
-        MockExportService.Setup(x => x.ExportPipelineAcademiesToSpreadsheetAsync(TrustUid)).ReturnsAsync(expectedBytes);
+        MockExportService.ExportPipelineAcademiesToSpreadsheetAsync(TrustUid).Returns(Task.FromResult(expectedBytes));
 
         // Act
         var result = await Sut.OnGetExportAsync(TrustUid);
@@ -45,7 +45,7 @@ public abstract class BasePipelineAcademiesAreaModelTests<T> : BaseAcademiesArea
         // Arrange
         var uid = "invalid-uid";
 
-        MockTrustService.Setup(x => x.GetTrustSummaryAsync(uid)).ReturnsAsync((TrustSummaryServiceModel?)null);
+        MockTrustService.GetTrustSummaryAsync(uid).Returns(Task.FromResult((TrustSummaryServiceModel?)null));
 
         // Act
         var result = await Sut.OnGetExportAsync(uid);
@@ -61,8 +61,8 @@ public abstract class BasePipelineAcademiesAreaModelTests<T> : BaseAcademiesArea
         var trustSummary = new TrustSummaryServiceModel(TrustUid, "Sample/Trust:Name?", "Multi-academy trust", 0);
         var expectedBytes = new byte[] { 1, 2, 3 };
 
-        MockTrustService.Setup(x => x.GetTrustSummaryAsync(TrustUid)).ReturnsAsync(trustSummary);
-        MockExportService.Setup(x => x.ExportPipelineAcademiesToSpreadsheetAsync(TrustUid)).ReturnsAsync(expectedBytes);
+        MockTrustService.GetTrustSummaryAsync(TrustUid)!.Returns(Task.FromResult(trustSummary));
+        MockExportService.ExportPipelineAcademiesToSpreadsheetAsync(TrustUid).Returns(Task.FromResult(expectedBytes));
 
         // Act
         var result = await Sut.OnGetExportAsync(TrustUid);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/FreeSchoolsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/FreeSchoolsModelTests.cs
@@ -11,8 +11,8 @@ public class FreeSchoolsModelTests : BasePipelineAcademiesAreaModelTests<FreeSch
     {
         Sut = new FreeSchoolsModel(
                 MockDataSourceService, MockLogger.CreateLogger<FreeSchoolsModel>(),
-                MockTrustService.Object, MockAcademyService.Object, MockExportService.Object,
-                MockDateTimeProvider.Object)
+                MockTrustService, MockAcademyService, MockExportService,
+                MockDateTimeProvider)
             { Uid = TrustUid };
     }
 
@@ -33,8 +33,8 @@ public class FreeSchoolsModelTests : BasePipelineAcademiesAreaModelTests<FreeSch
         };
 
         MockAcademyService
-            .Setup(a => a.GetAcademiesPipelineFreeSchoolsAsync(TrustReferenceNumber))
-            .ReturnsAsync(academies);
+            .GetAcademiesPipelineFreeSchoolsAsync(TrustReferenceNumber)
+            .Returns(Task.FromResult(academies));
 
         // Act
         await Sut.OnGetAsync();

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoardModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoardModelTests.cs
@@ -11,8 +11,8 @@ public class PostAdvisoryBoardModelTests : BasePipelineAcademiesAreaModelTests<P
     {
         Sut = new PostAdvisoryBoardModel(
                 MockDataSourceService, MockLogger.CreateLogger<PostAdvisoryBoardModel>(),
-                MockTrustService.Object, MockAcademyService.Object, MockExportService.Object,
-                MockDateTimeProvider.Object)
+                MockTrustService, MockAcademyService, MockExportService,
+                MockDateTimeProvider)
             { Uid = TrustUid };
     }
 
@@ -28,8 +28,7 @@ public class PostAdvisoryBoardModelTests : BasePipelineAcademiesAreaModelTests<P
             new(null, null, null, null, null, null)
         ];
 
-        MockAcademyService.Setup(a => a.GetAcademiesPipelinePostAdvisoryAsync(TrustReferenceNumber))
-            .ReturnsAsync(academies);
+        MockAcademyService.GetAcademiesPipelinePostAdvisoryAsync(TrustReferenceNumber).Returns(Task.FromResult(academies));
 
         _ = await Sut.OnGetAsync();
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoardModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoardModelTests.cs
@@ -11,8 +11,8 @@ public class PreAdvisoryBoardModelTests : BasePipelineAcademiesAreaModelTests<Pr
     {
         Sut = new PreAdvisoryBoardModel(
                 MockDataSourceService, MockLogger.CreateLogger<PreAdvisoryBoardModel>(),
-                MockTrustService.Object, MockAcademyService.Object, MockExportService.Object,
-                MockDateTimeProvider.Object)
+                MockTrustService, MockAcademyService, MockExportService,
+                MockDateTimeProvider)
             { Uid = TrustUid };
     }
 
@@ -27,8 +27,7 @@ public class PreAdvisoryBoardModelTests : BasePipelineAcademiesAreaModelTests<Pr
             new("4", null, null, null, null, null)
         ];
 
-        MockAcademyService.Setup(a => a.GetAcademiesPipelinePreAdvisoryAsync(TrustReferenceNumber))
-            .ReturnsAsync(academies);
+        MockAcademyService.GetAcademiesPipelinePreAdvisoryAsync(TrustReferenceNumber).Returns(Task.FromResult(academies));
 
         _ = await Sut.OnGetAsync();
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/BaseTrustPageTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/BaseTrustPageTests.cs
@@ -11,7 +11,7 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
 public abstract class BaseTrustPageTests<T> where T : TrustsAreaModel
 {
     protected T Sut = default!;
-    protected readonly Mock<ITrustService> MockTrustService = new();
+    protected readonly ITrustService MockTrustService = Substitute.For<ITrustService>();
     protected readonly IDataSourceService MockDataSourceService = Mocks.MockDataSourceService.CreateSubstitute();
     
     protected readonly DataSourceServiceModel GiasDataSource =
@@ -29,9 +29,12 @@ public abstract class BaseTrustPageTests<T> where T : TrustsAreaModel
     protected const string TrustUid = "1234";
     protected readonly TrustSummaryServiceModel DummyTrustSummary = new(TrustUid, "My Trust", "Multi-academy trust", 3);
 
+    private const string EmptyTrustUid = "";
+    protected readonly TrustSummaryServiceModel DummyTrustSummaryEmptyUid = new(EmptyTrustUid, "My Trust", "Multi-academy trust", 3);
+
     protected BaseTrustPageTests()
     {
-        MockTrustService.Setup(t => t.GetTrustSummaryAsync(TrustUid)).ReturnsAsync(DummyTrustSummary);
+        MockTrustService.GetTrustSummaryAsync(TrustUid)!.Returns(Task.FromResult(DummyTrustSummary));
     }
 
     [Fact]
@@ -52,8 +55,7 @@ public abstract class BaseTrustPageTests<T> where T : TrustsAreaModel
     [Fact]
     public async Task OnGetAsync_should_return_not_found_result_if_trust_is_not_found()
     {
-        MockTrustService.Setup(t => t.GetTrustSummaryAsync("1111"))
-            .ReturnsAsync((TrustSummaryServiceModel?)null);
+        MockTrustService.GetTrustSummaryAsync("1111").Returns(Task.FromResult<TrustSummaryServiceModel?>(null));
 
         Sut.Uid = "1111";
         var result = await Sut.OnGetAsync();
@@ -63,6 +65,8 @@ public abstract class BaseTrustPageTests<T> where T : TrustsAreaModel
     [Fact]
     public async Task OnGetAsync_should_return_not_found_result_if_Uid_is_not_provided()
     {
+        MockTrustService.GetTrustSummaryAsync("").Returns(Task.FromResult((TrustSummaryServiceModel?)null));
+        
         Sut.Uid = "";
         var result = await Sut.OnGetAsync();
         result.Should().BeOfType<NotFoundResult>();
@@ -123,8 +127,7 @@ public abstract class BaseTrustPageTests<T> where T : TrustsAreaModel
     [InlineData("5678")]
     public async Task OnGetAsync_should_set_NavigationLinks_to_trust_uid(string trustUid)
     {
-        MockTrustService.Setup(t => t.GetTrustSummaryAsync(trustUid))
-            .ReturnsAsync(DummyTrustSummary with { Uid = trustUid });
+        MockTrustService.GetTrustSummaryAsync(trustUid)!.Returns(Task.FromResult(DummyTrustSummary with { Uid = trustUid }));
         Sut.Uid = trustUid;
 
         _ = await Sut.OnGetAsync();
@@ -148,8 +151,7 @@ public abstract class BaseTrustPageTests<T> where T : TrustsAreaModel
     [InlineData("5678")]
     public async Task OnGetAsync_should_set_SubNavigationLinks_to_trust_uid(string trustUid)
     {
-        MockTrustService.Setup(t => t.GetTrustSummaryAsync(trustUid))
-            .ReturnsAsync(DummyTrustSummary with { Uid = trustUid });
+        MockTrustService.GetTrustSummaryAsync(trustUid)!.Returns(Task.FromResult(DummyTrustSummary with { Uid = trustUid }));
 
         Sut.Uid = trustUid;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/BaseContactsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/BaseContactsAreaModelTests.cs
@@ -26,16 +26,17 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
 
     protected BaseContactsAreaModelTests()
     {
-        MockTrustService.Setup(tp => tp.GetTrustContactsAsync(It.IsAny<string>()))
-            .ReturnsAsync(_baseTrustContactsServiceModel);
+        MockTrustService.GetTrustContactsAsync(Arg.Any<string>()).Returns(Task.FromResult(_baseTrustContactsServiceModel));
     }
 
     [Fact]
     public async Task OnGetAsync_sets_chair_of_trustees_to_be_current_chair()
     {
         var chairOfTrustees = new Person("Chair Of Trustees", "cot@test.com");
-        MockTrustService.Setup(tp => tp.GetTrustContactsAsync(TrustUid))
-            .ReturnsAsync(_baseTrustContactsServiceModel with { ChairOfTrustees = chairOfTrustees });
+        MockTrustService.GetTrustContactsAsync(TrustUid).Returns(Task.FromResult(_baseTrustContactsServiceModel with
+        {
+            ChairOfTrustees = chairOfTrustees
+        }));
 
         await Sut.OnGetAsync();
         Sut.ChairOfTrustees.Should().Be(chairOfTrustees);
@@ -45,8 +46,10 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     public async Task OnGetAsync_sets_accounting_officer_to_be_current_officer()
     {
         var accountingOfficer = new Person("Accounting Officer", "ao@test.com");
-        MockTrustService.Setup(tp => tp.GetTrustContactsAsync(TrustUid))
-            .ReturnsAsync(_baseTrustContactsServiceModel with { AccountingOfficer = accountingOfficer });
+        MockTrustService.GetTrustContactsAsync(TrustUid).Returns(Task.FromResult(_baseTrustContactsServiceModel with
+        {
+            AccountingOfficer = accountingOfficer
+        }));
 
         await Sut.OnGetAsync();
 
@@ -58,8 +61,8 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     {
         var chiefFinancialOfficer = new Person("Chief Financial Officer", "cfo@test.com");
 
-        MockTrustService.Setup(tp => tp.GetTrustContactsAsync(TrustUid))
-            .ReturnsAsync(_baseTrustContactsServiceModel with { ChiefFinancialOfficer = chiefFinancialOfficer });
+        MockTrustService.GetTrustContactsAsync(TrustUid)
+            .Returns(Task.FromResult(_baseTrustContactsServiceModel with { ChiefFinancialOfficer = chiefFinancialOfficer }));
 
         await Sut.OnGetAsync();
         Sut.ChiefFinancialOfficer.Should().Be(chiefFinancialOfficer);
@@ -68,8 +71,8 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     [Fact]
     public async Task OnGetAsync_sets_trust_relationship_manager()
     {
-        MockTrustService.Setup(tp => tp.GetTrustContactsAsync(TrustUid))
-            .ReturnsAsync(_baseTrustContactsServiceModel with { TrustRelationshipManager = _trustRelationshipManager });
+        MockTrustService.GetTrustContactsAsync(TrustUid)
+            .Returns(Task.FromResult(_baseTrustContactsServiceModel with { TrustRelationshipManager = _trustRelationshipManager }));
 
         await Sut.OnGetAsync();
         Sut.TrustRelationshipManager?.Should().Be(_trustRelationshipManager);
@@ -78,8 +81,8 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     [Fact]
     public async Task OnGetAsync_sets_trust_sfsolead()
     {
-        MockTrustService.Setup(tp => tp.GetTrustContactsAsync(TrustUid))
-            .ReturnsAsync(_baseTrustContactsServiceModel with { SfsoLead = _sfsoLead });
+        MockTrustService.GetTrustContactsAsync(TrustUid)
+            .Returns(Task.FromResult(_baseTrustContactsServiceModel with { SfsoLead = _sfsoLead }));
 
         await Sut.OnGetAsync();
         Sut.SfsoLead?.Should().Be(_sfsoLead);
@@ -88,8 +91,8 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     [Fact]
     public async Task OnGetAsync_sets_chair_of_trustees_to_null_when_trust_has_no_chair()
     {
-        MockTrustService.Setup(tp => tp.GetTrustContactsAsync(TrustUid))
-            .ReturnsAsync(_baseTrustContactsServiceModel with { ChairOfTrustees = null });
+        MockTrustService.GetTrustContactsAsync(TrustUid)
+            .Returns(Task.FromResult(_baseTrustContactsServiceModel with { ChairOfTrustees = null }));
 
         await Sut.OnGetAsync();
         Sut.ChairOfTrustees?.Should().Be(null);
@@ -98,8 +101,8 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     [Fact]
     public async Task OnGetAsync_sets_accounting_officer_to_null_be_when_trust_has_no_officer()
     {
-        MockTrustService.Setup(tp => tp.GetTrustContactsAsync(TrustUid))
-            .ReturnsAsync(_baseTrustContactsServiceModel with { AccountingOfficer = null });
+        MockTrustService.GetTrustContactsAsync(TrustUid)
+            .Returns(Task.FromResult(_baseTrustContactsServiceModel with { AccountingOfficer = null }));
 
         await Sut.OnGetAsync();
         Sut.AccountingOfficer?.Should().Be(null);
@@ -108,8 +111,8 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     [Fact]
     public async Task OnGetAsync_sets_chief_financial_officer_to_null_be_when_trust_has_no_officer()
     {
-        MockTrustService.Setup(tp => tp.GetTrustContactsAsync(TrustUid))
-            .ReturnsAsync(_baseTrustContactsServiceModel with { ChiefFinancialOfficer = null });
+        MockTrustService.GetTrustContactsAsync(TrustUid)
+            .Returns(Task.FromResult(_baseTrustContactsServiceModel with { ChiefFinancialOfficer = null }));
 
         await Sut.OnGetAsync();
         Sut.ChiefFinancialOfficer?.Should().Be(null);
@@ -146,8 +149,8 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     [Fact]
     public async Task OnGetAsync_sets_trustRelationshipManager_last_modified_details_in_data_source_list()
     {
-        MockTrustService.Setup(tp => tp.GetTrustContactsAsync(TrustUid))
-            .ReturnsAsync(_baseTrustContactsServiceModel with { TrustRelationshipManager = _trustRelationshipManager });
+        MockTrustService.GetTrustContactsAsync(TrustUid)
+            .Returns(Task.FromResult(_baseTrustContactsServiceModel with { TrustRelationshipManager = _trustRelationshipManager }));
 
         await Sut.OnGetAsync();
 
@@ -162,8 +165,8 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     [Fact]
     public async Task OnGetAsync_sets__sfsoLead_last_modified_details_in_data_source_list()
     {
-        MockTrustService.Setup(tp => tp.GetTrustContactsAsync(TrustUid))
-            .ReturnsAsync(_baseTrustContactsServiceModel with { SfsoLead = _sfsoLead });
+        MockTrustService.GetTrustContactsAsync(TrustUid)
+            .Returns(Task.FromResult(_baseTrustContactsServiceModel with { SfsoLead = _sfsoLead }));
 
         await Sut.OnGetAsync();
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditContactModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditContactModelTests.cs
@@ -7,19 +7,18 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Contacts;
 public class EditContactModelTests
 {
     private readonly EditContactModel _sut;
-    private readonly Mock<ITrustService> _mockTrustService = new();
+    private readonly ITrustService _mockTrustService = Substitute.For<ITrustService>();
 
     private readonly TrustSummaryServiceModel _fakeTrust = new("1234", "My Trust", "Multi-academy trust", 3);
 
     public EditContactModelTests()
     {
-        _mockTrustService.Setup(tp => tp.GetTrustContactsAsync("1234")).ReturnsAsync(
-            new TrustContactsServiceModel(null, null, null, null, null));
-        _mockTrustService.Setup(t => t.GetTrustSummaryAsync(_fakeTrust.Uid))
-            .ReturnsAsync(_fakeTrust);
+        _mockTrustService.GetTrustContactsAsync("1234").Returns(
+            Task.FromResult(new TrustContactsServiceModel(null, null, null, null, null)));
+        _mockTrustService.GetTrustSummaryAsync(_fakeTrust.Uid)!.Returns(Task.FromResult(_fakeTrust));
 
         _sut = new EditSfsoLeadModel(MockDataSourceService.CreateSubstitute(),
-                MockLogger.CreateLogger<EditSfsoLeadModel>(), _mockTrustService.Object)
+                MockLogger.CreateLogger<EditSfsoLeadModel>(), _mockTrustService)
             { Uid = "1234" };
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InDfeModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InDfeModelTests.cs
@@ -8,7 +8,7 @@ public class InDfeModelTests : BaseContactsAreaModelTests<InDfeModel>
     public InDfeModelTests()
     {
         Sut = new InDfeModel(MockDataSourceService,
-                MockTrustService.Object,
+                MockTrustService,
                 MockLogger.CreateLogger<InDfeModel>())
             { Uid = TrustUid };
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InTrustModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InTrustModelTests.cs
@@ -8,7 +8,7 @@ public class InTrustModelTests : BaseContactsAreaModelTests<InTrustModel>
     public InTrustModelTests()
     {
         Sut = new InTrustModel(MockDataSourceService,
-                MockTrustService.Object,
+                MockTrustService,
                 MockLogger.CreateLogger<InTrustModel>())
             { Uid = TrustUid };
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/BaseGovernanceAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/BaseGovernanceAreaModelTests.cs
@@ -13,8 +13,8 @@ public abstract class BaseGovernanceAreaModelTests<T> : BaseTrustPageTests<T>, I
 {
     protected BaseGovernanceAreaModelTests()
     {
-        MockTrustService.Setup(t => t.GetTrustGovernanceAsync(It.IsAny<string>()))
-            .ReturnsAsync(new TrustGovernanceServiceModel([], [], [], [], 0));
+        MockTrustService.GetTrustGovernanceAsync(Arg.Any<string>())
+            .Returns(Task.FromResult(new TrustGovernanceServiceModel([], [], [], [], 0)));
     }
 
     private static Governor[] GenerateGovernors(bool isCurrent, string role, int numberToGenerate)
@@ -60,12 +60,11 @@ public abstract class BaseGovernanceAreaModelTests<T> : BaseTrustPageTests<T>, I
             GenerateGovernors(false, "Trustee", 1),
             10);
 
-        MockTrustService.Setup(t => t.GetTrustGovernanceAsync(TrustUid))
-            .ReturnsAsync(trustGovernanceServiceModelWithData);
+        MockTrustService.GetTrustGovernanceAsync(TrustUid).Returns(Task.FromResult(trustGovernanceServiceModelWithData));
 
         await Sut.OnGetAsync();
 
-        MockTrustService.Verify(e => e.GetTrustGovernanceAsync(TrustUid), Times.Once);
+        await MockTrustService.Received(1).GetTrustGovernanceAsync(TrustUid);
         Sut.TrustGovernance.Should().BeEquivalentTo(trustGovernanceServiceModelWithData);
     }
 
@@ -78,13 +77,13 @@ public abstract class BaseGovernanceAreaModelTests<T> : BaseTrustPageTests<T>, I
     public async Task OnGetAsync_should_include_numbers_of_governors_in_subpage_link_text(int numTrustLeaders,
         int numMembers, int numTrustees, int numHistoricMembers)
     {
-        MockTrustService.Setup(t => t.GetTrustGovernanceAsync(TrustUid))
-            .ReturnsAsync(new TrustGovernanceServiceModel(
+        MockTrustService.GetTrustGovernanceAsync(TrustUid)
+            .Returns(Task.FromResult(new TrustGovernanceServiceModel(
                 GenerateGovernors(true, "Chair of Trustees", numTrustLeaders),
                 GenerateGovernors(true, "Member", numMembers),
                 GenerateGovernors(true, "Trustee", numTrustees),
                 GenerateGovernors(false, "Trustee", numHistoricMembers),
-                0));
+                0)));
 
         _ = await Sut.OnGetAsync();
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/HistoricMembersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/HistoricMembersModelTests.cs
@@ -8,7 +8,7 @@ public class HistoricMembersModelTests : BaseGovernanceAreaModelTests<HistoricMe
     public HistoricMembersModelTests()
     {
         Sut = new HistoricMembersModel(MockDataSourceService,
-                MockLogger.CreateLogger<HistoricMembersModel>(), MockTrustService.Object)
+                MockLogger.CreateLogger<HistoricMembersModel>(), MockTrustService)
             { Uid = TrustUid };
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/MembersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/MembersModelTests.cs
@@ -8,7 +8,7 @@ public class MembersModelTests : BaseGovernanceAreaModelTests<MembersModel>
     public MembersModelTests()
     {
         Sut = new MembersModel(MockDataSourceService,
-                MockLogger.CreateLogger<MembersModel>(), MockTrustService.Object)
+                MockLogger.CreateLogger<MembersModel>(), MockTrustService)
             { Uid = TrustUid };
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrustLeadershipModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrustLeadershipModelTests.cs
@@ -8,7 +8,7 @@ public class TrustLeadershipModelTests : BaseGovernanceAreaModelTests<TrustLeade
     public TrustLeadershipModelTests()
     {
         Sut = new TrustLeadershipModel(MockDataSourceService,
-                MockLogger.CreateLogger<TrustLeadershipModel>(), MockTrustService.Object)
+                MockLogger.CreateLogger<TrustLeadershipModel>(), MockTrustService)
             { Uid = TrustUid };
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrusteesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrusteesModelTests.cs
@@ -8,7 +8,7 @@ public class TrusteesModelTests : BaseGovernanceAreaModelTests<TrusteesModel>
     public TrusteesModelTests()
     {
         Sut = new TrusteesModel(MockDataSourceService,
-                MockLogger.CreateLogger<TrusteesModel>(), MockTrustService.Object)
+                MockLogger.CreateLogger<TrusteesModel>(), MockTrustService)
             { Uid = TrustUid };
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/BaseOfstedAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/BaseOfstedAreaModelTests.cs
@@ -14,9 +14,9 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Ofsted;
 public abstract class BaseOfstedAreaModelTests<T> : BaseTrustPageTests<T>, ITestSubpages, ITestExport
     where T : OfstedAreaModel
 {
-    protected readonly Mock<IAcademyService> MockAcademyService = new();
-    protected readonly Mock<IExportService> MockExportService = new();
-    protected readonly Mock<IDateTimeProvider> MockDateTimeProvider = new();
+    protected readonly IAcademyService MockAcademyService = Substitute.For<IAcademyService>();
+    protected readonly IExportService MockExportService = Substitute.For<IExportService>();
+    protected readonly IDateTimeProvider MockDateTimeProvider = Substitute.For<IDateTimeProvider>();
 
     [Fact]
     public override async Task OnGetAsync_sets_correct_data_source_list()
@@ -67,8 +67,7 @@ public abstract class BaseOfstedAreaModelTests<T> : BaseTrustPageTests<T>, ITest
                 new OfstedRating(2, new DateTime(2023, 1, 3)),
                 new OfstedRating(3, new DateTime(2023, 4, 1)))
         };
-        MockAcademyService.Setup(a => a.GetAcademiesInTrustOfstedAsync(Sut.Uid))
-            .ReturnsAsync(academies);
+        MockAcademyService.GetAcademiesInTrustOfstedAsync(Sut.Uid).Returns(Task.FromResult(academies));
 
         _ = await Sut.OnGetAsync();
 
@@ -80,8 +79,7 @@ public abstract class BaseOfstedAreaModelTests<T> : BaseTrustPageTests<T>, ITest
     {
         // Arrange
         byte[] expectedBytes = [1, 2, 3];
-        MockExportService.Setup(x => x.ExportOfstedDataToSpreadsheetAsync(TrustUid))
-            .ReturnsAsync(expectedBytes);
+        MockExportService.ExportOfstedDataToSpreadsheetAsync(TrustUid).Returns(Task.FromResult(expectedBytes));
 
         // Act
         var result = await Sut.OnGetExportAsync(TrustUid);
@@ -99,8 +97,7 @@ public abstract class BaseOfstedAreaModelTests<T> : BaseTrustPageTests<T>, ITest
         // Arrange
         var uid = "invalid-uid";
 
-        MockTrustService.Setup(x => x.GetTrustSummaryAsync(uid))
-            .ReturnsAsync((TrustSummaryServiceModel?)null);
+        MockTrustService.GetTrustSummaryAsync(uid).Returns(Task.FromResult<TrustSummaryServiceModel?>(null));
 
         // Act
         var result = await Sut.OnGetExportAsync(uid);
@@ -116,10 +113,8 @@ public abstract class BaseOfstedAreaModelTests<T> : BaseTrustPageTests<T>, ITest
         var uid = TrustUid;
         var expectedBytes = new byte[] { 1, 2, 3 };
 
-        MockTrustService.Setup(x => x.GetTrustSummaryAsync(uid))
-            .ReturnsAsync(DummyTrustSummary with { Name = "Sample/Trust:Name?" });
-        MockExportService.Setup(x => x.ExportOfstedDataToSpreadsheetAsync(uid))
-            .ReturnsAsync(expectedBytes);
+        MockTrustService.GetTrustSummaryAsync(uid)!.Returns(Task.FromResult(DummyTrustSummary with { Name = "Sample/Trust:Name?" }));
+        MockExportService.ExportOfstedDataToSpreadsheetAsync(uid).Returns(Task.FromResult(expectedBytes));
 
         // Act
         var result = await Sut.OnGetExportAsync(uid);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/CurrentRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/CurrentRatingsModelTests.cs
@@ -8,10 +8,10 @@ public class CurrentRatingsModelTests : BaseOfstedAreaModelTests<CurrentRatingsM
     public CurrentRatingsModelTests()
     {
         Sut = new CurrentRatingsModel(MockDataSourceService,
-                MockTrustService.Object,
-                MockAcademyService.Object,
-                MockExportService.Object,
-                MockDateTimeProvider.Object,
+                MockTrustService,
+                MockAcademyService,
+                MockExportService,
+                MockDateTimeProvider,
                 MockLogger.CreateLogger<CurrentRatingsModel>()
             )
             { Uid = TrustUid };

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/PreviousRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/PreviousRatingsModelTests.cs
@@ -8,10 +8,10 @@ public class PreviousRatingsModelTests : BaseOfstedAreaModelTests<PreviousRating
     public PreviousRatingsModelTests()
     {
         Sut = new PreviousRatingsModel(MockDataSourceService,
-                MockTrustService.Object,
-                MockAcademyService.Object,
-                MockExportService.Object,
-                MockDateTimeProvider.Object,
+                MockTrustService,
+                MockAcademyService,
+                MockExportService,
+                MockDateTimeProvider,
                 MockLogger.CreateLogger<PreviousRatingsModel>()
             )
             { Uid = TrustUid };

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SafeguardingAndConcernsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SafeguardingAndConcernsModelTests.cs
@@ -8,10 +8,10 @@ public class SafeguardingAndConcernsModelTests : BaseOfstedAreaModelTests<Safegu
     public SafeguardingAndConcernsModelTests()
     {
         Sut = new SafeguardingAndConcernsModel(MockDataSourceService,
-                MockTrustService.Object,
-                MockAcademyService.Object,
-                MockExportService.Object,
-                MockDateTimeProvider.Object,
+                MockTrustService,
+                MockAcademyService,
+                MockExportService,
+                MockDateTimeProvider,
                 MockLogger.CreateLogger<SafeguardingAndConcernsModel>()
             )
             { Uid = TrustUid };

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SingleHeadlineGradesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SingleHeadlineGradesModelTests.cs
@@ -8,10 +8,10 @@ public class SingleHeadlineGradesModelTests : BaseOfstedAreaModelTests<SingleHea
     public SingleHeadlineGradesModelTests()
     {
         Sut = new SingleHeadlineGradesModel(MockDataSourceService,
-                MockTrustService.Object,
-                MockAcademyService.Object,
-                MockExportService.Object,
-                MockDateTimeProvider.Object,
+                MockTrustService,
+                MockAcademyService,
+                MockExportService,
+                MockDateTimeProvider,
                 MockLogger.CreateLogger<SingleHeadlineGradesModel>()
             )
             { Uid = TrustUid };

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/BaseOverviewAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/BaseOverviewAreaModelTests.cs
@@ -15,14 +15,14 @@ public abstract class BaseOverviewAreaModelTests<T> : BaseTrustPageTests<T>, ITe
 
     protected BaseOverviewAreaModelTests()
     {
-        MockTrustService.Setup(t => t.GetTrustOverviewAsync(It.IsAny<string>()))
-            .ReturnsAsync((string uid) => BaseTrustOverviewServiceModel with { Uid = uid });
+        MockTrustService.GetTrustOverviewAsync(Arg.Any<string>())
+            .Returns(callinfo => BaseTrustOverviewServiceModel with { Uid = callinfo.Arg<string>() });
     }
 
     protected void SetupTrustOverview(TrustOverviewServiceModel trustOverviewServiceModel)
     {
-        MockTrustService.Setup(t => t.GetTrustOverviewAsync(trustOverviewServiceModel.Uid))
-            .ReturnsAsync(trustOverviewServiceModel);
+        MockTrustService.GetTrustOverviewAsync(trustOverviewServiceModel.Uid)
+            .Returns(Task.FromResult(trustOverviewServiceModel));
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/ReferenceNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/ReferenceNumbersModelTests.cs
@@ -11,7 +11,7 @@ public class ReferenceNumbersModelTests : BaseOverviewAreaModelTests<ReferenceNu
         Sut = new ReferenceNumbersModel(
                 MockDataSourceService,
                 MockLogger.CreateLogger<ReferenceNumbersModel>(),
-                MockTrustService.Object)
+                MockTrustService)
             { Uid = TrustUid };
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustDetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustDetailsModelTests.cs
@@ -6,15 +6,15 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts.Overview;
 
 public class TrustDetailsModelTests : BaseOverviewAreaModelTests<TrustDetailsModel>
 {
-    private readonly Mock<IOtherServicesLinkBuilder> _mockLinksToOtherServices = new();
+    private readonly IOtherServicesLinkBuilder _mockLinksToOtherServices = Substitute.For<IOtherServicesLinkBuilder>();
 
     public TrustDetailsModelTests()
     {
         Sut = new TrustDetailsModel(
                 MockDataSourceService,
                 MockLogger.CreateLogger<TrustDetailsModel>(),
-                MockTrustService.Object,
-                _mockLinksToOtherServices.Object)
+                MockTrustService,
+                _mockLinksToOtherServices)
             { Uid = TrustUid };
     }
 
@@ -22,7 +22,7 @@ public class TrustDetailsModelTests : BaseOverviewAreaModelTests<TrustDetailsMod
     public async Task CompaniesHouseLink_is_null_if_link_builder_returns_null()
     {
         SetupTrustOverview(BaseTrustOverviewServiceModel with { CompaniesHouseNumber = "123456" });
-        _mockLinksToOtherServices.Setup(l => l.CompaniesHouseListingLink("123456"))
+        _mockLinksToOtherServices.CompaniesHouseListingLink("123456")
             .Returns((string?)null);
 
         await Sut.OnGetAsync();
@@ -34,7 +34,7 @@ public class TrustDetailsModelTests : BaseOverviewAreaModelTests<TrustDetailsMod
     public async Task CompaniesHouseLink_is_string_if_link_builder_returns_string()
     {
         SetupTrustOverview(BaseTrustOverviewServiceModel with { CompaniesHouseNumber = "123456" });
-        _mockLinksToOtherServices.Setup(l => l.CompaniesHouseListingLink("123456"))
+        _mockLinksToOtherServices.CompaniesHouseListingLink("123456")
             .Returns("url");
 
         await Sut.OnGetAsync();
@@ -45,7 +45,7 @@ public class TrustDetailsModelTests : BaseOverviewAreaModelTests<TrustDetailsMod
     [Fact]
     public async Task GetInformationAboutSchoolsLink_is_returned_from_link_builder()
     {
-        _mockLinksToOtherServices.Setup(l => l.GetInformationAboutSchoolsListingLinkForTrust(TrustUid))
+        _mockLinksToOtherServices.GetInformationAboutSchoolsListingLinkForTrust(TrustUid)
             .Returns("url");
 
         await Sut.OnGetAsync();
@@ -57,9 +57,7 @@ public class TrustDetailsModelTests : BaseOverviewAreaModelTests<TrustDetailsMod
     public async Task SchoolsFinancialBenchmarkingLink_is_null_if_link_builder_returns_null()
     {
         SetupTrustOverview(BaseTrustOverviewServiceModel with { CompaniesHouseNumber = "123456" });
-        _mockLinksToOtherServices
-            .Setup(l => l.FinancialBenchmarkingInsightsToolListingLink(
-                BaseTrustOverviewServiceModel.CompaniesHouseNumber))
+        _mockLinksToOtherServices.FinancialBenchmarkingInsightsToolListingLink(Arg.Is<string>(x => x == "123456"))
             .Returns((string?)null);
         await Sut.OnGetAsync();
         Sut.FinancialBenchmarkingInsightsToolLink.Should().BeNull();
@@ -69,8 +67,8 @@ public class TrustDetailsModelTests : BaseOverviewAreaModelTests<TrustDetailsMod
     public async Task SchoolsFinancialBenchmarkingLink_is_string_if_link_builder_returns_string()
     {
         _mockLinksToOtherServices
-            .Setup(l => l.FinancialBenchmarkingInsightsToolListingLink(
-                BaseTrustOverviewServiceModel.CompaniesHouseNumber))
+            .FinancialBenchmarkingInsightsToolListingLink(
+                BaseTrustOverviewServiceModel.CompaniesHouseNumber)
             .Returns("url");
         await Sut.OnGetAsync();
         Sut.FinancialBenchmarkingInsightsToolLink.Should().Be("url");
@@ -79,8 +77,8 @@ public class TrustDetailsModelTests : BaseOverviewAreaModelTests<TrustDetailsMod
     [Fact]
     public async Task FindSchoolPerformanceLink_is_null_if_link_builder_returns_null()
     {
-        _mockLinksToOtherServices.Setup(l => l.FindSchoolPerformanceDataListingLink(BaseTrustOverviewServiceModel.Uid,
-                BaseTrustOverviewServiceModel.Type, BaseTrustOverviewServiceModel.SingleAcademyTrustAcademyUrn))
+        _mockLinksToOtherServices.FindSchoolPerformanceDataListingLink(BaseTrustOverviewServiceModel.Uid,
+                BaseTrustOverviewServiceModel.Type, BaseTrustOverviewServiceModel.SingleAcademyTrustAcademyUrn)
             .Returns((string?)null);
         await Sut.OnGetAsync();
         Sut.FindSchoolPerformanceLink.Should().BeNull();
@@ -89,8 +87,8 @@ public class TrustDetailsModelTests : BaseOverviewAreaModelTests<TrustDetailsMod
     [Fact]
     public async Task FindSchoolPerformanceLink_is_string_if_link_builder_returns_string()
     {
-        _mockLinksToOtherServices.Setup(l => l.FindSchoolPerformanceDataListingLink(BaseTrustOverviewServiceModel.Uid,
-                BaseTrustOverviewServiceModel.Type, BaseTrustOverviewServiceModel.SingleAcademyTrustAcademyUrn))
+        _mockLinksToOtherServices.FindSchoolPerformanceDataListingLink(BaseTrustOverviewServiceModel.Uid,
+                BaseTrustOverviewServiceModel.Type, BaseTrustOverviewServiceModel.SingleAcademyTrustAcademyUrn)
             .Returns("url");
         await Sut.OnGetAsync();
         Sut.FindSchoolPerformanceLink.Should().Be("url");
@@ -105,9 +103,7 @@ public class TrustDetailsModelTests : BaseOverviewAreaModelTests<TrustDetailsMod
     [Fact]
     public async Task OnGetAsync_should_Set_correct_SharepointLink()
     {
-        _mockLinksToOtherServices.Setup(l =>
-                l.SharepointFolderLink(BaseTrustOverviewServiceModel.GroupId))
-            .Returns("url/groupID");
+        _mockLinksToOtherServices.SharepointFolderLink(BaseTrustOverviewServiceModel.GroupId).Returns("url/groupID");
         await Sut.OnGetAsync();
 
         Sut.SharepointLink.Should().Be("url/groupID");

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustSummaryModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustSummaryModelTests.cs
@@ -11,7 +11,7 @@ public class TrustSummaryModelTests : BaseOverviewAreaModelTests<TrustSummaryMod
         Sut = new TrustSummaryModel(
                 MockDataSourceService,
                 MockLogger.CreateLogger<TrustSummaryModel>(),
-                MockTrustService.Object)
+                MockTrustService)
             { Uid = TrustUid };
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
@@ -18,14 +18,14 @@ public class TrustsAreaModelTests : BaseTrustPageTests<TrustsAreaModel>
 
     public TrustsAreaModelTests()
     {
-        Sut = new TrustsAreaModelImpl(MockDataSourceService, MockTrustService.Object, _logger)
+        Sut = new TrustsAreaModelImpl(MockDataSourceService, MockTrustService, _logger)
             { Uid = TrustUid };
     }
 
     [Fact]
     public void GroupUid_should_be_empty_string_by_default()
     {
-        Sut = new TrustsAreaModelImpl(MockDataSourceService, MockTrustService.Object, _logger);
+        Sut = new TrustsAreaModelImpl(MockDataSourceService, MockTrustService, _logger);
         Sut.Uid.Should().BeEquivalentTo(string.Empty);
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
@@ -9,16 +9,15 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
 public class AcademyServiceTests
 {
     private readonly AcademyService _sut;
-    private readonly Mock<IAcademyRepository> _mockAcademyRepository = new();
-    private readonly Mock<IPipelineEstablishmentRepository> _mockPipelineEstablishmentRepository = new();
-    private readonly Mock<IFreeSchoolMealsAverageProvider> _mockFreeSchoolMealsAverageProvider = new();
-    private readonly Mock<ITrustRepository> _mockTrustRepository = new();
+    private readonly IAcademyRepository _mockAcademyRepository = Substitute.For<IAcademyRepository>();
+    private readonly IPipelineEstablishmentRepository _mockPipelineEstablishmentRepository = Substitute.For<IPipelineEstablishmentRepository>();
+    private readonly IFreeSchoolMealsAverageProvider _mockFreeSchoolMealsAverageProvider = Substitute.For<IFreeSchoolMealsAverageProvider>();
 
     public AcademyServiceTests()
     {
-        _sut = new AcademyService(_mockAcademyRepository.Object,
-            _mockPipelineEstablishmentRepository.Object,
-            _mockFreeSchoolMealsAverageProvider.Object);
+        _sut = new AcademyService(_mockAcademyRepository,
+            _mockPipelineEstablishmentRepository,
+            _mockFreeSchoolMealsAverageProvider);
     }
 
     [Fact]
@@ -32,9 +31,8 @@ public class AcademyServiceTests
             new AcademyDetails("9876", "Academy 2", "Academy sponsor led", "Lincolnshire",
                 "(England/Wales) Rural town and fringe")
         ];
-
-        _mockAcademyRepository.Setup(a => a.GetAcademiesInTrustDetailsAsync(uid))
-            .ReturnsAsync(academies);
+        
+        _mockAcademyRepository.GetAcademiesInTrustDetailsAsync(uid).Returns(academies);
 
         var result = await _sut.GetAcademiesInTrustDetailsAsync(uid);
 
@@ -58,10 +56,9 @@ public class AcademyServiceTests
                 new OfstedRating((int)OfstedRatingScore.Good, new DateTime(2023, 1, 3)),
                 new OfstedRating((int)OfstedRatingScore.RequiresImprovement, new DateTime(2023, 4, 1)))
         };
-
-        _mockAcademyRepository.Setup(a => a.GetAcademiesInTrustOfstedAsync(uid))
-            .ReturnsAsync(academies);
-
+        
+        _mockAcademyRepository.GetAcademiesInTrustOfstedAsync(uid).Returns(academies);
+        
         var result = await _sut.GetAcademiesInTrustOfstedAsync(uid);
 
         result.Should().BeOfType<AcademyOfstedServiceModel[]>();
@@ -77,10 +74,9 @@ public class AcademyServiceTests
             BuildDummyAcademyPupilNumbers("9876", "phase1", new AgeRange(2, 15), 100, 200),
             BuildDummyAcademyPupilNumbers("8765", "phase2", new AgeRange(7, 12), 2, 5)
         ];
-
-        _mockAcademyRepository.Setup(a => a.GetAcademiesInTrustPupilNumbersAsync(uid))
-            .ReturnsAsync(academies);
-
+        
+        _mockAcademyRepository.GetAcademiesInTrustPupilNumbersAsync(uid).Returns(academies);
+        
         var result = await _sut.GetAcademiesInTrustPupilNumbersAsync(uid);
 
         result.Should().BeOfType<AcademyPupilNumbersServiceModel[]>();
@@ -116,10 +112,9 @@ public class AcademyServiceTests
             academy with { Urn = "4", EstablishmentName = "Academy 4", PercentageFreeSchoolMeals = null },
             academy with { Urn = "5", EstablishmentName = "Academy 5", PercentageFreeSchoolMeals = 100 }
         ];
-
-        _mockAcademyRepository.Setup(a => a.GetAcademiesInTrustFreeSchoolMealsAsync(uid))
-            .ReturnsAsync(academies);
-
+        
+        _mockAcademyRepository.GetAcademiesInTrustFreeSchoolMealsAsync(uid).Returns(academies);
+        
         var result = await _sut.GetAcademiesInTrustFreeSchoolMealsAsync(uid);
 
         result.Should().BeOfType<AcademyFreeSchoolMealsServiceModel[]>();
@@ -151,21 +146,14 @@ public class AcademyServiceTests
                 LocalAuthorityCode = 34, TypeOfEstablishment = "Foundation special school"
             }
         ];
-        _mockAcademyRepository.Setup(a => a.GetAcademiesInTrustFreeSchoolMealsAsync(uid))
-            .ReturnsAsync(academies);
+        _mockAcademyRepository.GetAcademiesInTrustFreeSchoolMealsAsync(uid).Returns(academies);
 
-        _mockFreeSchoolMealsAverageProvider.Setup(f => f.GetLaAverage(12, "Primary", "Community school"))
-            .Returns(22.4);
-        _mockFreeSchoolMealsAverageProvider.Setup(f => f.GetLaAverage(22, "Secondary", "Academy converter"))
-            .Returns(23.5);
-        _mockFreeSchoolMealsAverageProvider.Setup(f => f.GetLaAverage(34, string.Empty, "Foundation special school"))
-            .Returns(70);
-        _mockFreeSchoolMealsAverageProvider.Setup(f => f.GetNationalAverage("Primary", "Community school"))
-            .Returns(12.4);
-        _mockFreeSchoolMealsAverageProvider.Setup(f => f.GetNationalAverage("Secondary", "Academy converter"))
-            .Returns(13.5);
-        _mockFreeSchoolMealsAverageProvider.Setup(f => f.GetNationalAverage(string.Empty, "Foundation special school"))
-            .Returns(60);
+        _mockFreeSchoolMealsAverageProvider.GetLaAverage(12, "Primary", "Community school").Returns(22.4);
+        _mockFreeSchoolMealsAverageProvider.GetLaAverage(22, "Secondary", "Academy converter").Returns(23.5);
+        _mockFreeSchoolMealsAverageProvider.GetLaAverage(34, string.Empty, "Foundation special school").Returns(70);
+        _mockFreeSchoolMealsAverageProvider.GetNationalAverage("Primary", "Community school").Returns(12.4);
+        _mockFreeSchoolMealsAverageProvider.GetNationalAverage("Secondary", "Academy converter").Returns(13.5);
+        _mockFreeSchoolMealsAverageProvider.GetNationalAverage(string.Empty, "Foundation special school").Returns(60);
 
         var result = await _sut.GetAcademiesInTrustFreeSchoolMealsAsync(uid);
 
@@ -183,11 +171,9 @@ public class AcademyServiceTests
         // Arrange
         const string trustReferenceNumber = "TRN123";
         var repoSummary = new PipelineSummary(5, 3, 2);
-
-
-        _mockPipelineEstablishmentRepository
-            .Setup(r => r.GetAcademiesPipelineSummaryAsync(trustReferenceNumber))
-            .ReturnsAsync(repoSummary);
+        
+        _mockPipelineEstablishmentRepository.GetAcademiesPipelineSummaryAsync(trustReferenceNumber).Returns(
+            Task.FromResult(repoSummary));
 
         // Act
         var result = await _sut.GetAcademiesPipelineSummaryAsync(trustReferenceNumber);
@@ -206,11 +192,11 @@ public class AcademyServiceTests
         // Arrange
         const string trustReferenceNumber = "TRN123";
         _mockPipelineEstablishmentRepository
-            .Setup(r => r.GetAdvisoryConversionEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PreAdvisory))
-            .ReturnsAsync([]);
+            .GetAdvisoryConversionEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PreAdvisory)
+            .Returns(Task.FromResult<PipelineEstablishment[]>([]));
         _mockPipelineEstablishmentRepository
-            .Setup(r => r.GetAdvisoryTransferEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PreAdvisory))
-            .ReturnsAsync([]);
+            .GetAdvisoryTransferEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PreAdvisory)
+            .Returns(Task.FromResult<PipelineEstablishment[]>([]));
 
         // Act
         var result = await _sut.GetAcademiesPipelinePreAdvisoryAsync(trustReferenceNumber);
@@ -241,12 +227,10 @@ public class AcademyServiceTests
             ProjectType.Transfer,
             new DateTime(2023, 2, 1));
 
-        _mockPipelineEstablishmentRepository
-            .Setup(r => r.GetAdvisoryConversionEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PreAdvisory))
-            .ReturnsAsync(new[] { conversionEstablishment });
-        _mockPipelineEstablishmentRepository
-            .Setup(r => r.GetAdvisoryTransferEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PreAdvisory))
-            .ReturnsAsync(new[] { transferEstablishment });
+        _mockPipelineEstablishmentRepository.GetAdvisoryConversionEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PreAdvisory).Returns(
+            Task.FromResult(new[] { conversionEstablishment }));
+        _mockPipelineEstablishmentRepository.GetAdvisoryTransferEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PreAdvisory).Returns(
+            Task.FromResult(new[] { transferEstablishment }));
 
         // Act
         var result = await _sut.GetAcademiesPipelinePreAdvisoryAsync(trustReferenceNumber);
@@ -278,12 +262,10 @@ public class AcademyServiceTests
     {
         // Arrange
         const string trustReferenceNumber = "TRN123";
-        _mockPipelineEstablishmentRepository
-            .Setup(r => r.GetAdvisoryConversionEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PostAdvisory))
-            .ReturnsAsync(Array.Empty<PipelineEstablishment>());
-        _mockPipelineEstablishmentRepository
-            .Setup(r => r.GetAdvisoryTransferEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PostAdvisory))
-            .ReturnsAsync(Array.Empty<PipelineEstablishment>());
+        _mockPipelineEstablishmentRepository.GetAdvisoryConversionEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PostAdvisory).Returns(
+            Task.FromResult(Array.Empty<PipelineEstablishment>()));
+        _mockPipelineEstablishmentRepository.GetAdvisoryTransferEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PostAdvisory).Returns(
+            Task.FromResult(Array.Empty<PipelineEstablishment>()));
 
         // Act
         var result = await _sut.GetAcademiesPipelinePostAdvisoryAsync(trustReferenceNumber);
@@ -314,12 +296,10 @@ public class AcademyServiceTests
             "Transfer",
             new DateTime(2023, 4, 1));
 
-        _mockPipelineEstablishmentRepository
-            .Setup(r => r.GetAdvisoryConversionEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PostAdvisory))
-            .ReturnsAsync(new[] { conversionEstablishment });
-        _mockPipelineEstablishmentRepository
-            .Setup(r => r.GetAdvisoryTransferEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PostAdvisory))
-            .ReturnsAsync(new[] { transferEstablishment });
+        _mockPipelineEstablishmentRepository.GetAdvisoryConversionEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PostAdvisory).Returns(
+            Task.FromResult(new[] { conversionEstablishment }));
+        _mockPipelineEstablishmentRepository.GetAdvisoryTransferEstablishmentsAsync(trustReferenceNumber, AdvisoryType.PostAdvisory).Returns(
+            Task.FromResult(new[] { transferEstablishment }));
 
         // Act
         var result = await _sut.GetAcademiesPipelinePostAdvisoryAsync(trustReferenceNumber);
@@ -351,9 +331,8 @@ public class AcademyServiceTests
     {
         // Arrange
         const string trustReferenceNumber = "TRN123";
-        _mockPipelineEstablishmentRepository
-            .Setup(r => r.GetPipelineFreeSchoolProjectsAsync(trustReferenceNumber))
-            .ReturnsAsync([]);
+        _mockPipelineEstablishmentRepository.GetPipelineFreeSchoolProjectsAsync(trustReferenceNumber)
+            .Returns(Task.FromResult<PipelineEstablishment[]>([]));
 
         // Act
         var result = await _sut.GetAcademiesPipelineFreeSchoolsAsync(trustReferenceNumber);
@@ -367,9 +346,8 @@ public class AcademyServiceTests
     {
         // Arrange
         const string trustReferenceNumber = "TRN123";
-        _mockPipelineEstablishmentRepository
-            .Setup(r => r.GetPipelineFreeSchoolProjectsAsync(trustReferenceNumber))
-            .ReturnsAsync([]);
+        _mockPipelineEstablishmentRepository.GetPipelineFreeSchoolProjectsAsync(trustReferenceNumber)
+            .Returns(Task.FromResult<PipelineEstablishment[]>([]));
 
         // Act
         var result = await _sut.GetAcademiesPipelineFreeSchoolsAsync(trustReferenceNumber);
@@ -400,9 +378,9 @@ public class AcademyServiceTests
             "FreeSchool",
             new DateTime(2023, 6, 1));
 
-        _mockPipelineEstablishmentRepository
-            .Setup(r => r.GetPipelineFreeSchoolProjectsAsync(trustReferenceNumber))
-            .ReturnsAsync([freeSchoolEstablishment1, freeSchoolEstablishment2]);
+        _mockPipelineEstablishmentRepository.GetPipelineFreeSchoolProjectsAsync(trustReferenceNumber).Returns(
+            Task.FromResult<PipelineEstablishment[]>(
+                [freeSchoolEstablishment1, freeSchoolEstablishment2]));
 
         // Act
         var result = await _sut.GetAcademiesPipelineFreeSchoolsAsync(trustReferenceNumber);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/DataSourceServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/DataSourceServiceTests.cs
@@ -3,9 +3,7 @@ using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
-using Moq;
 using NSubstitute.ExceptionExtensions;
-using NSubstitute.ReceivedExtensions;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
 
@@ -151,7 +149,7 @@ public class DataSourceServiceTests
 
         await _sut.GetAsync(Source.Gias);
         
-        _mockMemoryCache.Object.DidNotReceive().CreateEntry(It.IsAny<Source>());
+        _mockMemoryCache.Object.DidNotReceive().CreateEntry(Arg.Any<object>());
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServiceTests.cs
@@ -11,23 +11,23 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
 
 public class ExportServiceTests
 {
-    private readonly Mock<IDateTimeProvider> _mockDateTimeProvider;
-    private readonly Mock<IAcademyRepository> _mockAcademyRepository;
-    private readonly Mock<ITrustRepository> _mockTrustRepository;
-    private readonly Mock<IAcademyService> _mockAcademyService;
+    private readonly IDateTimeProvider _mockDateTimeProvider;
+    private readonly IAcademyRepository _mockAcademyRepository;
+    private readonly ITrustRepository _mockTrustRepository;
+    private readonly IAcademyService _mockAcademyService;
     private readonly ExportService _sut;
 
     public ExportServiceTests()
     {
-        _mockDateTimeProvider = new Mock<IDateTimeProvider>();
-        _mockAcademyRepository = new Mock<IAcademyRepository>();
-        _mockTrustRepository = new Mock<ITrustRepository>();
-        _mockAcademyService = new Mock<IAcademyService>();
+        _mockDateTimeProvider = Substitute.For<IDateTimeProvider>();
+        _mockAcademyRepository = Substitute.For<IAcademyRepository>();
+        _mockTrustRepository = Substitute.For<ITrustRepository>();
+        _mockAcademyService = Substitute.For<IAcademyService>();
 
-        _mockDateTimeProvider.Setup(m => m.Now).Returns(DateTime.Now);
+        _mockDateTimeProvider.Now.Returns(DateTime.Now);
 
-        _sut = new ExportService(_mockAcademyRepository.Object, _mockTrustRepository.Object,
-            _mockAcademyService.Object);
+        _sut = new ExportService(_mockAcademyRepository, _mockTrustRepository,
+            _mockAcademyService);
     }
 
     [Fact]
@@ -53,30 +53,30 @@ public class ExportServiceTests
     {
         var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
 
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid)).ReturnsAsync(
-            new TrustSummary("Sample Trust", "Multi-academy trust"));
+        _mockTrustRepository.GetTrustSummaryAsync(trustSummary.Uid)!.Returns(
+            Task.FromResult(new TrustSummary("Sample Trust", "Multi-academy trust")));
 
         var now = DateTime.Now;
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid)).ReturnsAsync(
-            new AcademyDetails[]
+        _mockAcademyRepository.GetAcademiesInTrustDetailsAsync(trustSummary.Uid).Returns(
+            Task.FromResult(new AcademyDetails[]
             {
                 new("123456", "Academy 1", "Type A", "Local Authority 1", "Urban")
-            });
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustOfstedAsync(trustSummary.Uid)).ReturnsAsync(
-            new AcademyOfsted[]
+            }));
+        _mockAcademyRepository.GetAcademiesInTrustOfstedAsync(trustSummary.Uid).Returns(
+            Task.FromResult(new AcademyOfsted[]
             {
                 new("123456", "Academy 1", now, new OfstedRating(-1, null), new OfstedRating(1, now))
-            });
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid)).ReturnsAsync(
-            new AcademyPupilNumbers[]
+            }));
+        _mockAcademyRepository.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid).Returns(
+            Task.FromResult(new AcademyPupilNumbers[]
             {
                 new("123456", "Academy 1", "Primary", new AgeRange(5, 11), 500, 600)
-            });
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustFreeSchoolMealsAsync(trustSummary.Uid)).ReturnsAsync(
-            new AcademyFreeSchoolMeals[]
+            }));
+        _mockAcademyRepository.GetAcademiesInTrustFreeSchoolMealsAsync(trustSummary.Uid).Returns(
+            Task.FromResult(new AcademyFreeSchoolMeals[]
             {
                 new("123456", "Academy 1", 20, 1, "Type A", "Primary")
-            });
+            }));
 
         var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -129,33 +129,33 @@ public class ExportServiceTests
     {
         var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
 
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid)).ReturnsAsync(
-            new TrustSummary("Sample Trust", "Multi-academy trust"));
+        _mockTrustRepository.GetTrustSummaryAsync(trustSummary.Uid)!.Returns(
+            Task.FromResult(new TrustSummary("Sample Trust", "Multi-academy trust")));
 
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid)).ReturnsAsync(
-            new AcademyDetails[]
+        _mockAcademyRepository.GetAcademiesInTrustDetailsAsync(trustSummary.Uid).Returns(
+            Task.FromResult(new AcademyDetails[]
             {
                 new("123456", null, null, null, null)
-            });
+            }));
 
         var now = DateTime.Now;
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustOfstedAsync(trustSummary.Uid)).ReturnsAsync(
-            new AcademyOfsted[]
+        _mockAcademyRepository.GetAcademiesInTrustOfstedAsync(trustSummary.Uid).Returns(
+            Task.FromResult(new AcademyOfsted[]
             {
                 new("123456", null, now, new OfstedRating(-1, null), new OfstedRating(-1, null))
-            });
+            }));
 
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid)).ReturnsAsync(
-            new AcademyPupilNumbers[]
+        _mockAcademyRepository.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid).Returns(
+            Task.FromResult(new AcademyPupilNumbers[]
             {
                 new("123456", null, null, new AgeRange(5, 11), null, null)
-            });
+            }));
 
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustFreeSchoolMealsAsync(trustSummary.Uid)).ReturnsAsync(
-            new AcademyFreeSchoolMeals[]
+        _mockAcademyRepository.GetAcademiesInTrustFreeSchoolMealsAsync(trustSummary.Uid).Returns(
+            Task.FromResult(new AcademyFreeSchoolMeals[]
             {
                 new("123456", null, null, 1, null, null)
-            });
+            }));
 
         var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -192,7 +192,7 @@ public class ExportServiceTests
     public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnEmptyString_WhenOfstedRatingScoreIsNone()
     {
         var ofstedRatingScore = OfstedRatingScore.NotInspected;
-        var dateJoinedTrust = _mockDateTimeProvider.Object.Now;
+        var dateJoinedTrust = _mockDateTimeProvider.Now;
         DateTime? inspectionEndDate = dateJoinedTrust.AddDays(-1);
 
         var result =
@@ -205,7 +205,7 @@ public class ExportServiceTests
     public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnBeforeJoining_WhenInspectionDateIsBeforeJoiningDate()
     {
         var ofstedRatingScore = OfstedRatingScore.Good;
-        var dateJoinedTrust = _mockDateTimeProvider.Object.Now;
+        var dateJoinedTrust = _mockDateTimeProvider.Now;
         DateTime? inspectionEndDate = dateJoinedTrust.AddDays(-10);
 
         var result =
@@ -218,7 +218,7 @@ public class ExportServiceTests
     public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnAfterJoining_WhenInspectionDateIsAfterJoiningDate()
     {
         var ofstedRatingScore = OfstedRatingScore.Good;
-        var dateJoinedTrust = _mockDateTimeProvider.Object.Now.AddDays(-10);
+        var dateJoinedTrust = _mockDateTimeProvider.Now.AddDays(-10);
         DateTime? inspectionEndDate = dateJoinedTrust.AddDays(5);
 
         var result =
@@ -231,7 +231,7 @@ public class ExportServiceTests
     public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnEmptyString_WhenInspectionDateIsNull()
     {
         var ofstedRatingScore = OfstedRatingScore.Good;
-        var dateJoinedTrust = _mockDateTimeProvider.Object.Now;
+        var dateJoinedTrust = _mockDateTimeProvider.Now;
 
         var result = ExportService.IsOfstedRatingBeforeOrAfterJoining(ofstedRatingScore, dateJoinedTrust, null);
 
@@ -257,8 +257,7 @@ public class ExportServiceTests
     public async Task ExportAcademiesToSpreadsheet_ShouldHandleNullTrustSummaryAsync()
     {
         var uid = "some-uid";
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(uid))
-            .ReturnsAsync((TrustSummary?)null);
+        _mockTrustRepository.GetTrustSummaryAsync(uid).Returns(Task.FromResult<TrustSummary?>(null));
 
         var result = await _sut.ExportAcademiesToSpreadsheetAsync(uid);
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -274,15 +273,13 @@ public class ExportServiceTests
         var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
         var academyUrn = "123456";
 
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid))
-            .ReturnsAsync(new TrustSummary("Sample Trust", "Multi-academy trust"));
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid))
-            .ReturnsAsync(new AcademyDetails[]
-            {
-                new(academyUrn, "Academy 1", "Type A", "Local Authority 1", "Urban")
-            });
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustOfstedAsync(trustSummary.Uid))
-            .ReturnsAsync(Array.Empty<AcademyOfsted>());
+        _mockTrustRepository.GetTrustSummaryAsync(trustSummary.Uid)!.Returns(Task.FromResult(new TrustSummary("Sample Trust",
+            "Multi-academy trust")));
+        _mockAcademyRepository.GetAcademiesInTrustDetailsAsync(trustSummary.Uid).Returns(Task.FromResult(new AcademyDetails[]
+        {
+            new(academyUrn, "Academy 1", "Type A", "Local Authority 1", "Urban")
+        }));
+        _mockAcademyRepository.GetAcademiesInTrustOfstedAsync(trustSummary.Uid).Returns(Task.FromResult(Array.Empty<AcademyOfsted>()));
 
         var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -302,15 +299,15 @@ public class ExportServiceTests
         var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
         var academyUrn = "123456";
 
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid))
-            .ReturnsAsync(new TrustSummary("Sample Trust", "Multi-academy trust"));
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid))
-            .ReturnsAsync(new AcademyDetails[]
-            {
-                new(academyUrn, "Academy 1", "Type A", "Local Authority 1", "Urban")
-            });
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid))
-            .ReturnsAsync(Array.Empty<AcademyPupilNumbers>());
+        _mockTrustRepository.GetTrustSummaryAsync(trustSummary.Uid)!.Returns(Task.FromResult(new TrustSummary(
+            "Sample Trust",
+            "Multi-academy trust")));
+        _mockAcademyRepository.GetAcademiesInTrustDetailsAsync(trustSummary.Uid).Returns(Task.FromResult(new AcademyDetails[]
+        {
+            new(academyUrn, "Academy 1", "Type A", "Local Authority 1", "Urban")
+        }));
+        _mockAcademyRepository.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid).Returns(
+            Task.FromResult(Array.Empty<AcademyPupilNumbers>()));
 
         var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -327,18 +324,16 @@ public class ExportServiceTests
         var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
         var academyUrn = "123456";
 
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid))
-            .ReturnsAsync(new TrustSummary("Sample Trust", "Multi-academy trust"));
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid))
-            .ReturnsAsync(new AcademyDetails[]
-            {
-                new(academyUrn, "Academy 1", "Type A", "Local Authority 1", "Urban")
-            });
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid))
-            .ReturnsAsync(new AcademyPupilNumbers[]
-            {
-                new(academyUrn, "Academy 1", "Primary", new AgeRange(5, 11), 0, 300)
-            });
+        _mockTrustRepository.GetTrustSummaryAsync(trustSummary.Uid)!.Returns(Task.FromResult(new TrustSummary("Sample Trust",
+            "Multi-academy trust")));
+        _mockAcademyRepository.GetAcademiesInTrustDetailsAsync(trustSummary.Uid).Returns(Task.FromResult(new AcademyDetails[]
+        {
+            new(academyUrn, "Academy 1", "Type A", "Local Authority 1", "Urban")
+        }));
+        _mockAcademyRepository.GetAcademiesInTrustPupilNumbersAsync(trustSummary.Uid).Returns(Task.FromResult(new AcademyPupilNumbers[]
+        {
+            new(academyUrn, "Academy 1", "Primary", new AgeRange(5, 11), 0, 300)
+        }));
 
         var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -353,15 +348,14 @@ public class ExportServiceTests
         var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
         var academyUrn = "123456";
 
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid))
-            .ReturnsAsync(new TrustSummary("Sample Trust", "Multi-academy trust"));
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync(trustSummary.Uid))
-            .ReturnsAsync(new AcademyDetails[]
-            {
-                new(academyUrn, "Academy 1", "Type A", "Local Authority 1", "Urban")
-            });
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustFreeSchoolMealsAsync(trustSummary.Uid))
-            .ReturnsAsync(Array.Empty<AcademyFreeSchoolMeals>());
+        _mockTrustRepository.GetTrustSummaryAsync(trustSummary.Uid)!.Returns(Task.FromResult(new TrustSummary("Sample Trust",
+            "Multi-academy trust")));
+        _mockAcademyRepository.GetAcademiesInTrustDetailsAsync(trustSummary.Uid).Returns(Task.FromResult(new AcademyDetails[]
+        {
+            new(academyUrn, "Academy 1", "Type A", "Local Authority 1", "Urban")
+        }));
+        _mockAcademyRepository.GetAcademiesInTrustFreeSchoolMealsAsync(trustSummary.Uid).Returns(
+            Task.FromResult(Array.Empty<AcademyFreeSchoolMeals>()));
 
         var result = await _sut.ExportAcademiesToSpreadsheetAsync(trustSummary.Uid);
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -374,7 +368,7 @@ public class ExportServiceTests
     public void IsOfstedRatingBeforeOrAfterJoining_ShouldReturnAfterJoining_WhenInspectionDateIsEqualToJoiningDate()
     {
         var ofstedRatingScore = OfstedRatingScore.Good;
-        var dateJoinedTrust = _mockDateTimeProvider.Object.Now;
+        var dateJoinedTrust = _mockDateTimeProvider.Now;
         DateTime? inspectionEndDate = dateJoinedTrust;
 
         var result =
@@ -386,8 +380,8 @@ public class ExportServiceTests
     [Fact]
     public async Task ExportOfstedDataToSpreadsheet_ShouldGenerateCorrectHeadersAsync()
     {
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync("some-uid")).ReturnsAsync(
-            new TrustSummary("Some Trust", "Multi-academy trust"));
+        _mockTrustRepository.GetTrustSummaryAsync("some-uid")!.Returns(
+            Task.FromResult(new TrustSummary("Some Trust", "Multi-academy trust")));
 
         var result = await _sut.ExportOfstedDataToSpreadsheetAsync("some-uid");
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -409,8 +403,8 @@ public class ExportServiceTests
     [Fact]
     public async Task ExportOfstedDataToSpreadsheet_ShouldWriteTrustInformationAsync()
     {
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync("uid")).ReturnsAsync(
-            new TrustSummary("My Trust", "Multi-academy trust"));
+        _mockTrustRepository.GetTrustSummaryAsync("uid")!.Returns(
+            Task.FromResult(new TrustSummary("My Trust", "Multi-academy trust")));
 
         var result = await _sut.ExportOfstedDataToSpreadsheetAsync("uid");
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -423,10 +417,10 @@ public class ExportServiceTests
     [Fact]
     public async Task ExportOfstedDataToSpreadsheet_ShouldHandleEmptyAcademiesAsync()
     {
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync("uid")).ReturnsAsync(
-            new TrustSummary("Empty Trust", "Multi-academy trust"));
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync("uid"))
-            .ReturnsAsync(Array.Empty<AcademyDetails>());
+        _mockTrustRepository.GetTrustSummaryAsync("uid")!.Returns(
+            Task.FromResult(new TrustSummary("Empty Trust", "Multi-academy trust")));
+        _mockAcademyRepository.GetAcademiesInTrustDetailsAsync("uid")
+            .Returns(Task.FromResult(Array.Empty<AcademyDetails>()));
 
         var result = await _sut.ExportOfstedDataToSpreadsheetAsync("uid");
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -440,26 +434,26 @@ public class ExportServiceTests
     [Fact]
     public async Task ExportOfstedDataToSpreadsheet_ShouldWriteDateCellsAsDatesAsync()
     {
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync("uid"))
-            .ReturnsAsync(new TrustSummary("Test Trust", "Multi-academy trust"));
+        _mockTrustRepository.GetTrustSummaryAsync("uid")!
+            .Returns(Task.FromResult(new TrustSummary("Test Trust", "Multi-academy trust")));
 
         var joinedDate = new DateTime(2020, 1, 1);
         var currentInspectionDate = new DateTime(2021, 5, 20);
         var previousInspectionDate = new DateTime(2019, 12, 31);
 
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync("uid"))
-            .ReturnsAsync(new AcademyDetails[]
+        _mockAcademyRepository.GetAcademiesInTrustDetailsAsync("uid")
+            .Returns(Task.FromResult(new AcademyDetails[]
             {
                 new("A123", "Academy XYZ", "TypeX", "Local LA", "Urban")
-            });
+            }));
 
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustOfstedAsync("uid"))
-            .ReturnsAsync(new AcademyOfsted[]
+        _mockAcademyRepository.GetAcademiesInTrustOfstedAsync("uid")
+            .Returns(Task.FromResult(new AcademyOfsted[]
             {
                 new("A123", "Academy XYZ", joinedDate,
                     new OfstedRating((int)OfstedRatingScore.Good, previousInspectionDate),
                     new OfstedRating((int)OfstedRatingScore.Outstanding, currentInspectionDate))
-            });
+            }));
 
         var result = await _sut.ExportOfstedDataToSpreadsheetAsync("uid");
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -484,8 +478,7 @@ public class ExportServiceTests
     [Fact]
     public async Task ExportOfstedDataToSpreadsheet_ShouldHandleNullTrustSummaryAsync()
     {
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync("uid"))
-            .ReturnsAsync((TrustSummary?)null);
+        _mockTrustRepository.GetTrustSummaryAsync("uid").Returns(Task.FromResult<TrustSummary?>(null));
 
         var result = await _sut.ExportOfstedDataToSpreadsheetAsync("uid");
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -498,15 +491,15 @@ public class ExportServiceTests
     [Fact]
     public async Task ExportOfstedDataToSpreadsheet_ShouldHandleNoOfstedDataAsync()
     {
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync("uid"))
-            .ReturnsAsync(new TrustSummary("Test Trust", "Multi-academy trust"));
+        _mockTrustRepository.GetTrustSummaryAsync("uid")!.Returns(
+            Task.FromResult(new TrustSummary("Test Trust", "Multi-academy trust")));
 
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustDetailsAsync("uid"))
-            .ReturnsAsync([
-                new AcademyDetails("A123", "Academy XYZ", "TypeX", "Local LA", "Urban")
-            ]);
+        _mockAcademyRepository.GetAcademiesInTrustDetailsAsync("uid").Returns(Task.FromResult<AcademyDetails[]>(
+        [
+            new AcademyDetails("A123", "Academy XYZ", "TypeX", "Local LA", "Urban")
+        ]));
 
-        _mockAcademyRepository.Setup(m => m.GetAcademiesInTrustOfstedAsync("uid")).ReturnsAsync([]);
+        _mockAcademyRepository.GetAcademiesInTrustOfstedAsync("uid").Returns(Task.FromResult<AcademyOfsted[]>([]));
 
         var result = await _sut.ExportOfstedDataToSpreadsheetAsync("uid");
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -545,26 +538,27 @@ public class ExportServiceTests
         const string uid = "1";
         const string trustReferenceNumber = "TRN1111";
 
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(uid))
-            .ReturnsAsync(new TrustSummary("Sample Trust", "Multi-academy trust"));
-        _mockTrustRepository.Setup(m => m.GetTrustReferenceNumberAsync(uid))
-            .ReturnsAsync(trustReferenceNumber);
+        _mockTrustRepository.GetTrustSummaryAsync(uid)!.Returns(Task.FromResult(new TrustSummary("Sample Trust", "Multi-academy trust")));
+        _mockTrustRepository.GetTrustReferenceNumberAsync(uid).Returns(Task.FromResult(trustReferenceNumber));
 
-        _mockAcademyService.Setup(m => m.GetAcademiesPipelinePreAdvisoryAsync(trustReferenceNumber))
-            .ReturnsAsync([
+        _mockAcademyService.GetAcademiesPipelinePreAdvisoryAsync(trustReferenceNumber)
+            .Returns(Task.FromResult<AcademyPipelineServiceModel[]>(
+            [
                 new AcademyPipelineServiceModel("1", "Academy 1", new AgeRange(4, 11), "Local Authority 1",
                     "Pre-advisory", new DateTime(2025, 2, 19))
-            ]);
-        _mockAcademyService.Setup(m => m.GetAcademiesPipelinePostAdvisoryAsync(trustReferenceNumber))
-            .ReturnsAsync([
+            ]));
+        _mockAcademyService.GetAcademiesPipelinePostAdvisoryAsync(trustReferenceNumber)
+            .Returns(Task.FromResult<AcademyPipelineServiceModel[]>(
+            [
                 new AcademyPipelineServiceModel("2", "Academy 2", new AgeRange(2, 11), "Local Authority 2",
                     "Post-advisory", new DateTime(2026, 2, 20))
-            ]);
-        _mockAcademyService.Setup(m => m.GetAcademiesPipelineFreeSchoolsAsync(trustReferenceNumber))
-            .ReturnsAsync([
+            ]));
+        _mockAcademyService.GetAcademiesPipelineFreeSchoolsAsync(trustReferenceNumber)
+            .Returns(Task.FromResult<AcademyPipelineServiceModel[]>(
+            [
                 new AcademyPipelineServiceModel("3", "Academy 3", new AgeRange(11, 18), "Local Authority 3",
                     "Free school", new DateTime(2025, 6, 21))
-            ]);
+            ]));
 
         var result = await _sut.ExportPipelineAcademiesToSpreadsheetAsync(uid);
 
@@ -601,13 +595,12 @@ public class ExportServiceTests
         const string uid = "1";
         const string trustReferenceNumber = "TRN1111";
 
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(uid))
-            .ReturnsAsync(new TrustSummary("Sample Trust", "Multi-academy trust"));
-        _mockTrustRepository.Setup(m => m.GetTrustReferenceNumberAsync(uid))
-            .ReturnsAsync(trustReferenceNumber);
+        _mockTrustRepository.GetTrustSummaryAsync(uid)!.Returns(Task.FromResult(new TrustSummary("Sample Trust", "Multi-academy trust")));
+        _mockTrustRepository.GetTrustReferenceNumberAsync(uid).Returns(Task.FromResult(trustReferenceNumber));
 
-        _mockAcademyService.Setup(m => m.GetAcademiesPipelinePreAdvisoryAsync(trustReferenceNumber))
-            .ReturnsAsync([
+        _mockAcademyService.GetAcademiesPipelinePreAdvisoryAsync(trustReferenceNumber)
+            .Returns(Task.FromResult<AcademyPipelineServiceModel[]>(
+            [
                 new AcademyPipelineServiceModel("1", "z Academy", new AgeRange(4, 10), "Local Authority 1",
                     "Pre-advisory", new DateTime(2023, 2, 1)),
                 new AcademyPipelineServiceModel("2", "B Academy", new AgeRange(5, 11), "Local Authority 2",
@@ -616,9 +609,10 @@ public class ExportServiceTests
                     "Pre-advisory", new DateTime(2025, 4, 3)),
                 new AcademyPipelineServiceModel("4", "S Academy 2", new AgeRange(7, 13), "Local Authority 4",
                     "Pre-advisory", new DateTime(2026, 5, 4))
-            ]);
-        _mockAcademyService.Setup(m => m.GetAcademiesPipelinePostAdvisoryAsync(trustReferenceNumber))
-            .ReturnsAsync([
+            ]));
+        _mockAcademyService.GetAcademiesPipelinePostAdvisoryAsync(trustReferenceNumber)
+            .Returns(Task.FromResult<AcademyPipelineServiceModel[]>(
+            [
                 new AcademyPipelineServiceModel("5", "zz Academy", new AgeRange(4, 10), "Local Authority 1",
                     "Post-advisory", new DateTime(2023, 2, 1)),
                 new AcademyPipelineServiceModel("6", "Bb Academy 2", new AgeRange(5, 11), "Local Authority 2",
@@ -627,9 +621,10 @@ public class ExportServiceTests
                     "Post-advisory", new DateTime(2025, 4, 3)),
                 new AcademyPipelineServiceModel("8", "Ss Academy", new AgeRange(7, 13), "Local Authority 4",
                     "Post-advisory", new DateTime(2026, 5, 4))
-            ]);
-        _mockAcademyService.Setup(m => m.GetAcademiesPipelineFreeSchoolsAsync(trustReferenceNumber))
-            .ReturnsAsync([
+            ]));
+        _mockAcademyService.GetAcademiesPipelineFreeSchoolsAsync(trustReferenceNumber)
+            .Returns(Task.FromResult<AcademyPipelineServiceModel[]>(
+            [
                 new AcademyPipelineServiceModel("9", "Aaa Academy", new AgeRange(4, 10), "Local Authority 1",
                     "Free school", new DateTime(2023, 2, 1)),
                 new AcademyPipelineServiceModel("10", "Zzz Academy", new AgeRange(5, 11), "Local Authority 2",
@@ -638,7 +633,7 @@ public class ExportServiceTests
                     "Free school", new DateTime(2025, 4, 3)),
                 new AcademyPipelineServiceModel("12", "Fff Academy", new AgeRange(7, 13), "Local Authority 4",
                     "Free school", new DateTime(2026, 5, 4))
-            ]);
+            ]));
 
         var result = await _sut.ExportPipelineAcademiesToSpreadsheetAsync(uid);
 
@@ -714,20 +709,20 @@ public class ExportServiceTests
         var trustSummary = new TrustSummaryServiceModel("1", "Sample Trust", "Multi-academy trust", 1);
         var trustReferenceNumber = "TRN1111";
 
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync(trustSummary.Uid)).ReturnsAsync(
-            new TrustSummary("Sample Trust", "Multi-academy trust"));
+        _mockTrustRepository.GetTrustSummaryAsync(trustSummary.Uid)!.Returns(
+            Task.FromResult(new TrustSummary("Sample Trust", "Multi-academy trust")));
 
-        _mockTrustRepository.Setup(m => m.GetTrustReferenceNumberAsync(trustSummary.Uid)).ReturnsAsync(
-            "TRN1111"
+        _mockTrustRepository.GetTrustReferenceNumberAsync(trustSummary.Uid).Returns(
+            Task.FromResult("TRN1111")
         );
 
-        _mockAcademyService.Setup(m => m.GetAcademiesPipelinePreAdvisoryAsync(trustReferenceNumber)).ReturnsAsync(
-            new AcademyPipelineServiceModel[]
-            {
-                new("1", null, null,
-                    null, "Pre-advisory", null)
-            }
-        );
+        _mockAcademyService.GetAcademiesPipelinePreAdvisoryAsync(trustReferenceNumber).Returns(
+            Task.FromResult(new AcademyPipelineServiceModel[]
+                {
+                    new("1", null, null,
+                        null, "Pre-advisory", null)
+                }
+            ));
 
         var result = await _sut.ExportPipelineAcademiesToSpreadsheetAsync(trustSummary.Uid);
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -758,8 +753,8 @@ public class ExportServiceTests
     [Fact]
     public async Task ExportPipelineAcademiesToSpreadsheet_ShouldWriteTrustInformationAsync()
     {
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync("uid")).ReturnsAsync(
-            new TrustSummary("My Trust", "Multi-academy trust"));
+        _mockTrustRepository.GetTrustSummaryAsync("uid")!.Returns(
+            Task.FromResult(new TrustSummary("My Trust", "Multi-academy trust")));
 
         var result = await _sut.ExportPipelineAcademiesToSpreadsheetAsync("uid");
         using var workbook = new XLWorkbook(new MemoryStream(result));
@@ -772,8 +767,7 @@ public class ExportServiceTests
     [Fact]
     public async Task ExportPipelineAcademiesToSpreadsheet_ShouldHandleNullTrustSummaryAsync()
     {
-        _mockTrustRepository.Setup(x => x.GetTrustSummaryAsync("uid"))
-            .ReturnsAsync((TrustSummary?)null);
+        _mockTrustRepository.GetTrustSummaryAsync("uid").Returns(Task.FromResult<TrustSummary?>(null));
 
         var result = await _sut.ExportPipelineAcademiesToSpreadsheetAsync("uid");
         using var workbook = new XLWorkbook(new MemoryStream(result));

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceGovernanceTurnoverTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/TrustServiceGovernanceTurnoverTests.cs
@@ -10,19 +10,19 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
 public class TrustServiceGovernanceTurnoverTests
 {
     private readonly TrustService _sut;
-    private readonly Mock<IAcademyRepository> _mockAcademyRepository = new();
-    private readonly Mock<ITrustRepository> _mockTrustRepository = new();
-    private readonly Mock<IContactRepository> _mockContactRepository = new();
-    private readonly Mock<IDateTimeProvider> _mockDateTimeProvider = new();
+    private readonly IAcademyRepository _mockAcademyRepository = Substitute.For<IAcademyRepository>();
+    private readonly ITrustRepository _mockTrustRepository = Substitute.For<ITrustRepository>();
+    private readonly IContactRepository _mockContactRepository = Substitute.For<IContactRepository>();
+    private readonly IDateTimeProvider _mockDateTimeProvider = Substitute.For<IDateTimeProvider>();
     private readonly MockMemoryCache _mockMemoryCache = new();
 
     public TrustServiceGovernanceTurnoverTests()
     {
-        _sut = new TrustService(_mockAcademyRepository.Object,
-                                _mockTrustRepository.Object,
-                                _mockContactRepository.Object,
+        _sut = new TrustService(_mockAcademyRepository,
+                                _mockTrustRepository,
+                                _mockContactRepository,
                                 _mockMemoryCache.Object,
-                                _mockDateTimeProvider.Object);
+                                _mockDateTimeProvider);
     }
     [Fact]
     public void GetGovernanceTurnoverRate_Returns_Zero_When_No_CurrentGovernors()
@@ -35,7 +35,7 @@ public class TrustServiceGovernanceTurnoverTests
             HistoricMembers: []
         );
 
-        _mockDateTimeProvider.Setup(d => d.Today).Returns(new DateTime(2023, 10, 1));
+        _mockDateTimeProvider.Today.Returns(new DateTime(2023, 10, 1));
 
         // Act
         var result = _sut.GetGovernanceTurnoverRate(trustGovernance);
@@ -50,7 +50,7 @@ public class TrustServiceGovernanceTurnoverTests
         // Arrange
         var startDate = new DateTime(2022, 1, 1);
         var endDate = new DateTime(2023, 1, 1);
-        _mockDateTimeProvider.Setup(d => d.Today).Returns(new DateTime(2023, 10, 1));
+        _mockDateTimeProvider.Today.Returns(new DateTime(2023, 10, 1));
 
         var governor = new Governor("1", "UID", "John Doe", "Member", "Appointing Body", startDate, endDate, null);
         var trustGovernance = new TrustGovernance(

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Usings.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Usings.cs
@@ -1,4 +1,3 @@
 global using Xunit;
 global using FluentAssertions;
 global using NSubstitute;
-global using Moq;


### PR DESCRIPTION
_Replaced moq with nsubstitute in the memory cache mock. Removed moq from the project_

[User Story 200994](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/200994): Build: Moq to NSubstitute

<!-- Do you need to add any environment variables? -->

## Changes

_Add a summary of the changes in this pull request_

## Screenshots of UI changes

### Before

### After

## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
