### PR TITLE
[205375] Configure `ContactsInDfeForSchools` feature flag for dev and test

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/appsettings.Development.json
+++ b/DfE.FindInformationAcademiesTrusts/appsettings.Development.json
@@ -1,0 +1,5 @@
+{
+  "FeatureManagement": {
+    "ContactsInDfeForSchools": true
+  }
+}

--- a/DfE.FindInformationAcademiesTrusts/appsettings.Test.json
+++ b/DfE.FindInformationAcademiesTrusts/appsettings.Test.json
@@ -1,0 +1,5 @@
+{
+  "FeatureManagement": {
+    "ContactsInDfeForSchools": true
+  }
+}


### PR DESCRIPTION
This PR enables the `ContactsInDfeForSchools` feature flag in the development and test environments.

> [!Note]
> See [User Story 205375](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/205375): Build: contacts 'In DfE' for a school

## Changes

- Added `appsettings.Development.json` and `appsettings.Test.json` to set the `ContactsInDfeForSchools` feature flag in both environments

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
