### PR TITLE
Added date joined and removed (England/Wales) from urban rural

### DIFF
--- a/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb/Repositories/AcademyRepository.cs
@@ -2,6 +2,7 @@ using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Contexts;
 using DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Extensions;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Academy;
 using Microsoft.EntityFrameworkCore;
+using System.Globalization;
 
 namespace DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.Repositories;
 
@@ -19,7 +20,8 @@ public class AcademyRepository(IAcademiesDbContext academiesDbContext)
                         e.EstablishmentName,
                         e.TypeOfEstablishmentName,
                         e.LaName,
-                        e.UrbanRuralName))
+                        e.UrbanRuralName,
+                        DateOnly.ParseExact(gl.JoinedDate!, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None)))
             .ToArrayAsync();
     }
 

--- a/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/AcademyDetails.cs
+++ b/DfE.FindInformationAcademiesTrusts.Data/Repositories/Academy/AcademyDetails.cs
@@ -5,5 +5,6 @@ public record AcademyDetails(
     string? EstablishmentName,
     string? TypeOfEstablishment,
     string? LocalAuthority,
-    string? UrbanRural
+    string? UrbanRural,
+    DateOnly DateAcademyJoinedTrust
 );

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml
@@ -16,7 +16,7 @@
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">School name</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">URN</th>
-        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Date joined trust</th>
+        <th scope="col" class="govuk-body govuk-table__header column-header-date" aria-sort="none">Date joined trust</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Local authority</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Type</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Rural or urban</th>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Trusts/Academies/InTrust/Details.cshtml
@@ -16,6 +16,7 @@
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="ascending">School name</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">URN</th>
+        <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Date joined trust</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Local authority</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Type</th>
         <th scope="col" class="govuk-body govuk-table__header" aria-sort="none">Rural or urban</th>
@@ -30,6 +31,9 @@
             @academy.EstablishmentName
           </td>
           <td class="govuk-body govuk-table__cell" data-testid="urn">@academy.Urn</td>
+        <td class="govuk-body govuk-table__cell" data-sort-value="@academy.DateAcademyJoinedTrust.ToString(StringFormatConstants.SortableDateFormat)" data-testid="academy-date-joined">
+              @academy.DateAcademyJoinedTrust.ToString(StringFormatConstants.DisplayDateFormat)
+          </td>
           <td class="govuk-body govuk-table__cell" data-testid="local-authority">@academy.LocalAuthority</td>
           <td class="govuk-body govuk-table__cell" data-testid="type-of-establishment">@academy.TypeOfEstablishment</td>
           <td class="govuk-body govuk-table__cell" data-testid="urban-or-rural">@academy.UrbanRural</td>

--- a/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyDetailsServiceModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyDetailsServiceModel.cs
@@ -5,5 +5,6 @@ public record AcademyDetailsServiceModel(
     string? EstablishmentName,
     string? LocalAuthority,
     string? TypeOfEstablishment,
-    string? UrbanRural
+    string? UrbanRural,
+    DateOnly DateAcademyJoinedTrust
 );

--- a/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyService.cs
+++ b/DfE.FindInformationAcademiesTrusts/Services/Academy/AcademyService.cs
@@ -29,7 +29,7 @@ public class AcademyService(
 
         return academies.Select(a =>
             new AcademyDetailsServiceModel(a.Urn, a.EstablishmentName, a.LocalAuthority, a.TypeOfEstablishment,
-                a.UrbanRural)).ToArray();
+                a.UrbanRural?.Replace("(England/Wales) ", ""), a.DateAcademyJoinedTrust)).ToArray();
     }
 
     public async Task<AcademyOfstedServiceModel[]> GetAcademiesInTrustOfstedAsync(string uid)

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/trustAcademiesPage/academies-in-trust.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/trustAcademiesPage/academies-in-trust.cy.ts
@@ -31,6 +31,11 @@ describe("Testing the components of the Academies page", () => {
                 .checkSchoolTypesOnDetailsTable();
         });
 
