### PR TITLE
Custom Event Tracking in App Insights

### DIFF
--- a/DfE.FindInformationAcademiesTrusts/Pages/Shared/_AppInsights.cshtml
+++ b/DfE.FindInformationAcademiesTrusts/Pages/Shared/_AppInsights.cshtml
@@ -26,5 +26,24 @@
       }
    });
 
+    // track click event by css class name
+    document.addEventListener("click", function (e) {
+        const trackedClasses = ["govuk-details__summary-text"];
+
+        const el = e.target.closest(trackedClasses.map(c => "." + c).join(","));
+        if (!el) return;
+
+        const matchedClass = trackedClasses.find(c => el.classList.contains(c));
+
+        window.appInsights.trackEvent({
+            name: "RSD track clicks accordion",
+            properties: {
+                className: matchedClass,
+                text: el.innerText?.trim()
+            }
+        });
+    });
+
+
    window.appInsights.setAuthenticatedUserContext("@authenticatedUserId", null, true);
 </script>


### PR DESCRIPTION
Allow AppInsight to track click event on all UI elements below:

<img width="536" height="334" alt="image" src="https://github.com/user-attachments/assets/f0cd7726-c8ac-4a10-98f5-c3603b2d2721" />

On AppInsights, this is the expected result:

<img width="1064" height="144" alt="image" src="https://github.com/user-attachments/assets/dbab1fca-dd0d-467f-a7a3-944669a17aa0" />

<img width="868" height="287" alt="image" src="https://github.com/user-attachments/assets/0be74ae7-50cc-4a8f-a0f5-1228e0a33884" />

<img width="1237" height="509" alt="image" src="https://github.com/user-attachments/assets/8f1bbff2-06b0-490c-a392-67d7f1075dbd" />

<!-- Add a link to the user story -->
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/System%20Sustainability/Stories?workitem=279014

## Checklist

- [x] Pull request attached to the appropriate user story in Azure DevOps
- [ ] ADR decision log updated (if needed)
- [ ] Release notes added to CHANGELOG.md
- [x] Testing complete - all manual and automated tests pass
