### PR TITLE
Run SonarQube on all PRs

### DIFF
--- a/.github/workflows/continuous-integration-lint.yml
+++ b/.github/workflows/continuous-integration-lint.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main, '**-feature' ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Run SonarQube on all PRs - this is so we can chain branches for easier review