### PR TITLE
typo fix and changed h3 to be a label

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_PageSearchForm.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_PageSearchForm.cshtml
@@ -5,11 +5,11 @@
 }
 
 <div data-testid="app-search-form">
-    <h3 class="govuk-heading-m govuk-!-margin-bottom-3">
+    <label class="govuk-heading-m govuk-!-margin-bottom-3" for="@Model.PageSearchFormInputId">
         Search for a trust or school
-    </h3>
+        </label>
   <div class="govuk-hint">
-      Search by URN (unique reference number), TRN (trust reference number) of name. Include any punctuation in names. 
+      Search by URN (unique reference number), TRN (trust reference number) or name. Include any punctuation in names. 
   </div>
 
   @* This is used by the no javascript users *@


### PR DESCRIPTION
[User Story 216619](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/216619): Build: Home page fixes

## Changes

- Changed h3 for 'Search for a trust or school' to be a label with a for attribute linked to the search box
- Typo fix of/or

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/37ba764c-875c-45d6-9db7-2b15ce3e4a26)


### After
![image](https://github.com/user-attachments/assets/2b45c277-4b97-487e-80ba-67e17ba87c8f)


## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
