### PR TITLE
[205375] Add 'Contacts in DfE' page for schools

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/ContactsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/ContactsAreaModel.cs
@@ -26,9 +26,12 @@ public class ContactsAreaModel(
         if (pageResult.GetType() == typeof(NotFoundResult)) return pageResult;
 
         var giasDataSource = await dataSourceService.GetAsync(Source.Gias);
+        var fiatDataSource = await dataSourceService.GetSchoolContactDataSourceAsync(Urn, SchoolContactRole.RegionsGroupLocalAuthorityLead);
 
         DataSourcesPerPage =
         [
+            new DataSourcePageListEntry(InDfeModel.SubPageName,
+                [new DataSourceListEntry(fiatDataSource, "Regions group LA lead")]),
             new DataSourcePageListEntry(InSchoolModel.SubPageName(SchoolCategory),
                 [new DataSourceListEntry(giasDataSource, "Head teacher name")])
         ];

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/ContactsAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/ContactsAreaModel.cs
@@ -11,13 +11,14 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
 public class ContactsAreaModel(
     ISchoolService schoolService,
     ITrustService trustService,
-    IDataSourceService dataSourceService)
-    : SchoolAreaModel(schoolService, trustService)
+    IDataSourceService dataSourceService,
+    ISchoolNavMenu schoolNavMenu)
+    : SchoolAreaModel(schoolService, trustService, schoolNavMenu)
 {
     public const string PageName = "Contacts";
 
     public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };
