### PR TITLE
Output stryker report when mutation tests fails

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -45,6 +45,7 @@ jobs:
       run: dotnet stryker --reporter "markdown" --reporter "html" --output "${{ github.workspace }}"
 
     - name: Print stryker report
+      if: ${{ !cancelled() }}
       run: |
         # Construct the full path to the markdown file
         REPORT_FILE="${{ github.workspace }}/reports/mutation-report.md"
@@ -60,6 +61,7 @@ jobs:
 
     - name: Upload Stryker report
       uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
       with:
         name: stryker-report
         path: ${{ github.workspace }}/reports/mutation-report.html


### PR DESCRIPTION
[User Story 210050](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/210050): Tech debt: Stryker - print and link report when run fails

## Changes

Set stryker report printing and upload to occur so long as the run wasn't cancelled (i.e. it will run on a success or failure)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
