### PR TITLE
Add Retry behaviour to SQL contexts

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
@@ -32,17 +32,38 @@ public static class Dependencies
     public static void AddDependenciesTo(WebApplicationBuilder builder)
     {
         builder.Services.AddDbContext<AcademiesDbContext>(options =>
-            options.UseSqlServer(builder.Configuration.GetConnectionString("AcademiesDb") ??
-                                 throw new InvalidOperationException("Connection string 'AcademiesDb' not found."))
-                .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)); // Academies db data is always readonly;
+            options.UseSqlServer(
+                builder.Configuration.GetConnectionString("AcademiesDb") ??
+                    throw new InvalidOperationException("Connection string 'AcademiesDb' not found."),
+                sqlServerOptionsAction: sqlOptions =>
+                {
+                    sqlOptions.EnableRetryOnFailure(
+                        maxRetryCount: 2, // retry up to a maximum of 2 times
+                        maxRetryDelay: TimeSpan.FromSeconds(5), // wait up to 5s for the server to respond before retry
+                        errorNumbersToAdd: null
+                    );
+                }
+            ).UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+        );
+
         builder.Services.AddScoped<IAcademiesDbContext>(provider =>
             provider.GetService<AcademiesDbContext>() ??
             throw new InvalidOperationException("AcademiesDbContext not registered"));
 
         builder.Services.AddDbContext<FiatDbContext>(options =>
-            options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection") ??
-                                 throw new InvalidOperationException(
-                                     "FIAT database connection string 'DefaultConnection' not found.")));
+            options.UseSqlServer(
+                builder.Configuration.GetConnectionString("DefaultConnection") ??
+                    throw new InvalidOperationException("FIAT database connection string 'DefaultConnection' not found."),
+                sqlServerOptionsAction: sqlOptions =>
+                {
+                    sqlOptions.EnableRetryOnFailure(
+                        maxRetryCount: 2, // retry up to a maximum of 2 times
+                        maxRetryDelay: TimeSpan.FromSeconds(5), // wait up to 5s for the server to respond before retry
+                        errorNumbersToAdd: null
+                    );
+                }
+            )
+        );
 
         builder.Services.AddScoped<SetChangedByInterceptor>();
         builder.Services.AddScoped<IUserDetailsProvider, HttpContextUserDetailsProvider>();


### PR DESCRIPTION
## Changes

* Occasionally there are DbContext timeouts that fire transiently. They are uncommon, but it would be useful for us to be able to retry the connections if there is a blip in connectivity

* I've set the initial retry behaviour quite low as to not overwhelm the remote resource

## Checklist

- [ ] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