-    
+
     public override async Task<IActionResult> OnGetAsync()
     {
         var pageResult = await base.OnGetAsync();

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InDfe.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InDfe.cshtml
@@ -1,0 +1,25 @@
+@page "/schools/contacts/in-dfe"
+@model InDfeModel
+
+@{
+    Layout = "_SchoolLayout";
+}
+
+<div class="govuk-grid-row" data-testid="school-contacts-section">
+    <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m" data-testid="subpage-header">
+            @Model.PageMetadata.SubPageName
+        </h2>
+
+        <div class="govuk-summary-card" data-testid="contact-card-regions-group-la-lead">
+            <div class="govuk-summary-card__title-wrapper">
+                <h3 class="govuk-summary-card__title" data-testid="contact-card-title-regions-group-la-lead">
+                    Regions group local authority lead
+                </h3>
+            </div>
+            <partial name="Contact/_DisplayContact" model="Model.RegionsGroupLocalAuthorityLead"
+                view-data='new ViewDataDictionary(ViewData) { { "contactType", "regions-group-local-authority-lead" } }' />
+        </div>
+        <hr class="govuk-section-break govuk-section-break--m" data-testid="contacts-section-divider">
+    </div>
+</div>

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InDfe.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InDfe.cshtml.cs
@@ -1,0 +1,41 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared;
+using DfE.FindInformationAcademiesTrusts.Services.DataSource;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+using DfE.FindInformationAcademiesTrusts.Services.Trust;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+
+namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
+
+[FeatureGate(FeatureFlags.ContactsInDfeForSchools)]
+public class InDfeModel(
+    ISchoolService schoolService,
+    ITrustService trustService,
+    ISchoolContactsService schoolContactsService,
+    IDataSourceService dataSourceService,
+    ISchoolNavMenu schoolNavMenu)
+    : ContactsAreaModel(schoolService, trustService, dataSourceService, schoolNavMenu)
+{
+    public override PageMetadata PageMetadata => base.PageMetadata with
+    {
+        SubPageName = SubPageName
+    };
+
+    public static string SubPageName => "Contacts in DfE";
+
+    public Person RegionsGroupLocalAuthorityLead { get; private set; } = null!;
+
+    public override async Task<IActionResult> OnGetAsync()
+    {
+        var pageResult = await base.OnGetAsync();
+        if (pageResult is NotFoundResult) return pageResult;
+
+        var contacts = await schoolContactsService.GetInternalContactsAsync(Urn);
+
+        RegionsGroupLocalAuthorityLead = contacts.RegionsGroupLocalAuthorityLead;
+
+        return pageResult;
+    }
+}

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InSchool.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Contacts/InSchool.cshtml.cs
@@ -12,8 +12,9 @@ public class InSchoolModel(
     ISchoolService schoolService,
     ITrustService trustService,
     ISchoolContactsService schoolContactsService,
-    IDataSourceService dataSourceService)
-    : ContactsAreaModel(schoolService, trustService, dataSourceService)
+    IDataSourceService dataSourceService,
+    ISchoolNavMenu schoolNavMenu)
+    : ContactsAreaModel(schoolService, trustService, dataSourceService, schoolNavMenu)
 {
     public override PageMetadata PageMetadata => base.PageMetadata with
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/ISchoolAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/ISchoolAreaModel.cs
@@ -1,6 +1,7 @@
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared.NavMenu;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools;
@@ -14,4 +15,6 @@ public interface ISchoolAreaModel
     string SchoolName { get; }
     string SchoolType { get; }
     TrustSummaryServiceModel? TrustSummary { get; }
+    NavLink[] ServiceNavLinks { get; }
+    NavLink[] SubNavLinks { get; }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/Details.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/Details.cshtml.cs
@@ -12,7 +12,8 @@ public class DetailsModel(
     ITrustService trustService,
     ISchoolOverviewDetailsService schoolOverviewDetailsService,
     IOtherServicesLinkBuilder otherServicesLinkBuilder,
-    IDataSourceService dataSourceService) : OverviewAreaModel(schoolService, trustService, dataSourceService)
+    IDataSourceService dataSourceService,
+    ISchoolNavMenu schoolNavMenu) : OverviewAreaModel(schoolService, trustService, dataSourceService, schoolNavMenu)
 {
     public override PageMetadata PageMetadata => base.PageMetadata with
     {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/OverviewAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/OverviewAreaModel.cs
@@ -11,7 +11,8 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
 public abstract class OverviewAreaModel(
     ISchoolService schoolService,
     ITrustService trustService,
-    IDataSourceService dataSourceService) : SchoolAreaModel(schoolService, trustService)
+    IDataSourceService dataSourceService,
+    ISchoolNavMenu schoolNavMenu) : SchoolAreaModel(schoolService, trustService, schoolNavMenu)
 {
     public const string PageName = "Overview";
     public override PageMetadata PageMetadata => base.PageMetadata with { PageName = PageName };

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/Sen.cshtml.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/Overview/Sen.cshtml.cs
@@ -6,10 +6,12 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
 
-public class SenModel(ISchoolService schoolService, 
-    ITrustService trustService, 
+public class SenModel(
+    ISchoolService schoolService,
+    ITrustService trustService,
     ISchoolOverviewSenService schoolOverviewSenService,
-    IDataSourceService dataSourceService) : OverviewAreaModel(schoolService, trustService, dataSourceService)
+    IDataSourceService dataSourceService,
+    ISchoolNavMenu schoolNavMenu) : OverviewAreaModel(schoolService, trustService, dataSourceService, schoolNavMenu)
 {
     public override PageMetadata PageMetadata => base.PageMetadata with
     {
@@ -26,7 +28,7 @@ public class SenModel(ISchoolService schoolService,
     public string? SenCapacity { get; set; }
     public string? ResourcedProvisionType { get; set; }
     public List<string> SenProvisionTypes { get; set; } = new();
-    
+
     private static readonly string NotAvailable = "Not available";
 
     public override async Task<IActionResult> OnGetAsync()
@@ -40,11 +42,13 @@ public class SenModel(ISchoolService schoolService,
         SenOnRoll = SchoolOverviewSenServiceModel.SenOnRoll ?? NotAvailable;
         SenCapacity = SchoolOverviewSenServiceModel.SenCapacity ?? NotAvailable;
         ResourcedProvisionType = SchoolOverviewSenServiceModel.ResourcedProvisionTypes ?? NotAvailable;
-        SenProvisionTypes = SchoolOverviewSenServiceModel.SenProvisionTypes[0] != null ? SchoolOverviewSenServiceModel.SenProvisionTypes :
-        [
-            "Not available"
-        ];
-        
+        SenProvisionTypes = SchoolOverviewSenServiceModel.SenProvisionTypes[0] != null
+            ? SchoolOverviewSenServiceModel.SenProvisionTypes
+            :
+            [
+                "Not available"
+            ];
+
         return pageResult;
     }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolAreaModel.cs
@@ -43,8 +43,8 @@ public class SchoolAreaModel(
 
         SchoolSummary = schoolSummary;
 
-        ServiceNavLinks = schoolNavMenu.GetServiceNavLinks(this);
-        SubNavLinks = schoolNavMenu.GetSubNavLinks(this);
+        ServiceNavLinks = await schoolNavMenu.GetServiceNavLinksAsync(this);
+        SubNavLinks = await schoolNavMenu.GetSubNavLinksAsync(this);
 
         return Page();
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolAreaModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolAreaModel.cs
@@ -1,13 +1,17 @@
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared;
 using DfE.FindInformationAcademiesTrusts.Pages.Shared.DataSource;
+using DfE.FindInformationAcademiesTrusts.Pages.Shared.NavMenu;
 using DfE.FindInformationAcademiesTrusts.Services.School;
 using DfE.FindInformationAcademiesTrusts.Services.Trust;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools;
 
-public class SchoolAreaModel(ISchoolService schoolService, ITrustService trustService) : BasePageModel, ISchoolAreaModel
+public class SchoolAreaModel(
+    ISchoolService schoolService,
+    ITrustService trustService,
+    ISchoolNavMenu schoolNavMenu) : BasePageModel, ISchoolAreaModel
 {
     [BindProperty(SupportsGet = true)] public int Urn { get; set; }
 
@@ -20,6 +24,8 @@ public class SchoolAreaModel(ISchoolService schoolService, ITrustService trustSe
     public SchoolCategory SchoolCategory => SchoolSummary.Category;
 
     public TrustSummaryServiceModel? TrustSummary { get; private set; }
+    public NavLink[] ServiceNavLinks { get; set; } = null!;
+    public NavLink[] SubNavLinks { get; set; } = null!;
 
     public virtual async Task<IActionResult> OnGetAsync()
     {
@@ -36,6 +42,9 @@ public class SchoolAreaModel(ISchoolService schoolService, ITrustService trustSe
         }
 
         SchoolSummary = schoolSummary;
+
+        ServiceNavLinks = schoolNavMenu.GetServiceNavLinks(this);
+        SubNavLinks = schoolNavMenu.GetSubNavLinks(this);
 
         return Page();
     }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolNavMenu.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/SchoolNavMenu.cs
@@ -5,9 +5,15 @@ using DfE.FindInformationAcademiesTrusts.Pages.Shared.NavMenu;
 
 namespace DfE.FindInformationAcademiesTrusts.Pages.Schools;
 
-public static class SchoolNavMenu
+public interface ISchoolNavMenu
 {
-    public static NavLink[] GetServiceNavLinks(ISchoolAreaModel activePage)
+    NavLink[] GetServiceNavLinks(ISchoolAreaModel activePage);
+    NavLink[] GetSubNavLinks(ISchoolAreaModel activePage);
+}
+
+public class SchoolNavMenu : ISchoolNavMenu
+{
+    public NavLink[] GetServiceNavLinks(ISchoolAreaModel activePage)
     {
         return
         [
@@ -28,7 +34,7 @@ public static class SchoolNavMenu
             new Dictionary<string, string> { { "urn", activePage.Urn.ToString() } });
     }
 
-    public static NavLink[] GetSubNavLinks(ISchoolAreaModel activePage)
+    public NavLink[] GetSubNavLinks(ISchoolAreaModel activePage)
     {
         return activePage switch
         {

--- a/DfE.FindInformationAcademiesTrusts/Pages/Schools/_SchoolLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Schools/_SchoolLayout.cshtml
@@ -5,8 +5,8 @@
   ViewData["Title"] = Model.PageMetadata.BrowserTitle;
 }
 
-<partial name="_SchoolBanner" model="@Model" />
-<partial name="Shared/NavMenu/_ServiceNav" model="@SchoolNavMenu.GetServiceNavLinks(Model)" />
+<partial name="_SchoolBanner" model="@Model"/>
+<partial name="Shared/NavMenu/_ServiceNav" model="@Model.ServiceNavLinks"/>
 <div class="govuk-main-wrapper govuk-!-padding-top-6">
   <div class="dfe-width-container">
     <div class="govuk-grid-row">
@@ -15,10 +15,10 @@
           <header>
             <h1 class="govuk-heading-l" data-testid="page-name">@Model.PageMetadata.PageName</h1>
           </header>
-          <partial name="Shared/NavMenu/_SubNav" model="@SchoolNavMenu.GetSubNavLinks(Model)" />
+          <partial name="Shared/NavMenu/_SubNav" model="@Model.SubNavLinks"/>
           @RenderBody()
         </main>
-        <partial name="Shared/DataSource/_SourceList" model="@Model.DataSourcesPerPage" />
+        <partial name="Shared/DataSource/_SourceList" model="@Model.DataSourcesPerPage"/>
       </div>
     </div>
   </div>

--- a/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
+++ b/DfE.FindInformationAcademiesTrusts/Setup/Dependencies.cs
@@ -15,6 +15,7 @@ using DfE.FindInformationAcademiesTrusts.Data.Repositories.Search;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.Trust;
 using DfE.FindInformationAcademiesTrusts.Data.Repositories.TrustDocument;
 using DfE.FindInformationAcademiesTrusts.Pages;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools;
 using DfE.FindInformationAcademiesTrusts.Services.Academy;
 using DfE.FindInformationAcademiesTrusts.Services.DataSource;
 using DfE.FindInformationAcademiesTrusts.Services.Export;
@@ -34,13 +35,13 @@ public static class Dependencies
         builder.Services.AddDbContext<AcademiesDbContext>(options =>
             options.UseSqlServer(
                 builder.Configuration.GetConnectionString("AcademiesDb") ??
-                    throw new InvalidOperationException("Connection string 'AcademiesDb' not found."),
-                sqlServerOptionsAction: sqlOptions =>
+                throw new InvalidOperationException("Connection string 'AcademiesDb' not found."),
+                sqlOptions =>
                 {
                     sqlOptions.EnableRetryOnFailure(
-                        maxRetryCount: 2, // retry up to a maximum of 2 times
-                        maxRetryDelay: TimeSpan.FromSeconds(5), // wait up to 5s for the server to respond before retry
-                        errorNumbersToAdd: null
+                        2, // retry up to a maximum of 2 times
+                        TimeSpan.FromSeconds(5), // wait up to 5s for the server to respond before retry
+                        null
                     );
                 }
             ).UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
@@ -53,13 +54,13 @@ public static class Dependencies
         builder.Services.AddDbContext<FiatDbContext>(options =>
             options.UseSqlServer(
                 builder.Configuration.GetConnectionString("DefaultConnection") ??
-                    throw new InvalidOperationException("FIAT database connection string 'DefaultConnection' not found."),
-                sqlServerOptionsAction: sqlOptions =>
+                throw new InvalidOperationException("FIAT database connection string 'DefaultConnection' not found."),
+                sqlOptions =>
                 {
                     sqlOptions.EnableRetryOnFailure(
-                        maxRetryCount: 2, // retry up to a maximum of 2 times
-                        maxRetryDelay: TimeSpan.FromSeconds(5), // wait up to 5s for the server to respond before retry
-                        errorNumbersToAdd: null
+                        2, // retry up to a maximum of 2 times
+                        TimeSpan.FromSeconds(5), // wait up to 5s for the server to respond before retry
+                        null
                     );
                 }
             )
@@ -100,6 +101,8 @@ public static class Dependencies
         builder.Services.AddScoped<ISchoolOverviewSenService, SchoolOverviewSenService>();
         builder.Services.AddScoped<ISearchService, SearchService>();
         builder.Services.AddScoped<ITrustSchoolSearchRepository, TrustSchoolSearchRepository>();
+
+        builder.Services.AddScoped<ISchoolNavMenu, SchoolNavMenu>();
 
         builder.Services.AddHttpContextAccessor();
     }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockDataSourceService.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Mocks/MockDataSourceService.cs
@@ -6,6 +6,7 @@ namespace DfE.FindInformationAcademiesTrusts.UnitTests.Mocks;
 public static class MockDataSourceService
 {
     private static readonly DateTime StaticTime = new(2023, 11, 9, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly string UpdatedBy = "some.user@education.gov.uk";
 
     public static IDataSourceService CreateSubstitute()
     {
@@ -18,6 +19,11 @@ public static class MockDataSourceService
                 var source = (Source)args[0];
                 return Task.FromResult(GetDummyDataSource(source));
             });
+
+        mockDataSourceService
+            .GetSchoolContactDataSourceAsync(Arg.Any<int>(), Arg.Any<SchoolContactRole>())
+            .Returns(Fiat);
+
         return mockDataSourceService;
     }
 
@@ -40,6 +46,8 @@ public static class MockDataSourceService
     public static DataSourceServiceModel Complete { get; } = GetDummyDataSource(Source.Complete);
     public static DataSourceServiceModel Gias { get; } = GetDummyDataSource(Source.Gias);
     public static DataSourceServiceModel Prepare { get; } = GetDummyDataSource(Source.Prepare);
+
+    public static DataSourceServiceModel Fiat { get; } = new(Source.FiatDb, StaticTime, null, UpdatedBy);
 
     public static DataSourceServiceModel ManageFreeSchool { get; } =
         GetDummyDataSource(Source.ManageFreeSchoolProjects);

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/BaseSchoolPageTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/BaseSchoolPageTests.cs
@@ -14,6 +14,7 @@ public abstract class BaseSchoolPageTests<T> where T : SchoolAreaModel
     protected readonly ISchoolService MockSchoolService = Substitute.For<ISchoolService>();
     protected readonly ITrustService MockTrustService = Substitute.For<ITrustService>();
     protected readonly IDataSourceService MockDataSourceService = Mocks.MockDataSourceService.CreateSubstitute();
+    protected readonly ISchoolNavMenu MockSchoolNavMenu = Substitute.For<ISchoolNavMenu>();
 
     protected const int SchoolUrn = 123456;
     protected const int AcademyUrn = 888888;

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/BaseContactsAreaModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/BaseContactsAreaModelTests.cs
@@ -31,8 +31,13 @@ public abstract class BaseContactsAreaModelTests<T> : BaseSchoolPageTests<T> whe
 
         _ = await Sut.OnGetAsync();
         await MockDataSourceService.Received(1).GetAsync(Source.Gias);
+        await MockDataSourceService.Received(1)
+            .GetSchoolContactDataSourceAsync(AcademyUrn, SchoolContactRole.RegionsGroupLocalAuthorityLead);
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
+            new DataSourcePageListEntry("Contacts in DfE", [
+                new DataSourceListEntry(Mocks.MockDataSourceService.Fiat, "Regions group LA lead")
+            ]),
             new DataSourcePageListEntry("In this academy", [
                 new DataSourceListEntry(Mocks.MockDataSourceService.Gias, "Head teacher name")
             ])
@@ -45,8 +50,13 @@ public abstract class BaseContactsAreaModelTests<T> : BaseSchoolPageTests<T> whe
 
         _ = await Sut.OnGetAsync();
         await MockDataSourceService.Received(1).GetAsync(Source.Gias);
+        await MockDataSourceService.Received(1)
+            .GetSchoolContactDataSourceAsync(SchoolUrn, SchoolContactRole.RegionsGroupLocalAuthorityLead);
 
         Sut.DataSourcesPerPage.Should().BeEquivalentTo([
+            new DataSourcePageListEntry("Contacts in DfE", [
+                new DataSourceListEntry(Mocks.MockDataSourceService.Fiat, "Regions group LA lead")
+            ]),
             new DataSourcePageListEntry("In this school", [
                 new DataSourceListEntry(Mocks.MockDataSourceService.Gias, DataField: "Head teacher name")
             ])

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/InDfeModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/InDfeModelTests.cs
@@ -1,0 +1,60 @@
+using DfE.FindInformationAcademiesTrusts.Data;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
+using DfE.FindInformationAcademiesTrusts.Services.School;
+
+namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.Contacts;
+
+public class InDfeModelTests : BaseContactsAreaModelTests<InDfeModel>
+{
+    private readonly ISchoolContactsService _mockSchoolContactsService = Substitute.For<ISchoolContactsService>();
+
+    private readonly SchoolInternalContactsServiceModel _dummySchoolContactsServiceModel =
+        new(new Person("Aaron Aaronson", "aa@education.gov.uk"));
+
+    public InDfeModelTests()
+    {
+        _mockSchoolContactsService.GetInternalContactsAsync(Arg.Any<int>()).Returns(_dummySchoolContactsServiceModel);
+
+        Sut = new InDfeModel(MockSchoolService, MockTrustService, _mockSchoolContactsService, MockDataSourceService,
+                MockSchoolNavMenu)
+        { Urn = SchoolUrn };
+    }
+
+    public override async Task OnGetAsync_should_configure_PageMetadata_SubPageName()
+    {
+        await OnGetAsync_should_configure_PageMetadata_SubPageName_for_school();
+        await OnGetAsync_should_configure_PageMetadata_SubPageName_for_academy();
+    }
+
+    private async Task OnGetAsync_should_configure_PageMetadata_SubPageName_for_school()
+    {
+        Sut.Urn = SchoolUrn;
+
+        await Sut.OnGetAsync();
+
+        Sut.PageMetadata.SubPageName.Should().Be("Contacts in DfE");
+    }
+
+    private async Task OnGetAsync_should_configure_PageMetadata_SubPageName_for_academy()
+    {
+        Sut.Urn = AcademyUrn;
+
+        await Sut.OnGetAsync();
+
+        Sut.PageMetadata.SubPageName.Should().Be("Contacts in DfE");
+    }
+
+    [Fact]
+    public void SubPageNavMenuName_should_be_ContactsInDfE()
+    {
+        InDfeModel.SubPageName.Should().Be("Contacts in DfE");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_should_set_RegionsGroupLocalAuthorityLead_contact_details()
+    {
+        await Sut.OnGetAsync();
+
+        Sut.RegionsGroupLocalAuthorityLead.Should().Be(_dummySchoolContactsServiceModel.RegionsGroupLocalAuthorityLead);
+    }
+}

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/InSchoolModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Contacts/InSchoolModelTests.cs
@@ -17,8 +17,9 @@ public class InSchoolModelTests : BaseContactsAreaModelTests<InSchoolModel>
     {
         _mockSchoolContactsService.GetInSchoolContactsAsync(Arg.Any<int>()).Returns(_dummyInSchoolContacts);
 
-        Sut = new InSchoolModel(MockSchoolService, MockTrustService, _mockSchoolContactsService, MockDataSourceService)
-            { Urn = SchoolUrn };
+        Sut = new InSchoolModel(MockSchoolService, MockTrustService, _mockSchoolContactsService, MockDataSourceService,
+                MockSchoolNavMenu)
+        { Urn = SchoolUrn };
     }
 
     public override async Task OnGetAsync_should_configure_PageMetadata_SubPageName()

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/DetailsModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/DetailsModelTests.cs
@@ -24,7 +24,8 @@ public class DetailsModelTests : BaseOverviewAreaModelTests<DetailsModel>
             .Returns(_dummySchoolDetails);
 
         Sut = new DetailsModel(MockSchoolService, MockTrustService, _mockSchoolOverviewDetailsService,
-            _mockOtherServicesLinkBuilder, MockDataSourceService) { Urn = SchoolUrn };
+            _mockOtherServicesLinkBuilder, MockDataSourceService, MockSchoolNavMenu)
+        { Urn = SchoolUrn };
     }
 
     [Fact]

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/SenModelTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/Overview/SenModelTests.cs
@@ -20,8 +20,9 @@ public class SenModelTests : BaseOverviewAreaModelTests<SenModel>
     {
         _mockSchoolOverviewSenService.GetSchoolOverviewSenAsync(Arg.Any<int>())
             .Returns(_dummySenDetails);
-        
-        Sut = new SenModel(MockSchoolService, MockTrustService, _mockSchoolOverviewSenService, MockDataSourceService);
+
+        Sut = new SenModel(MockSchoolService, MockTrustService, _mockSchoolOverviewSenService, MockDataSourceService,
+            MockSchoolNavMenu);
         Sut.Urn = SchoolUrn;
     }
 
@@ -29,7 +30,7 @@ public class SenModelTests : BaseOverviewAreaModelTests<SenModel>
     public override async Task OnGetAsync_should_configure_PageMetadata_SubPageName()
     {
         await Sut.OnGetAsync();
-        
+
         Sut.PageMetadata.SubPageName.Should().Be("SEN (special educational needs)");
     }
 
@@ -37,19 +38,19 @@ public class SenModelTests : BaseOverviewAreaModelTests<SenModel>
     public async Task OnGetAsync_should_set_SchoolOverviewSenServiceModel()
     {
         await Sut.OnGetAsync();
-        
+
         Sut.SchoolOverviewSenServiceModel.Should().Be(_dummySenDetails);
     }
-    
+
     [Theory]
-    [InlineData(null,null, null, null, null)]
-    [InlineData("2",null, null, null, null)]
-    [InlineData(null,"32", null, null, null)]
-    [InlineData(null,null, "77", null, null)]
-    [InlineData(null,null, null, "8", null)]
-    [InlineData(null,null, null, null, "Provision")]
+    [InlineData(null, null, null, null, null)]
+    [InlineData("2", null, null, null, null)]
+    [InlineData(null, "32", null, null, null)]
+    [InlineData(null, null, "77", null, null)]
+    [InlineData(null, null, null, "8", null)]
+    [InlineData(null, null, null, null, "Provision")]
     public async Task OnGetAsync_should_set_null_values_correctly(
-        string? resourcedProvisionOnRoll, 
+        string? resourcedProvisionOnRoll,
         string? resourcedProvisionCapacity,
         string? senOnRoll,
         string? senCapacity,
@@ -63,13 +64,13 @@ public class SenModelTests : BaseOverviewAreaModelTests<SenModel>
             SenCapacity = senCapacity,
             ResourcedProvisionTypes = resourcedProvisionTypes
         };
-        
+
         var resourcedProvisionOnRollValue = resourcedProvisionOnRoll ?? "Not available";
         var resourcedProvisionCapacityValue = resourcedProvisionCapacity ?? "Not available";
         var senOnRollValue = senOnRoll ?? "Not available";
         var senCapacityValue = senCapacity ?? "Not available";
         var resourcedProvisionTypesValue = resourcedProvisionTypes ?? "Not available";
-        
+
         _mockSchoolOverviewSenService.GetSchoolOverviewSenAsync(Arg.Any<int>())
             .Returns(_dummySenDetails);
         await Sut.OnGetAsync();
@@ -85,11 +86,11 @@ public class SenModelTests : BaseOverviewAreaModelTests<SenModel>
     public async Task OnGetAsync_should_set_empty_sen_provision_types_correctly()
     {
         _dummySenDetails = _dummySenDetails with { SenProvisionTypes = [null!] };
-        
+
         _mockSchoolOverviewSenService.GetSchoolOverviewSenAsync(Arg.Any<int>())
             .Returns(_dummySenDetails);
         await Sut.OnGetAsync();
-        
+
         Sut.SenProvisionTypes.Should().Contain(["Not available"]);
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
@@ -9,11 +10,11 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
     [Theory]
     [InlineData(123456)]
     [InlineData(567878)]
-    public void GetServiceNavLinks_should_set_route_data_to_urn(int expectedUrn)
+    public async Task GetServiceNavLinksAsync_should_set_route_data_to_urn(int expectedUrn)
     {
         var activePage = GetMockSchoolPage(typeof(DetailsModel), expectedUrn);
 
-        var results = Sut.GetServiceNavLinks(activePage);
+        var results = await Sut.GetServiceNavLinksAsync(activePage);
 
         results.Should().AllSatisfy(link =>
         {
@@ -26,12 +27,13 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
     [Theory]
     [InlineData(SchoolCategory.LaMaintainedSchool, "School")]
     [InlineData(SchoolCategory.Academy, "Academy")]
-    public void GetServiceNavLinks_should_set_hidden_text_to_school_type_on_details_page(SchoolCategory schoolCategory,
+    public async Task GetServiceNavLinksAsync_should_set_hidden_text_to_school_type_on_details_page(
+        SchoolCategory schoolCategory,
         string expectedHiddenText)
     {
         var activePage = GetMockSchoolPage(typeof(DetailsModel), schoolCategory: schoolCategory);
 
-        var results = Sut.GetServiceNavLinks(activePage);
+        var results = await Sut.GetServiceNavLinksAsync(activePage);
 
         results.Should().AllSatisfy(link => { link.VisuallyHiddenLinkText.Should().Be(expectedHiddenText); });
     }
@@ -39,22 +41,25 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
     [Theory]
     [InlineData(SchoolCategory.LaMaintainedSchool, "School")]
     [InlineData(SchoolCategory.Academy, "Academy")]
-    public void GetServiceNavLinks_should_set_hidden_text_to_school_type_on_contacts_page(SchoolCategory schoolCategory,
+    public async Task GetServiceNavLinksAsync_should_set_hidden_text_to_school_type_on_contacts_page(
+        SchoolCategory schoolCategory,
         string expectedHiddenText)
     {
         var activePage = GetMockSchoolPage(typeof(InSchoolModel), schoolCategory: schoolCategory);
 
-        var results = Sut.GetServiceNavLinks(activePage);
+        var results = await Sut.GetServiceNavLinksAsync(activePage);
 
         results.Should().AllSatisfy(link => { link.VisuallyHiddenLinkText.Should().Be(expectedHiddenText); });
     }
 
     [Fact]
-    public void GetServiceNavLinks_should_return_expected_links()
+    public async Task
+        GetServiceNavLinksAsync_should_return_expected_links_when_ContactsInDfeForSchools_feature_flag_is_disabled()
     {
+        MockFeatureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools).Returns(false);
         var activePage = GetMockSchoolPage(typeof(DetailsModel));
 
-        var results = Sut.GetServiceNavLinks(activePage);
+        var results = await Sut.GetServiceNavLinksAsync(activePage);
 
         results.Should().SatisfyRespectively(
             l =>
@@ -72,24 +77,72 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
         );
     }
 
-    [Theory]
-    [MemberData(nameof(SubPageTypes))]
-    public void GetServiceNavLinks_should_set_active_page_link_when_on_any_subpage(Type activePageType)
+    [Fact]
+    public async Task
+        GetServiceNavLinksAsync_should_return_expected_links_when_ContactsInDfeForSchools_feature_flag_is_enabled()
     {
-        var activePage = GetMockSchoolPage(activePageType);
-        var expectedActivePageLink = GetExpectedServiceNavAspLink(activePageType);
+        MockFeatureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools).Returns(true);
+        var activePage = GetMockSchoolPage(typeof(DetailsModel));
 
-        var results = Sut.GetServiceNavLinks(activePage);
+        var results = await Sut.GetServiceNavLinksAsync(activePage);
+
+        results.Should().SatisfyRespectively(
+            l =>
+            {
+                l.LinkDisplayText.Should().Be("Overview");
+                l.AspPage.Should().Be("/Schools/Overview/Details");
+                l.TestId.Should().Be("overview-nav");
+            },
+            l =>
+            {
+                l.LinkDisplayText.Should().Be("Contacts");
+                l.AspPage.Should().Be("/Schools/Contacts/InDfe");
+                l.TestId.Should().Be("contacts-nav");
+            }
+        );
+    }
+
+    [Theory]
+    [MemberData(nameof(ContactsInDfeForSchoolsEnabledSubPageTypes))]
+    public async Task
+        GetServiceNavLinksAsync_should_set_active_page_link_when_on_any_subpage_and_ContactsInDfeForSchools_feature_flag_is_disabled(
+            Type activePageType)
+    {
+        MockFeatureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools).Returns(false);
+        var activePage = GetMockSchoolPage(activePageType);
+        var expectedActivePageLink = GetExpectedServiceNavAspLink(activePageType, false);
+
+        var results = await Sut.GetServiceNavLinksAsync(activePage);
 
         results.Should().ContainSingle(l => l.LinkIsActive).Which.AspPage.Should().Be(expectedActivePageLink);
     }
 
-    private static string GetExpectedServiceNavAspLink(Type pageType)
+    [Theory]
+    [MemberData(nameof(ContactsInDfeForSchoolsEnabledSubPageTypes))]
+    public async Task
+        GetServiceNavLinksAsync_should_set_active_page_link_when_on_any_subpage_and_ContactsInDfeForSchools_feature_flag_is_enabled(
+            Type activePageType)
     {
+        MockFeatureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools).Returns(true);
+        var activePage = GetMockSchoolPage(activePageType);
+        var expectedActivePageLink = GetExpectedServiceNavAspLink(activePageType, true);
+
+        var results = await Sut.GetServiceNavLinksAsync(activePage);
+
+        results.Should().ContainSingle(l => l.LinkIsActive).Which.AspPage.Should().Be(expectedActivePageLink);
+    }
+
+    private static string GetExpectedServiceNavAspLink(Type pageType, bool contactsInDfeForSchoolsFeatureFlagEnabled)
+    {
+        var contactLink = contactsInDfeForSchoolsFeatureFlagEnabled
+            ? "/Schools/Contacts/InDfe"
+            : "/Schools/Contacts/InSchool";
+
         return pageType.Name switch
         {
             nameof(DetailsModel) => "/Schools/Overview/Details",
-            nameof(InSchoolModel) => "/Schools/Contacts/InSchool",
+            nameof(InDfeModel) => contactLink,
+            nameof(InSchoolModel) => contactLink,
             nameof(SenModel) => "/Schools/Overview/Details",
             _ => throw new ArgumentException("Couldn't get expected service nav asp link for given page type",
                 nameof(pageType))

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuServiceNavTests.cs
@@ -1,7 +1,6 @@
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
-using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
-using Sut = DfE.FindInformationAcademiesTrusts.Pages.Schools.SchoolNavMenu;
+using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.SchoolNavMenu;
 
@@ -36,7 +35,7 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
 
         results.Should().AllSatisfy(link => { link.VisuallyHiddenLinkText.Should().Be(expectedHiddenText); });
     }
-    
+
     [Theory]
     [InlineData(SchoolCategory.LaMaintainedSchool, "School")]
     [InlineData(SchoolCategory.Academy, "Academy")]
@@ -91,7 +90,7 @@ public class SchoolNavMenuServiceNavTests : SchoolNavMenuTestsBase
         {
             nameof(DetailsModel) => "/Schools/Overview/Details",
             nameof(InSchoolModel) => "/Schools/Contacts/InSchool",
-                nameof(SenModel) => "/Schools/Overview/Details",
+            nameof(SenModel) => "/Schools/Overview/Details",
             _ => throw new ArgumentException("Couldn't get expected service nav asp link for given page type",
                 nameof(pageType))
         };

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuSubNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuSubNavTests.cs
@@ -1,3 +1,4 @@
+using DfE.FindInformationAcademiesTrusts.Configuration;
 using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
@@ -10,11 +11,11 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
     [Theory]
     [InlineData(123456)]
     [InlineData(567890)]
-    public void GetSubNavLinks_should_set_route_data_to_urn(int expectedUrn)
+    public async Task GetSubNavLinksAsync_should_set_route_data_to_urn(int expectedUrn)
     {
         var activePage = GetMockSchoolPage(typeof(DetailsModel), expectedUrn);
 
-        var results = Sut.GetSubNavLinks(activePage);
+        var results = await Sut.GetSubNavLinksAsync(activePage);
 
         results.Should().AllSatisfy(link =>
         {
@@ -25,13 +26,13 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
     }
 
     [Theory]
-    [MemberData(nameof(SubPageTypes))]
-    public void GetSubNavLinks_should_set_hidden_text_to_page_name(Type activePageType)
+    [MemberData(nameof(ContactsInDfeForSchoolsEnabledSubPageTypes))]
+    public async Task GetSubNavLinksAsync_should_set_hidden_text_to_page_name(Type activePageType)
     {
         var activePage = GetMockSchoolPage(activePageType);
         var expectedPageName = GetExpectedPageName(activePageType);
 
-        var results = Sut.GetSubNavLinks(activePage);
+        var results = await Sut.GetSubNavLinksAsync(activePage);
 
         results.Should().AllSatisfy(link => { link.VisuallyHiddenLinkText.Should().Be(expectedPageName); });
     }
@@ -41,6 +42,7 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
         return pageType.Name switch
         {
             nameof(DetailsModel) => "Overview",
+            nameof(InDfeModel) => "Contacts",
             nameof(InSchoolModel) => "Contacts",
             nameof(SenModel) => "Overview",
             _ => throw new ArgumentException("Couldn't get expected name for given page type", nameof(pageType))
@@ -48,22 +50,41 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
     }
 
     [Theory]
-    [MemberData(nameof(SubPageTypes))]
-    public void GetSubNavLinks_should_set_active_sub_page_link(Type activePageType)
+    [MemberData(nameof(ContactsInDfeForSchoolsDisabledSubPageTypes))]
+    public async Task
+        GetSubNavLinksAsync_should_set_active_sub_page_link_when_ContactsInDfeForSchools_feature_flag_is_disabled(
+            Type activePageType)
     {
+        MockFeatureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools).Returns(false);
         var activePage = GetMockSchoolPage(activePageType);
-        var expectedActiveSubPageLink = GetSubPageLinkTo(activePageType);
+        var expectedActiveSubPageLink = GetSubPageLinkTo(activePageType, false);
 
-        var results = Sut.GetSubNavLinks(activePage);
+        var results = await Sut.GetSubNavLinksAsync(activePage);
 
         results.Should().ContainSingle(l => l.LinkIsActive).Which.AspPage.Should().Be(expectedActiveSubPageLink);
     }
 
-    private static string GetSubPageLinkTo(Type pageType)
+    [Theory]
+    [MemberData(nameof(ContactsInDfeForSchoolsEnabledSubPageTypes))]
+    public async Task
+        GetSubNavLinksAsync_should_set_active_sub_page_link_when_ContactsInDfeForSchools_feature_flag_is_enabled(
+            Type activePageType)
+    {
+        MockFeatureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools).Returns(true);
+        var activePage = GetMockSchoolPage(activePageType);
+        var expectedActiveSubPageLink = GetSubPageLinkTo(activePageType, true);
+
+        var results = await Sut.GetSubNavLinksAsync(activePage);
+
+        results.Should().ContainSingle(l => l.LinkIsActive).Which.AspPage.Should().Be(expectedActiveSubPageLink);
+    }
+
+    private static string GetSubPageLinkTo(Type pageType, bool contactsInDfeForSchoolsFeatureFlagEnabled)
     {
         return pageType.Name switch
         {
             nameof(DetailsModel) => "/Schools/Overview/Details",
+            nameof(InDfeModel) => "/Schools/Contacts/InDfe",
             nameof(InSchoolModel) => "/Schools/Contacts/InSchool",
             nameof(SenModel) => "/Schools/Overview/Sen",
             _ => throw new ArgumentException("Couldn't get expected sub page nav asp link for given page type",
@@ -74,12 +95,12 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
     [Theory]
     [InlineData(SchoolCategory.LaMaintainedSchool, "School details")]
     [InlineData(SchoolCategory.Academy, "Academy details")]
-    public void GetSubNavLinks_should_return_expected_links_for_overview(SchoolCategory schoolCategory,
+    public async Task GetSubNavLinksAsync_should_return_expected_LinksAsync_for_overview(SchoolCategory schoolCategory,
         string expectedText)
     {
         var activePage = GetMockSchoolPage(typeof(DetailsModel), schoolCategory: schoolCategory);
 
-        var results = Sut.GetSubNavLinks(activePage);
+        var results = await Sut.GetSubNavLinksAsync(activePage);
 
         results.Should().SatisfyRespectively(
             l =>
@@ -100,12 +121,15 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
     [Theory]
     [InlineData(SchoolCategory.LaMaintainedSchool, "In this school")]
     [InlineData(SchoolCategory.Academy, "In this academy")]
-    public void GetSubNavLinks_should_return_expected_links_for_contacts(SchoolCategory schoolCategory,
-        string expectedText)
+    public async Task
+        GetSubNavLinksAsync_should_return_expected_LinksAsync_for_contacts_when_ContactsInDfeForSchools_feature_flag_is_disabled(
+            SchoolCategory schoolCategory,
+            string expectedText)
     {
+        MockFeatureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools).Returns(false);
         var activePage = GetMockSchoolPage(typeof(InSchoolModel), schoolCategory: schoolCategory);
 
-        var results = Sut.GetSubNavLinks(activePage);
+        var results = await Sut.GetSubNavLinksAsync(activePage);
 
         results.Should().SatisfyRespectively(l =>
             {
@@ -116,14 +140,42 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
         );
     }
 
+    [Theory]
+    [InlineData(SchoolCategory.LaMaintainedSchool, "In this school")]
+    [InlineData(SchoolCategory.Academy, "In this academy")]
+    public async Task
+        GetSubNavLinksAsync_should_return_expected_LinksAsync_for_contacts_when_ContactsInDfeForSchools_feature_flag_is_enabled(
+            SchoolCategory schoolCategory,
+            string expectedText)
+    {
+        MockFeatureManager.IsEnabledAsync(FeatureFlags.ContactsInDfeForSchools).Returns(true);
+        var activePage = GetMockSchoolPage(typeof(InSchoolModel), schoolCategory: schoolCategory);
+
+        var results = await Sut.GetSubNavLinksAsync(activePage);
+
+        results.Should().SatisfyRespectively(l =>
+            {
+                l.LinkDisplayText.Should().Be("Contacts in DfE");
+                l.AspPage.Should().Be("/Schools/Contacts/InDfe");
+                l.TestId.Should().Be("contacts-in-dfe-subnav");
+            },
+            l =>
+            {
+                l.LinkDisplayText.Should().Be(expectedText);
+                l.AspPage.Should().Be("/Schools/Contacts/InSchool");
+                l.TestId.Should().Be("contacts-in-this-school-subnav");
+            }
+        );
+    }
+
     [Fact]
-    public void GetSubNavLinks_should_throw_if_page_not_supported()
+    public async Task GetSubNavLinksAsync_should_throw_if_page_not_supported()
     {
         var activePage = Substitute.For<ISchoolAreaModel>();
 
-        var action = () => Sut.GetSubNavLinks(activePage);
+        var action = async () => await Sut.GetSubNavLinksAsync(activePage);
 
-        action.Should().Throw<ArgumentOutOfRangeException>()
-            .Which.Message.Should().StartWith("Page type is not supported.");
+        var result = await action.Should().ThrowAsync<ArgumentException>();
+        result.Which.Message.Should().StartWith("Page type is not supported.");
     }
 }

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuSubNavTests.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuSubNavTests.cs
@@ -2,7 +2,6 @@ using DfE.FindInformationAcademiesTrusts.Data.Enums;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
-using Sut = DfE.FindInformationAcademiesTrusts.Pages.Schools.SchoolNavMenu;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.SchoolNavMenu;
 
@@ -43,7 +42,7 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
         {
             nameof(DetailsModel) => "Overview",
             nameof(InSchoolModel) => "Contacts",
-                nameof(SenModel) => "Overview",
+            nameof(SenModel) => "Overview",
             _ => throw new ArgumentException("Couldn't get expected name for given page type", nameof(pageType))
         };
     }
@@ -108,8 +107,7 @@ public class SchoolNavMenuSubNavTests : SchoolNavMenuTestsBase
 
         var results = Sut.GetSubNavLinks(activePage);
 
-        results.Should().SatisfyRespectively(
-            l =>
+        results.Should().SatisfyRespectively(l =>
             {
                 l.LinkDisplayText.Should().Be(expectedText);
                 l.AspPage.Should().Be("/Schools/Contacts/InSchool");

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
@@ -3,20 +3,37 @@ using DfE.FindInformationAcademiesTrusts.Pages.Schools;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
 using DfE.FindInformationAcademiesTrusts.Services.School;
+using Microsoft.FeatureManagement;
 using Sut = DfE.FindInformationAcademiesTrusts.Pages.Schools.SchoolNavMenu;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.SchoolNavMenu;
 
 public abstract class SchoolNavMenuTestsBase
 {
-    protected Sut Sut = new();
+    protected IVariantFeatureManager MockFeatureManager = Substitute.For<IVariantFeatureManager>();
+    protected readonly Sut Sut;
 
-    public static TheoryData<Type> SubPageTypes =>
+    public SchoolNavMenuTestsBase()
+    {
+        Sut = new Sut(MockFeatureManager);
+    }
+
+    public static TheoryData<Type> ContactsInDfeForSchoolsDisabledSubPageTypes =>
     [
         //Overview
         typeof(DetailsModel),
         typeof(SenModel),
         //Contacts
+        typeof(InSchoolModel)
+    ];
+
+    public static TheoryData<Type> ContactsInDfeForSchoolsEnabledSubPageTypes =>
+    [
+        //Overview
+        typeof(DetailsModel),
+        typeof(SenModel),
+        //Contacts
+        typeof(InDfeModel),
         typeof(InSchoolModel)
     ];
 

--- a/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
+++ b/tests/DfE.FindInformationAcademiesTrusts.UnitTests/Pages/Schools/SchoolNavMenu/SchoolNavMenuTestsBase.cs
@@ -3,11 +3,14 @@ using DfE.FindInformationAcademiesTrusts.Pages.Schools;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Contacts;
 using DfE.FindInformationAcademiesTrusts.Pages.Schools.Overview;
 using DfE.FindInformationAcademiesTrusts.Services.School;
+using Sut = DfE.FindInformationAcademiesTrusts.Pages.Schools.SchoolNavMenu;
 
 namespace DfE.FindInformationAcademiesTrusts.UnitTests.Pages.Schools.SchoolNavMenu;
 
 public abstract class SchoolNavMenuTestsBase
 {
+    protected Sut Sut = new();
+
     public static TheoryData<Type> SubPageTypes =>
     [
         //Overview


### PR DESCRIPTION
This PR introduces a new 'Contacts in DfE' page to the 'Contacts' section when looking at information about a school.

> [!Note]
> See [#205375 Build: contacts 'In DfE' for a school](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/205375) on Azure DevOps.
>
> This PR depends on #856 and #858.

## Changes

- A new page has been introduced for DfE contact information, available at `/schools/contacts/in-dfe?urn={urn}`, which currently displays the Regions Group Local Authority Lead
- The data source list in the schools area has been updated to include an entry about the Regions Group Local Authority Lead
- The nav menu in the school area has been updated to add an entry for the DfE contacts page, and to make the DfE contacts subpage the primary page for the Contacts link

## Screenshots of UI changes

### Before

![](https://github.com/user-attachments/assets/ddbbe8e9-10c0-40dd-b4b7-44ff77813c91)

### After

![](https://github.com/user-attachments/assets/46e86711-ae28-4af9-a8d9-814ead5e4571)

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
