### PR TITLE
Remove unnecessary working-directory from workflow

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -45,7 +45,6 @@ jobs:
       run: dotnet stryker --reporter "markdown" --reporter "html" --output "${{ github.workspace }}"
 
     - name: Print stryker report
-      working-directory: StrykerOutput
       run: |
         # Construct the full path to the markdown file
         REPORT_FILE="${{ github.workspace }}/reports/mutation-report.md"


### PR DESCRIPTION
Fixes failing .net tests because the StrkyerOutput folder doesn't exist