### PR TITLE
Remove moq from academiesdb unit tests

### DIFF
--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.csproj
@@ -14,7 +14,6 @@
         <PackageReference Include="FluentAssertions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Identity.Web" Version="3.8.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -7,7 +7,6 @@ using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Ops;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Sharepoint;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Tad;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.PipelineAcademy;
-using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -1,4 +1,3 @@
-using System.Linq.Expressions;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Cdm;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
@@ -8,72 +7,74 @@ using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Ops;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Sharepoint;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Tad;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.PipelineAcademy;
-using Microsoft.EntityFrameworkCore;
+using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 
-public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
+public class MockAcademiesDbContext
 {
-    //application
-    private readonly List<ApplicationEvent> _applicationEvents = [];
+    public readonly IAcademiesDbContext Object = Substitute.For<IAcademiesDbContext>();
 
-    private readonly List<ApplicationSetting> _applicationSettings = [];
+    //application
+    private readonly MockDbSet<ApplicationEvent> _applicationEvents = new();
+    private readonly MockDbSet<ApplicationSetting> _applicationSettings = new();
 
     //cdm
-    private readonly List<CdmSystemuser> _cdmSystemusers = [];
-
-    private readonly List<CdmAccount> _cdmAccounts = [];
+    private readonly MockDbSet<CdmSystemuser> _cdmSystemusers = new();
+    private readonly MockDbSet<CdmAccount> _cdmAccounts = new();
 
     //gias
-    private readonly List<GiasEstablishment> _giasEstablishments = [];
-    private readonly List<GiasGovernance> _giasGovernances = [];
-    private readonly List<GiasGroup> _giasGroups = [];
-    private readonly List<GiasGroupLink> _giasGroupLinks = [];
-    private readonly List<GiasEstablishmentLink> _giasEstablishmentLinks = [];
+    private readonly MockDbSet<GiasEstablishment> _giasEstablishments = new();
+    private readonly MockDbSet<GiasGovernance> _giasGovernances = new();
+    private readonly MockDbSet<GiasGroup> _giasGroups = new();
+    private readonly MockDbSet<GiasGroupLink> _giasGroupLinks = new();
+    private readonly MockDbSet<GiasEstablishmentLink> _giasEstablishmentLinks = new();
 
     //mis_mstr
-    private readonly List<MisMstrEstablishmentFiat> _misMstrEstablishmentFiat = [];
-    private readonly List<MisMstrFurtherEducationEstablishmentFiat> _misMstrFurtherEducationEstablishmentFiat = [];
+    private readonly MockDbSet<MisMstrEstablishmentFiat> _misMstrEstablishmentFiat = new();
+
+    private readonly MockDbSet<MisMstrFurtherEducationEstablishmentFiat> _misMstrFurtherEducationEstablishmentFiat =
+        new();
 
     //mstr
-    private readonly List<MstrTrust> _mstrTrusts = [];
-    private readonly List<MstrAcademyConversion> _mstrAcademyConversions = [];
-    private readonly List<MstrAcademyTransfer> _mstrAcademyTransfers = [];
-    private readonly List<MstrFreeSchoolProject> _mstrFreeSchoolProjects = [];
+    private readonly MockDbSet<MstrTrust> _mstrTrusts = new();
+    private readonly MockDbSet<MstrAcademyConversion> _mstrAcademyConversions = new();
+    private readonly MockDbSet<MstrAcademyTransfer> _mstrAcademyTransfers = new();
+    private readonly MockDbSet<MstrFreeSchoolProject> _mstrFreeSchoolProjects = new();
 
     //sharepoint
-    private readonly List<SharepointTrustDocLink> _sharepointTrustDocLinks = [];
+    private readonly MockDbSet<SharepointTrustDocLink> _sharepointTrustDocLinks = new();
 
     //tad
-    private readonly List<TadTrustGovernance> _tadTrustGovernances = [];
+    private readonly MockDbSet<TadTrustGovernance> _tadTrustGovernances = new();
+
 
     public MockAcademiesDbContext()
     {
         //application
-        SetupMockDbContext(_applicationEvents, context => context.ApplicationEvents);
-        SetupMockDbContext(_applicationSettings, context => context.ApplicationSettings);
+        Object.ApplicationEvents.Returns(_applicationEvents.Object);
+        Object.ApplicationSettings.Returns(_applicationSettings.Object);
         //cdm
-        SetupMockDbContext(_cdmSystemusers, context => context.CdmSystemusers);
-        SetupMockDbContext(_cdmAccounts, context => context.CdmAccounts);
+        Object.CdmSystemusers.Returns(_cdmSystemusers.Object);
+        Object.CdmAccounts.Returns(_cdmAccounts.Object);
         //gias
-        SetupMockDbContext(_giasEstablishments, context => context.GiasEstablishments);
-        SetupMockDbContext(_giasGovernances, context => context.GiasGovernances);
-        SetupMockDbContext(_giasGroups, context => context.Groups);
-        SetupMockDbContext(_giasGroupLinks, context => context.GiasGroupLinks);
-        SetupMockDbContext(_giasEstablishmentLinks, context => context.GiasEstablishmentLink);
+        Object.GiasEstablishments.Returns(_giasEstablishments.Object);
+        Object.GiasGovernances.Returns(_giasGovernances.Object);
+        Object.Groups.Returns(_giasGroups.Object);
+        Object.GiasGroupLinks.Returns(_giasGroupLinks.Object);
+        Object.GiasEstablishmentLink.Returns(_giasEstablishmentLinks.Object);
         //mis_mstr
-        SetupMockDbContext(_misMstrEstablishmentFiat, context => context.MisMstrEstablishmentsFiat);
-        SetupMockDbContext(_misMstrFurtherEducationEstablishmentFiat,
-            context => context.MisMstrFurtherEducationEstablishmentsFiat);
+        Object.MisMstrEstablishmentsFiat.Returns(_misMstrEstablishmentFiat.Object);
+        Object.MisMstrFurtherEducationEstablishmentsFiat.Returns(_misMstrFurtherEducationEstablishmentFiat.Object);
         //mstr
-        SetupMockDbContext(_mstrAcademyConversions, context => context.MstrAcademyConversions);
-        SetupMockDbContext(_mstrAcademyTransfers, context => context.MstrAcademyTransfers);
-        SetupMockDbContext(_mstrFreeSchoolProjects, context => context.MstrFreeSchoolProjects);
-        SetupMockDbContext(_mstrTrusts, context => context.MstrTrusts);
+        Object.MstrAcademyConversions.Returns(_mstrAcademyConversions.Object);
+        Object.MstrAcademyTransfers.Returns(_mstrAcademyTransfers.Object);
+        Object.MstrFreeSchoolProjects.Returns(_mstrFreeSchoolProjects.Object);
+        Object.MstrTrusts.Returns(_mstrTrusts.Object);
         //sharepoint
-        SetupMockDbContext(_sharepointTrustDocLinks, context => context.SharepointTrustDocLinks);
+        Object.SharepointTrustDocLinks.Returns(_sharepointTrustDocLinks.Object);
         //tad
-        SetupMockDbContext(_tadTrustGovernances, context => context.TadTrustGovernances);
+        Object.TadTrustGovernances.Returns(_tadTrustGovernances.Object);
 
         //Set up some unused data to ensure we are actually retrieving the right data in our tests
         var otherTrust = AddGiasGroup(groupName: "Some other trust");
@@ -92,12 +93,6 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
             AddTadTrustGovernance(new TadTrustGovernance { Gid = $"{i}", Email = $"governor{i}@othertrust.com" });
             AddMstrFreeSchoolProject(otherTrust.GroupId!);
         }
-    }
-
-    public void SetupMockDbContext<T>(List<T> items, Expression<Func<IAcademiesDbContext, DbSet<T>>> dbContextTable)
-        where T : class
-    {
-        Setup(dbContextTable).Returns(new MockDbSet<T>(items).Object);
     }
 
     public MstrTrust AddMstrTrust(string? groupUid = null, string? region = "North East")
