### PR TITLE
Fix accessibility issue in the 'About the data we use' page

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/AboutData.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/AboutData.cshtml
@@ -3,20 +3,21 @@
 
 @{
   Model.ShowBreadcrumb = false;
-  Model.BannerHeading = "About the data we use";
   Layout = "_ContentLayout";
-  ViewData["Title"] = Model.BannerHeading;
+  ViewData["Title"] = "About the data we use";
 }
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
+    <h1 class="govuk-heading-l">About the data we use</h1>
+
     <!--Intro copy-->
     <p class="govuk-body">
-      Find information about schools and trusts (FAST) brings together data from different places. 
+      Find information about schools and trusts (FAST) brings together data from different places.
     </p>
 
     <p class="govuk-body">
-      We do not own the information we show from other services. 
+      We do not own the information we show from other services.
     </p>
 
     <p class="govuk-body">
@@ -38,7 +39,7 @@
 
     <!--Intro copy 2 -->
     <p class="govuk-body">
-      To report a problem with data taken from another source, you must contact the service responsible for it. 
+      To report a problem with data taken from another source, you must contact the service responsible for it.
     </p>
 
     <!--h2 When we fetch data-->
@@ -52,10 +53,10 @@
     <!--When we fetch data para -->
     <p class="govuk-body">
       If there are changes that FAST needs to reflect, providing the place we take the data from has been updated, you should see them the next time we take a copy.
-    </p> 
+    </p>
 
     <p class="govuk-body">
-      We do this as often as we can so that the information you see is as up to date as possible. 
+      We do this as often as we can so that the information you see is as up to date as possible.
     </p>
 
     <!--h3 daily-->
@@ -63,7 +64,7 @@
 
     <!--Daily paras -->
     <p class="govuk-body">
-      Most FAST information comes from <a class="govuk-link" href="https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/RSD.aspx">Regions Group tools and systems</a> or <a class="govuk-link" href="https://get-information-schools.service.gov.uk/">Get information about schools (GIAS)</a> and gets updated <strong>every morning</strong>. 
+      Most FAST information comes from <a class="govuk-link" href="https://educationgovuk.sharepoint.com/sites/lvewp00299/SitePages/RSD.aspx">Regions Group tools and systems</a> or <a class="govuk-link" href="https://get-information-schools.service.gov.uk/">Get information about schools (GIAS)</a> and gets updated <strong>every morning</strong>.
     </p>
 
     <p class="govuk-body">
@@ -73,13 +74,13 @@
     <!--Daily morning bullets-->
     <ul class="govuk-list govuk-list--bullet">
       <li>
-      names, addresses and reference numbers
+        names, addresses and reference numbers
       </li>
       <li>
-      current academies in a trust 
+        current academies in a trust
       </li>
       <li>
-      details of any academies in the pipeline
+        details of any academies in the pipeline
       </li>
     </ul>
 
@@ -88,16 +89,16 @@
 
     <!--Spring census para -->
     <p class="govuk-body">
-    Some information we take from GIAS comes from the Spring census. This gets updated <strong>every year</strong> and includes:
+      Some information we take from GIAS comes from the Spring census. This gets updated <strong>every year</strong> and includes:
     </p>
 
     <!--Spring census bullets-->
     <ul class="govuk-list govuk-list--bullet">
       <li>
-      pupil numbers
+        pupil numbers
       </li>
       <li>
-      free school meals figures
+        free school meals figures
       </li>
     </ul>
 
@@ -106,7 +107,7 @@
 
     <!--Ofsted data para -->
     <p class="govuk-body">
-      We take most Ofsted information from: 
+      We take most Ofsted information from:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
@@ -124,7 +125,7 @@
 
     <p class="govuk-body">
       Both reports are upated <strong>every month</strong>.
-    </p> 
+    </p>
 
     <p class="govuk-body">
       Adding the monthly data is a manual process and we cannot give an exact date for when it will be visible in FAST.
@@ -135,7 +136,7 @@
     </p>
 
     <p class="govuk-body">
-      We add the new report data for these schools <strong>every week</strong>. The data for this is sent to us directly from Ofsted. 
+      We add the new report data for these schools <strong>every week</strong>. The data for this is sent to us directly from Ofsted.
     </p>
 
     <!--h3 Other data-->

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/ContentPageModel.cs
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/ContentPageModel.cs
@@ -6,5 +6,4 @@ namespace DfE.FindInformationAcademiesTrusts.Pages.Shared;
 public class ContentPageModel : BasePageModel
 {
     public bool ShowBreadcrumb { get; set; } = true;
-    public string? BannerHeading { get; set; }
 }

--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_ContentLayout.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_ContentLayout.cshtml
@@ -4,18 +4,6 @@
   Layout = "_Layout";
 }
 
-@if (Model.BannerHeading is not null)
-{
-  <div class="app-banner" data-testid="aboutdata-header">
-    <div class="dfe-width-container">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-three-quarters">
-          <h1 class="govuk-heading-l app-banner--heading govuk-!-margin-top-3 govuk-!-margin-bottom-3">@Model.BannerHeading</h1>
-        </div>
-      </div>
-    </div>
-  </div>
-}
 <div class="govuk-main-wrapper @(Model.ShowBreadcrumb ? "govuk-!-padding-top-0" : "govuk-!-padding-top-6")">
   <div class="dfe-width-container">
     @if (Model.ShowBreadcrumb)


### PR DESCRIPTION
This page was introduced in #919, but the heading within the banner is not part of any accessibility landmark, which causes problems for screenreaders.

This banner heading was introduced to the `_ContentLayout` partial in order to align the page visually with how it was presented in the prototype. The 'main' landmark is not part of this partial so any text rendered here will not be visible.

However, rendering the banner within the 'main' landmark causes it to render with visible margins.

Therefore, the page has had the banner removed and the heading is now rendered as plain text within the 'main' landmark, which is more consistent with the other content pages and more suitable for accessibility tools.

## Changes

- The `_ContentLayout` partial has had the conditional rendering of a `div.app-banner` removed.
- The `ContentPageModel` class has had the `BannerHeading` property removed as it is no longer in use.
- The `AboutData` view has been updated to align with the other content pages, including moving the `h1` into the main content.

## Screenshots of UI changes

### Before

The heading is within a banner and outside of the main content:
<img width="2419" height="3756" alt="" src="https://github.com/user-attachments/assets/a888c7c7-dcec-42e3-abd1-4a26c6f26437" />

### After

The banner has been replaced with a plain heading on the 'About the data we use' page:
<img width="2419" height="3702" alt="" src="https://github.com/user-attachments/assets/dc5dc6d4-04e0-4ab5-b8a9-fb031d5b2d3e" />

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [ ] Testing complete - all manual and automated tests pass
