### PR TITLE
add feature flag to hide governance turnover calculation

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Configuration/FeatureFlags.cs
+++ b/DfE.FindInformationAcademiesTrusts/Configuration/FeatureFlags.cs
@@ -4,4 +4,5 @@ public static class FeatureFlags
 {
     public const string TestFlag = "TestFlag";
     public const string UpdatedFooterHelpLink = "UpdatedFooterHelpLink";
+    public const string GovernanceTurnover = "GovernanceTurnover";
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/_GovernanceTurnover.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/_GovernanceTurnover.cshtml
@@ -1,4 +1,6 @@
-﻿@model GovernanceAreaModel
+﻿@using DfE.FindInformationAcademiesTrusts.Configuration
+@model GovernanceAreaModel
+<feature name="@FeatureFlags.GovernanceTurnover">
 <div class="govuk-summary-card">
   <div class="govuk-summary-card__title-wrapper">
     <h2 class="govuk-summary-card__title">Governance turnover</h2>
@@ -10,3 +12,4 @@
     <p class="govuk-body">Governance turnover % is calculated based on the total number of appointments and resignations in the past calendar year, divided by the total number of current governors.</p>
   </div>
 </div>
+</feature>

--- a/DfE.FindInformationAcademiesTrusts/appsettings.json
+++ b/DfE.FindInformationAcademiesTrusts/appsettings.json
@@ -40,7 +40,8 @@
   },
   "FeatureManagement": {
     "TestFlag": false,
-    "UpdatedFooterHelpLink": true
+    "UpdatedFooterHelpLink": true,
+    "GovernanceTurnover": false
   },
   "DataProtection": {
     "KeyVaultKey": "",


### PR DESCRIPTION
_Feature flag to hide the governance turnover section while we determine a fix_

[User Story 206275](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/206275): Feature flag - hide governance turnover calculation

<!-- Do you need to add any environment variables? -->

## Changes

_Add a summary of the changes in this pull request_

## Screenshots of UI changes

### Before

![image](https://github.com/user-attachments/assets/d88687d2-2433-43bc-b71f-9ea487b059ec)

### After

![image](https://github.com/user-attachments/assets/8623b8bb-e22e-4eaf-b4f1-3a5e9cf83266)

## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
