### PR TITLE
TrustDocumentRepository enhancements

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Contexts/AcademiesDbContext.SharePointTrustDocLinks.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Contexts/AcademiesDbContext.SharePointTrustDocLinks.cs
@@ -38,6 +38,10 @@ public partial class AcademiesDbContext
             entity.Property(e => e.TrustRefNumber)
                 .HasMaxLength(10)
                 .IsUnicode(false);
+
+            // Query filter
+            entity.HasQueryFilter(doc => doc.DocumentLink != null
+                                         && doc.TrustRefNumber != null);
         });
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustDocumentRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustDocumentRepository.cs
@@ -24,9 +24,7 @@ public class TrustDocumentRepository(IAcademiesDbContext academiesDbContext, ILo
         var (trustOpenDate, trustReferenceNumber) = await GetTrustInfoFromGias(uid);
 
         var allSharepointTrustDocLinksForFinancialDocType = await academiesDbContext.SharepointTrustDocLinks
-            .Where(doc => doc.DocumentLink != null
-                          && doc.TrustRefNumber != null
-                          && doc.TrustRefNumber == trustReferenceNumber
+            .Where(doc => doc.TrustRefNumber == trustReferenceNumber
                           && FolderPrefixes[financialDocumentType].Contains(doc.FolderPrefix))
             .Select(doc => new { doc.FolderYear, DocumentLink = doc.DocumentLink!, doc.CreatedDateTime })
             .ToArrayAsync();

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustDocumentRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/TrustDocumentRepository.cs
@@ -26,12 +26,7 @@ public class TrustDocumentRepository(IAcademiesDbContext academiesDbContext) : I
             .ToArrayAsync();
 
         var trustDocuments = sharepointTrustDocLinks
-            .Select(doc =>
-                new TrustDocument(
-                    new DateOnly(doc.FolderYear - 1, 9, 1),
-                    new DateOnly(doc.FolderYear, 8, 31),
-                    doc.DocumentLink
-                ))
+            .Select(doc => new TrustDocument(doc.FolderYear, doc.DocumentLink))
             .ToArray();
 
         return trustDocuments;

--- a/DfE.FindInformationAcademiesTrusts.Data/FinancialYear.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/FinancialYear.cs
@@ -1,0 +1,13 @@
+namespace DfE.FindInformationAcademiesTrusts.Data;
+
+public record FinancialYear
+{
+    public FinancialYear(int year)
+    {
+        Start = new DateOnly(year - 1, 09, 01);
+        End = new DateOnly(year, 08, 31);
+    }
+
+    public DateOnly Start { get; }
+    public DateOnly End { get; }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/TrustDocument/ITrustDocumentRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/TrustDocument/ITrustDocumentRepository.cs
@@ -4,6 +4,6 @@ namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.TrustDocument;
 
 public interface ITrustDocumentRepository
 {
-    Task<TrustDocument[]> GetFinancialDocumentsAsync(string trustReferenceNumber,
+    Task<(TrustDocument[] financialDocuments, DateOnly trustOpenDate)> GetFinancialDocumentsAsync(string uid,
         FinancialDocumentType financialDocumentType);
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/TrustDocument/TrustDocument.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/TrustDocument/TrustDocument.cs
@@ -1,6 +1,13 @@
 namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.TrustDocument;
 
-public record TrustDocument(
-    DateOnly FinancialYearStart,
-    DateOnly FinancialYearEnd,
-    string DocumentLink);
+public record TrustDocument
+{
+    public TrustDocument(int financialYearEndYear, string link)
+    {
+        FinancialYear = new FinancialYear(financialYearEndYear);
+        Link = link;
+    }
+
+    public FinancialYear FinancialYear { get; }
+    public string Link { get; }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -387,7 +387,8 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
                 FolderPrefix = folderPrefix,
                 TrustRefNumber = trustReferenceNumber,
                 DocumentFilename = $"Trust Document {i}",
-                DocumentLink = $"www.trustDocumentLink{i}.com"
+                DocumentLink = $"www.trustDocumentLink{i}.com",
+                FolderYear = 2000 + i
             })
         );
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustDocumentRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustDocumentRepositoryTests.cs
@@ -2,7 +2,6 @@ using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Sharepoint;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
-using DfE.FindInformationAcademiesTrusts.Data.Repositories.TrustDocument;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;
 
@@ -71,11 +70,8 @@ public class TrustDocumentRepositoryTests
 
         var result = await _sut.GetFinancialDocumentsAsync("TR01234", financialDocType);
 
-        var expectedFinancialYearStart = new DateOnly(year - 1, 9, 1);
-        var expectedFinancialYearEnd = new DateOnly(year, 8, 31);
-
-        result.Should().ContainSingle()
-            .Which.Should().BeEquivalentTo(
-                new TrustDocument(expectedFinancialYearStart, expectedFinancialYearEnd, link));
+        var actualDoc = result.Should().ContainSingle().Subject;
+        actualDoc.FinancialYear.Should().Be(new FinancialYear(year));
+        actualDoc.Link.Should().Be(link);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/FinancialYearTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/FinancialYearTests.cs
@@ -1,0 +1,26 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.UnitTests;
+
+public class FinancialYearTests
+{
+    [Theory]
+    [InlineData(2025, 2024)]
+    [InlineData(2023, 2022)]
+    public void Start_should_be_1st_september_year_before_given_year(int endYear, int expectedStartYear)
+    {
+        var financialYear = new FinancialYear(endYear);
+        financialYear.Start.Year.Should().Be(expectedStartYear);
+        financialYear.Start.Month.Should().Be(9);
+        financialYear.Start.Day.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(2024)]
+    [InlineData(2022)]
+    public void End_should_be_31st_august_year_before_given_year(int endYear)
+    {
+        var financialYear = new FinancialYear(endYear);
+        financialYear.End.Year.Should().Be(endYear);
+        financialYear.End.Month.Should().Be(8);
+        financialYear.End.Day.Should().Be(31);
+    }
+}


### PR DESCRIPTION
- Encapsulate financial year definition into a new financial year type which can then be used for comparing financial years
- Return the trust open date from `GetFinancialDocumentsAsync` so it can be later used by the financial document service
- Ensure that only one document is returned per financial year (and that it is the newest document held for the year)
- Move null query filters to the entity - they're there to make querying more efficient, not for the logic of getting docs