+        it("Checks that the removed England/Wales is not present on the trust details page", () => {
+            academiesInTrustPage
+                .checkEnglandWalesIdentifierNotPresent();
+        });
+
         it("Checks the detail page sorting", () => {
             cy.visit('/trusts/academies/in-trust/details?uid=5143');
             academiesInTrustPage

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/trustAcademiesPage/academies-in-trust.cy.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/e2e/regression/trusts/trustAcademiesPage/academies-in-trust.cy.ts
@@ -42,6 +42,11 @@ describe("Testing the components of the Academies page", () => {
                 .checkTrustDetailsSorting();
         });
 
+        it("Checks the trust joined date is present and valid", () => {
+            academiesInTrustPage
+                .checkTrustJoinedDatePresentAndValid();
+        });
+
         it('should match the academy count in the sidebar with the actual table row count on the Details page', () => {
             academiesInTrustPage.getAcademyCountFromSidebar().then(expectedCount => {
                 academiesInTrustPage.getTableRowCountOnDetailsPage().should('eq', expectedCount);

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/commonPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/commonPage.ts
@@ -125,6 +125,14 @@ class CommonPage {
         return this;
     }
 
+    public readonly checkValueIsValidDate = (element: JQuery<HTMLElement>) => {
+        const text = element.text().trim();
+
+        // Resolves to a date ({2 digits} {month} {4 digits}) or "No data" string
+        // Tech debt - We are allowing Sep and Sept due to different cultures set on remote vs local builds
+        expect(text).to.match(/^\d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec) \d{4}$|^No data$/);
+    };
+
 }
 
 const commonPage = new CommonPage();

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesInTrustPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesInTrustPage.ts
@@ -20,6 +20,8 @@ class AcademiesInTrustPage {
             schoolNameHeader: () => table().find("th:contains('School name')"),
             urn: () => table().find('[data-testid="urn"]'),
             urnHeader: () => table().find("th:contains('URN')"),
+            dateJoinedTrust: () => table().find('[data-testid="academy-date-joined"]'),
+            dateJoinedTrustHeader: () => table().find("th:contains('Date joined trust')"),
             localAuthority: () => table().find('[data-testid="local-authority"]'),
             localAuthorityHeader: () => table().find("th:contains('Local authority')"),
             schoolType: () => table().find('[data-testid="type-of-establishment"]'),
@@ -125,6 +127,7 @@ class AcademiesInTrustPage {
         const { detailsPage } = this.elements;
         TableUtility.checkStringSorting(detailsPage.schoolName, detailsPage.schoolNameHeader);
         TableUtility.checkStringSorting(detailsPage.urn, detailsPage.urnHeader);
+        TableUtility.checkStringSorting(detailsPage.dateJoinedTrust, detailsPage.dateJoinedTrustHeader);
         TableUtility.checkStringSorting(detailsPage.localAuthority, detailsPage.localAuthorityHeader);
         TableUtility.checkStringSorting(detailsPage.schoolType, detailsPage.schoolTypeHeader);
         TableUtility.checkStringSorting(detailsPage.ruralOrUrban, detailsPage.ruralOrUrbanHeader);
@@ -146,6 +149,11 @@ class AcademiesInTrustPage {
         TableUtility.checkNumericSorting(freeSchoolMeals.pupilsEligible, freeSchoolMeals.pupilsEligibleHeader);
         TableUtility.checkNumericSorting(freeSchoolMeals.localAuthorityAverage, freeSchoolMeals.localAuthorityAverageHeader);
         TableUtility.checkNumericSorting(freeSchoolMeals.nationalAverage, freeSchoolMeals.nationalAverageHeader);
+    }
+
+    public checkEnglandWalesIdentifierNotPresent() {
+        this.elements.detailsPage.table().should('not.contain', 'England and Wales');
+        return this;
     }
 }
 

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesInTrustPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/academiesInTrustPage.ts
@@ -1,3 +1,4 @@
+import commonPage from "../commonPage";
 import { TableUtility } from "../tableUtility";
 
 class AcademiesInTrustPage {
@@ -155,6 +156,12 @@ class AcademiesInTrustPage {
         this.elements.detailsPage.table().should('not.contain', 'England and Wales');
         return this;
     }
+
+    public checkTrustJoinedDatePresentAndValid(): this {
+        this.elements.detailsPage.dateJoinedTrust().each(commonPage.checkValueIsValidDate);
+        return this;
+    }
+
 }
 
 const academiesInTrustPage = new AcademiesInTrustPage();

--- a/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
+++ b/tests/DFE.FindInformationAcademiesTrusts.CypressTests/cypress/pages/trusts/ofstedPage.ts
@@ -1,3 +1,4 @@
+import commonPage from "../commonPage";
 import { TableUtility } from "../tableUtility";
 
 class OfstedPage {
@@ -98,14 +99,6 @@ class OfstedPage {
         expect(text).to.match(/^(Good|Not available|Outstanding|Requires improvement|Inadequate|Not inspected|Insufficient evidence|Does not apply)$/);
     };
 
-    private readonly checkValueIsValidDate = (element: JQuery<HTMLElement>) => {
-        const text = element.text().trim();
-
-        // Resolves to a date ({2 digits} {month} {4 digits}) or "No data" string
-        // Tech debt - We are allowing Sep and Sept due to different cultures set on remote vs local builds
-        expect(text).to.match(/^\d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec) \d{4}$|^No data$/);
-    };
-
     private readonly checkValueIsValidBeforeOrAfterJoiningTag = (element: JQuery<HTMLElement>) => {
         const text = element.text().trim();
         expect(text).to.match(/^(Before|After|Not yet inspected)$/);
@@ -167,17 +160,17 @@ class OfstedPage {
     }
 
     public checkSHGDateJoinedPresent(): this {
-        this.elements.singleHeadlineGrades.dateJoined().each(this.checkValueIsValidDate);
+        this.elements.singleHeadlineGrades.dateJoined().each(commonPage.checkValueIsValidDate);
         return this;
     }
 
     public checkSHGDateOfCurrentInspectionPresent(): this {
-        this.elements.singleHeadlineGrades.dateOfCurrentInspection().each(this.checkValueIsValidDate);
+        this.elements.singleHeadlineGrades.dateOfCurrentInspection().each(commonPage.checkValueIsValidDate);
         return this;
     }
 
     public checkSHGDateOfPreviousInspectionPresent(): this {
-        this.elements.singleHeadlineGrades.dateOfPreviousInspection().each(this.checkValueIsValidDate);
+        this.elements.singleHeadlineGrades.dateOfPreviousInspection().each(commonPage.checkValueIsValidDate);
         return this;
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.Data.AcademiesDb.UnitTests/Mocks/MockAcademiesDbContext.cs
@@ -104,7 +104,8 @@ public class MockAcademiesDbContext
         {
             GroupUid = giasGroup.GroupUid,
             Urn = giasEstablishment.Urn.ToString(),
-            GroupType = giasGroup.GroupType
+            GroupType = giasGroup.GroupType,
+            JoinedDate = "01/01/2022"
         });
     }
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Trusts/Academies/InTrust/DetailsModelTests.cs
@@ -30,10 +30,10 @@ public class AcademiesDetailsModelTests : AcademiesInTrustAreaModelTests<Academi
     {
         var academies = new[]
         {
-            new AcademyDetailsServiceModel("1", "", "", "", ""),
-            new AcademyDetailsServiceModel("2", "", "", "", ""),
-            new AcademyDetailsServiceModel("3", "", "", "", "")
-        };
+           new AcademyDetailsServiceModel("1", "", "", "", "", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10))),
+           new AcademyDetailsServiceModel("2", "", "", "", "", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10))),
+           new AcademyDetailsServiceModel("3", "", "", "", "", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))
+       };
         MockAcademyService.GetAcademiesInTrustDetailsAsync(Sut.Uid).Returns(Task.FromResult(academies));
 
         _ = await Sut.OnGetAsync();

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
@@ -28,12 +28,13 @@ public class AcademyServiceTests
     public async Task GetAcademiesInTrustDetailsAsync_should_return_mapped_result_from_repository()
     {
         const string uid = "1234";
+
         AcademyDetails[] academies =
         [
             new("9876", "Academy 1", "Academy converter", "Oxfordshire",
                 "Urban city and town", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10))),
             new("9876", "Academy 2", "Academy sponsor led", "Lincolnshire",
-                "Rural town and fringe", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))
+                "Rural town and fringe", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-5)))
         ];
         
         _mockAcademyRepository.GetAcademiesInTrustDetailsAsync(uid).Returns(academies);
