### PR TITLE
Move `TrustPageMetadata` to `Shared.PageMetadata`

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/PageMetadata.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/PageMetadata.cs
@@ -1,7 +1,7 @@
-namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+namespace DfE.FindInformationAcademiesTrusts.Pages.Shared;
 
-public record TrustPageMetadata(
-    string TrustName,
+public record PageMetadata(
+    string EntityName,
     bool ModelStateIsValid,
     string? PageName = null,
     string? SubPageName = null,
@@ -11,7 +11,7 @@ public record TrustPageMetadata(
     {
         get
         {
-            var orderedTitleParts = new[] { TabName, SubPageName, PageName, TrustName }.Where(s => s is not null);
+            var orderedTitleParts = new[] { TabName, SubPageName, PageName, EntityName }.Where(s => s is not null);
             var browserTitle = string.Join(" - ", orderedTitleParts);
 
             if (!ModelStateIsValid)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/AcademiesAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/AcademiesAreaModel.cs
@@ -1,5 +1,6 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Extensions;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.NavMenu;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
@@ -16,7 +17,7 @@ public abstract class AcademiesAreaModel(
 ) : TrustsAreaModel(dataSourceService, trustService)
 {
     public const string PageName = "Academies";
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = PageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };
 
     internal readonly IAcademyService AcademyService = academyService;
     public IDateTimeProvider DateTimeProvider { get; } = dateTimeProvider;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/AcademiesInTrustAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/AcademiesInTrustAreaModel.cs
@@ -1,5 +1,6 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
@@ -24,7 +25,7 @@ public abstract class AcademiesInTrustAreaModel(
 {
     public const string SubPageName = "In this trust";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 
     public override async Task<IActionResult> OnGetAsync()
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -24,7 +25,7 @@ public class AcademiesInTrustDetailsModel(
 {
     public const string TabName = "Details";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = TabName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { TabName = TabName };
 
     public AcademyDetailsServiceModel[] Academies { get; set; } = default!;
     public IOtherServicesLinkBuilder LinkBuilder { get; } = linkBuilder;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/FreeSchoolMeals.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/FreeSchoolMeals.cshtml.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -23,7 +24,7 @@ public class FreeSchoolMealsModel(
 {
     public const string TabName = "Free school meals";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = TabName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { TabName = TabName };
 
     public AcademyFreeSchoolMealsServiceModel[] Academies { get; set; } = default!;
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/PupilNumbers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/PupilNumbers.cshtml.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -23,7 +24,7 @@ public class PupilNumbersModel(
 {
     public const string TabName = "Pupil numbers";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = TabName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { TabName = TabName };
 
     public AcademyPupilNumbersServiceModel[] Academies { get; set; } = default!;
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/FreeSchools.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/FreeSchools.cshtml.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -18,7 +19,7 @@ public class FreeSchoolsModel(
 {
     public const string TabName = "Free schools";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = TabName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { TabName = TabName };
 
     public AcademyPipelineServiceModel[] PipelineFreeSchools { get; set; } = [];
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PipelineAcademiesAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PipelineAcademiesAreaModel.cs
@@ -1,5 +1,6 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
@@ -24,7 +25,7 @@ public abstract class PipelineAcademiesAreaModel(
 {
     public const string SubPageName = "Pipeline academies";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 
     public override async Task<IActionResult> OnGetAsync()
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoard.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoard.cshtml.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -18,7 +19,7 @@ public class PostAdvisoryBoardModel(
 {
     public const string TabName = "Post advisory board";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = TabName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { TabName = TabName };
 
     public AcademyPipelineServiceModel[] PostAdvisoryPipelineEstablishments { get; set; } = [];
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoard.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoard.cshtml.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -18,7 +19,7 @@ public class PreAdvisoryBoardModel(
 {
     public const string TabName = "Pre advisory board";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { TabName = TabName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { TabName = TabName };
 
     public AcademyPipelineServiceModel[] PreAdvisoryPipelineEstablishments { get; set; } = [];
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_AcademiesLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/_AcademiesLayout.cshtml
@@ -4,7 +4,7 @@
     Layout = "_TrustLayout";
 }
 
-<h3 class="govuk-heading-m">@Model.TrustPageMetadata.SubPageName</h3>
+<h3 class="govuk-heading-m">@Model.PageMetadata.SubPageName</h3>
 <div class="govuk-tabs">
     <ul class="govuk-tabs__list">
         @foreach (var tab in Model.TabList)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/ContactsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/ContactsAreaModel.cs
@@ -1,6 +1,7 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Extensions;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
@@ -16,7 +17,7 @@ public class ContactsAreaModel(
 {
     public const string PageName = "Contacts";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = PageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };
 
     public Person? ChairOfTrustees { get; set; }
     public Person? AccountingOfficer { get; set; }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditContactModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditContactModel.cs
@@ -2,6 +2,7 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Extensions;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
@@ -15,7 +16,7 @@ public abstract class EditContactModel(
     ContactRole role)
     : TrustsAreaModel(dataSourceService, trustService)
 {
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with
+    public override PageMetadata PageMetadata => base.PageMetadata with
     {
         SubPageName = $"Edit {role.MapRoleToViewString()} details",
         PageName = ContactsAreaModel.PageName

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditSfsoLead.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditSfsoLead.cshtml
@@ -3,7 +3,7 @@
 
 @{
   Layout = "_Layout";
-  ViewData["Title"] = Model.TrustPageMetadata.BrowserTitle;
+  ViewData["Title"] = Model.PageMetadata.BrowserTitle;
 }
 
-<partial name="_EditContactsForm" model="@Model"/>
+<partial name="_EditContactsForm" model="@Model" />

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditTrustRelationshipManager.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/EditTrustRelationshipManager.cshtml
@@ -3,7 +3,7 @@
 
 @{
   Layout = "_Layout";
-  ViewData["Title"] = Model.TrustPageMetadata.BrowserTitle;
+  ViewData["Title"] = Model.PageMetadata.BrowserTitle;
 }
 
-<partial name="_EditContactsForm" model="@Model"/>
+<partial name="_EditContactsForm" model="@Model" />

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/InDfe.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/InDfe.cshtml.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
@@ -10,5 +11,5 @@ public class InDfeModel(
 {
     public const string SubPageName = "In DfE";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/InTrust.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/InTrust.cshtml.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
@@ -10,5 +11,5 @@ public class InTrustModel(
 {
     public const string SubPageName = "In this trust";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/_EditContactsForm.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Contacts/_EditContactsForm.cshtml
@@ -11,7 +11,7 @@
             <fieldset class="govuk-fieldset">
               <div>
                 <legend class="govuk-!-padding-0">
-                  <h1 class="govuk-heading-l">@Model.TrustPageMetadata.PageName</h1>
+                  <h1 class="govuk-heading-l">@Model.PageMetadata.PageName</h1>
                 </legend>
               </div>
               <partial name="Shared/_ErrorSummary" model="@Model"/>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialDocumentsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialDocumentsAreaModel.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
@@ -14,7 +15,7 @@ public abstract class FinancialDocumentsAreaModel(
 {
     public const string PageName = "Financial documents";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = PageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };
 
     public virtual bool InternalUseOnly => true;
     protected abstract FinancialDocumentType FinancialDocumentType { get; }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialStatements.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/FinancialStatements.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
@@ -13,7 +14,7 @@ public class FinancialStatementsModel(
 {
     public const string SubPageName = "Financial statements";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 
     public override bool InternalUseOnly => false;
     protected override FinancialDocumentType FinancialDocumentType => FinancialDocumentType.FinancialStatement;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/InternalScrutinyReports.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/InternalScrutinyReports.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
@@ -13,7 +14,7 @@ public class InternalScrutinyReportsModel(
 {
     public const string SubPageName = "Internal scrutiny reports";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 
     protected override FinancialDocumentType FinancialDocumentType => FinancialDocumentType.InternalScrutinyReport;
     public override string FinancialDocumentDisplayName => "scrutiny report";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/ManagementLetters.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/ManagementLetters.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
@@ -13,7 +14,7 @@ public class ManagementLettersModel(
 {
     public const string SubPageName = "Management letters";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 
     protected override FinancialDocumentType FinancialDocumentType => FinancialDocumentType.ManagementLetter;
     public override string FinancialDocumentDisplayName => "management letter";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklists.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklists.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
@@ -13,7 +14,7 @@ public class SelfAssessmentChecklistsModel(
 {
     public const string SubPageName = "Self-assessment checklists";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 
     protected override FinancialDocumentType FinancialDocumentType => FinancialDocumentType.SelfAssessmentChecklist;
     public override string FinancialDocumentDisplayName => "self-assessment checklist";

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/_FinancialDocumentsLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/FinancialDocuments/_FinancialDocumentsLayout.cshtml
@@ -7,13 +7,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m" data-testid="subpage-header">
-      @Model.TrustPageMetadata.SubPageName
+      @Model.PageMetadata.SubPageName
     </h2>
     <p class="govuk-body" data-testid="you-must-have-permission-message">You must have permission to view these
       documents.</p>
     @if (Model.InternalUseOnly)
     {
-      <partial name="Shared/_InternalUseOnlyWarning" model="@Model.TrustPageMetadata.SubPageName" />
+      <partial name="Shared/_InternalUseOnlyWarning" model="@Model.PageMetadata.SubPageName" />
     }
     <dl class="govuk-summary-list">
       @foreach (var doc in Model.FinancialDocuments)

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/GovernanceAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/GovernanceAreaModel.cs
@@ -1,4 +1,5 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
@@ -13,7 +14,7 @@ public class GovernanceAreaModel(
 {
     public const string PageName = "Governance";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = PageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };
 
     public TrustGovernanceServiceModel TrustGovernance { get; set; } = default!;
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/HistoricMembers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/HistoricMembers.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+﻿using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Governance;
@@ -10,5 +11,5 @@ public class HistoricMembersModel(
 {
     public const string SubPageName = "Historic members";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Members.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Members.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+﻿using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Governance;
@@ -10,5 +11,5 @@ public class MembersModel(
 {
     public const string SubPageName = "Members";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/TrustLeadership.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/TrustLeadership.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+﻿using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Governance;
@@ -10,5 +11,5 @@ public class TrustLeadershipModel(
 {
     public const string SubPageName = "Trust leadership";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Trustees.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Governance/Trustees.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+﻿using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Governance;
@@ -10,5 +11,5 @@ public class TrusteesModel(
 {
     public const string SubPageName = "Trustees";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/ITrustsAreaModel.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
@@ -11,5 +12,5 @@ public interface ITrustsAreaModel
 
     List<DataSourcePageListEntry> DataSourcesPerPage { get; }
 
-    TrustPageMetadata TrustPageMetadata { get; }
+    PageMetadata PageMetadata { get; }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/CurrentRatings.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/CurrentRatings.cshtml.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -16,5 +17,5 @@ public class CurrentRatingsModel(
 {
     public const string SubPageName = "Current ratings";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/OfstedAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/OfstedAreaModel.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
@@ -19,7 +20,7 @@ public class OfstedAreaModel(
 {
     public const string PageName = "Ofsted";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = PageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };
 
     public AcademyOfstedServiceModel[] Academies { get; set; } = default!;
     private IAcademyService AcademyService { get; } = academyService;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/PreviousRatings.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/PreviousRatings.cshtml.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -15,5 +16,5 @@ public class PreviousRatingsModel(
     academyService, ofstedDataExportService, dateTimeProvider)
 {
     public const string SubPageName = "Previous ratings";
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SafeguardingAndConcerns.cshtml.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -16,5 +17,5 @@ public class SafeguardingAndConcernsModel(
 {
     public const string SubPageName = "Safeguarding and concerns";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Ofsted/SingleHeadlineGrades.cshtml.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -16,5 +17,5 @@ public class SingleHeadlineGradesModel(
 {
     public const string SubPageName = "Single headline grades";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/OverviewAreaModel.cs
@@ -1,4 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
@@ -13,7 +14,7 @@ public class OverviewAreaModel(
 {
     public const string PageName = "Overview";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { PageName = PageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };
 
     public TrustOverviewServiceModel TrustOverview { get; set; } = default!;
 

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/ReferenceNumbers.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/ReferenceNumbers.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+﻿using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Overview;
@@ -10,6 +11,6 @@ public class ReferenceNumbersModel(
 {
     public const string SubPageName = "Reference numbers";
 
-    public override TrustPageMetadata TrustPageMetadata =>
-        base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata =>
+        base.PageMetadata with { SubPageName = SubPageName };
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustDetails.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+﻿using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
 
@@ -12,7 +13,7 @@ public class TrustDetailsModel(
 {
     public const string SubPageName = "Trust details";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 
     public string? CompaniesHouseLink { get; set; }
     public string? GetInformationAboutSchoolsLink { get; set; }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustSummary.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Overview/TrustSummary.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+﻿using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Trusts.Overview;
@@ -10,7 +11,7 @@ public class TrustSummaryModel(
 {
     public const string SubPageName = "Trust summary";
 
-    public override TrustPageMetadata TrustPageMetadata => base.TrustPageMetadata with { SubPageName = SubPageName };
+    public override PageMetadata PageMetadata => base.PageMetadata with { SubPageName = SubPageName };
 
     public IEnumerable<(string Authority, int Total)> AcademiesInEachLocalAuthority =>
         TrustOverview.AcademiesByLocalAuthority

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/TrustsAreaModel.cs
@@ -17,7 +17,7 @@ public abstract class TrustsAreaModel(
     [BindProperty(SupportsGet = true)] public string Uid { get; set; } = "";
     public TrustSummaryServiceModel TrustSummary { get; set; } = default!;
     public List<DataSourcePageListEntry> DataSourcesPerPage { get; set; } = [];
-    public virtual TrustPageMetadata TrustPageMetadata => new(TrustSummary.Name, ModelState.IsValid);
+    public virtual PageMetadata PageMetadata => new(TrustSummary.Name, ModelState.IsValid);
 
     public virtual async Task<IActionResult> OnGetAsync()
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBreadcrumbs.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustBreadcrumbs.cshtml
@@ -15,7 +15,7 @@
           </a>
         </li>
         <li class="govuk-breadcrumbs__list-item" data-testid="breadcrumb-page-name">
-          @Model.TrustPageMetadata.PageName
+          @Model.PageMetadata.PageName
         </li>
       </ol>
     </nav>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/_TrustLayout.cshtml
@@ -2,7 +2,7 @@
 
 @{
   Layout = "_Layout";
-  ViewData["Title"] = Model.TrustPageMetadata.BrowserTitle;
+  ViewData["Title"] = Model.PageMetadata.BrowserTitle;
 }
 
 <partial name="_TrustBanner" model="@Model" />
@@ -14,7 +14,7 @@
         <main id="main-content">
           @await RenderSectionAsync("TrustPageMessage", false)
           <header>
-            <h1 class="govuk-heading-l" data-testid="page-name">@Model.TrustPageMetadata.PageName</h1>
+            <h1 class="govuk-heading-l" data-testid="page-name">@Model.PageMetadata.PageName</h1>
           </header>
           <partial name="Shared/NavMenu/_SubNav" model="@TrustNavMenu.GetSubNavLinks(Model)" />
           @RenderBody()

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/PageMetadataTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Shared/PageMetadataTests.cs
@@ -1,14 +1,14 @@
-using DfE.FindInformationAcademiesTrusts.Pages.Trusts;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 
-namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Trusts;
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Shared;
 
-public class TrustPageMetadataTests
+public class PageMetadataTests
 {
     [Fact]
     public void TrustPageMetadata_can_be_composed_in_parts()
     {
         //This is similar to how it is being used in the page object models
-        var sut = new TrustPageMetadata("MY TRUST", true);
+        var sut = new PageMetadata("MY TRUST", true);
         sut.BrowserTitle.Should().Be("MY TRUST");
 
         sut = sut with { PageName = "Page" };
@@ -43,7 +43,7 @@ public class TrustPageMetadataTests
         string? subPageName,
         string? tabName, string expected)
     {
-        var sut = new TrustPageMetadata(trustName, modelStateIsValid, pageName, subPageName, tabName);
+        var sut = new PageMetadata(trustName, modelStateIsValid, pageName, subPageName, tabName);
 
         sut.BrowserTitle.Should().Be(expected);
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/BaseAcademiesAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/BaseAcademiesAreaModelTests.cs
@@ -33,7 +33,7 @@ public abstract class BaseAcademiesAreaModelTests<T> : BaseTrustPageTests<T>, IT
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.PageName.Should().Be("Academies");
+        Sut.PageMetadata.PageName.Should().Be("Academies");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/BaseAcademiesInTrustAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/BaseAcademiesInTrustAreaModelTests.cs
@@ -102,7 +102,7 @@ public abstract class AcademiesInTrustAreaModelTests<T> : BaseAcademiesAreaModel
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("In this trust");
+        Sut.PageMetadata.SubPageName.Should().Be("In this trust");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/DetailsModelTests.cs
@@ -46,7 +46,7 @@ public class AcademiesDetailsModelTests : AcademiesInTrustAreaModelTests<Academi
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.TabName.Should().Be("Details");
+        Sut.PageMetadata.TabName.Should().Be("Details");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/FreeSchoolMealsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/FreeSchoolMealsModelTests.cs
@@ -36,7 +36,7 @@ public class FreeSchoolMealsModelTests : AcademiesInTrustAreaModelTests<FreeScho
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.TabName.Should().Be("Free school meals");
+        Sut.PageMetadata.TabName.Should().Be("Free school meals");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/PupilNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/PupilNumbersModelTests.cs
@@ -59,7 +59,7 @@ public class PupilNumbersModelTests : AcademiesInTrustAreaModelTests<PupilNumber
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.TabName.Should().Be("Pupil numbers");
+        Sut.PageMetadata.TabName.Should().Be("Pupil numbers");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/BasePipelineAcademiesAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/BasePipelineAcademiesAreaModelTests.cs
@@ -106,7 +106,7 @@ public abstract class BasePipelineAcademiesAreaModelTests<T> : BaseAcademiesArea
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Pipeline academies");
+        Sut.PageMetadata.SubPageName.Should().Be("Pipeline academies");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/FreeSchoolsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/FreeSchoolsModelTests.cs
@@ -47,7 +47,7 @@ public class FreeSchoolsModelTests : BasePipelineAcademiesAreaModelTests<FreeSch
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.TabName.Should().Be("Free schools");
+        Sut.PageMetadata.TabName.Should().Be("Free schools");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoardModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/PostAdvisoryBoardModelTests.cs
@@ -40,7 +40,7 @@ public class PostAdvisoryBoardModelTests : BasePipelineAcademiesAreaModelTests<P
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.TabName.Should().Be("Post advisory board");
+        Sut.PageMetadata.TabName.Should().Be("Post advisory board");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoardModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/Pipeline/PreAdvisoryBoardModelTests.cs
@@ -39,7 +39,7 @@ public class PreAdvisoryBoardModelTests : BasePipelineAcademiesAreaModelTests<Pr
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.TabName.Should().Be("Pre advisory board");
+        Sut.PageMetadata.TabName.Should().Be("Pre advisory board");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/BaseTrustPageTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/BaseTrustPageTests.cs
@@ -85,7 +85,7 @@ public abstract class BaseTrustPageTests<T> where T : TrustsAreaModel
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
+        Sut.PageMetadata.EntityName.Should().Be("My Trust");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/BaseContactsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/BaseContactsAreaModelTests.cs
@@ -192,7 +192,7 @@ public abstract class BaseContactsAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.PageName.Should().Be("Contacts");
+        Sut.PageMetadata.PageName.Should().Be("Contacts");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditSfsoLeadModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditSfsoLeadModelTests.cs
@@ -91,11 +91,11 @@ public class EditSfsoLeadModelTests
             .Returns(Task.FromResult(new TrustContactUpdatedServiceModel(true, true)));
         _ = await _sut.OnPostAsync();
 
-        _sut.TrustPageMetadata.SubPageName.Should()
+        _sut.PageMetadata.SubPageName.Should()
             .Be("Edit SFSO (Schools financial support and oversight) lead details");
-        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
-        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
-        _sut.TrustPageMetadata.ModelStateIsValid.Should().BeTrue();
+        _sut.PageMetadata.PageName.Should().Be("Contacts");
+        _sut.PageMetadata.EntityName.Should().Be("My Trust");
+        _sut.PageMetadata.ModelStateIsValid.Should().BeTrue();
     }
 
     [Fact]
@@ -104,10 +104,10 @@ public class EditSfsoLeadModelTests
         _sut.ModelState.AddModelError("Test", "Test");
         _ = await _sut.OnPostAsync();
 
-        _sut.TrustPageMetadata.SubPageName.Should()
+        _sut.PageMetadata.SubPageName.Should()
             .Be("Edit SFSO (Schools financial support and oversight) lead details");
-        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
-        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
-        _sut.TrustPageMetadata.ModelStateIsValid.Should().BeFalse();
+        _sut.PageMetadata.PageName.Should().Be("Contacts");
+        _sut.PageMetadata.EntityName.Should().Be("My Trust");
+        _sut.PageMetadata.ModelStateIsValid.Should().BeFalse();
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/EditTrustRelationshipManagerModelTests.cs
@@ -93,10 +93,10 @@ public class EditTrustRelationshipManagerModelTests
             .Returns(Task.FromResult(new TrustContactUpdatedServiceModel(true, true)));
         _ = await _sut.OnPostAsync();
 
-        _sut.TrustPageMetadata.SubPageName.Should().Be("Edit Trust relationship manager details");
-        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
-        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
-        _sut.TrustPageMetadata.ModelStateIsValid.Should().BeTrue();
+        _sut.PageMetadata.SubPageName.Should().Be("Edit Trust relationship manager details");
+        _sut.PageMetadata.PageName.Should().Be("Contacts");
+        _sut.PageMetadata.EntityName.Should().Be("My Trust");
+        _sut.PageMetadata.ModelStateIsValid.Should().BeTrue();
     }
 
     [Fact]
@@ -105,9 +105,9 @@ public class EditTrustRelationshipManagerModelTests
         _sut.ModelState.AddModelError("Test", "Test");
         _ = await _sut.OnPostAsync();
 
-        _sut.TrustPageMetadata.SubPageName.Should().Be("Edit Trust relationship manager details");
-        _sut.TrustPageMetadata.PageName.Should().Be("Contacts");
-        _sut.TrustPageMetadata.TrustName.Should().Be("My Trust");
-        _sut.TrustPageMetadata.ModelStateIsValid.Should().BeFalse();
+        _sut.PageMetadata.SubPageName.Should().Be("Edit Trust relationship manager details");
+        _sut.PageMetadata.PageName.Should().Be("Contacts");
+        _sut.PageMetadata.EntityName.Should().Be("My Trust");
+        _sut.PageMetadata.ModelStateIsValid.Should().BeFalse();
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InDfeModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InDfeModelTests.cs
@@ -16,6 +16,6 @@ public class InDfeModelTests : BaseContactsAreaModelTests<InDfeModel>
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("In DfE");
+        Sut.PageMetadata.SubPageName.Should().Be("In DfE");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InTrustModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Contacts/InTrustModelTests.cs
@@ -16,6 +16,6 @@ public class InTrustModelTests : BaseContactsAreaModelTests<InTrustModel>
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("In this trust");
+        Sut.PageMetadata.SubPageName.Should().Be("In this trust");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/BaseFinancialDocumentsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/BaseFinancialDocumentsAreaModelTests.cs
@@ -46,7 +46,7 @@ public abstract class BaseFinancialDocumentsAreaModelTests<T> : BaseTrustPageTes
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.PageName.Should().Be("Financial documents");
+        Sut.PageMetadata.PageName.Should().Be("Financial documents");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/FinancialStatementModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/FinancialStatementModelTests.cs
@@ -17,7 +17,7 @@ public class FinancialStatementModelTests : BaseFinancialDocumentsAreaModelTests
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Financial statements");
+        Sut.PageMetadata.SubPageName.Should().Be("Financial statements");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/InternalScrutinyReportsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/InternalScrutinyReportsModelTests.cs
@@ -17,7 +17,7 @@ public class InternalScrutinyReportsModelTests : BaseFinancialDocumentsAreaModel
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Internal scrutiny reports");
+        Sut.PageMetadata.SubPageName.Should().Be("Internal scrutiny reports");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/ManagementLettersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/ManagementLettersModelTests.cs
@@ -17,7 +17,7 @@ public class ManagementLettersModelTests : BaseFinancialDocumentsAreaModelTests<
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Management letters");
+        Sut.PageMetadata.SubPageName.Should().Be("Management letters");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklistsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/FinancialDocuments/SelfAssessmentChecklistsModelTests.cs
@@ -17,7 +17,7 @@ public class SelfAssessmentChecklistsModelTests : BaseFinancialDocumentsAreaMode
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Self-assessment checklists");
+        Sut.PageMetadata.SubPageName.Should().Be("Self-assessment checklists");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/BaseGovernanceAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/BaseGovernanceAreaModelTests.cs
@@ -68,7 +68,7 @@ public abstract class BaseGovernanceAreaModelTests<T> : BaseTrustPageTests<T>, I
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.PageName.Should().Be("Governance");
+        Sut.PageMetadata.PageName.Should().Be("Governance");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/HistoricMembersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/HistoricMembersModelTests.cs
@@ -15,6 +15,6 @@ public class HistoricMembersModelTests : BaseGovernanceAreaModelTests<HistoricMe
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Historic members");
+        Sut.PageMetadata.SubPageName.Should().Be("Historic members");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/MembersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/MembersModelTests.cs
@@ -15,6 +15,6 @@ public class MembersModelTests : BaseGovernanceAreaModelTests<MembersModel>
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Members");
+        Sut.PageMetadata.SubPageName.Should().Be("Members");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrustLeadershipModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrustLeadershipModelTests.cs
@@ -15,6 +15,6 @@ public class TrustLeadershipModelTests : BaseGovernanceAreaModelTests<TrustLeade
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Trust leadership");
+        Sut.PageMetadata.SubPageName.Should().Be("Trust leadership");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrusteesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Governance/TrusteesModelTests.cs
@@ -15,6 +15,6 @@ public class TrusteesModelTests : BaseGovernanceAreaModelTests<TrusteesModel>
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Trustees");
+        Sut.PageMetadata.SubPageName.Should().Be("Trustees");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/BaseOfstedAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/BaseOfstedAreaModelTests.cs
@@ -141,7 +141,7 @@ public abstract class BaseOfstedAreaModelTests<T> : BaseTrustPageTests<T>, ITest
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.PageName.Should().Be("Ofsted");
+        Sut.PageMetadata.PageName.Should().Be("Ofsted");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/CurrentRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/CurrentRatingsModelTests.cs
@@ -20,6 +20,6 @@ public class CurrentRatingsModelTests : BaseOfstedAreaModelTests<CurrentRatingsM
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Current ratings");
+        Sut.PageMetadata.SubPageName.Should().Be("Current ratings");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/PreviousRatingsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/PreviousRatingsModelTests.cs
@@ -20,6 +20,6 @@ public class PreviousRatingsModelTests : BaseOfstedAreaModelTests<PreviousRating
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Previous ratings");
+        Sut.PageMetadata.SubPageName.Should().Be("Previous ratings");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SafeguardingAndConcernsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SafeguardingAndConcernsModelTests.cs
@@ -20,6 +20,6 @@ public class SafeguardingAndConcernsModelTests : BaseOfstedAreaModelTests<Safegu
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Safeguarding and concerns");
+        Sut.PageMetadata.SubPageName.Should().Be("Safeguarding and concerns");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SingleHeadlineGradesModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Ofsted/SingleHeadlineGradesModelTests.cs
@@ -20,6 +20,6 @@ public class SingleHeadlineGradesModelTests : BaseOfstedAreaModelTests<SingleHea
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Single headline grades");
+        Sut.PageMetadata.SubPageName.Should().Be("Single headline grades");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/BaseOverviewAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/BaseOverviewAreaModelTests.cs
@@ -41,7 +41,7 @@ public abstract class BaseOverviewAreaModelTests<T> : BaseTrustPageTests<T>, ITe
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.PageName.Should().Be("Overview");
+        Sut.PageMetadata.PageName.Should().Be("Overview");
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/ReferenceNumbersModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/ReferenceNumbersModelTests.cs
@@ -17,6 +17,6 @@ public class ReferenceNumbersModelTests : BaseOverviewAreaModelTests<ReferenceNu
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Reference numbers");
+        Sut.PageMetadata.SubPageName.Should().Be("Reference numbers");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustDetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustDetailsModelTests.cs
@@ -112,6 +112,6 @@ public class TrustDetailsModelTests : BaseOverviewAreaModelTests<TrustDetailsMod
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Trust details");
+        Sut.PageMetadata.SubPageName.Should().Be("Trust details");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustSummaryModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Overview/TrustSummaryModelTests.cs
@@ -49,6 +49,6 @@ public class TrustSummaryModelTests : BaseOverviewAreaModelTests<TrustSummaryMod
     {
         _ = await Sut.OnGetAsync();
 
-        Sut.TrustPageMetadata.SubPageName.Should().Be("Trust summary");
+        Sut.PageMetadata.SubPageName.Should().Be("Trust summary");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/TrustsAreaModelTests.cs
@@ -27,7 +27,7 @@ public class TrustsAreaModelTests : BaseTrustPageTests<TrustsAreaModel>
     public override async Task OnGetAsync_should_configure_TrustPageMetadata_PageName()
     {
         await Sut.OnGetAsync();
-        Sut.TrustPageMetadata.PageName.Should().BeNull();
+        Sut.PageMetadata.PageName.Should().BeNull();
     }
 
     public override async Task OnGetAsync_sets_correct_data_source_list()


### PR DESCRIPTION
Move `TrustPageMetadata` to `Shared.PageMetadata` so it can be used by the school pages

[User Story 208370](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/208370): Build : Basic Page Layout

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
