### PR TITLE
Associate pages with their names

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/AcademiesAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/AcademiesAreaModel.cs
@@ -18,8 +18,8 @@ public abstract class AcademiesAreaModel(
     IDateTimeProvider dateTimeProvider
 ) : TrustsAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { PageName = ViewConstants.AcademiesPageName };
+    public const string PageName = "Academies";
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = PageName };
 
     internal readonly IAcademyService AcademyService = academyService;
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/AcademiesInTrustAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/AcademiesInTrustAreaModel.cs
@@ -24,12 +24,9 @@ public abstract class AcademiesInTrustAreaModel(
     dateTimeProvider
 )
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with
-        {
-            PageName = ViewConstants.AcademiesPageName,
-            SubPageName = ViewConstants.AcademiesInTrustSubNavName
-        };
+    public const string SubPageName = "In this trust";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 
     public override async Task<IActionResult> OnGetAsync()
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/AcademiesInTrustAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/AcademiesInTrustAreaModel.cs
@@ -47,11 +47,10 @@ public abstract class AcademiesInTrustAreaModel(
         ];
 
         DataSourcesPerPage.AddRange([
-            new DataSourcePageListEntry(ViewConstants.AcademiesInTrustDetailsPageName,
+            new DataSourcePageListEntry(AcademiesInTrustDetailsModel.TabName,
                 [new DataSourceListEntry(giasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.AcademiesInTrustPupilNumbersPageName,
-                [new DataSourceListEntry(giasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.AcademiesInTrustFreeSchoolMealsPageName, [
+            new DataSourcePageListEntry(PupilNumbersModel.TabName, [new DataSourceListEntry(giasDataSource)]),
+            new DataSourcePageListEntry(FreeSchoolMealsModel.TabName, [
                 new DataSourceListEntry(giasDataSource, "Pupils eligible for free school meals"),
                 new DataSourceListEntry(eesDataSource, "Local authority average 2023/24"),
                 new DataSourceListEntry(eesDataSource, "National average 2023/24")

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml.cs
@@ -24,8 +24,9 @@ public class AcademiesInTrustDetailsModel(
     dateTimeProvider
 )
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { TabName = ViewConstants.AcademiesInTrustDetailsPageName };
+    public const string TabName = "Details";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = TabName };
 
     public AcademyDetailsServiceModel[] Academies { get; set; } = default!;
     public IOtherServicesLinkBuilder LinkBuilder { get; } = linkBuilder;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/FreeSchoolMeals.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/FreeSchoolMeals.cshtml.cs
@@ -23,8 +23,9 @@ public class FreeSchoolMealsModel(
     dateTimeProvider
 )
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { TabName = ViewConstants.AcademiesInTrustFreeSchoolMealsPageName };
+    public const string TabName = "Free school meals";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = TabName };
 
     public AcademyFreeSchoolMealsServiceModel[] Academies { get; set; } = default!;
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/PupilNumbers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/PupilNumbers.cshtml.cs
@@ -23,10 +23,9 @@ public class PupilNumbersModel(
     dateTimeProvider
 )
 {
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with
-    {
-        TabName = ViewConstants.AcademiesInTrustPupilNumbersPageName
-    };
+    public const string TabName = "Pupil numbers";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = TabName };
 
     public AcademyPupilNumbersServiceModel[] Academies { get; set; } = default!;
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/FreeSchools.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/FreeSchools.cshtml.cs
@@ -17,8 +17,9 @@ public class FreeSchoolsModel(
     : PipelineAcademiesAreaModel(dataSourceService, trustService, academyService, exportService, logger,
         dateTimeProvider)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { TabName = "Free schools" };
+    public const string TabName = "Free schools";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = TabName };
 
     public AcademyPipelineServiceModel[] PipelineFreeSchools { get; set; } = [];
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PipelineAcademiesAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PipelineAcademiesAreaModel.cs
@@ -47,12 +47,9 @@ public abstract class PipelineAcademiesAreaModel(
         var completeSource = await DataSourceService.GetAsync(Source.Complete);
         var manageFreeSchoolSource = await DataSourceService.GetAsync(Source.ManageFreeSchoolProjects);
         DataSourcesPerPage.AddRange([
-            new DataSourcePageListEntry(ViewConstants.PipelineAcademiesPreAdvisoryBoardPageName,
-                [new DataSourceListEntry(prepareSource)]),
-            new DataSourcePageListEntry(ViewConstants.PipelineAcademiesPostAdvisoryBoardPageName,
-                [new DataSourceListEntry(completeSource)]),
-            new DataSourcePageListEntry(ViewConstants.PipelineAcademiesFreeSchoolsPageName,
-                [new DataSourceListEntry(manageFreeSchoolSource)])
+            new DataSourcePageListEntry(PreAdvisoryBoardModel.TabName, [new DataSourceListEntry(prepareSource)]),
+            new DataSourcePageListEntry(PostAdvisoryBoardModel.TabName, [new DataSourceListEntry(completeSource)]),
+            new DataSourcePageListEntry(FreeSchoolsModel.TabName, [new DataSourceListEntry(manageFreeSchoolSource)])
         ]);
 
         return pageResult;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PipelineAcademiesAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PipelineAcademiesAreaModel.cs
@@ -24,8 +24,9 @@ public abstract class PipelineAcademiesAreaModel(
     dateTimeProvider
 )
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = "Pipeline academies" };
+    public const string SubPageName = "Pipeline academies";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 
     public override async Task<IActionResult> OnGetAsync()
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoard.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoard.cshtml.cs
@@ -17,8 +17,9 @@ public class PostAdvisoryBoardModel(
     : PipelineAcademiesAreaModel(dataSourceService, trustService, academyService, exportService, logger,
         dateTimeProvider)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { TabName = "Post advisory board" };
+    public const string TabName = "Post advisory board";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = TabName };
 
     public AcademyPipelineServiceModel[] PostAdvisoryPipelineEstablishments { get; set; } = [];
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoard.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoard.cshtml.cs
@@ -17,8 +17,9 @@ public class PreAdvisoryBoardModel(
     : PipelineAcademiesAreaModel(dataSourceService, trustService, academyService, exportService, logger,
         dateTimeProvider)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { TabName = "Pre advisory board" };
+    public const string TabName = "Pre advisory board";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = TabName };
 
     public AcademyPipelineServiceModel[] PreAdvisoryPipelineEstablishments { get; set; } = [];
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/ContactsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/ContactsAreaModel.cs
@@ -14,8 +14,9 @@ public class ContactsAreaModel(
 )
     : TrustsAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { PageName = ViewConstants.ContactsPageName };
+    public const string PageName = "Contacts";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = PageName };
 
     public Person? ChairOfTrustees { get; set; }
     public Person? AccountingOfficer { get; set; }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/ContactsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/ContactsAreaModel.cs
@@ -46,7 +46,7 @@ public class ContactsAreaModel(
         var mstrDataSource = await DataSourceService.GetAsync(Source.Mstr);
 
         DataSourcesPerPage.AddRange([
-            new DataSourcePageListEntry(ViewConstants.ContactsInDfePageName, [
+            new DataSourcePageListEntry(InDfeModel.SubPageName, [
                     new DataSourceListEntry(new DataSourceServiceModel(Source.FiatDb,
                             TrustRelationshipManager?.LastModifiedAtTime, null,
                             TrustRelationshipManager?.LastModifiedByEmail),
@@ -56,7 +56,7 @@ public class ContactsAreaModel(
                         SfsoLead?.LastModifiedByEmail), ContactRole.SfsoLead.MapRoleToViewString())
                 ]
             ),
-            new DataSourcePageListEntry("In this trust", [
+            new DataSourcePageListEntry(InTrustModel.SubPageName, [
                     new DataSourceListEntry(giasDataSource, "Accounting officer name"),
                     new DataSourceListEntry(giasDataSource, "Chief financial officer name"),
                     new DataSourceListEntry(giasDataSource, "Chair of trustees name"),

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditContactModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditContactModel.cs
@@ -20,7 +20,7 @@ public abstract class EditContactModel(
     public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with
     {
         SubPageName = $"Edit {role.MapRoleToViewString()} details",
-        PageName = ViewConstants.ContactsPageName
+        PageName = ContactsAreaModel.PageName
     };
 
     public const string NameField = "Name";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/InDfe.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/InDfe.cshtml.cs
@@ -9,6 +9,7 @@ public class InDfeModel(
     ILogger<InDfeModel> logger)
     : ContactsAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.ContactsInDfePageName };
+    public const string SubPageName = "In DfE";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/InTrust.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/InTrust.cshtml.cs
@@ -9,6 +9,7 @@ public class InTrustModel(
     ILogger<InTrustModel> logger)
     : ContactsAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = "In this trust" };
+    public const string SubPageName = "In this trust";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialDocumentsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialDocumentsAreaModel.cs
@@ -13,8 +13,9 @@ public abstract class FinancialDocumentsAreaModel(
     IFinancialDocumentService financialDocumentService)
     : TrustsAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { PageName = ViewConstants.FinancialDocumentsPageName };
+    public const string PageName = "Financial documents";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = PageName };
 
     public virtual bool InternalUseOnly => true;
     protected abstract FinancialDocumentType FinancialDocumentType { get; }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialStatements.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialStatements.cshtml.cs
@@ -12,8 +12,9 @@ public class FinancialStatementsModel(
     IFinancialDocumentService financialDocumentService)
     : FinancialDocumentsAreaModel(dataSourceService, trustService, logger, financialDocumentService)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.FinancialDocumentsFinancialStatementsSubPageName };
+    public const string SubPageName = "Financial statements";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 
     public override bool InternalUseOnly => false;
     protected override FinancialDocumentType FinancialDocumentType => FinancialDocumentType.FinancialStatement;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/InternalScrutinyReports.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/InternalScrutinyReports.cshtml.cs
@@ -12,10 +12,9 @@ public class InternalScrutinyReportsModel(
     IFinancialDocumentService financialDocumentService)
     : FinancialDocumentsAreaModel(dataSourceService, trustService, logger, financialDocumentService)
 {
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with
-    {
-        SubPageName = ViewConstants.FinancialDocumentsInternalScrutinyReportsSubPageName
-    };
+    public const string SubPageName = "Internal scrutiny reports";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 
     protected override FinancialDocumentType FinancialDocumentType => FinancialDocumentType.InternalScrutinyReport;
     public override string FinancialDocumentDisplayName => "scrutiny report";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/ManagementLetters.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/ManagementLetters.cshtml.cs
@@ -12,8 +12,9 @@ public class ManagementLettersModel(
     IFinancialDocumentService financialDocumentService)
     : FinancialDocumentsAreaModel(dataSourceService, trustService, logger, financialDocumentService)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.FinancialDocumentsManagementLettersSubPageName };
+    public const string SubPageName = "Management letters";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 
     protected override FinancialDocumentType FinancialDocumentType => FinancialDocumentType.ManagementLetter;
     public override string FinancialDocumentDisplayName => "management letter";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklists.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklists.cshtml.cs
@@ -12,10 +12,9 @@ public class SelfAssessmentChecklistsModel(
     IFinancialDocumentService financialDocumentService)
     : FinancialDocumentsAreaModel(dataSourceService, trustService, logger, financialDocumentService)
 {
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with
-    {
-        SubPageName = ViewConstants.FinancialDocumentsSelfAssessmentChecklistsSubPageName
-    };
+    public const string SubPageName = "Self-assessment checklists";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 
     protected override FinancialDocumentType FinancialDocumentType => FinancialDocumentType.SelfAssessmentChecklist;
     public override string FinancialDocumentDisplayName => "self-assessment checklist";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/GovernanceAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/GovernanceAreaModel.cs
@@ -47,14 +47,10 @@ public class GovernanceAreaModel(
         var giasDataSource = await DataSourceService.GetAsync(Source.Gias);
 
         DataSourcesPerPage.AddRange([
-            new DataSourcePageListEntry(ViewConstants.GovernanceTrustLeadershipPageName,
-                [new DataSourceListEntry(giasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.GovernanceTrusteesPageName,
-                [new DataSourceListEntry(giasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.GovernanceMembersPageName,
-                [new DataSourceListEntry(giasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.GovernanceHistoricMembersPageName,
-                [new DataSourceListEntry(giasDataSource)])
+            new DataSourcePageListEntry(TrustLeadershipModel.SubPageName, [new DataSourceListEntry(giasDataSource)]),
+            new DataSourcePageListEntry(TrusteesModel.SubPageName, [new DataSourceListEntry(giasDataSource)]),
+            new DataSourcePageListEntry(MembersModel.SubPageName, [new DataSourceListEntry(giasDataSource)]),
+            new DataSourcePageListEntry(HistoricMembersModel.SubPageName, [new DataSourceListEntry(giasDataSource)])
         ]);
 
         return pageResult;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/GovernanceAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/GovernanceAreaModel.cs
@@ -11,8 +11,9 @@ public class GovernanceAreaModel(
     ILogger<GovernanceAreaModel> logger)
     : TrustsAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { PageName = ViewConstants.GovernancePageName };
+    public const string PageName = "Governance";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = PageName };
 
     public TrustGovernanceServiceModel TrustGovernance { get; set; } = default!;
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/HistoricMembers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/HistoricMembers.cshtml.cs
@@ -9,6 +9,7 @@ public class HistoricMembersModel(
     ITrustService trustService)
     : GovernanceAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.GovernanceHistoricMembersPageName };
+    public const string SubPageName = "Historic members";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Members.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Members.cshtml.cs
@@ -9,6 +9,7 @@ public class MembersModel(
     ITrustService trustService)
     : GovernanceAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.GovernanceMembersPageName };
+    public const string SubPageName = "Members";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/TrustLeadership.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/TrustLeadership.cshtml.cs
@@ -9,6 +9,7 @@ public class TrustLeadershipModel(
     ITrustService trustService)
     : GovernanceAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.GovernanceTrustLeadershipPageName };
+    public const string SubPageName = "Trust leadership";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Trustees.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Trustees.cshtml.cs
@@ -9,6 +9,7 @@ public class TrusteesModel(
     ITrustService trustService)
     : GovernanceAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.GovernanceTrusteesPageName };
+    public const string SubPageName = "Trustees";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/CurrentRatings.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/CurrentRatings.cshtml.cs
@@ -15,6 +15,7 @@ public class CurrentRatingsModel(
     ILogger<CurrentRatingsModel> logger) : OfstedAreaModel(dataSourceService, trustService,
     academyService, exportService, dateTimeProvider, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.OfstedCurrentRatingsPageName };
+    public const string SubPageName = "Current ratings";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/OfstedAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/OfstedAreaModel.cs
@@ -51,23 +51,23 @@ public class OfstedAreaModel(
         var misDataSource = await DataSourceService.GetAsync(Source.Mis);
 
         DataSourcesPerPage.AddRange([
-            new DataSourcePageListEntry(ViewConstants.OfstedSingleHeadlineGradesPageName, [
+            new DataSourcePageListEntry(SingleHeadlineGradesModel.SubPageName, [
                     new DataSourceListEntry(giasDataSource, "Date joined trust"),
                     new DataSourceListEntry(misDataSource, "All single headline grades"),
                     new DataSourceListEntry(misDataSource, "All inspection dates")
                 ]
             ),
-            new DataSourcePageListEntry(ViewConstants.OfstedCurrentRatingsPageName, [
+            new DataSourcePageListEntry(CurrentRatingsModel.SubPageName, [
                     new DataSourceListEntry(misDataSource, "Current Ofsted rating"),
                     new DataSourceListEntry(misDataSource, "Date of current inspection")
                 ]
             ),
-            new DataSourcePageListEntry(ViewConstants.OfstedPreviousRatingsPageName, [
+            new DataSourcePageListEntry(PreviousRatingsModel.SubPageName, [
                     new DataSourceListEntry(misDataSource, "Previous Ofsted rating"),
                     new DataSourceListEntry(misDataSource, "Date of previous inspection")
                 ]
             ),
-            new DataSourcePageListEntry(ViewConstants.OfstedSafeguardingAndConcernsPageName, [
+            new DataSourcePageListEntry(SafeguardingAndConcernsModel.SubPageName, [
                     new DataSourceListEntry(misDataSource, "Effective safeguarding"),
                     new DataSourceListEntry(misDataSource, "Category of concern"),
                     new DataSourceListEntry(misDataSource, "Date of current inspection")

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/OfstedAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/OfstedAreaModel.cs
@@ -17,8 +17,9 @@ public class OfstedAreaModel(
     ILogger<OfstedAreaModel> logger)
     : TrustsAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { PageName = ViewConstants.OfstedPageName };
+    public const string PageName = "Ofsted";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = PageName };
 
     public AcademyOfstedServiceModel[] Academies { get; set; } = default!;
     private IAcademyService AcademyService { get; } = academyService;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/PreviousRatings.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/PreviousRatings.cshtml.cs
@@ -15,6 +15,6 @@ public class PreviousRatingsModel(
     ILogger<PreviousRatingsModel> logger) : OfstedAreaModel(dataSourceService, trustService,
     academyService, exportService, dateTimeProvider, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.OfstedPreviousRatingsPageName };
+    public const string SubPageName = "Previous ratings";
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml.cs
@@ -15,6 +15,7 @@ public class SafeguardingAndConcernsModel(
     ILogger<SafeguardingAndConcernsModel> logger) : OfstedAreaModel(dataSourceService, trustService,
     academyService, exportService, dateTimeProvider, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.OfstedSafeguardingAndConcernsPageName };
+    public const string SubPageName = "Safeguarding and concerns";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml.cs
@@ -15,6 +15,7 @@ public class SingleHeadlineGradesModel(
     ILogger<SingleHeadlineGradesModel> logger) : OfstedAreaModel(dataSourceService, trustService,
     academyService, exportService, dateTimeProvider, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.OfstedSingleHeadlineGradesPageName };
+    public const string SubPageName = "Single headline grades";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
@@ -38,9 +38,9 @@ public class OverviewAreaModel(
         // Add data sources
         var giasDataSource = await DataSourceService.GetAsync(Source.Gias);
         DataSourcesPerPage.AddRange([
-            new DataSourcePageListEntry(ViewConstants.OverviewTrustDetailsPageName, [new DataSourceListEntry(giasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.OverviewTrustSummaryPageName, [new DataSourceListEntry(giasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.OverviewReferenceNumbersPageName, [new DataSourceListEntry(giasDataSource)])
+            new DataSourcePageListEntry(TrustDetailsModel.SubPageName, [new DataSourceListEntry(giasDataSource)]),
+            new DataSourcePageListEntry(TrustSummaryModel.SubPageName, [new DataSourceListEntry(giasDataSource)]),
+            new DataSourcePageListEntry(ReferenceNumbersModel.SubPageName, [new DataSourceListEntry(giasDataSource)])
         ]);
 
         return Page();

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
@@ -11,7 +11,10 @@ public class OverviewAreaModel(
     ILogger<OverviewAreaModel> logger)
     : TrustsAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = ViewConstants.OverviewPageName };
+    public const string PageName = "Overview";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = PageName };
+
     public TrustOverviewServiceModel TrustOverview { get; set; } = default!;
 
     public override async Task<IActionResult> OnGetAsync()

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/ReferenceNumbers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/ReferenceNumbers.cshtml.cs
@@ -9,6 +9,8 @@ public class ReferenceNumbersModel(
     ITrustService trustService)
     : OverviewAreaModel(dataSourceService, trustService, logger)
 {
+    public const string SubPageName = "Reference numbers";
+
     public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.OverviewReferenceNumbersPageName };
+        base.TrustPageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml.cs
@@ -11,8 +11,9 @@ public class TrustDetailsModel(
     IOtherServicesLinkBuilder otherServicesLinkBuilder)
     : OverviewAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.OverviewTrustDetailsPageName };
+    public const string SubPageName = "Trust details";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 
     public string? CompaniesHouseLink { get; set; }
     public string? GetInformationAboutSchoolsLink { get; set; }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustSummary.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustSummary.cshtml.cs
@@ -9,8 +9,9 @@ public class TrustSummaryModel(
     ITrustService trustService)
     : OverviewAreaModel(dataSourceService, trustService, logger)
 {
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = ViewConstants.OverviewTrustSummaryPageName };
+    public const string SubPageName = "Trust summary";
+
+    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
 
     public IEnumerable<(string Authority, int Total)> AcademiesInEachLocalAuthority =>
         TrustOverview.AcademiesByLocalAuthority

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/BaseAcademiesInTrustAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/BaseAcademiesInTrustAreaModelTests.cs
@@ -84,11 +84,11 @@ public abstract class AcademiesInTrustAreaModelTests<T> : BaseAcademiesAreaModel
         await MockDataSourceService.Received(1).GetAsync(Source.Gias);
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
-            new DataSourcePageListEntry(ViewConstants.AcademiesInTrustDetailsPageName,
+            new DataSourcePageListEntry("Details",
                 [new DataSourceListEntry(GiasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.AcademiesInTrustPupilNumbersPageName,
+            new DataSourcePageListEntry("Pupil numbers",
                 [new DataSourceListEntry(GiasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.AcademiesInTrustFreeSchoolMealsPageName,
+            new DataSourcePageListEntry("Free school meals",
             [
                 new DataSourceListEntry(GiasDataSource, "Pupils eligible for free school meals"),
                 new DataSourceListEntry(EesDataSource, "Local authority average 2023/24"),

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/DetailsModelTests.cs
@@ -48,7 +48,7 @@ public class AcademiesDetailsModelTests : AcademiesInTrustAreaModelTests<Academi
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.TabName.Should().Be(ViewConstants.AcademiesInTrustDetailsPageName);
+        Sut.TrustPageMetadata.TabName.Should().Be("Details");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/BasePipelineAcademiesAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/BasePipelineAcademiesAreaModelTests.cs
@@ -93,11 +93,11 @@ public abstract class BasePipelineAcademiesAreaModelTests<T> : BaseAcademiesArea
         await MockDataSourceService.Received(1).GetAsync(Source.Complete);
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
-            new DataSourcePageListEntry(ViewConstants.PipelineAcademiesPreAdvisoryBoardPageName,
+            new DataSourcePageListEntry("Pre advisory board",
                 [new DataSourceListEntry(Mocks.MockDataSourceService.Prepare)]),
-            new DataSourcePageListEntry(ViewConstants.PipelineAcademiesPostAdvisoryBoardPageName,
+            new DataSourcePageListEntry("Post advisory board",
                 [new DataSourceListEntry(Mocks.MockDataSourceService.Complete)]),
-            new DataSourcePageListEntry(ViewConstants.PipelineAcademiesFreeSchoolsPageName,
+            new DataSourcePageListEntry("Free schools",
                 [new DataSourceListEntry(Mocks.MockDataSourceService.ManageFreeSchool)])
         ]);
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/BaseContactsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/BaseContactsAreaModelTests.cs
@@ -127,14 +127,14 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
         await MockDataSourceService.Received(1).GetAsync(Source.Mstr);
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
-            new DataSourcePageListEntry(ViewConstants.ContactsInDfePageName, [
+            new DataSourcePageListEntry("In DfE", [
                     new DataSourceListEntry(new DataSourceServiceModel(Source.FiatDb, null, null),
                         "Trust relationship manager"),
                     new DataSourceListEntry(new DataSourceServiceModel(Source.FiatDb, null, null),
                         "SFSO (Schools financial support and oversight) lead")
                 ]
             ),
-            new DataSourcePageListEntry(ViewConstants.ContactsInTrustPageName, [
+            new DataSourcePageListEntry("In this trust", [
                     new DataSourceListEntry(GiasDataSource, "Accounting officer name"),
                     new DataSourceListEntry(GiasDataSource, "Chief financial officer name"),
                     new DataSourceListEntry(GiasDataSource, "Chair of trustees name"),

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditSfsoLeadModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditSfsoLeadModelTests.cs
@@ -106,7 +106,7 @@ public class EditSfsoLeadModelTests
 
         _sut.TrustPageMetadata.SubPageName.Should()
             .Be("Edit SFSO (Schools financial support and oversight) lead details");
-        _sut.TrustPageMetadata.PageName.Should().Be(ViewConstants.ContactsPageName);
+        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
         _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
         _sut.TrustPageMetadata.ModelStateIsValid.Should().BeTrue();
     }
@@ -119,7 +119,7 @@ public class EditSfsoLeadModelTests
 
         _sut.TrustPageMetadata.SubPageName.Should()
             .Be("Edit SFSO (Schools financial support and oversight) lead details");
-        _sut.TrustPageMetadata.PageName.Should().Be(ViewConstants.ContactsPageName);
+        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
         _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
         _sut.TrustPageMetadata.ModelStateIsValid.Should().BeFalse();
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
@@ -106,7 +106,7 @@ public class EditTrustRelationshipManagerModelTests
         _ = await _sut.OnPostAsync();
 
         _sut.TrustPageMetadata.SubPageName.Should().Be("Edit Trust relationship manager details");
-        _sut.TrustPageMetadata.PageName.Should().Be(ViewConstants.ContactsPageName);
+        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
         _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
         _sut.TrustPageMetadata.ModelStateIsValid.Should().BeTrue();
     }
@@ -118,7 +118,7 @@ public class EditTrustRelationshipManagerModelTests
         _ = await _sut.OnPostAsync();
 
         _sut.TrustPageMetadata.SubPageName.Should().Be("Edit Trust relationship manager details");
-        _sut.TrustPageMetadata.PageName.Should().Be(ViewConstants.ContactsPageName);
+        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
         _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
         _sut.TrustPageMetadata.ModelStateIsValid.Should().BeFalse();
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/BaseGovernanceAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/BaseGovernanceAreaModelTests.cs
@@ -39,14 +39,10 @@ public abstract class BaseGovernanceAreaModelTests<T> : BaseTrustPageTests<T>, I
         await MockDataSourceService.Received(1).GetAsync(Source.Gias);
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
-            new DataSourcePageListEntry(ViewConstants.GovernanceTrustLeadershipPageName,
-                [new DataSourceListEntry(GiasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.GovernanceTrusteesPageName,
-                [new DataSourceListEntry(GiasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.GovernanceMembersPageName,
-                [new DataSourceListEntry(GiasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.GovernanceHistoricMembersPageName,
-                [new DataSourceListEntry(GiasDataSource)])
+            new DataSourcePageListEntry("Trust leadership", [new DataSourceListEntry(GiasDataSource)]),
+            new DataSourcePageListEntry("Trustees", [new DataSourceListEntry(GiasDataSource)]),
+            new DataSourcePageListEntry("Members", [new DataSourceListEntry(GiasDataSource)]),
+            new DataSourcePageListEntry("Historic members", [new DataSourceListEntry(GiasDataSource)])
         ]);
     }
 
@@ -99,8 +95,8 @@ public abstract class BaseGovernanceAreaModelTests<T> : BaseTrustPageTests<T>, I
     public override async Task OnGetAsync_should_configure_TrustPageMetadata_PageName()
     {
         _ = await Sut.OnGetAsync();
-
-        Sut.TrustPageMetadata.PageName.Should().Be(ViewConstants.GovernancePageName);
+        
+        Sut.TrustPageMetadata.PageName.Should().Be("Governance");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/BaseOfstedAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/BaseOfstedAreaModelTests.cs
@@ -27,23 +27,23 @@ public abstract class BaseOfstedAreaModelTests<T> : BaseTrustPageTests<T>, ITest
         await MockDataSourceService.Received(1).GetAsync(Source.Mis);
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
-            new DataSourcePageListEntry(ViewConstants.OfstedSingleHeadlineGradesPageName, [
+            new DataSourcePageListEntry("Single headline grades", [
                     new DataSourceListEntry(GiasDataSource, "Date joined trust"),
                     new DataSourceListEntry(MisDataSource, "All single headline grades"),
                     new DataSourceListEntry(MisDataSource, "All inspection dates")
                 ]
             ),
-            new DataSourcePageListEntry(ViewConstants.OfstedCurrentRatingsPageName, [
+            new DataSourcePageListEntry("Current ratings", [
                     new DataSourceListEntry(MisDataSource, "Current Ofsted rating"),
                     new DataSourceListEntry(MisDataSource, "Date of current inspection")
                 ]
             ),
-            new DataSourcePageListEntry(ViewConstants.OfstedPreviousRatingsPageName, [
+            new DataSourcePageListEntry("Previous ratings", [
                     new DataSourceListEntry(MisDataSource, "Previous Ofsted rating"),
                     new DataSourceListEntry(MisDataSource, "Date of previous inspection")
                 ]
             ),
-            new DataSourcePageListEntry(ViewConstants.OfstedSafeguardingAndConcernsPageName, [
+            new DataSourcePageListEntry("Safeguarding and concerns", [
                     new DataSourceListEntry(MisDataSource, "Effective safeguarding"),
                     new DataSourceListEntry(MisDataSource, "Category of concern"),
                     new DataSourceListEntry(MisDataSource, "Date of current inspection")

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/BaseOverviewAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/BaseOverviewAreaModelTests.cs
@@ -30,14 +30,11 @@ public abstract class BaseOverviewAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     {
         _ = await Sut.OnGetAsync();
         await MockDataSourceService.Received(1).GetAsync(Source.Gias);
-        
+
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
-            new DataSourcePageListEntry(ViewConstants.OverviewTrustDetailsPageName,
-                [new DataSourceListEntry(GiasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.OverviewTrustSummaryPageName,
-                [new DataSourceListEntry(GiasDataSource)]),
-            new DataSourcePageListEntry(ViewConstants.OverviewReferenceNumbersPageName,
-                [new DataSourceListEntry(GiasDataSource)])
+            new DataSourcePageListEntry("Trust details", [new DataSourceListEntry(GiasDataSource)]),
+            new DataSourcePageListEntry("Trust summary", [new DataSourceListEntry(GiasDataSource)]),
+            new DataSourcePageListEntry("Reference numbers", [new DataSourceListEntry(GiasDataSource)])
         ]);
     }
 
@@ -85,7 +82,7 @@ public abstract class BaseOverviewAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.PageName.Should().Be(ViewConstants.OverviewPageName);
+        Sut.TrustPageMetadata.PageName.Should().Be("Overview");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/ReferenceNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/ReferenceNumbersModelTests.cs
@@ -29,6 +29,6 @@ public class ReferenceNumbersModelTests : BaseOverviewAreaModelTests<ReferenceNu
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be(ViewConstants.OverviewReferenceNumbersPageName);
+        Sut.TrustPageMetadata.SubPageName.Should().Be("Reference numbers");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustDetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustDetailsModelTests.cs
@@ -123,6 +123,6 @@ public class TrustDetailsModelTests : BaseOverviewAreaModelTests<TrustDetailsMod
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be(ViewConstants.OverviewTrustDetailsPageName);
+        Sut.TrustPageMetadata.SubPageName.Should().Be("Trust details");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustSummaryModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustSummaryModelTests.cs
@@ -61,6 +61,6 @@ public class TrustSummaryModelTests : BaseOverviewAreaModelTests<TrustSummaryMod
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be(ViewConstants.OverviewTrustSummaryPageName);
+        Sut.TrustPageMetadata.SubPageName.Should().Be("Trust summary");
     }
 }


### PR DESCRIPTION
Pre-work for nav refactor - make page names, subpage names and tab names available from their respective page madels

[User Story 207933](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/207933): Tech debt: Refactor nav links

## Changes

- make page names, subpage names and tab names available from their respective page madels
- use expected strings directly in unit tests so we we're not testing prod code with itself

## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