@@ -422,20 +423,11 @@ public class AcademyServiceTests
                 "(England/Wales) Rural town and fringe", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))
         ];
 
-        AcademyDetails[] expectedAcademies =
-        [
-            new("9876", "Academy 1", "Academy converter", "Oxfordshire",
-                "Urban city and town", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10))),
-            new("9876", "Academy 2", "Academy sponsor led", "Lincolnshire",
-                "Rural town and fringe", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))
-        ];
-
-
         _mockAcademyRepository.GetAcademiesInTrustDetailsAsync(uid).Returns(academies);
 
-        var result = await _sut.GetAcademiesInTrustDetailsAsync(uid);
+        AcademyDetailsServiceModel[] result = await _sut.GetAcademiesInTrustDetailsAsync(uid);
 
-        result.Should().BeOfType<AcademyDetailsServiceModel[]>();
-        result.Should().BeEquivalentTo(expectedAcademies);
+        result[0].UrbanRural.Should().Be("Urban city and town");
+        result[1].UrbanRural.Should().Be("Rural town and fringe");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/AcademyServiceTests.cs
@@ -30,10 +30,10 @@ public class AcademyServiceTests
         const string uid = "1234";
         AcademyDetails[] academies =
         [
-            new AcademyDetails("9876", "Academy 1", "Academy converter", "Oxfordshire",
-                "(England/Wales) Urban city and town"),
-            new AcademyDetails("9876", "Academy 2", "Academy sponsor led", "Lincolnshire",
-                "(England/Wales) Rural town and fringe")
+            new("9876", "Academy 1", "Academy converter", "Oxfordshire",
+                "Urban city and town", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10))),
+            new("9876", "Academy 2", "Academy sponsor led", "Lincolnshire",
+                "Rural town and fringe", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))
         ];
         
         _mockAcademyRepository.GetAcademiesInTrustDetailsAsync(uid).Returns(academies);