@@ -393,30 +388,5 @@ public class MockAcademiesDbContext : Mock<IAcademiesDbContext>
 
         _sharepointTrustDocLinks.AddRange(sharepointTrustDocLinks);
         return sharepointTrustDocLinks;
-    }
-}
-
-file static class MockDbSetExtensions
-{
-    public static int GetNextId<T>(this List<T> entities, Func<T, int> identifier, int? specifiedId = null)
-    {
-        var nextId = specifiedId ?? entities.Count + 1;
-
-        //Don't allow duplicate IDs
-        if (entities.Any(entity => identifier(entity) == nextId))
-            entities.Remove(entities.Single(entity => identifier(entity) == nextId));
-
-        return nextId;
-    }
-
-    public static string GetNextId<T>(this List<T> entities, Func<T, string> identifier, string? specifiedId = null)
-    {
-        var nextId = specifiedId ?? (entities.Count + 1).ToString();
-
-        //Don't allow duplicate IDs
-        if (entities.Any(entity => identifier(entity) == nextId))
-            entities.Remove(entities.Single(entity => identifier(entity) == nextId));
-
-        return nextId;
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -14,57 +14,57 @@ public class MockAcademiesDbContext
     public readonly IAcademiesDbContext Object = Substitute.For<IAcademiesDbContext>();
 
     //application
-    private readonly MockDbSet<ApplicationEvent> _applicationEvents = new();
-    private readonly MockDbSet<ApplicationSetting> _applicationSettings = new();
+    public MockDbSet<ApplicationEvent> ApplicationEvents { get; } = new();
+    public MockDbSet<ApplicationSetting> ApplicationSettings { get; } = new();
 
     //gias
-    private readonly MockDbSet<GiasEstablishment> _giasEstablishments = new();
-    private readonly MockDbSet<GiasGovernance> _giasGovernances = new();
-    private readonly MockDbSet<GiasGroup> _giasGroups = new();
-    private readonly MockDbSet<GiasGroupLink> _giasGroupLinks = new();
-    private readonly MockDbSet<GiasEstablishmentLink> _giasEstablishmentLinks = new();
+    public MockDbSet<GiasEstablishment> GiasEstablishments { get; } = new();
+    public MockDbSet<GiasGovernance> GiasGovernances { get; } = new();
+    public MockDbSet<GiasGroup> GiasGroups { get; } = new();
+    public MockDbSet<GiasGroupLink> GiasGroupLinks { get; } = new();
+    public MockDbSet<GiasEstablishmentLink> GiasEstablishmentLinks { get; } = new();
 
     //mis_mstr
-    private readonly MockDbSet<MisMstrEstablishmentFiat> _misMstrEstablishmentFiat = new();
+    public MockDbSet<MisMstrEstablishmentFiat> MisMstrEstablishmentFiat { get; } = new();
 
-    private readonly MockDbSet<MisMstrFurtherEducationEstablishmentFiat> _misMstrFurtherEducationEstablishmentFiat =
+    public MockDbSet<MisMstrFurtherEducationEstablishmentFiat> MisMstrFurtherEducationEstablishmentFiat { get; } =
         new();
 
     //mstr
-    private readonly MockDbSet<MstrTrust> _mstrTrusts = new();
-    private readonly MockDbSet<MstrAcademyConversion> _mstrAcademyConversions = new();
-    private readonly MockDbSet<MstrAcademyTransfer> _mstrAcademyTransfers = new();
-    private readonly MockDbSet<MstrFreeSchoolProject> _mstrFreeSchoolProjects = new();
+    public MockDbSet<MstrTrust> MstrTrusts { get; } = new();
+    public MockDbSet<MstrAcademyConversion> MstrAcademyConversions { get; } = new();
+    public MockDbSet<MstrAcademyTransfer> MstrAcademyTransfers { get; } = new();
+    public MockDbSet<MstrFreeSchoolProject> MstrFreeSchoolProjects { get; } = new();
 
     //sharepoint
-    private readonly MockDbSet<SharepointTrustDocLink> _sharepointTrustDocLinks = new();
+    public MockDbSet<SharepointTrustDocLink> SharepointTrustDocLinks { get; } = new();
 
     //tad
-    private readonly MockDbSet<TadTrustGovernance> _tadTrustGovernances = new();
+    public MockDbSet<TadTrustGovernance> TadTrustGovernances { get; } = new();
 
     public MockAcademiesDbContext()
     {
         //application
-        Object.ApplicationEvents.Returns(_applicationEvents.Object);
-        Object.ApplicationSettings.Returns(_applicationSettings.Object);
+        Object.ApplicationEvents.Returns(ApplicationEvents.Object);
+        Object.ApplicationSettings.Returns(ApplicationSettings.Object);
         //gias
-        Object.GiasEstablishments.Returns(_giasEstablishments.Object);
-        Object.GiasGovernances.Returns(_giasGovernances.Object);
-        Object.Groups.Returns(_giasGroups.Object);
-        Object.GiasGroupLinks.Returns(_giasGroupLinks.Object);
-        Object.GiasEstablishmentLink.Returns(_giasEstablishmentLinks.Object);
+        Object.GiasEstablishments.Returns(GiasEstablishments.Object);
+        Object.GiasGovernances.Returns(GiasGovernances.Object);
+        Object.Groups.Returns(GiasGroups.Object);
+        Object.GiasGroupLinks.Returns(GiasGroupLinks.Object);
+        Object.GiasEstablishmentLink.Returns(GiasEstablishmentLinks.Object);
         //mis_mstr
-        Object.MisMstrEstablishmentsFiat.Returns(_misMstrEstablishmentFiat.Object);
-        Object.MisMstrFurtherEducationEstablishmentsFiat.Returns(_misMstrFurtherEducationEstablishmentFiat.Object);
+        Object.MisMstrEstablishmentsFiat.Returns(MisMstrEstablishmentFiat.Object);
+        Object.MisMstrFurtherEducationEstablishmentsFiat.Returns(MisMstrFurtherEducationEstablishmentFiat.Object);
         //mstr
-        Object.MstrAcademyConversions.Returns(_mstrAcademyConversions.Object);
-        Object.MstrAcademyTransfers.Returns(_mstrAcademyTransfers.Object);
-        Object.MstrFreeSchoolProjects.Returns(_mstrFreeSchoolProjects.Object);
-        Object.MstrTrusts.Returns(_mstrTrusts.Object);
+        Object.MstrAcademyConversions.Returns(MstrAcademyConversions.Object);
+        Object.MstrAcademyTransfers.Returns(MstrAcademyTransfers.Object);
+        Object.MstrFreeSchoolProjects.Returns(MstrFreeSchoolProjects.Object);
+        Object.MstrTrusts.Returns(MstrTrusts.Object);
         //sharepoint
-        Object.SharepointTrustDocLinks.Returns(_sharepointTrustDocLinks.Object);
+        Object.SharepointTrustDocLinks.Returns(SharepointTrustDocLinks.Object);
         //tad
-        Object.TadTrustGovernances.Returns(_tadTrustGovernances.Object);
+        Object.TadTrustGovernances.Returns(TadTrustGovernances.Object);
 
         //Set up some unused data to ensure we are actually retrieving the right data in our tests
         var otherTrust = AddGiasGroup(groupName: "Some other trust");
@@ -78,9 +78,9 @@ public class MockAcademiesDbContext
             //Entities linked to some other trust
             var otherAcademy = AddGiasEstablishment(establishmentName: $"Some other academy {i}");
             AddGiasGroupLink(otherAcademy, otherTrust);
-            AddGiasGovernance(new GiasGovernance
+            GiasGovernances.Add(new GiasGovernance
                 { Gid = $"{i}", Uid = otherTrust.GroupUid!, Forename1 = $"Governor {i}" });
-            AddTadTrustGovernance(new TadTrustGovernance { Gid = $"{i}", Email = $"governor{i}@othertrust.com" });
+            TadTrustGovernances.Add(new TadTrustGovernance { Gid = $"{i}", Email = $"governor{i}@othertrust.com" });
             AddMstrFreeSchoolProject(otherTrust.GroupId!);
         }
     }
@@ -89,31 +89,21 @@ public class MockAcademiesDbContext
     {
         var mstrTrust = new MstrTrust
         {
-            GroupUid = groupUid ?? (_mstrTrusts.Count + 1).ToString(),
+            GroupUid = groupUid ?? (MstrTrusts.Count + 1).ToString(),
             GORregion = region
         };
-        _mstrTrusts.Add(mstrTrust);
+        MstrTrusts.Add(mstrTrust);
         return mstrTrust;
     }
 
     public void AddGiasGroupLink(GiasEstablishment giasEstablishment, GiasGroup giasGroup)
     {
-        AddGiasGroupLink(new GiasGroupLink
+        GiasGroupLinks.Add(new GiasGroupLink
         {
             GroupUid = giasGroup.GroupUid,
             Urn = giasEstablishment.Urn.ToString(),
             GroupType = giasGroup.GroupType
         });
-    }
-
-    public void AddGiasGroupLink(GiasGroupLink giasGroupLink)
-    {
-        _giasGroupLinks.Add(giasGroupLink);
-    }
-
-    public void AddGiasGroupLinks(IEnumerable<GiasGroupLink> giasGroupLink)
-    {
-        _giasGroupLinks.AddRange(giasGroupLink);
     }
 
     public void AddGiasGroupLinksForGiasEstablishmentsToGiasGroup(IEnumerable<GiasEstablishment> giasEstablishments,
@@ -125,88 +115,34 @@ public class MockAcademiesDbContext
         }
     }
 
-    public void AddGiasEstablishmentLink(GiasEstablishmentLink giasEstablishmentLink)
-    {
-        _giasEstablishmentLinks.Add(giasEstablishmentLink);
-    }
-
-    public void AddGiasEstablishmentLinks(IEnumerable<GiasEstablishmentLink> giasEstablishmentLinks)
-    {
-        _giasEstablishmentLinks.AddRange(giasEstablishmentLinks);
-    }
-
-    public void AddEstablishmentFiat(MisMstrEstablishmentFiat misMstrEstablishmentFiat)
-    {
-        _misMstrEstablishmentFiat.Add(misMstrEstablishmentFiat);
-    }
-
     public void AddEstablishmentFiat(int urn, string? inspectionStartDate = null)
     {
-        AddEstablishmentFiat(new MisMstrEstablishmentFiat
+        MisMstrEstablishmentFiat.Add(new MisMstrEstablishmentFiat
         {
             Urn = urn,
             InspectionStartDate = inspectionStartDate
         });
     }
 
-    public void AddEstablishmentsFiat(params MisMstrEstablishmentFiat[] establishmentsFiat)
-    {
-        AddEstablishmentsFiat((IEnumerable<MisMstrEstablishmentFiat>)establishmentsFiat);
-    }
-
-    public void AddEstablishmentsFiat(IEnumerable<MisMstrEstablishmentFiat> establishmentsFiat)
-    {
-        _misMstrEstablishmentFiat.AddRange(establishmentsFiat);
-    }
-
-    public void AddFurtherEducationEstablishmentFiat(
-        MisMstrFurtherEducationEstablishmentFiat misMstrFurtherEducationEstablishmentFiat)
-    {
-        _misMstrFurtherEducationEstablishmentFiat.Add(misMstrFurtherEducationEstablishmentFiat);
-    }
-
-    public void AddFurtherEducationEstablishmentsFiat(
-        IEnumerable<MisMstrFurtherEducationEstablishmentFiat> furtherEducationEstablishmentsFiat)
-    {
-        _misMstrFurtherEducationEstablishmentFiat.AddRange(furtherEducationEstablishmentsFiat);
-    }
-
-    public void AddFurtherEducationEstablishmentsFiat(
-        params MisMstrFurtherEducationEstablishmentFiat[] furtherEducationEstablishmentsFiat)
-    {
-        AddFurtherEducationEstablishmentsFiat(
-            (IEnumerable<MisMstrFurtherEducationEstablishmentFiat>)furtherEducationEstablishmentsFiat);
-    }
-
-    public void AddGiasEstablishment(GiasEstablishment giasEstablishment)
-    {
-        _giasEstablishments.Add(giasEstablishment);
-    }
-
     public GiasEstablishment AddGiasEstablishment(int? urn = null, string? establishmentName = null)
     {
         var giasEstablishment = new GiasEstablishment
         {
-            Urn = _giasEstablishments.GetNextId(e => e.Urn, urn),
-            EstablishmentName = establishmentName ?? $"Academy {_giasEstablishments.Count + 1}"
+            Urn = GiasEstablishments.GetNextId(e => e.Urn, urn),
+            EstablishmentName = establishmentName ?? $"Academy {GiasEstablishments.Count + 1}"
         };
-        AddGiasEstablishment(giasEstablishment);
+        GiasEstablishments.Add(giasEstablishment);
 
         return giasEstablishment;
-    }
-
-    public void AddGiasEstablishments(IEnumerable<GiasEstablishment> giasEstablishments)
-    {
-        _giasEstablishments.AddRange(giasEstablishments);
     }
 
     public void AddApplicationEvent(string description,
         DateTime? dateTime,
         string? message = "Finished", char? eventType = 'I')
     {
-        _applicationEvents.Add(new ApplicationEvent
+        ApplicationEvents.Add(new ApplicationEvent
         {
-            Id = _applicationEvents.GetNextId(e => e.Id),
+            Id = ApplicationEvents.GetNextId(e => e.Id),
             DateTime = dateTime,
             Source = "source",
             UserName = "Test User",
@@ -224,22 +160,17 @@ public class MockAcademiesDbContext
 
     public void AddApplicationSetting(string key, DateTime? modified)
     {
-        _applicationSettings.Add(new ApplicationSetting
+        ApplicationSettings.Add(new ApplicationSetting
         {
             Key = key,
             Modified = modified
         });
     }
 
-    public void AddGiasGroup(GiasGroup giasGroup)
-    {
-        _giasGroups.Add(giasGroup);
-    }
-
     public GiasGroup AddGiasGroup(string? groupUid = null, string? groupName = null, string? groupId = null,
         string? groupType = null)
     {
-        var nextGroupUid = _giasGroups.GetNextId(g => g.GroupUid!, groupUid);
+        var nextGroupUid = GiasGroups.GetNextId(g => g.GroupUid!, groupUid);
 
         var giasGroup = new GiasGroup
         {
@@ -248,19 +179,9 @@ public class MockAcademiesDbContext
             GroupUid = nextGroupUid,
             GroupType = groupType ?? "Multi-academy trust"
         };
-        AddGiasGroup(giasGroup);
+        GiasGroups.Add(giasGroup);
 
         return giasGroup;
-    }
-
-    public void AddGiasGovernance(GiasGovernance governance)
-    {
-        _giasGovernances.Add(governance);
-    }
-
-    public void AddTadTrustGovernance(TadTrustGovernance tadTrustGovernance)
-    {
-        _tadTrustGovernances.Add(tadTrustGovernance);
     }
 
     public void AddMstrFreeSchoolProject(string trustId,
@@ -274,9 +195,9 @@ public class MockAcademiesDbContext
         DateTime? provisionalOpeningDate = null,
         DateTime? lastDataRefresh = null)
     {
-        _mstrFreeSchoolProjects.Add(new MstrFreeSchoolProject
+        MstrFreeSchoolProjects.Add(new MstrFreeSchoolProject
         {
-            SK = _mstrFreeSchoolProjects.GetNextId(e => e.SK),
+            SK = MstrFreeSchoolProjects.GetNextId(e => e.SK),
             TrustID = trustId,
             Stage = stage,
             RouteOfProject = "Free School",
@@ -313,9 +234,9 @@ public class MockAcademiesDbContext
         DateTime? expectedOpeningDate = null,
         string? daoProgress = null)
     {
-        _mstrAcademyConversions.Add(new MstrAcademyConversion
+        MstrAcademyConversions.Add(new MstrAcademyConversion
         {
-            SK = _mstrAcademyConversions.GetNextId(e => e.SK),
+            SK = MstrAcademyConversions.GetNextId(e => e.SK),
             TrustID = trustId,
             ProjectStatus = projectStatus,
             InPrepare = inPrepare,
@@ -342,9 +263,9 @@ public class MockAcademiesDbContext
         DateTime? expectedTransferDate = null,
         DateTime? lastDataRefresh = null)
     {
-        _mstrAcademyTransfers.Add(new MstrAcademyTransfer
+        MstrAcademyTransfers.Add(new MstrAcademyTransfer
         {
-            SK = _mstrAcademyTransfers.GetNextId(e => e.SK),
+            SK = MstrAcademyTransfers.GetNextId(e => e.SK),
             NewProvisionalTrustID = newProvisionalTrustId,
             AcademyTransferStatus = academyTransferStatus,
             InPrepare = inPrepare,
@@ -359,11 +280,6 @@ public class MockAcademiesDbContext
         });
     }
 
-    public void AddTrustDocLink(SharepointTrustDocLink sharepointTrustDocLink)
-    {
-        _sharepointTrustDocLinks.Add(sharepointTrustDocLink);
-    }
-
     public SharepointTrustDocLink[] AddTrustDocLinks(string trustReferenceNumber, string folderPrefix, int number)
     {
         var sharepointTrustDocLinks = Enumerable.Range(1, number).Select(i =>
@@ -376,7 +292,7 @@ public class MockAcademiesDbContext
                 FolderYear = 2000 + i
             }).ToArray();
 
-        _sharepointTrustDocLinks.AddRange(sharepointTrustDocLinks);
+        SharepointTrustDocLinks.AddRange(sharepointTrustDocLinks);
         return sharepointTrustDocLinks;
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -1,5 +1,4 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
-using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Cdm;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis_Mstr;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mstr;
@@ -17,10 +16,6 @@ public class MockAcademiesDbContext
     //application
     private readonly MockDbSet<ApplicationEvent> _applicationEvents = new();
     private readonly MockDbSet<ApplicationSetting> _applicationSettings = new();
-
-    //cdm
-    private readonly MockDbSet<CdmSystemuser> _cdmSystemusers = new();
-    private readonly MockDbSet<CdmAccount> _cdmAccounts = new();
 
     //gias
     private readonly MockDbSet<GiasEstablishment> _giasEstablishments = new();
@@ -47,15 +42,11 @@ public class MockAcademiesDbContext
     //tad
     private readonly MockDbSet<TadTrustGovernance> _tadTrustGovernances = new();
 
-
     public MockAcademiesDbContext()
     {
         //application
         Object.ApplicationEvents.Returns(_applicationEvents.Object);
         Object.ApplicationSettings.Returns(_applicationSettings.Object);
-        //cdm
-        Object.CdmSystemusers.Returns(_cdmSystemusers.Object);
-        Object.CdmAccounts.Returns(_cdmAccounts.Object);
         //gias
         Object.GiasEstablishments.Returns(_giasEstablishments.Object);
         Object.GiasGovernances.Returns(_giasGovernances.Object);

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockDbSet.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockDbSet.cs
@@ -1,7 +1,6 @@
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
-using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
@@ -1,7 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Extensions;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
-using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/AcademyRepositoryTests.cs
@@ -28,7 +28,7 @@ public class AcademyRepositoryTests
             LaName = $"Local authority {n}",
             UrbanRuralName = $"UrbanRuralName {n}"
         }).ToArray();
-        _mockAcademiesDbContext.AddGiasEstablishments(giasEstablishments);
+        _mockAcademiesDbContext.GiasEstablishments.AddRange(giasEstablishments);
         _mockAcademiesDbContext.AddGiasGroupLinksForGiasEstablishmentsToGiasGroup(giasEstablishments, giasGroup);
 
         var result = await _sut.GetAcademiesInTrustDetailsAsync(GroupUid);
@@ -63,12 +63,12 @@ public class AcademyRepositoryTests
     [InlineData(3)]
     public async Task GetNumberOfAcademiesInTrustAsync_should_return_number_of_grouplinks_for_uid(int numAcademies)
     {
-        _mockAcademiesDbContext.AddGiasGroupLink(new GiasGroupLink
+        _mockAcademiesDbContext.GiasGroupLinks.Add(new GiasGroupLink
             { GroupUid = "some other trust", Urn = "some other academy" });
 
         for (var i = 0; i < numAcademies; i++)
         {
-            _mockAcademiesDbContext.AddGiasGroupLink(new GiasGroupLink { GroupUid = GroupUid, Urn = $"{i}" });
+            _mockAcademiesDbContext.GiasGroupLinks.Add(new GiasGroupLink { GroupUid = GroupUid, Urn = $"{i}" });
         }
 
         var result = await _sut.GetNumberOfAcademiesInTrustAsync(GroupUid);
@@ -125,7 +125,7 @@ public class AcademyRepositoryTests
             StatutoryLowAge = $"{n + 1}",
             StatutoryHighAge = $"{n + 10}"
         }).ToArray();
-        _mockAcademiesDbContext.AddGiasEstablishments(giasEstablishments);
+        _mockAcademiesDbContext.GiasEstablishments.AddRange(giasEstablishments);
         _mockAcademiesDbContext.AddGiasGroupLinksForGiasEstablishmentsToGiasGroup(giasEstablishments, giasGroup);
 
         var result = await _sut.GetAcademiesInTrustPupilNumbersAsync(GroupUid);
@@ -164,7 +164,7 @@ public class AcademyRepositoryTests
             LaCode = $"{n}",
             PercentageFsm = $"{n - 950.5}"
         }).ToArray();
-        _mockAcademiesDbContext.AddGiasEstablishments(giasEstablishments);
+        _mockAcademiesDbContext.GiasEstablishments.AddRange(giasEstablishments);
         _mockAcademiesDbContext.AddGiasGroupLinksForGiasEstablishmentsToGiasGroup(giasEstablishments, giasGroup);
 
         var result = await _sut.GetAcademiesInTrustFreeSchoolMealsAsync(GroupUid);
@@ -200,7 +200,7 @@ public class AcademyRepositoryTests
             SchoolCapacity = (n * 15).ToString()
         }).ToArray();
 
-        _mockAcademiesDbContext.AddGiasEstablishments(giasEstablishments);
+        _mockAcademiesDbContext.GiasEstablishments.AddRange(giasEstablishments);
         _mockAcademiesDbContext.AddGiasGroupLinksForGiasEstablishmentsToGiasGroup(giasEstablishments, giasGroup);
 
         // Act
@@ -227,8 +227,8 @@ public class AcademyRepositoryTests
             NumberOfPupils = null,
             SchoolCapacity = null
         };
-        _mockAcademiesDbContext.AddGiasEstablishment(giasEstablishment);
-        _mockAcademiesDbContext.AddGiasGroupLink(new GiasGroupLink
+        _mockAcademiesDbContext.GiasEstablishments.Add(giasEstablishment);
+        _mockAcademiesDbContext.GiasGroupLinks.Add(new GiasGroupLink
         {
             GroupUid = giasGroup.GroupUid,
             Urn = giasEstablishment.Urn.ToString()

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/DataSourceRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/DataSourceRepositoryTests.cs
@@ -1,8 +1,6 @@
 ﻿using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
-using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.DataSource;
-using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.Extensions.Logging;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/OfstedRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/OfstedRepositoryTests.cs
@@ -5,6 +5,7 @@ using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using FluentAssertions.Execution;
 using Microsoft.Extensions.Logging;
+using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;
 
@@ -559,7 +560,7 @@ public class OfstedRepositoryTests
 
         await _sut.GetAcademiesInTrustOfstedAsync(GroupUid);
 
-        _mockAcademiesDbContext.Verify(x => x.GiasEstablishmentLink, Times.Never());
+        _ = _mockAcademiesDbContext.Object.DidNotReceive().GiasEstablishmentLink;
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/OfstedRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/OfstedRepositoryTests.cs
@@ -1,11 +1,8 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Mis_Mstr;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
-using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
-using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using FluentAssertions.Execution;
 using Microsoft.Extensions.Logging;
-using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/PipelineEstablishmentRepository/GetAcademiesPipelineSummaryAsyncTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/PipelineEstablishmentRepository/GetAcademiesPipelineSummaryAsyncTests.cs
@@ -1,5 +1,4 @@
-﻿using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
-using DfE.FindInformationAcademiesTrusts.Data.Repositories.PipelineAcademy;
+﻿using DfE.FindInformationAcademiesTrusts.Data.Repositories.PipelineAcademy;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories.PipelineEstablishmentRepository;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/PipelineEstablishmentRepository/PipelineEstablishmentRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/PipelineEstablishmentRepository/PipelineEstablishmentRepositoryTests.cs
@@ -1,5 +1,4 @@
-﻿using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
-using DfE.FindInformationAcademiesTrusts.Data.Repositories.PipelineAcademy;
+﻿using DfE.FindInformationAcademiesTrusts.Data.Repositories.PipelineAcademy;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories.PipelineEstablishmentRepository;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustDocumentRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustDocumentRepositoryTests.cs
@@ -1,9 +1,7 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Sharepoint;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
-using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
-using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 using Microsoft.Extensions.Logging;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustDocumentRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustDocumentRepositoryTests.cs
@@ -40,7 +40,7 @@ public class TrustDocumentRepositoryTests
         for (var i = 0; i < folderPrefixes.Length; i++)
         {
             var folderPrefix = folderPrefixes[i];
-            _mockAcademiesDb.AddTrustDocLink(new SharepointTrustDocLink
+            _mockAcademiesDb.SharepointTrustDocLinks.Add(new SharepointTrustDocLink
             {
                 FolderPrefix = folderPrefix,
                 TrustRefNumber = TrustReferenceNumber,
@@ -83,7 +83,7 @@ public class TrustDocumentRepositoryTests
     {
         var link = $"www.link-to-{folderPrefix}-{folderYear}.com";
 
-        _mockAcademiesDb.AddTrustDocLink(new SharepointTrustDocLink
+        _mockAcademiesDb.SharepointTrustDocLinks.Add(new SharepointTrustDocLink
         {
             FolderPrefix = folderPrefix,
             TrustRefNumber = TrustReferenceNumber,
@@ -108,7 +108,7 @@ public class TrustDocumentRepositoryTests
     {
         var link = $"www.link-to-{folderPrefix}-{folderYear}.com";
 
-        _mockAcademiesDb.AddTrustDocLink(new SharepointTrustDocLink
+        _mockAcademiesDb.SharepointTrustDocLinks.Add(new SharepointTrustDocLink
         {
             FolderPrefix = folderPrefix,
             TrustRefNumber = TrustReferenceNumber,
@@ -161,33 +161,35 @@ public class TrustDocumentRepositoryTests
     [Fact]
     public async Task GetFinancialDocumentsAsync_should_return_newest_doc_when_more_than_one_in_year()
     {
-        _mockAcademiesDb.AddTrustDocLink(new SharepointTrustDocLink
-        {
-            FolderPrefix = "AFS",
-            TrustRefNumber = TrustReferenceNumber,
-            DocumentFilename = "Old Trust Document",
-            DocumentLink = "www.old.com",
-            CreatedDateTime = new DateTime(2019, 11, 01, 11, 21, 31, DateTimeKind.Utc),
-            FolderYear = 2019
-        });
-        _mockAcademiesDb.AddTrustDocLink(new SharepointTrustDocLink
-        {
-            FolderPrefix = "AFS",
-            TrustRefNumber = TrustReferenceNumber,
-            DocumentFilename = "New Trust Document",
-            DocumentLink = "www.new.com",
-            CreatedDateTime = new DateTime(2019, 12, 30, 9, 29, 39, DateTimeKind.Utc),
-            FolderYear = 2019
-        });
-        _mockAcademiesDb.AddTrustDocLink(new SharepointTrustDocLink
-        {
-            FolderPrefix = "AFS",
-            TrustRefNumber = TrustReferenceNumber,
-            DocumentFilename = "Oldest Trust Document",
-            DocumentLink = "www.oldest.com",
-            CreatedDateTime = new DateTime(2019, 10, 01, 1, 2, 3, DateTimeKind.Utc),
-            FolderYear = 2019
-        });
+        _mockAcademiesDb.SharepointTrustDocLinks.AddRange([
+            new SharepointTrustDocLink()
+            {
+                FolderPrefix = "AFS",
+                TrustRefNumber = TrustReferenceNumber,
+                DocumentFilename = "Old Trust Document",
+                DocumentLink = "www.old.com",
+                CreatedDateTime = new DateTime(2019, 11, 01, 11, 21, 31, DateTimeKind.Utc),
+                FolderYear = 2019
+            },
+            new SharepointTrustDocLink
+            {
+                FolderPrefix = "AFS",
+                TrustRefNumber = TrustReferenceNumber,
+                DocumentFilename = "New Trust Document",
+                DocumentLink = "www.new.com",
+                CreatedDateTime = new DateTime(2019, 12, 30, 9, 29, 39, DateTimeKind.Utc),
+                FolderYear = 2019
+            },
+            new SharepointTrustDocLink
+            {
+                FolderPrefix = "AFS",
+                TrustRefNumber = TrustReferenceNumber,
+                DocumentFilename = "Oldest Trust Document",
+                DocumentLink = "www.oldest.com",
+                CreatedDateTime = new DateTime(2019, 10, 01, 1, 2, 3, DateTimeKind.Utc),
+                FolderYear = 2019
+            }
+        ]);
 
         var result = await _sut.GetFinancialDocumentsAsync(Uid, FinancialDocumentType.FinancialStatement);
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
@@ -80,7 +80,7 @@ public class TrustRepositoryTests
         const string postcode = "a postcode";
         const string expectedAddress = "an address";
 
-        _mockAcademiesDbContext.AddGiasGroup(new GiasGroup
+        _mockAcademiesDbContext.GiasGroups.Add(new GiasGroup
         {
             GroupUid = "2806",
             GroupType = "Multi-academy trust",
@@ -100,7 +100,7 @@ public class TrustRepositoryTests
     [Fact]
     public async Task GetTrustOverviewAsync_should_set_properties_from_giasGroup()
     {
-        _mockAcademiesDbContext.AddGiasGroup(new GiasGroup
+        _mockAcademiesDbContext.GiasGroups.Add(new GiasGroup
         {
             GroupUid = "2806",
             GroupId = "TR0012",
@@ -284,7 +284,7 @@ public class TrustRepositoryTests
             AppointingBody = "Nick Warms"
         };
 
-        _mockAcademiesDbContext.AddGiasGovernance(input);
+        _mockAcademiesDbContext.GiasGovernances.Add(input);
         var result = await _sut.GetTrustContactsAsync("1234");
         result.ChairOfTrustees.Should().NotBeNull();
         result.ChairOfTrustees!.FullName.Should().Be("First Second Last");
@@ -350,8 +350,8 @@ public class TrustRepositoryTests
             Email = email
         };
 
-        _mockAcademiesDbContext.AddGiasGovernance(giasGovernance);
-        _mockAcademiesDbContext.AddTadTrustGovernance(tadTrustGovernance);
+        _mockAcademiesDbContext.GiasGovernances.Add(giasGovernance);
+        _mockAcademiesDbContext.TadTrustGovernances.Add(tadTrustGovernance);
 
         return governor;
     }
@@ -406,7 +406,7 @@ public class TrustRepositoryTests
     [Fact]
     public async Task GetTrustReferenceNumberAsync_should_throw_if_trustReferenceNumber_is_null()
     {
-        _mockAcademiesDbContext.AddGiasGroup(new GiasGroup
+        _mockAcademiesDbContext.GiasGroups.Add(new GiasGroup
         {
             GroupUid = "0401",
             GroupId = null,

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
@@ -3,7 +3,6 @@ using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Tad;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
-using Moq;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;
 
@@ -11,7 +10,9 @@ public class TrustRepositoryTests
 {
     private readonly TrustRepository _sut;
     private readonly MockAcademiesDbContext _mockAcademiesDbContext = new();
-    private readonly Mock<IStringFormattingUtilities> _mockStringFormattingUtilities = new();
+
+    private readonly IStringFormattingUtilities _mockStringFormattingUtilities =
+        Substitute.For<IStringFormattingUtilities>();
 
     private readonly DateTime _lastYear = DateTime.Today.AddYears(-1);
     private readonly DateTime _nextYear = DateTime.Today.AddYears(1);
@@ -22,12 +23,7 @@ public class TrustRepositoryTests
 
     public TrustRepositoryTests()
     {
-        _mockStringFormattingUtilities
-            .Setup(u => u.BuildAddressString(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<string>()))
-            .Returns(string.Empty);
-
-        _sut = new TrustRepository(_mockAcademiesDbContext.Object, _mockStringFormattingUtilities.Object);
+        _sut = new TrustRepository(_mockAcademiesDbContext.Object, _mockStringFormattingUtilities);
     }
 
     [Theory]
@@ -94,8 +90,7 @@ public class TrustRepositoryTests
             GroupContactPostcode = postcode
         });
 
-        _mockStringFormattingUtilities.Setup(u => u.BuildAddressString(street, locality, town, postcode))
-            .Returns(expectedAddress);
+        _mockStringFormattingUtilities.BuildAddressString(street, locality, town, postcode).Returns(expectedAddress);
 
         var result = await _sut.GetTrustOverviewAsync("2806");
 
@@ -124,7 +119,7 @@ public class TrustRepositoryTests
             "Multi-academy trust",
             "",
             "",
-            new DateTime(2007, 6, 28)
+            new DateTime(2007, 6, 28, 0, 0, 0, DateTimeKind.Utc)
         ));
     }
 
@@ -435,7 +430,7 @@ public class TrustRepositoryTests
 
         var currentName = "James";
         var newName = "Pete";
-        ;
+
         var newChairId = "5678";
 
         _ = CreateGovernor("1234", newChairId, startDateOfNewChair, null, "Chair of Trustees", newName);

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Repositories/TrustRepositoryTests.cs
@@ -2,8 +2,8 @@ using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Exceptions;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Tad;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
-using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
+using Moq;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Repositories;
 
@@ -433,12 +433,13 @@ public class TrustRepositoryTests
         var startDateOfNewChair = DateTime.Now.AddDays(2);
         var endDateOfCurrent = DateTime.Now.AddDays(1);
 
-        string currentName = "James";
-        string newName = "Pete";
-;       string newChairId = "5678";
+        var currentName = "James";
+        var newName = "Pete";
+        ;
+        var newChairId = "5678";
 
-        _ = CreateGovernor("1234", newChairId, startDateOfNewChair, null, "Chair of Trustees", forename1: newName);
-        _ = CreateGovernor("1234", "9999", null, endDateOfCurrent, "Chair of Trustees", forename1: currentName);
+        _ = CreateGovernor("1234", newChairId, startDateOfNewChair, null, "Chair of Trustees", newName);
+        _ = CreateGovernor("1234", "9999", null, endDateOfCurrent, "Chair of Trustees", currentName);
 
         var result = await _sut.GetTrustContactsAsync("1234");
         result.ChairOfTrustees.Should().NotBeNull();

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
@@ -6,7 +6,9 @@ public class TrustSearchTests
 {
     private readonly TrustSearch _sut;
     private readonly MockAcademiesDbContext _mockAcademiesDbContext = new();
-    private readonly IStringFormattingUtilities _mockStringFormattingUtilities = Substitute.For<IStringFormattingUtilities>();
+
+    private readonly IStringFormattingUtilities _mockStringFormattingUtilities =
+        Substitute.For<IStringFormattingUtilities>();
 
     public TrustSearchTests()
     {
@@ -112,7 +114,7 @@ public class TrustSearchTests
     [Fact]
     public async Task SearchAsync_should_map_properties()
     {
-        _mockAcademiesDbContext.AddGiasGroup(new GiasGroup
+        _mockAcademiesDbContext.GiasGroups.Add(new GiasGroup
         {
             GroupUid = "1234",
             GroupType = "Multi-academy trust",
@@ -133,7 +135,7 @@ public class TrustSearchTests
     [Fact]
     public async Task SearchAutocompleteAsync_should_map_properties()
     {
-        _mockAcademiesDbContext.AddGiasGroup(new GiasGroup
+        _mockAcademiesDbContext.GiasGroups.Add(new GiasGroup
         {
             GroupUid = "1234",
             GroupType = "Multi-academy trust",
@@ -159,7 +161,7 @@ public class TrustSearchTests
         const string town = "a town";
         const string postcode = "a postcode";
         const string expectedAddress = "an address";
-        _mockAcademiesDbContext.AddGiasGroup(new GiasGroup
+        _mockAcademiesDbContext.GiasGroups.Add(new GiasGroup
         {
             GroupUid = "1234",
             GroupType = "Multi-academy trust",
@@ -186,7 +188,7 @@ public class TrustSearchTests
         const string town = "a town";
         const string postcode = "a postcode";
         const string expectedAddress = "an address";
-        _mockAcademiesDbContext.AddGiasGroup(new GiasGroup
+        _mockAcademiesDbContext.GiasGroups.Add(new GiasGroup
         {
             GroupUid = "1234",
             GroupType = "Multi-academy trust",

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
@@ -1,5 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
+using NSubstitute;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests;
 
@@ -240,7 +241,7 @@ public class TrustSearchTests
     public async Task SearchAsync_should_not_call_database_if_empty_search_term(string? term)
     {
         await _sut.SearchAsync(term);
-        _mockAcademiesDbContext.Verify(academiesDbContext => academiesDbContext.Groups, Times.Never);
+        _ = _mockAcademiesDbContext.Object.DidNotReceive().Groups;
     }
 
     [Theory]
@@ -250,7 +251,7 @@ public class TrustSearchTests
     public async Task SearchAutocompleteAsync_should_not_call_database_if_empty_search_term(string? term)
     {
         await _sut.SearchAutocompleteAsync(term);
-        _mockAcademiesDbContext.Verify(academiesDbContext => academiesDbContext.Groups, Times.Never);
+        _ = _mockAcademiesDbContext.Object.DidNotReceive().Groups;
     }
 
     [Theory]

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
@@ -1,5 +1,4 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
-using Moq;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests;
 
@@ -7,16 +6,11 @@ public class TrustSearchTests
 {
     private readonly TrustSearch _sut;
     private readonly MockAcademiesDbContext _mockAcademiesDbContext = new();
-    private readonly Mock<IStringFormattingUtilities> _mockStringFormattingUtilities = new();
+    private readonly IStringFormattingUtilities _mockStringFormattingUtilities = Substitute.For<IStringFormattingUtilities>();
 
     public TrustSearchTests()
     {
-        _mockStringFormattingUtilities
-            .Setup(u => u.BuildAddressString(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<string>()))
-            .Returns(string.Empty);
-
-        _sut = new TrustSearch(_mockAcademiesDbContext.Object, _mockStringFormattingUtilities.Object);
+        _sut = new TrustSearch(_mockAcademiesDbContext.Object, _mockStringFormattingUtilities);
     }
 
     [Theory]
@@ -176,8 +170,7 @@ public class TrustSearchTests
             GroupContactTown = town,
             GroupContactPostcode = postcode
         });
-        _mockStringFormattingUtilities.Setup(u => u.BuildAddressString(street, locality, town, postcode))
-            .Returns(expectedAddress);
+        _mockStringFormattingUtilities.BuildAddressString(street, locality, town, postcode).Returns(expectedAddress);
 
         var result = await _sut.SearchAsync("Inspire");
 
@@ -204,8 +197,7 @@ public class TrustSearchTests
             GroupContactTown = town,
             GroupContactPostcode = postcode
         });
-        _mockStringFormattingUtilities.Setup(u => u.BuildAddressString(street, locality, town, postcode))
-            .Returns(expectedAddress);
+        _mockStringFormattingUtilities.BuildAddressString(street, locality, town, postcode).Returns(expectedAddress);
 
         var result = await _sut.SearchAutocompleteAsync("Inspire");
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/TrustSearchTests.cs
@@ -1,6 +1,5 @@
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Models.Gias;
-using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
-using NSubstitute;
+using Moq;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests;
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Usings.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Usings.cs
@@ -1,4 +1,5 @@
-global using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb;
+global using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests.Mocks;
 global using Xunit;
 global using FluentAssertions;
-global using Moq;
+global using NSubstitute;
+global using DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests.csproj
@@ -11,7 +11,6 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="7.0.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-        <PackageReference Include="Moq" Version="4.20.72"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/GlobalUsings.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.Hardcoded.UnitTests/GlobalUsings.cs
@@ -1,3 +1,2 @@
 global using Xunit;
 global using FluentAssertions;
-global using Moq;

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/DfE.FindInformationAcademiesTrusts.Data.UnitTests.csproj
@@ -13,7 +13,6 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="7.0.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-        <PackageReference Include="Moq" Version="4.20.72"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/GlobalUsings.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.UnitTests/GlobalUsings.cs
@@ -1,3 +1,2 @@
 global using Xunit;
 global using FluentAssertions;
-global using Moq;


### PR DESCRIPTION
- Remove usages of `Moq` from `MockAcademiesDbContext`
- Remove usages of `Moq` from academies db unit tests
- Remove `Moq` nuget package from all unit test projects
- Refactor `MockAcademiesDbContext` to reduce complexity