### PR TITLE
Academy/School page header

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
@@ -69,6 +69,16 @@ public class AcademyRepository(IAcademiesDbContext academiesDbContext)
             .FirstOrDefaultAsync();
     }
 
+    public async Task<string?> GetTrustUidFromAcademyUrnAsync(int urn)
+    {
+        return await academiesDbContext.GiasGroupLinks
+            .Where(gl => 
+                gl.Urn == urn.ToString() && 
+                (gl.GroupType == "Multi-academy trust" || gl.GroupType == "Single-academy trust"))
+            .Select(gl => gl.GroupUid)
+            .SingleOrDefaultAsync();
+    }
+
     public async Task<AcademyOverview[]> GetOverviewOfAcademiesInTrustAsync(string uid)
     {
         return await academiesDbContext.GiasGroupLinks

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/IAcademyRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/IAcademyRepository.cs
@@ -8,4 +8,5 @@ public interface IAcademyRepository
     Task<AcademyPupilNumbers[]> GetAcademiesInTrustPupilNumbersAsync(string uid);
     Task<AcademyFreeSchoolMeals[]> GetAcademiesInTrustFreeSchoolMealsAsync(string uid);
     Task<AcademyOverview[]> GetOverviewOfAcademiesInTrustAsync(string uid);
+    Task<string?> GetTrustUidFromAcademyUrnAsync(int urn);
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/ISchoolAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/ISchoolAreaModel.cs
@@ -1,6 +1,7 @@
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools;
 
@@ -12,4 +13,5 @@ public interface ISchoolAreaModel
     PageMetadata PageMetadata { get; }
     string SchoolName { get; }
     string SchoolType { get; }
+    TrustSummaryServiceModel? TrustSummary { get; }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/Details.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/Details.cshtml.cs
@@ -1,10 +1,11 @@
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.School;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
 
-public class DetailsModel(ISchoolService schoolService) : OverviewAreaModel(schoolService)
+public class DetailsModel(ISchoolService schoolService, ITrustService trustService) : OverviewAreaModel(schoolService, trustService)
 {
     public override PageMetadata PageMetadata => base.PageMetadata with
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/OverviewAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/OverviewAreaModel.cs
@@ -1,9 +1,10 @@
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Services.School;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
 
-public abstract class OverviewAreaModel(ISchoolService schoolService) : SchoolAreaModel(schoolService)
+public abstract class OverviewAreaModel(ISchoolService schoolService, ITrustService trustService) : SchoolAreaModel(schoolService, trustService)
 {
     public const string PageName = "Overview";
     public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolAreaModel.cs
@@ -2,11 +2,12 @@ using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.School;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools;
 
-public class SchoolAreaModel(ISchoolService schoolService) : BasePageModel, ISchoolAreaModel
+public class SchoolAreaModel(ISchoolService schoolService, ITrustService trustService) : BasePageModel, ISchoolAreaModel
 {
     [BindProperty(SupportsGet = true)] public int Urn { get; set; }
 
@@ -18,6 +19,8 @@ public class SchoolAreaModel(ISchoolService schoolService) : BasePageModel, ISch
     public string SchoolType => SchoolSummary.Type;
     public SchoolCategory SchoolCategory => SchoolSummary.Category;
 
+    public TrustSummaryServiceModel? TrustSummary { get; private set; }
+
     public virtual async Task<IActionResult> OnGetAsync()
     {
         var schoolSummary = await schoolService.GetSchoolSummaryAsync(Urn);
@@ -25,6 +28,11 @@ public class SchoolAreaModel(ISchoolService schoolService) : BasePageModel, ISch
         if (schoolSummary == null)
         {
             return new NotFoundResult();
+        }
+
+        if (schoolSummary.Category == SchoolCategory.Academy)
+        {
+            TrustSummary = await trustService.GetTrustSummaryAsync(schoolSummary.Urn);
         }
 
         SchoolSummary = schoolSummary;

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/_SchoolBanner.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/_SchoolBanner.cshtml
@@ -1,15 +1,31 @@
-﻿@model ISchoolAreaModel
+﻿@using DfE.FindInformationAcademiesTrusts.Data.Enums
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@model ISchoolAreaModel
 
-<aside class="app-banner" data-testid="app-school-header">
-  <div class="dfe-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-three-quarters">
-        <partial name="_SchoolBreadcrumbs" model="@Model" />
-        <h2 class="govuk-heading-l app-banner--heading govuk-!-margin-top-3 govuk-!-margin-bottom-3"
-            data-testid="school-name-heading">@Model.SchoolName</h2>
-        <p class="govuk-body app-banner--body govuk-!-margin-bottom-0"
-           data-testid="school-type">@Model.SchoolType</p>
-      </div>
+<aside class="app-banner school" data-testid="app-school-header">
+    <div class="dfe-width-container">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-three-quarters">
+                <partial name="_SchoolBreadcrumbs" model="@Model"/>
+                <h2 class="govuk-heading-l app-banner--heading govuk-!-margin-top-3 govuk-!-margin-bottom-3"
+                    data-testid="school-name-heading">
+                    @Model.SchoolName
+                </h2>
+                <p class="govuk-body app-banner--body govuk-!-margin-bottom-0"
+                   data-testid="school-type">
+                    @Model.SchoolType
+                </p>
+
+                @if (Model is { SchoolCategory: SchoolCategory.Academy, TrustSummary: not null })
+                {
+                    <p class="govuk-caption-m govuk-!-margin-top-2 govuk-!-margin-bottom-0">
+                        Trust:
+                        <a data-testid="header-trust-link" class="govuk-link" asp-page="/Trusts/Overview/TrustDetails" asp-route-uid="@Model.TrustSummary.Uid">
+                            @Model.TrustSummary.Name
+                        </a>
+                    </p>
+                }
+            </div>
+        </div>
     </div>
-  </div>
 </aside>

--- a/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Trust/TrustService.cs
@@ -10,6 +10,7 @@ namespace DfE.FindInformationAcademiesTrusts.Services.Trust;
 public interface ITrustService
 {
     Task<TrustSummaryServiceModel?> GetTrustSummaryAsync(string uid);
+    Task<TrustSummaryServiceModel?> GetTrustSummaryAsync(int urn);
     Task<TrustGovernanceServiceModel> GetTrustGovernanceAsync(string uid);
     Task<TrustContactsServiceModel> GetTrustContactsAsync(string uid);
     Task<TrustOverviewServiceModel> GetTrustOverviewAsync(string uid);
@@ -28,6 +29,18 @@ public class TrustService(
     IDateTimeProvider dateTimeProvider)
     : ITrustService
 {
+    public async Task<TrustSummaryServiceModel?> GetTrustSummaryAsync(int urn)
+    {
+        var uid = await academyRepository.GetTrustUidFromAcademyUrnAsync(urn);
+
+        if (uid is null)
+        {
+            return null;
+        }
+
+        return await GetTrustSummaryAsync(uid);
+    }
+
     public async Task<TrustSummaryServiceModel?> GetTrustSummaryAsync(string uid)
     {
         var cacheKey = $"{nameof(TrustService)}:{uid}";

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
@@ -12,6 +12,10 @@
   @include govuk-responsive-padding(3, "bottom");
   background-color: $app-color-blue-light;
 
+  &.school {
+    background-color: $app-color-purple-light;
+  }
+
   .app-banner--heading {
     color: $app-color-dfe-blue;
   }

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_components.scss
@@ -13,7 +13,7 @@
   background-color: $app-color-blue-light;
 
   &.school {
-    background-color: $app-color-purple-light;
+    background-color: $app-color-dfe-purple-light;
   }
 
   .app-banner--heading {

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_variables.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_variables.scss
@@ -1,5 +1,5 @@
 $app-color-blue-light: #ebf2f6;
-$app-color-purple-light: tint(govuk-colour("purple"), 90%);
 
 // colours taken from DfE Frontend
 $app-color-dfe-blue: #003a69;
+$app-color-dfe-purple-light: #F4F0FF;

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_variables.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_variables.scss
@@ -1,4 +1,5 @@
 $app-color-blue-light: #ebf2f6;
+$app-color-purple-light: tint(govuk-colour("purple"), 90%);
 
 // colours taken from DfE Frontend
 $app-color-dfe-blue: #003a69;

--- a/DfE.FindInformationAcademiesTrusts/assets/sass/_variables.scss
+++ b/DfE.FindInformationAcademiesTrusts/assets/sass/_variables.scss
@@ -2,4 +2,4 @@ $app-color-blue-light: #ebf2f6;
 
 // colours taken from DfE Frontend
 $app-color-dfe-blue: #003a69;
-$app-color-dfe-purple-light: #F4F0FF;
+$app-color-dfe-purple-light: #f4f0ff;

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation/schools-navigation.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation/schools-navigation.cy.ts
@@ -1,7 +1,20 @@
 import { TestDataStore } from "../../../support/test-data-store";
 import commonPage from "../../../pages/commonPage";
+import schoolsPage from "../../../pages/schools/schoolsPage";
+import navigation from "../../../pages/navigation";
+import overviewPage from "../../../pages/trusts/overviewPage";
 
 describe('Schools Navigation Tests', () => {
+    const navTestAcademy = {
+        academyURN: 140214,
+        trustAcademyName: "ABBEY ACADEMIES TRUST",
+    };
+
+    const navTestSchool = {
+        schoolURN: 123452,
+        trustAcademyName: "ABBEY ACADEMIES TRUST",
+    };
+
     beforeEach(() => {
         cy.login();
     });
@@ -32,6 +45,24 @@ describe('Schools Navigation Tests', () => {
                     });
                 });
             });
+        });
+
+        it('Should check that an academy has the link to the trust in the header and it takes me to the correct trust', () => {
+            cy.visit(`/schools/overview/details?urn=${navTestAcademy.academyURN}`);
+            schoolsPage
+                .checkAcademyLinkPresentAndCorrect(`${navTestAcademy.trustAcademyName}`)
+                .clickAcademyTrustLink();
+            navigation
+                .checkCurrentURLIsCorrect('/trusts/overview/trust-details?uid=2044');
+            overviewPage
+                .checkTrustDetailsSubHeaderPresent();
+
+        });
+
+        it('Should check that an school does not have the link to the trust in the header', () => {
+            cy.visit(`/schools/overview/details?urn=${navTestSchool.schoolURN}`);
+            schoolsPage
+                .checkAcademyLinkNotPresentForSchool();
         });
     });
 });

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation/schools-navigation.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/navigation/schools-navigation.cy.ts
@@ -12,7 +12,6 @@ describe('Schools Navigation Tests', () => {
 
     const navTestSchool = {
         schoolURN: 123452,
-        trustAcademyName: "ABBEY ACADEMIES TRUST",
     };
 
     beforeEach(() => {

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/schools/schoolsPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/schools/schoolsPage.ts
@@ -5,6 +5,7 @@ class SchoolsPage {
         pageName: () => cy.get('[data-testid="page-name"]'),
         subpageHeader: () => cy.get('[data-testid="subpage-header"]'),
         schoolType: () => cy.get('[data-testid="school-type"]'),
+        trustLink: () => cy.get('[data-testid="header-trust-link"]'),
         nav: {
             overviewNav: () => cy.get('[data-testid="overview-nav"]'),
         },
@@ -27,6 +28,23 @@ class SchoolsPage {
         this.elements.pageName().should('contain', 'Overview');
         return this;
     }
+
+    public checkAcademyLinkPresentAndCorrect(trustAcademyName: string): this {
+        this.elements.trustLink().should('be.visible');
+        this.elements.trustLink().should('contain.text', trustAcademyName);
+        return this;
+    }
+
+    public checkAcademyLinkNotPresentForSchool(): this {
+        this.elements.trustLink().should('not.exist');
+        return this;
+    }
+
+    public clickAcademyTrustLink(): this {
+        this.elements.trustLink().click();
+        return this;
+    }
+
 }
 
 const schoolsPage = new SchoolsPage();

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/BaseOverviewAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/BaseOverviewAreaModelTests.cs
@@ -7,6 +7,8 @@ public abstract class BaseOverviewAreaModelTests<T> : BaseSchoolPageTests<T> whe
     [Fact]
     public override async Task OnGetAsync_should_configure_PageMetadata_PageName()
     {
+        Sut.Urn = DummySchoolSummary.Urn;
+
         await Sut.OnGetAsync();
 
         Sut.PageMetadata.PageName.Should().Be("Overview");

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/DetailsModelTests.cs
@@ -7,7 +7,7 @@ public class DetailsModelTests : BaseOverviewAreaModelTests<DetailsModel>
 {
     public DetailsModelTests()
     {
-        Sut = new DetailsModel(MockSchoolService) { Urn = Urn };
+        Sut = new DetailsModel(MockSchoolService, MockTrustService);
     }
 
     [Fact]
@@ -19,7 +19,9 @@ public class DetailsModelTests : BaseOverviewAreaModelTests<DetailsModel>
 
     private async Task OnGetAsync_should_configure_PageMetadata_SubPageName_for_school()
     {
-        MockSchoolService.GetSchoolSummaryAsync(Urn)
+        Sut.Urn = SchoolUrn;
+
+        MockSchoolService.GetSchoolSummaryAsync(SchoolUrn)
             .Returns(DummySchoolSummary with { Category = SchoolCategory.LaMaintainedSchool });
 
         await Sut.OnGetAsync();
@@ -29,7 +31,9 @@ public class DetailsModelTests : BaseOverviewAreaModelTests<DetailsModel>
 
     private async Task OnGetAsync_should_configure_PageMetadata_SubPageName_for_academy()
     {
-        MockSchoolService.GetSchoolSummaryAsync(Urn)
+        Sut.Urn = AcademyUrn;
+
+        MockSchoolService.GetSchoolSummaryAsync(AcademyUrn)
             .Returns(DummySchoolSummary with { Category = SchoolCategory.Academy });
 
         await Sut.OnGetAsync();


### PR DESCRIPTION
Header styling for school or academy headers and link back to trust information for an academy.

[User Story 205658](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/205658): Build: Academy/School page header

## Screenshots of UI changes

### School

![image](https://github.com/user-attachments/assets/28cd39fb-e16e-4ec0-b414-839d7afaebdd)

### Academy

![image](https://github.com/user-attachments/assets/78ce8885-cdd7-4285-8313-cd1cfe64dd9d)


## Changes

- New style class for school header
- Link to trust from the academy header

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