@@ -407,5 +407,35 @@ public class AcademyServiceTests
         result[1].LocalAuthority.Should().Be("Authority FS2");
         result[1].ProjectType.Should().Be("FreeSchool");
         result[1].ChangeDate.Should().Be(new DateTime(2023, 6, 1));
+    }
+
+    [Fact]
+    public async Task GetAcademiesInTrustDetailsAsync_ShouldRemoveEnglandWalesFromUrbanRural()
+    {
+        const string uid = "1234";
+        
+        AcademyDetails[] academies =
+        [
+            new("9876", "Academy 1", "Academy converter", "Oxfordshire",
+                "(England/Wales) Urban city and town", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10))),
+            new("9876", "Academy 2", "Academy sponsor led", "Lincolnshire",
+                "(England/Wales) Rural town and fringe", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))
+        ];
+
+        AcademyDetails[] expectedAcademies =
+        [
+            new("9876", "Academy 1", "Academy converter", "Oxfordshire",
+                "Urban city and town", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10))),
+            new("9876", "Academy 2", "Academy sponsor led", "Lincolnshire",
+                "Rural town and fringe", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))
+        ];
+
+
+        _mockAcademyRepository.GetAcademiesInTrustDetailsAsync(uid).Returns(academies);
+
+        var result = await _sut.GetAcademiesInTrustDetailsAsync(uid);
+
+        result.Should().BeOfType<AcademyDetailsServiceModel[]>();
+        result.Should().BeEquivalentTo(expectedAcademies);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServices/AcademiesExportServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServices/AcademiesExportServiceTests.cs
@@ -64,7 +64,7 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services.ExportServices
         {
             var now = DateTime.Now;
             _mockAcademyService.GetAcademiesInTrustDetailsAsync(trustUid).Returns([
-                new("123456", "Academy 1", "Local Authority 1", "Type A", "Urban")
+                new("123456", "Academy 1", "Local Authority 1", "Type A", "Urban", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))
             ]);
             _mockAcademyService.GetAcademiesInTrustOfstedAsync(trustUid).Returns([
                 new("123456", "Academy 1", now, new OfstedRating(1, now.AddDays(-1)), new OfstedRating(1, now))
@@ -135,7 +135,7 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services.ExportServices
         public async Task ExportAcademiesToSpreadsheet_ShouldCorrectlyHandleNullValuesAsync()
         {
             _mockAcademyService.GetAcademiesInTrustDetailsAsync(trustUid)
-                .Returns([new("123456", null, null, null, null)]);
+                .Returns([new("123456", null, null, null, null, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))]);
 
             var now = DateTime.Now;
             _mockAcademyService.GetAcademiesInTrustOfstedAsync(trustUid).Returns([
@@ -181,7 +181,7 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services.ExportServices
         public async Task ExportAcademiesToSpreadsheet_ShouldHandleNullOfstedData()
         {
             _mockAcademyService.GetAcademiesInTrustDetailsAsync(trustUid).Returns([
-                new("123456", "Academy 1", "Local Authority 1", "Type A", "Urban")
+                new("123456", "Academy 1", "Local Authority 1", "Type A", "Urban", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))
             ]);
             _mockAcademyService.GetAcademiesInTrustOfstedAsync(trustUid).Returns([]);
 
@@ -210,7 +210,7 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services.ExportServices
         {
             var now = DateTime.Now;
             _mockAcademyService.GetAcademiesInTrustDetailsAsync(trustUid).Returns([
-                new("123456", "Academy 1", "Local Authority 1", "Type A", "Urban")
+                new("123456", "Academy 1", "Local Authority 1", "Type A", "Urban", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))
             ]);
             _mockAcademyService.GetAcademiesInTrustOfstedAsync(trustUid).Returns([
                 new("123456", "Academy 1", now, new OfstedRating(-1, null), new OfstedRating(1, now))
@@ -244,7 +244,7 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services.ExportServices
         {
             var now = DateTime.Now;
             _mockAcademyService.GetAcademiesInTrustDetailsAsync(trustUid).Returns([
-                new("123456", "Academy 1", "Local Authority 1", "Type A", "Urban")
+                new("123456", "Academy 1", "Local Authority 1", "Type A", "Urban", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))
             ]);
 
             _mockAcademyService.GetAcademiesInTrustOfstedAsync(trustUid).Returns([

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServices/OfstedDataExportServiceTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Services/ExportServices/OfstedDataExportServiceTests.cs
@@ -94,7 +94,7 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services.ExportServices
             var previousInspectionDate = new DateTime(2019, 12, 31);
 
             _mockAcademyService.GetAcademiesInTrustDetailsAsync(trustUid)
-                .Returns([new("A123", "Academy XYZ", "TypeX", "Local LA", "Urban")]);
+                .Returns([new("A123", "Academy XYZ", "TypeX", "Local LA", "Urban", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))]);
 
             _mockAcademyService.GetAcademiesInTrustOfstedAsync(trustUid)
                 .Returns([
@@ -138,7 +138,7 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services.ExportServices
         [Fact]
         public async Task ExportOfstedDataToSpreadsheet_ShouldHandleNoOfstedDataAsync()
         {
-            _mockAcademyService.GetAcademiesInTrustDetailsAsync(trustUid).Returns([new ("A123", "Academy XYZ", "Local LA", "TypeX", "Urban")]);
+            _mockAcademyService.GetAcademiesInTrustDetailsAsync(trustUid).Returns([new ("A123", "Academy XYZ", "Local LA", "TypeX", "Urban", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))]);
 
             _mockAcademyService.GetAcademiesInTrustOfstedAsync(trustUid).Returns([]);
 
@@ -180,7 +180,7 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Services.ExportServices
             var previousInspectionDate = new DateTime(2019, 12, 31);
 
             _mockAcademyService.GetAcademiesInTrustDetailsAsync(trustUid)
-                .Returns([new("A123", null, "TypeX", "Local LA", "Urban")]);
+                .Returns([new("A123", null, "TypeX", "Local LA", "Urban", DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)))]);
 
             _mockAcademyService.GetAcademiesInTrustOfstedAsync(trustUid)
                 .Returns([


### PR DESCRIPTION
[User Story 207175](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/207175): Build: add 'Date joined' and Rural/Urban to 'Academies in this trust' page

## Changes

Add date joined and remove the wording for (England/Wales) for the rural/urban columns


## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/f75c1beb-d7c9-43b7-a49f-2a1173c81bf1)

### After
![image](https://github.com/user-attachments/assets/7ce6373e-073a-4511-a565-e1bf2006170f)


## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [x] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
