### PR TITLE
Setup routing to school pages

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Contexts/AcademiesDbContext.GiasEstablishment.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Contexts/AcademiesDbContext.GiasEstablishment.cs
@@ -1,12 +1,25 @@
-﻿using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using Microsoft.EntityFrameworkCore;
-using System.Diagnostics.CodeAnalysis;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
 
 public partial class AcademiesDbContext
 {
     public DbSet<GiasEstablishment> GiasEstablishments { get; set; }
+
+    private static readonly string[] SupportedEstablishmentTypeGroups =
+    [
+        "Academies",
+        "Colleges",
+        "Free Schools",
+        "Local authority maintained schools",
+        "Special schools"
+    ];
+
+    public static readonly Expression<Func<GiasEstablishment, bool>> GiasEstablishmentsQueryFilter =
+        e => SupportedEstablishmentTypeGroups.Contains(e.EstablishmentTypeGroupName);
 
     [ExcludeFromCodeCoverage]
     protected static void OnModelCreatingGiasEstablishments(ModelBuilder modelBuilder)
@@ -363,6 +376,8 @@ public partial class AcademiesDbContext
             entity.Property(e => e.UrbanRuralName)
                 .IsUnicode(false)
                 .HasColumnName("UrbanRural (name)");
+
+            entity.HasQueryFilter(GiasEstablishmentsQueryFilter);
         });
     }
 }

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/SchoolRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/SchoolRepository.cs
@@ -1,0 +1,19 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.School;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
+
+public class SchoolRepository : ISchoolRepository
+{
+    public Task<SchoolSummary?> GetSchoolSummaryAsync(string urn)
+    {
+        if (urn.StartsWith('3'))
+            return Task.FromResult<SchoolSummary?>(null);
+
+        var schoolName = urn.EndsWith('2') ? $"Cool School {urn}" : $"Chill Academy {urn}";
+        var schoolType = urn.EndsWith('2') ? "Community school" : "Academy sponsor led";
+        var schoolCategory = urn.EndsWith('2') ? SchoolCategory.LaMaintainedSchool : SchoolCategory.Academy;
+
+        return Task.FromResult(new SchoolSummary(schoolName, schoolType, schoolCategory))!;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/SchoolRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/SchoolRepository.cs
@@ -7,12 +7,10 @@ namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 
 public class SchoolRepository(IAcademiesDbContext academiesDbContext) : ISchoolRepository
 {
-    public async Task<SchoolSummary?> GetSchoolSummaryAsync(string urn)
+    public async Task<SchoolSummary?> GetSchoolSummaryAsync(int urn)
     {
-        var intUrn = int.Parse(urn);
-
         return await academiesDbContext.GiasEstablishments
-            .Where(e => e.Urn == intUrn)
+            .Where(e => e.Urn == urn)
             .Select(e => new SchoolSummary(
                 e.EstablishmentName!,
                 e.TypeOfEstablishmentName!,

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/School/ISchoolRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/School/ISchoolRepository.cs
@@ -2,5 +2,5 @@ namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.School;
 
 public interface ISchoolRepository
 {
-    Task<SchoolSummary?> GetSchoolSummaryAsync(string urn);
+    Task<SchoolSummary?> GetSchoolSummaryAsync(int urn);
 }

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/School/ISchoolRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/School/ISchoolRepository.cs
@@ -1,0 +1,6 @@
+namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.School;
+
+public interface ISchoolRepository
+{
+    Task<SchoolSummary?> GetSchoolSummaryAsync(string urn);
+}

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/School/SchoolSummary.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/School/SchoolSummary.cs
@@ -1,0 +1,5 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.Repositories.School;
+
+public record SchoolSummary(string Name, string Type, SchoolCategory Category);

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/ISchoolAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/ISchoolAreaModel.cs
@@ -6,7 +6,7 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Schools;
 
 public interface ISchoolAreaModel
 {
-    string Urn { get; }
+    int Urn { get; }
     SchoolCategory SchoolCategory { get; }
     List<DataSourcePageListEntry> DataSourcesPerPage { get; }
     PageMetadata PageMetadata { get; }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/Details.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/Details.cshtml.cs
@@ -1,9 +1,10 @@
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.School;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
 
-public class DetailsModel : OverviewAreaModel
+public class DetailsModel(ISchoolService schoolService) : OverviewAreaModel(schoolService)
 {
     public override PageMetadata PageMetadata => base.PageMetadata with
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/OverviewAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/OverviewAreaModel.cs
@@ -1,8 +1,9 @@
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.School;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
 
-public class OverviewAreaModel : SchoolAreaModel
+public abstract class OverviewAreaModel(ISchoolService schoolService) : SchoolAreaModel(schoolService)
 {
     public const string PageName = "Overview";
     public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolAreaModel.cs
@@ -1,30 +1,34 @@
-using System.Diagnostics.CodeAnalysis;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.School;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools;
 
-[ExcludeFromCodeCoverage] //Temporary exclusion while this contains dummy data
-public class SchoolAreaModel : BasePageModel, ISchoolAreaModel
+public class SchoolAreaModel(ISchoolService schoolService) : BasePageModel, ISchoolAreaModel
 {
     [BindProperty(SupportsGet = true)] public string Urn { get; set; } = "";
-
-    public SchoolCategory SchoolCategory => Urn.EndsWith('2')
-        ? SchoolCategory.LaMaintainedSchool
-        : SchoolCategory.Academy;
 
     public List<DataSourcePageListEntry> DataSourcesPerPage { get; set; } = [];
     public virtual PageMetadata PageMetadata => new(SchoolName, ModelState.IsValid);
 
-    public string SchoolName
-        => Urn.EndsWith('2')
-            ? $"Cool School {Urn}"
-            : $"Chill Academy {Urn}";
+    public SchoolSummaryServiceModel SchoolSummary { get; set; } = null!;
+    public string SchoolName => SchoolSummary.Name;
+    public string SchoolType => SchoolSummary.Type;
+    public SchoolCategory SchoolCategory => SchoolSummary.Category;
 
-    public string SchoolType
-        => Urn.EndsWith('2')
-            ? "Community school"
-            : "Academy sponsor led";
+    public virtual async Task<IActionResult> OnGetAsync()
+    {
+        var schoolSummary = await schoolService.GetSchoolSummaryAsync(Urn);
+
+        if (schoolSummary == null)
+        {
+            return new NotFoundResult();
+        }
+
+        SchoolSummary = schoolSummary;
+
+        return Page();
+    }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolAreaModel.cs
@@ -8,7 +8,7 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Schools;
 
 public class SchoolAreaModel(ISchoolService schoolService) : BasePageModel, ISchoolAreaModel
 {
-    [BindProperty(SupportsGet = true)] public string Urn { get; set; } = "";
+    [BindProperty(SupportsGet = true)] public int Urn { get; set; }
 
     public List<DataSourcePageListEntry> DataSourcesPerPage { get; set; } = [];
     public virtual PageMetadata PageMetadata => new(SchoolName, ModelState.IsValid);

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolNavMenu.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolNavMenu.cs
@@ -22,7 +22,7 @@ public static class SchoolNavMenu
             linkDisplayText,
             aspPage,
             $"{linkDisplayText}-nav".Kebabify(),
-            new Dictionary<string, string> { { "urn", activePage.Urn } });
+            new Dictionary<string, string> { { "urn", activePage.Urn.ToString() } });
     }
 
     public static NavLink[] GetSubNavLinks(ISchoolAreaModel activePage)
@@ -52,7 +52,7 @@ public static class SchoolNavMenu
             linkDisplayText,
             aspPage,
             testIdOverride ?? $"{serviceName}-{linkDisplayText}-subnav".Kebabify(),
-            new Dictionary<string, string> { { "urn", activePage.Urn } }
+            new Dictionary<string, string> { { "urn", activePage.Urn.ToString() } }
         );
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Services/School/SchoolService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/School/SchoolService.cs
@@ -5,12 +5,12 @@ namespace DfE.FindInformationAcademiesTrusts.Services.School;
 
 public interface ISchoolService
 {
-    Task<SchoolSummaryServiceModel?> GetSchoolSummaryAsync(string urn);
+    Task<SchoolSummaryServiceModel?> GetSchoolSummaryAsync(int urn);
 }
 
 public class SchoolService(IMemoryCache memoryCache, ISchoolRepository schoolRepository) : ISchoolService
 {
-    public async Task<SchoolSummaryServiceModel?> GetSchoolSummaryAsync(string urn)
+    public async Task<SchoolSummaryServiceModel?> GetSchoolSummaryAsync(int urn)
     {
         var cacheKey = $"{nameof(GetSchoolSummaryAsync)}:{urn}";
 

--- a/DfE.FindInformationAcademiesTrusts/Services/School/SchoolService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/School/SchoolService.cs
@@ -1,0 +1,20 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+
+namespace DfE.FindInformationAcademiesTrusts.Services.School;
+
+public interface ISchoolService
+{
+    Task<SchoolSummaryServiceModel?> GetSchoolSummaryAsync(string urn);
+}
+
+public class SchoolService : ISchoolService
+{
+    public Task<SchoolSummaryServiceModel?> GetSchoolSummaryAsync(string urn)
+    {
+        var schoolName = urn.EndsWith('2') ? $"Super Cool School {urn}" : $"Super Chill Academy {urn}";
+        var schoolType = urn.EndsWith('2') ? "Community school" : "Academy sponsor led";
+        var schoolCategory = urn.EndsWith('2') ? SchoolCategory.LaMaintainedSchool : SchoolCategory.Academy;
+
+        return Task.FromResult(new SchoolSummaryServiceModel(urn, schoolName, schoolType, schoolCategory))!;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Services/School/SchoolSummaryServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/School/SchoolSummaryServiceModel.cs
@@ -1,0 +1,5 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+
+namespace DfE.FindInformationAcademiesTrusts.Services.School;
+
+public record SchoolSummaryServiceModel(string Urn, string Name, string Type, SchoolCategory Category);

--- a/DfE.FindInformationAcademiesTrusts/Services/School/SchoolSummaryServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/School/SchoolSummaryServiceModel.cs
@@ -2,4 +2,4 @@ using DfE.FindInformationAcademiesTrusts.Data.Enums;
 
 namespace DfE.FindInformationAcademiesTrusts.Services.School;
 
-public record SchoolSummaryServiceModel(string Urn, string Name, string Type, SchoolCategory Category);
+public record SchoolSummaryServiceModel(int Urn, string Name, string Type, SchoolCategory Category);

--- a/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
@@ -10,6 +10,7 @@ using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.DataSource;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Ofsted;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.PipelineAcademy;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.School;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.TrustDocument;
 using DfE.FindInformationAcademiesTrusts.Pages;
@@ -57,6 +58,7 @@ public static class Dependencies
         builder.Services.AddScoped<IContactRepository, ContactRepository>();
         builder.Services.AddScoped<IPipelineEstablishmentRepository, PipelineEstablishmentRepository>();
         builder.Services.AddScoped<ITrustDocumentRepository, TrustDocumentRepository>();
+        builder.Services.AddScoped<ISchoolRepository, SchoolRepository>();
 
         builder.Services.AddScoped<IDataSourceService, DataSourceService>();
         builder.Services.AddScoped<ITrustService, TrustService>();

--- a/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
@@ -17,6 +17,7 @@ using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
 using DfE.FindInformationAcademiesTrusts.Services.FinancialDocument;
+using DfE.FindInformationAcademiesTrusts.Services.School;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.EntityFrameworkCore;
 
@@ -61,6 +62,7 @@ public static class Dependencies
         builder.Services.AddScoped<ITrustService, TrustService>();
         builder.Services.AddScoped<IAcademyService, AcademyService>();
         builder.Services.AddScoped<IFinancialDocumentService, FinancialDocumentService>();
+        builder.Services.AddScoped<ISchoolService, SchoolService>();
 
         builder.Services.AddScoped<IPipelineAcademiesExportService, PipelineAcademiesExportService>();
         builder.Services.AddScoped<IOfstedDataExportService, OfstedDataExportService>();

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation/schools-navigation.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation/schools-navigation.cy.ts
@@ -1,0 +1,37 @@
+import { TestDataStore } from "../../../support/test-data-store";
+import commonPage from "../../../pages/commonPage";
+
+describe('Schools Navigation Tests', () => {
+    beforeEach(() => {
+        cy.login();
+    });
+
+    describe("Routing tests", () => {
+
+        const schoolTypesNotToShow = [
+            { urn: 136083, unsupportedSchoolType: "Independent schools" },
+            { urn: 150163, unsupportedSchoolType: "Online provider" },
+            { urn: 131832, unsupportedSchoolType: "Other types" },
+            { urn: 133793, unsupportedSchoolType: "Universities" }
+        ];
+
+        schoolTypesNotToShow.forEach(({ urn, unsupportedSchoolType }) => {
+            TestDataStore.GetAllSchoolSubpagesForUrn(urn).forEach(({ pageName, subpages }) => {
+
+                describe(pageName, () => {
+
+                    subpages.forEach(({ subpageName, url }) => {
+                        it(`Should check that navigating to subpages for unsupported school type displays the 404 not found page ${pageName} > ${subpageName} > ${unsupportedSchoolType}`, () => {
+                            // Go to the given subpage
+                            cy.visit(url, { failOnStatusCode: false });
+
+                            // Check that the data sources component has a subheading for each subnav
+                            commonPage
+                                .check404PageDisplayed();
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/schools/school-page.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/schools/school-page.cy.ts
@@ -1,24 +1,34 @@
 import schoolsPage from "../../../pages/schools/schoolsPage";
-import { testSchoolData } from "../../../support/test-data-store";
+import { TestDataStore, testSchoolData } from "../../../support/test-data-store";
 
-describe("Testing the components of the Schools page", () => {
+describe("Testing the common components of the Schools pages", () => {
+    beforeEach(() => {
+        cy.login();
+    });
 
     describe("Header items", () => {
         testSchoolData.forEach(({ typeOfSchool, urn }) => {
-            beforeEach(() => {
-                cy.login();
-            });
 
-            [`/schools/overview/details?urn=${urn}`].forEach((url) => {
-                it(`Checks the school type is correct on a ${typeOfSchool} on the urn ${urn}`, () => {
-                    cy.visit(url);
-                    schoolsPage
-                        .checkCorrectSchoolTypePresent();
+            TestDataStore.GetAllSchoolSubpagesForUrn(urn).forEach(({ pageName, subpages }) => {
+
+                describe(`${pageName} - ${typeOfSchool}`, () => {
+
+                    subpages.forEach(({ subpageName, url }) => {
+                        it(`Checks the school type is correct on ${pageName} > ${subpageName} for a ${typeOfSchool} on the urn ${urn}`, () => {
+                            cy.visit(url);
+                            schoolsPage
+                                .checkCorrectSchoolTypePresent();
+                        });
+                    });
                 });
             });
+        });
+    });
 
-            it(`Checks the page name is correct on a ${typeOfSchool} on the urn ${urn}`, () => {
-                cy.visit(`/schools/overview/details?uid=${urn}`);
+    describe("Overview", () => {
+        testSchoolData.forEach(({ typeOfSchool, urn }) => {
+            it(`Checks the page name is correct for a ${typeOfSchool} on the urn ${urn}`, () => {
+                cy.visit(`/schools/overview/details?urn=${urn}`);
                 schoolsPage
                     .checkOverviewPageNamePresent();
             });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/commonPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/commonPage.ts
@@ -115,6 +115,16 @@ class CommonPage {
             .should('not.contain', 'unknown');
     }
 
+    public check404PageDisplayed(): this {
+        cy.get('h1').should('contain.text', 'Page not found');
+        cy.intercept('**', (req) => {
+            req.on('response', (res) => {
+                expect(res.statusCode).to.eq(404);
+            });
+        }).as('check404Response');
+        return this;
+    }
+
 }
 
 const commonPage = new CommonPage();

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/schools/schoolsPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/schools/schoolsPage.ts
@@ -16,7 +16,7 @@ class SchoolsPage {
     };
 
     public checkValueIsValidSchoolType = (element: JQuery<HTMLElement>) =>
-        this.checkElementMatches(element, /^(Community school|Academy sponsor led|)$/);
+        this.checkElementMatches(element, /^(Community school|Academy converter)$/);
 
     public checkCorrectSchoolTypePresent(): this {
         this.elements.schoolType().each(this.checkValueIsValidSchoolType);

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/support/test-data-store.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/support/test-data-store.ts
@@ -42,6 +42,16 @@ export class TestDataStore {
                     { subpageName: "Trustees", url: `/trusts/governance/trustees?uid=${uid}` },
                     { subpageName: "Members", url: `/trusts/governance/members?uid=${uid}` },
                     { subpageName: "Historic members", url: `/trusts/governance/historic-members?uid=${uid}` }
+            ]
+        },
+    ];
+
+    public static readonly GetAllSchoolSubpagesForUrn = (urn: number) =>
+        [
+            {
+                pageName: "Overview",
+                subpages: [
+                    { subpageName: "School details", url: `/schools/overview/details?urn=${urn}` },
                 ]
             },
         ];
@@ -54,7 +64,7 @@ export const testSchoolData = [
     },
     {
         typeOfSchool: "Academy sponsor led",
-        urn: 5712
+        urn: 137083
     }
 ]; export const testPreAdvisoryData = [
     {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/support/test-data-store.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/support/test-data-store.ts
@@ -42,9 +42,9 @@ export class TestDataStore {
                     { subpageName: "Trustees", url: `/trusts/governance/trustees?uid=${uid}` },
                     { subpageName: "Members", url: `/trusts/governance/members?uid=${uid}` },
                     { subpageName: "Historic members", url: `/trusts/governance/historic-members?uid=${uid}` }
-            ]
-        },
-    ];
+                ]
+            },
+        ];
 
     public static readonly GetAllSchoolSubpagesForUrn = (urn: number) =>
         [
@@ -63,7 +63,7 @@ export const testSchoolData = [
         urn: 123452
     },
     {
-        typeOfSchool: "Academy sponsor led",
+        typeOfSchool: "Academy converter",
         urn: 137083
     }
 ]; export const testPreAdvisoryData = [
@@ -112,4 +112,3 @@ export const trustsWithGovernanceData = [
         uid: 5712
     }
 ];
-

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -18,7 +18,9 @@ public class MockAcademiesDbContext
     public MockDbSet<ApplicationSetting> ApplicationSettings { get; } = new();
 
     //gias
-    public MockDbSet<GiasEstablishment> GiasEstablishments { get; } = new();
+    public MockDbSet<GiasEstablishment> GiasEstablishments { get; } =
+        new(AcademiesDbContext.GiasEstablishmentsQueryFilter);
+
     public MockDbSet<GiasGovernance> GiasGovernances { get; } = new();
     public MockDbSet<GiasGroup> GiasGroups { get; } = new();
     public MockDbSet<GiasGroupLink> GiasGroupLinks { get; } = new();

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockDbSet.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockDbSet.cs
@@ -13,10 +13,13 @@ public class MockDbSet<TEntity> where TEntity : class
     private readonly List<TEntity> _items = [];
     public DbSet<TEntity> Object { get; } = Substitute.For<DbSet<TEntity>, IAsyncEnumerable<TEntity>, IQueryable>();
 
-    public MockDbSet()
+    public MockDbSet(Expression<Func<TEntity, bool>>? filter = null)
     {
         var itemsAsQueryable = _items.AsQueryable();
 
+        if (filter is not null)
+            itemsAsQueryable = itemsAsQueryable.Where(filter);
+        
         ((IAsyncEnumerable<TEntity>)Object).GetAsyncEnumerator()
             .Returns(new TestAsyncEnumerator<TEntity>(itemsAsQueryable.GetEnumerator()));
         ((IQueryable)Object).Provider.Returns(new TestAsyncQueryProvider<TEntity>(itemsAsQueryable.Provider));

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
@@ -26,7 +26,8 @@ public class AcademyRepositoryTests
             EstablishmentName = $"Academy {n}",
             TypeOfEstablishmentName = $"Academy type {n}",
             LaName = $"Local authority {n}",
-            UrbanRuralName = $"UrbanRuralName {n}"
+            UrbanRuralName = $"UrbanRuralName {n}",
+            EstablishmentTypeGroupName = "Academies"
         }).ToArray();
         _mockAcademiesDbContext.GiasEstablishments.AddRange(giasEstablishments);
         _mockAcademiesDbContext.AddGiasGroupLinksForGiasEstablishmentsToGiasGroup(giasEstablishments, giasGroup);
@@ -120,6 +121,7 @@ public class AcademyRepositoryTests
             Urn = n,
             EstablishmentName = $"Academy {n}",
             PhaseOfEducationName = $"Phase of Education {n}",
+            EstablishmentTypeGroupName = "Academies",
             NumberOfPupils = $"{n}",
             SchoolCapacity = $"{n}",
             StatutoryLowAge = $"{n + 1}",
@@ -161,6 +163,7 @@ public class AcademyRepositoryTests
             EstablishmentName = $"Academy {n}",
             PhaseOfEducationName = $"Phase of Education {n}",
             TypeOfEstablishmentName = $"Type of Education {n}",
+            EstablishmentTypeGroupName = "Academies",
             LaCode = $"{n}",
             PercentageFsm = $"{n - 950.5}"
         }).ToArray();
@@ -196,6 +199,7 @@ public class AcademyRepositoryTests
             Urn = n,
             EstablishmentName = $"Academy {n}",
             LaName = $"Local authority {n}",
+            EstablishmentTypeGroupName = "Academies",
             NumberOfPupils = (n * 10).ToString(),
             SchoolCapacity = (n * 15).ToString()
         }).ToArray();
@@ -223,6 +227,7 @@ public class AcademyRepositoryTests
         {
             Urn = 2000,
             EstablishmentName = "Academy Missing Data",
+            EstablishmentTypeGroupName = "Academies",
             LaName = null,
             NumberOfPupils = null,
             SchoolCapacity = null
@@ -239,7 +244,7 @@ public class AcademyRepositoryTests
         result.Should().NotBeNull();
         result.Length.Should().Be(1);
 
-        var academy = result.First();
+        var academy = result[0];
         academy.Urn.Should().Be("2000");
         academy.LocalAuthority.Should().Be(string.Empty);
         academy.NumberOfPupils.Should().BeNull();

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/SchoolRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/SchoolRepositoryTests.cs
@@ -19,7 +19,7 @@ public class SchoolRepositoryTests
     [Fact]
     public async Task GetSchoolSummaryAsync_should_return_null_if_not_found()
     {
-        var result = await _sut.GetSchoolSummaryAsync("999999");
+        var result = await _sut.GetSchoolSummaryAsync(999999);
         result.Should().BeNull();
     }
 
@@ -48,7 +48,7 @@ public class SchoolRepositoryTests
             EstablishmentTypeGroupName = typeGroup
         });
 
-        var result = await _sut.GetSchoolSummaryAsync(urn.ToString());
+        var result = await _sut.GetSchoolSummaryAsync(urn);
         result.Should().BeEquivalentTo(new SchoolSummary(name, type, expectedCategory));
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/SchoolRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/SchoolRepositoryTests.cs
@@ -1,0 +1,54 @@
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
+using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.School;
+
+namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;
+
+public class SchoolRepositoryTests
+{
+    private readonly SchoolRepository _sut;
+    private readonly MockAcademiesDbContext _mockAcademiesDbContext = new();
+
+    public SchoolRepositoryTests()
+    {
+        _sut = new SchoolRepository(_mockAcademiesDbContext.Object);
+    }
+
+    [Fact]
+    public async Task GetSchoolSummaryAsync_should_return_null_if_not_found()
+    {
+        var result = await _sut.GetSchoolSummaryAsync("999999");
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(123456, "Academy converter", "Academies", SchoolCategory.Academy)]
+    [InlineData(234567, "Sixth form centres", "Colleges", SchoolCategory.LaMaintainedSchool)]
+    [InlineData(345678, "Free schools special", "Free Schools", SchoolCategory.LaMaintainedSchool)]
+    [InlineData(456789, "Foundation school", "Local authority maintained schools", SchoolCategory.LaMaintainedSchool)]
+    [InlineData(456789, "Non-maintained special school", "Special schools", SchoolCategory.LaMaintainedSchool)]
+    public async Task GetSchoolSummaryAsync_should_return_schoolSummary_if_found(int urn, string type, string typeGroup,
+        SchoolCategory expectedCategory)
+    {
+        var name = $"School {urn}";
+        _mockAcademiesDbContext.AddGiasEstablishment(new GiasEstablishment
+        {
+            Urn = urn,
+            EstablishmentName = name,
+            TypeOfEstablishmentName = type,
+            EstablishmentTypeGroupName = typeGroup
+        });
+        _mockAcademiesDbContext.AddGiasEstablishment(new GiasEstablishment
+        {
+            Urn = urn + 1,
+            EstablishmentName = "Different school",
+            TypeOfEstablishmentName = type,
+            EstablishmentTypeGroupName = typeGroup
+        });
+
+        var result = await _sut.GetSchoolSummaryAsync(urn.ToString());
+        result.Should().BeEquivalentTo(new SchoolSummary(name, type, expectedCategory));
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/BaseSchoolPageTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/BaseSchoolPageTests.cs
@@ -10,7 +10,7 @@ public abstract class BaseSchoolPageTests<T> where T : SchoolAreaModel
 {
     protected T Sut = null!;
     protected readonly ISchoolService MockSchoolService = Substitute.For<ISchoolService>();
-    protected const string Urn = "1234";
+    protected const int Urn = 123456;
 
     protected readonly SchoolSummaryServiceModel DummySchoolSummary =
         new(Urn, "Cool school", "Community school", SchoolCategory.LaMaintainedSchool);
@@ -47,9 +47,9 @@ public abstract class BaseSchoolPageTests<T> where T : SchoolAreaModel
     [Fact]
     public async Task OnGetAsync_should_return_not_found_result_if_school_is_not_found()
     {
-        MockSchoolService.GetSchoolSummaryAsync("1111").Returns((SchoolSummaryServiceModel?)null);
+        MockSchoolService.GetSchoolSummaryAsync(111111).Returns((SchoolSummaryServiceModel?)null);
 
-        Sut.Urn = "1111";
+        Sut.Urn = 111111;
         var result = await Sut.OnGetAsync();
         result.Should().BeOfType<NotFoundResult>();
     }
@@ -57,9 +57,9 @@ public abstract class BaseSchoolPageTests<T> where T : SchoolAreaModel
     [Fact]
     public async Task OnGetAsync_should_return_not_found_result_if_urn_is_not_provided()
     {
-        MockSchoolService.GetSchoolSummaryAsync("").Returns((SchoolSummaryServiceModel?)null);
+        MockSchoolService.GetSchoolSummaryAsync(0).Returns((SchoolSummaryServiceModel?)null);
 
-        Sut.Urn = "";
+        Sut.Urn = 0;
         var result = await Sut.OnGetAsync();
         result.Should().BeOfType<NotFoundResult>();
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/BaseSchoolPageTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/BaseSchoolPageTests.cs
@@ -1,15 +1,23 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools;
 
 public abstract class BaseSchoolPageTests<T> where T : SchoolAreaModel
 {
     protected T Sut = null!;
+    protected readonly ISchoolService MockSchoolService = Substitute.For<ISchoolService>();
+    protected const string Urn = "1234";
 
-    [Fact]
-    public void ShowHeaderSearch_should_be_true()
+    protected readonly SchoolSummaryServiceModel DummySchoolSummary =
+        new(Urn, "Cool school", "Community school", SchoolCategory.LaMaintainedSchool);
+
+    protected BaseSchoolPageTests()
     {
-        Sut.ShowHeaderSearch.Should().Be(true);
+        MockSchoolService.GetSchoolSummaryAsync(Urn).Returns(DummySchoolSummary);
     }
 
     [Fact]
@@ -20,4 +28,46 @@ public abstract class BaseSchoolPageTests<T> where T : SchoolAreaModel
 
     [Fact]
     public abstract Task OnGetAsync_sets_correct_data_source_list();
+
+    [Fact]
+    public void ShowHeaderSearch_should_be_true()
+    {
+        Sut.ShowHeaderSearch.Should().Be(true);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_fetch_a_SchoolSummary_by_urn()
+    {
+        Sut.Urn = DummySchoolSummary.Urn;
+
+        await Sut.OnGetAsync();
+        Sut.SchoolSummary.Should().Be(DummySchoolSummary);
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_return_not_found_result_if_school_is_not_found()
+    {
+        MockSchoolService.GetSchoolSummaryAsync("1111").Returns((SchoolSummaryServiceModel?)null);
+
+        Sut.Urn = "1111";
+        var result = await Sut.OnGetAsync();
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_return_not_found_result_if_urn_is_not_provided()
+    {
+        MockSchoolService.GetSchoolSummaryAsync("").Returns((SchoolSummaryServiceModel?)null);
+
+        Sut.Urn = "";
+        var result = await Sut.OnGetAsync();
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_return_page_result_if_urn_exists()
+    {
+        var result = await Sut.OnGetAsync();
+        result.Should().BeOfType<PageResult>();
+    }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/BaseOverviewAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/BaseOverviewAreaModelTests.cs
@@ -5,16 +5,18 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.Overview;
 public abstract class BaseOverviewAreaModelTests<T> : BaseSchoolPageTests<T> where T : OverviewAreaModel
 {
     [Fact]
-    public override Task OnGetAsync_should_configure_PageMetadata_PageName()
+    public override async Task OnGetAsync_should_configure_PageMetadata_PageName()
     {
+        await Sut.OnGetAsync();
+
         Sut.PageMetadata.PageName.Should().Be("Overview");
-        return Task.CompletedTask;
     }
 
     [Fact]
-    public override Task OnGetAsync_sets_correct_data_source_list()
+    public override async Task OnGetAsync_sets_correct_data_source_list()
     {
+        await Sut.OnGetAsync();
+
         Sut.DataSourcesPerPage.Should().BeEmpty();
-        return Task.CompletedTask;
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/DetailsModelTests.cs
@@ -7,7 +7,7 @@ public class DetailsModelTests : BaseOverviewAreaModelTests<DetailsModel>
 {
     public DetailsModelTests()
     {
-        Sut = new DetailsModel();
+        Sut = new DetailsModel(MockSchoolService) { Urn = Urn };
     }
 
     [Fact]
@@ -17,18 +17,24 @@ public class DetailsModelTests : BaseOverviewAreaModelTests<DetailsModel>
         await OnGetAsync_should_configure_PageMetadata_SubPageName_for_academy();
     }
 
-    private Task OnGetAsync_should_configure_PageMetadata_SubPageName_for_school()
+    private async Task OnGetAsync_should_configure_PageMetadata_SubPageName_for_school()
     {
-        Sut.Urn = "222222";
+        MockSchoolService.GetSchoolSummaryAsync(Urn)
+            .Returns(DummySchoolSummary with { Category = SchoolCategory.LaMaintainedSchool });
+
+        await Sut.OnGetAsync();
+
         Sut.PageMetadata.SubPageName.Should().Be("School details");
-        return Task.CompletedTask;
     }
 
-    private Task OnGetAsync_should_configure_PageMetadata_SubPageName_for_academy()
+    private async Task OnGetAsync_should_configure_PageMetadata_SubPageName_for_academy()
     {
-        Sut.Urn = "123456";
+        MockSchoolService.GetSchoolSummaryAsync(Urn)
+            .Returns(DummySchoolSummary with { Category = SchoolCategory.Academy });
+
+        await Sut.OnGetAsync();
+
         Sut.PageMetadata.SubPageName.Should().Be("Academy details");
-        return Task.CompletedTask;
     }
 
     [Theory]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
@@ -7,9 +7,9 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.SchoolNavMe
 public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
 {
     [Theory]
-    [InlineData("1234")]
-    [InlineData("5678")]
-    public void GetServiceNavLinks_should_set_route_data_to_urn(string expectedUrn)
+    [InlineData(123456)]
+    [InlineData(567878)]
+    public void GetServiceNavLinks_should_set_route_data_to_urn(int expectedUrn)
     {
         var activePage = GetMockSchoolPage(typeof(DetailsModel), expectedUrn);
 
@@ -19,7 +19,7 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
         {
             var route = link.AspAllRouteData.Should().ContainSingle().Subject;
             route.Key.Should().Be("urn");
-            route.Value.Should().Be(expectedUrn);
+            route.Value.Should().Be(expectedUrn.ToString());
         });
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuSubNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuSubNavTests.cs
@@ -8,9 +8,9 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.SchoolNavMe
 public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
 {
     [Theory]
-    [InlineData("1234")]
-    [InlineData("5678")]
-    public void GetSubNavLinks_should_set_route_data_to_urn(string expectedUrn)
+    [InlineData(123456)]
+    [InlineData(567890)]
+    public void GetSubNavLinks_should_set_route_data_to_urn(int expectedUrn)
     {
         var activePage = GetMockSchoolPage(typeof(DetailsModel), expectedUrn);
 
@@ -20,7 +20,7 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
         {
             var route = link.AspAllRouteData.Should().ContainSingle().Subject;
             route.Key.Should().Be("urn");
-            route.Value.Should().Be(expectedUrn);
+            route.Value.Should().Be(expectedUrn.ToString());
         });
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
@@ -13,7 +13,7 @@ public abstract class SchoolNavMenuTestsBase
         typeof(DetailsModel)
     ];
 
-    protected static SchoolAreaModel GetMockSchoolPage(Type pageType, string urn = "123456",
+    protected static SchoolAreaModel GetMockSchoolPage(Type pageType, int urn = 123456,
         SchoolCategory schoolCategory = SchoolCategory.LaMaintainedSchool)
     {
         //Create a mock page

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
@@ -1,6 +1,7 @@
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
+using DfE.FindInformationAcademiesTrusts.Services.School;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.SchoolNavMenu;
 
@@ -12,7 +13,7 @@ public abstract class SchoolNavMenuTestsBase
         typeof(DetailsModel)
     ];
 
-    protected static SchoolAreaModel GetMockSchoolPage(Type pageType, string? urn = null,
+    protected static SchoolAreaModel GetMockSchoolPage(Type pageType, string urn = "123456",
         SchoolCategory schoolCategory = SchoolCategory.LaMaintainedSchool)
     {
         //Create a mock page
@@ -26,7 +27,8 @@ public abstract class SchoolNavMenuTestsBase
                        throw new ArgumentException("Couldn't create mock for given page type", nameof(pageType));
 
         //Set properties applicable to all types
-        mockPage.Urn = urn ?? (schoolCategory == SchoolCategory.Academy ? "123456" : "222222");
+        mockPage.Urn = urn;
+        mockPage.SchoolSummary = new SchoolSummaryServiceModel(urn, "Chill primary school", "", schoolCategory);
 
         return mockPage;
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/SchoolServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/SchoolServiceTests.cs
@@ -1,0 +1,74 @@
+using DfE.FindInformationAcademiesTrusts.Data.Enums;
+using DfE.FindInformationAcademiesTrusts.Data.Repositories.School;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services;
+
+public class SchoolServiceTests
+{
+    private readonly SchoolService _sut;
+    private readonly ISchoolRepository _mockSchoolRepository = Substitute.For<ISchoolRepository>();
+    private readonly MockMemoryCache _mockMemoryCache = new();
+
+    public SchoolServiceTests()
+    {
+        _sut = new SchoolService(_mockMemoryCache.Object, _mockSchoolRepository);
+    }
+
+    [Fact]
+    public async Task GetSchoolSummaryAsync_cached_should_return_cached_result()
+    {
+        const string urn = "123456";
+        const string key = $"{nameof(SchoolService.GetSchoolSummaryAsync)}:{urn}";
+        var cachedResult = new SchoolSummaryServiceModel(urn, "Chill primary school", "Academy sponsor led",
+            SchoolCategory.LaMaintainedSchool);
+        _mockMemoryCache.AddMockCacheEntry(key, cachedResult);
+
+        var result = await _sut.GetSchoolSummaryAsync(urn);
+        result.Should().Be(cachedResult);
+
+        await _mockSchoolRepository.DidNotReceive().GetSchoolSummaryAsync(urn);
+    }
+
+    [Fact]
+    public async Task GetSchoolSummaryAsync_should_return_null_if_not_found()
+    {
+        _mockSchoolRepository.GetSchoolSummaryAsync("this urn doesn't exist").Returns((SchoolSummary?)null);
+
+        var result = await _sut.GetSchoolSummaryAsync("this urn doesn't exist");
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("280689", "My School", "Foundation school", SchoolCategory.LaMaintainedSchool)]
+    [InlineData("900855", "My Academy", "Academy converter", SchoolCategory.Academy)]
+    public async Task GetSchoolSummaryAsync_should_return_schoolSummary_if_found(string urn, string name, string type,
+        SchoolCategory category)
+    {
+        _mockSchoolRepository.GetSchoolSummaryAsync(urn).Returns(new SchoolSummary(name, type, category));
+
+        var result = await _sut.GetSchoolSummaryAsync(urn);
+        result.Should().BeEquivalentTo(new SchoolSummaryServiceModel(urn, name, type, category));
+    }
+
+    [Theory]
+    [InlineData("280689", "My School", "Foundation school", SchoolCategory.LaMaintainedSchool)]
+    [InlineData("900855", "My Academy", "Academy converter", SchoolCategory.Academy)]
+    public async Task GetSchoolSummaryAsync_uncached_should_cache_result(string urn, string name, string type,
+        SchoolCategory category)
+    {
+        var key = $"{nameof(SchoolService.GetSchoolSummaryAsync)}:{urn}";
+
+        _mockSchoolRepository.GetSchoolSummaryAsync(urn).Returns(new SchoolSummary(name, type, category));
+
+        await _sut.GetSchoolSummaryAsync(urn);
+
+        _mockMemoryCache.Object.Received(1).CreateEntry(key);
+
+        var cachedEntry = _mockMemoryCache.MockCacheEntries[key];
+
+        cachedEntry.Value.Should().BeEquivalentTo(new SchoolSummaryServiceModel(urn, name, type, category));
+        cachedEntry.SlidingExpiration.Should().Be(TimeSpan.FromMinutes(10));
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/SchoolServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/SchoolServiceTests.cs
@@ -19,8 +19,8 @@ public class SchoolServiceTests
     [Fact]
     public async Task GetSchoolSummaryAsync_cached_should_return_cached_result()
     {
-        const string urn = "123456";
-        const string key = $"{nameof(SchoolService.GetSchoolSummaryAsync)}:{urn}";
+        const int urn = 123456;
+        var key = $"{nameof(SchoolService.GetSchoolSummaryAsync)}:{urn}";
         var cachedResult = new SchoolSummaryServiceModel(urn, "Chill primary school", "Academy sponsor led",
             SchoolCategory.LaMaintainedSchool);
         _mockMemoryCache.AddMockCacheEntry(key, cachedResult);
@@ -34,16 +34,16 @@ public class SchoolServiceTests
     [Fact]
     public async Task GetSchoolSummaryAsync_should_return_null_if_not_found()
     {
-        _mockSchoolRepository.GetSchoolSummaryAsync("this urn doesn't exist").Returns((SchoolSummary?)null);
+        _mockSchoolRepository.GetSchoolSummaryAsync(999999).Returns((SchoolSummary?)null);
 
-        var result = await _sut.GetSchoolSummaryAsync("this urn doesn't exist");
+        var result = await _sut.GetSchoolSummaryAsync(999999);
         result.Should().BeNull();
     }
 
     [Theory]
-    [InlineData("280689", "My School", "Foundation school", SchoolCategory.LaMaintainedSchool)]
-    [InlineData("900855", "My Academy", "Academy converter", SchoolCategory.Academy)]
-    public async Task GetSchoolSummaryAsync_should_return_schoolSummary_if_found(string urn, string name, string type,
+    [InlineData(280689, "My School", "Foundation school", SchoolCategory.LaMaintainedSchool)]
+    [InlineData(900855, "My Academy", "Academy converter", SchoolCategory.Academy)]
+    public async Task GetSchoolSummaryAsync_should_return_schoolSummary_if_found(int urn, string name, string type,
         SchoolCategory category)
     {
         _mockSchoolRepository.GetSchoolSummaryAsync(urn).Returns(new SchoolSummary(name, type, category));
@@ -53,9 +53,9 @@ public class SchoolServiceTests
     }
 
     [Theory]
-    [InlineData("280689", "My School", "Foundation school", SchoolCategory.LaMaintainedSchool)]
-    [InlineData("900855", "My Academy", "Academy converter", SchoolCategory.Academy)]
-    public async Task GetSchoolSummaryAsync_uncached_should_cache_result(string urn, string name, string type,
+    [InlineData(280689, "My School", "Foundation school", SchoolCategory.LaMaintainedSchool)]
+    [InlineData(900855, "My Academy", "Academy converter", SchoolCategory.Academy)]
+    public async Task GetSchoolSummaryAsync_uncached_should_cache_result(int urn, string name, string type,
         SchoolCategory category)
     {
         var key = $"{nameof(SchoolService.GetSchoolSummaryAsync)}:{urn}";


### PR DESCRIPTION
Ensure that School pages only go urns that are supported by FIAT

[User Story 208389](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/208389): Build: Setup routing to academy/school pages

## Changes

- Add connection to db for `SchoolSummaryServiceModel`
- Add filter to exclude `GiasEstablishments` which have types unsupported by FIAT (e.g. Universities)
- Make `URN` an int for the school pages

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
