### PR TITLE
Add manual trigger to lint workflow

### DIFF
--- a/.github/workflows/continuous-integration-lint.yml
+++ b/.github/workflows/continuous-integration-lint.yml
@@ -4,6 +4,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main, '**-feature' ]
+  workflow_dispatch:
 
 env:
   NODE_VERSION: '22'


### PR DESCRIPTION
Allows SonarQube to be manually triggered on any branch